### PR TITLE
feat: add monthly rewards display to dashboard and landing page

### DIFF
--- a/src/api/models/Dashboard.ts
+++ b/src/api/models/Dashboard.ts
@@ -32,6 +32,43 @@ export type Stats = {
   recentLinesChanged: string | number;
   totalIssues: number;
   totalCommits: string | number;
+  prices?: {
+    tao: {
+      data: {
+        price: number;
+        symbol: string;
+        name: string;
+        market_cap: number;
+        volume_24h: number;
+        percent_change_1h: number;
+        percent_change_24h: number;
+        percent_change_7d: number;
+        percent_change_30d: number;
+        last_updated: string;
+      };
+      lastUpdated: string;
+      nextUpdate: string;
+    };
+    alpha: {
+      data: {
+        price: number;
+        symbol: string;
+        name: string;
+        netuid: number;
+        market_cap: number;
+        liquidity: number;
+        price_change_1_hour: number;
+        price_change_1_day: number;
+        price_change_1_week: number;
+        price_change_1_month: number;
+        tao_volume_24_hr: number;
+        alpha_volume_24_hr: number;
+        timestamp: string;
+      };
+      lastUpdated: string;
+      nextUpdate: string;
+    };
+  };
 };
 
 export type CommitLog = {

--- a/src/components/dashboard/KpiCard.tsx
+++ b/src/components/dashboard/KpiCard.tsx
@@ -24,7 +24,9 @@ const KpiCard: React.FC<KpiCardProps> = ({
   const titleSize = isLarge ? (isMobile ? 14 : 16) : (isMobile ? 12 : 14);
 
   const formattedValue = value !== undefined && value !== null
-    ? (typeof value === "number" || typeof value === "string" 
+    ? (typeof value === "string" && value.startsWith("$")
+        ? value // Already formatted with currency
+        : typeof value === "number" || typeof value === "string" 
         ? Number(value).toLocaleString() 
         : value)
     : undefined;

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -20,7 +20,10 @@ const DashboardPage: React.FC = () => {
 
   // Calculate daily rewards: TAO price × Alpha price × 2952 (daily Alpha emissions for miners)
   const dailyRewards = React.useMemo(() => {
-    if (!stats?.prices?.tao?.data?.price || !stats?.prices?.alpha?.data?.price) {
+    if (
+      !stats?.prices?.tao?.data?.price ||
+      !stats?.prices?.alpha?.data?.price
+    ) {
       return undefined;
     }
     const taoPrice = stats.prices.tao.data.price;
@@ -33,7 +36,11 @@ const DashboardPage: React.FC = () => {
   const monthlyRewards = React.useMemo(() => {
     if (!dailyRewards) return undefined;
     const now = new Date();
-    const daysInMonth = new Date(now.getFullYear(), now.getMonth() + 1, 0).getDate();
+    const daysInMonth = new Date(
+      now.getFullYear(),
+      now.getMonth() + 1,
+      0,
+    ).getDate();
     return dailyRewards * daysInMonth;
   }, [dailyRewards]);
 
@@ -81,23 +88,13 @@ const DashboardPage: React.FC = () => {
           }}
         >
           {/* Top Row: Total Lines Committed + Monthly Rewards */}
-          <Grid container spacing={{ xs: 1.5, md: 2 }} sx={{ flexShrink: 0 }}>
-            <Grid item xs={12} md={6}>
-              <KpiCard
-                title="Total Lines Committed"
-                value={stats?.totalLinesChanged}
-                subtitle="Cumulative code contributions"
-                variant="large"
-              />
-            </Grid>
-            <Grid item xs={12} md={6}>
-              <KpiCard
-                title="Monthly Rewards"
-                value={monthlyRewards ? `$${monthlyRewards.toFixed(2)}` : undefined}
-                subtitle="Total potential mining rewards this month"
-                variant="large"
-              />
-            </Grid>
+          <Grid item xs={12} md={6}>
+            <KpiCard
+              title="Total Lines Committed"
+              value={stats?.totalLinesChanged}
+              subtitle="Cumulative code contributions"
+              variant="large"
+            />
           </Grid>
 
           {/* Middle Row: 4 KPI Cards - Responsive Grid */}

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -18,6 +18,25 @@ const DashboardPage: React.FC = () => {
 
   const { data: stats } = useStats();
 
+  // Calculate daily rewards: TAO price × Alpha price × 2952 (daily Alpha emissions for miners)
+  const dailyRewards = React.useMemo(() => {
+    if (!stats?.prices?.tao?.data?.price || !stats?.prices?.alpha?.data?.price) {
+      return undefined;
+    }
+    const taoPrice = stats.prices.tao.data.price;
+    const alphaPrice = stats.prices.alpha.data.price;
+    const dailyAlphaEmissions = 2952;
+    return taoPrice * alphaPrice * dailyAlphaEmissions;
+  }, [stats?.prices]);
+
+  // Calculate monthly rewards: daily rewards × days in current month
+  const monthlyRewards = React.useMemo(() => {
+    if (!dailyRewards) return undefined;
+    const now = new Date();
+    const daysInMonth = new Date(now.getFullYear(), now.getMonth() + 1, 0).getDate();
+    return dailyRewards * daysInMonth;
+  }, [dailyRewards]);
+
   // Dynamic sidebar width based on screen size
   const sidebarWidth =
     isMobile || isTablet ? "100%" : isLargeScreen ? "340px" : "300px";
@@ -61,15 +80,25 @@ const DashboardPage: React.FC = () => {
             },
           }}
         >
-          {/* Top Row: Focal Point - Total Lines Committed */}
-          <Box sx={{ flexShrink: 0 }}>
-            <KpiCard
-              title="Total Lines Committed"
-              value={stats?.totalLinesChanged}
-              subtitle="Cumulative code contributions"
-              variant="large"
-            />
-          </Box>
+          {/* Top Row: Total Lines Committed + Monthly Rewards */}
+          <Grid container spacing={{ xs: 1.5, md: 2 }} sx={{ flexShrink: 0 }}>
+            <Grid item xs={12} md={6}>
+              <KpiCard
+                title="Total Lines Committed"
+                value={stats?.totalLinesChanged}
+                subtitle="Cumulative code contributions"
+                variant="large"
+              />
+            </Grid>
+            <Grid item xs={12} md={6}>
+              <KpiCard
+                title="Monthly Rewards"
+                value={monthlyRewards ? `$${monthlyRewards.toFixed(2)}` : undefined}
+                subtitle="Total potential mining rewards this month"
+                variant="large"
+              />
+            </Grid>
+          </Grid>
 
           {/* Middle Row: 4 KPI Cards - Responsive Grid */}
           <Grid container spacing={{ xs: 1.5, md: 2 }} sx={{ flexShrink: 0 }}>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,8 +1,24 @@
 import React from "react";
 import { Box, Stack, Typography } from "@mui/material";
 import { Page } from "../components/layout";
+import { useStats } from "../api";
 
 const HomePage: React.FC = () => {
+  const { data: stats } = useStats();
+
+  // Calculate monthly rewards: TAO price × Alpha price × 2952 × days in current month
+  const monthlyRewards = React.useMemo(() => {
+    if (!stats?.prices?.tao?.data?.price || !stats?.prices?.alpha?.data?.price) {
+      return undefined;
+    }
+    const taoPrice = stats.prices.tao.data.price;
+    const alphaPrice = stats.prices.alpha.data.price;
+    const dailyAlphaEmissions = 2952;
+    const now = new Date();
+    const daysInMonth = new Date(now.getFullYear(), now.getMonth() + 1, 0).getDate();
+    return taoPrice * alphaPrice * dailyAlphaEmissions * daysInMonth;
+  }, [stats?.prices]);
+
   return (
     <Page title="Home">
       <Box
@@ -53,6 +69,67 @@ const HomePage: React.FC = () => {
           >
             The workforce for open source.
           </Typography>
+
+          {/* Monthly Rewards Banner */}
+          {monthlyRewards && (
+            <Box
+              sx={{
+                mt: { xs: 4, sm: 5 },
+                px: { xs: 3, sm: 5, md: 7 },
+                py: { xs: 2.5, sm: 3.5 },
+                borderRadius: 2,
+                background: "rgba(0, 0, 0, 0.4)",
+                border: "1px solid rgba(255, 255, 255, 0.15)",
+                backdropFilter: "blur(10px)",
+                boxShadow: "0 8px 32px rgba(0, 0, 0, 0.3)",
+                transition: "all 0.3s ease-in-out",
+                "&:hover": {
+                  border: "1px solid rgba(255, 255, 255, 0.25)",
+                  boxShadow: "0 12px 48px rgba(0, 0, 0, 0.4)",
+                  transform: "translateY(-2px)",
+                },
+              }}
+            >
+              <Stack alignItems="center" gap={{ xs: 1, sm: 1.5 }}>
+                <Typography
+                  variant="body2"
+                  color="rgba(255, 255, 255, 0.5)"
+                  sx={{
+                    fontSize: { xs: "0.7rem", sm: "0.75rem" },
+                    textTransform: "uppercase",
+                    letterSpacing: "0.15em",
+                    fontWeight: 500,
+                  }}
+                >
+                  Monthly Reward Pool
+                </Typography>
+                <Typography
+                  variant="h2"
+                  color="#ffffff"
+                  fontWeight="600"
+                  sx={{
+                    fontFamily: '"JetBrains Mono", monospace',
+                    fontSize: { xs: "2rem", sm: "2.75rem", md: "3.5rem" },
+                    letterSpacing: "-0.02em",
+                  }}
+                >
+                  ${monthlyRewards.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+                </Typography>
+                <Typography
+                  variant="body2"
+                  color="rgba(255, 255, 255, 0.4)"
+                  sx={{
+                    fontSize: { xs: "0.75rem", sm: "0.85rem" },
+                    textAlign: "center",
+                    maxWidth: "400px",
+                    lineHeight: 1.6,
+                  }}
+                >
+                  Compete for rewards by contributing quality code to open source
+                </Typography>
+              </Stack>
+            </Box>
+          )}
         </Stack>
       </Box>
     </Page>


### PR DESCRIPTION
- Add price data types to Stats model for TAO and Alpha
- Calculate monthly rewards based on TAO price × Alpha price × 2952 emissions × days in month
- Add Monthly Rewards KPI card to dashboard alongside Total Lines Committed
- Add sophisticated rewards banner to landing page with glass morphism design
- Update KpiCard to handle pre-formatted currency strings
- Emphasize competitive aspect of contributing quality code to open source