### PR TITLE
fix: use UTC dates consistently across chart and live activity

### DIFF
--- a/src/api/models/Dashboard.ts
+++ b/src/api/models/Dashboard.ts
@@ -23,7 +23,7 @@ export type LanguageWeight = {
 
 export type CommitsTrend = {
   date: string;
-  linesCommitted: number;
+  linesCommitted: number | string; // API returns string, needs conversion
 };
 
 export type Stats = {

--- a/src/components/dashboard/CommitTrendChart.tsx
+++ b/src/components/dashboard/CommitTrendChart.tsx
@@ -3,6 +3,9 @@ import ReactECharts from "echarts-for-react";
 import { Card, CardContent, Typography, useTheme, useMediaQuery } from "@mui/material";
 import { useHistoricalTrend } from "../../api";
 import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
+
+dayjs.extend(utc);
 
 const CommitTrendChart: React.FC = () => {
   const theme = useTheme();
@@ -11,9 +14,9 @@ const CommitTrendChart: React.FC = () => {
 
   const { data } = useHistoricalTrend();
 
-  // Filter data to only include the last 7 days
+  // Filter data to only include the last 10 days (using UTC)
   const filteredData = data?.filter((item) =>
-    dayjs(item.date).isAfter(dayjs().subtract(7, "day"))
+    dayjs.utc(item.date).isAfter(dayjs.utc().subtract(10, "day"))
   );
 
   const option = {
@@ -24,9 +27,9 @@ const CommitTrendChart: React.FC = () => {
       trigger: "axis",
       formatter: (params: any) => {
         const data = params[0];
-        return `${dayjs(data.axisValue).format(
+        return `${dayjs.utc(data.axisValue).format(
           "YYYY-MM-DD",
-        )}<br/>Lines Committed: ${data.value.toLocaleString()}`;
+        )} UTC<br/>Lines Committed: ${data.value.toLocaleString()}`;
       },
       backgroundColor: "rgba(18, 18, 20, 0.95)",
       borderColor: "rgba(255, 255, 255, 0.1)",
@@ -54,7 +57,7 @@ const CommitTrendChart: React.FC = () => {
         fontFamily: '"JetBrains Mono", monospace',
         fontSize: isMobile ? 10 : 11,
         formatter: (value: string) => {
-          const date = dayjs(value);
+          const date = dayjs.utc(value);
           return `${date.month() + 1}/${date.date()}`;
         },
         margin: isMobile ? 8 : 12,
@@ -95,7 +98,7 @@ const CommitTrendChart: React.FC = () => {
       {
         name: "Lines Committed",
         type: "line",
-        data: filteredData?.map((item) => item.linesCommitted),
+        data: filteredData?.map((item) => typeof item.linesCommitted === 'string' ? parseInt(item.linesCommitted) : item.linesCommitted),
         smooth: true,
         lineStyle: {
           color: theme.palette.primary.main,

--- a/src/components/dashboard/LiveCommitLog.tsx
+++ b/src/components/dashboard/LiveCommitLog.tsx
@@ -13,6 +13,9 @@ import { GitHub } from "@mui/icons-material";
 import theme from "../../theme";
 import { useInfiniteCommitLog } from "../../api";
 import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
+
+dayjs.extend(utc);
 
 interface CommitLogEntry {
   pullRequestNumber: number;
@@ -422,7 +425,7 @@ const LiveCommitLog: React.FC = () => {
                             fontFamily: '"JetBrains Mono", monospace',
                           }}
                         >
-                          {dayjs(entry.mergedAt).format("MMM D, h:mm A")}
+                          {dayjs(entry.mergedAt).utc().format("MMM D, h:mm A")} UTC
                         </Typography>
                       </Stack>
 


### PR DESCRIPTION
- Update CommitTrendChart to use UTC for date filtering and display
- Update LiveCommitLog to display dates in UTC timezone
- Fix linesCommitted type to accept string or number from API
- Convert string values to numbers for proper chart rendering
- Increase chart lookback period from 7 to 10 days

This ensures date consistency between the chart and live activity components, matching the API's UTC-based data.