### PR TITLE
Better surfacing of low value PRs

### DIFF
--- a/src/api/ApiUtils.ts
+++ b/src/api/ApiUtils.ts
@@ -8,13 +8,12 @@ export const useApiQuery = <TResponse = void, TSelect = TResponse>(
   queryParams?: Record<string, string | number | undefined>,
   enabled?: boolean,
 ) => {
-  const encodedUrl = encodeURI(url);
   const baseUrl = import.meta.env.VITE_REACT_APP_BASE_URL;
 
   return useQuery<TResponse, AxiosError, TSelect>({
-    queryKey: [queryName, encodedUrl, queryParams],
+    queryKey: [queryName, url, queryParams],
     queryFn: async () => {
-      const requestUrl = baseUrl ? `${baseUrl}${encodedUrl}` : encodedUrl;
+      const requestUrl = baseUrl ? `${baseUrl}${url}` : url;
       const { data } = await axios.get(requestUrl, { params: queryParams });
       return data;
     },

--- a/src/api/ReposApi.ts
+++ b/src/api/ReposApi.ts
@@ -32,7 +32,6 @@ export const useRepositoryMaintainers = (repo: string) =>
 /**
  * Get all issues for a specific repository
  * @param repo - Full repository name (e.g., "opentensor/btcli")
- * NOTE: Backend endpoint not yet implemented
  */
 export const useRepositoryIssues = (repo: string) =>
   useReposQuery<RepositoryIssue[]>(
@@ -44,7 +43,6 @@ export const useRepositoryIssues = (repo: string) =>
  * Get pull requests for a specific repository filtered by state
  * @param repo - Full repository name (e.g., "opentensor/btcli")
  * @param state - Optional filter: "open", "closed", "merged"
- * NOTE: Backend endpoint not yet implemented
  */
 export const useRepositoryPRs = (repo: string, state?: string) =>
   useReposQuery<CommitLog[]>(

--- a/src/api/models/Dashboard.ts
+++ b/src/api/models/Dashboard.ts
@@ -100,6 +100,9 @@ export type CommitLog = {
   predictedAlphaPerDay?: number;
   predictedTaoPerDay?: number;
   predictedUsdPerDay?: number;
+
+  // Low value PR indicator
+  lowValuePr?: boolean;
 };
 
 export type MinerEvaluation = {
@@ -229,6 +232,8 @@ export type PullRequestDetails = {
   predictedAlphaPerDay?: number;
   predictedTaoPerDay?: number;
   predictedUsdPerDay?: number;
+  // Low value PR indicator
+  lowValuePr?: boolean;
 };
 
 export type PullRequestComment = {

--- a/src/components/dashboard/LiveCommitLog.tsx
+++ b/src/components/dashboard/LiveCommitLog.tsx
@@ -224,7 +224,8 @@ const CommitLogItem: React.FC<{
                   sx={{
                     color: "#facc15",
                     borderColor: alpha("#facc15", 0.4),
-                    background: "linear-gradient(135deg, rgba(250, 204, 21, 0.2) 0%, rgba(250, 204, 21, 0.1) 100%)",
+                    background:
+                      "linear-gradient(135deg, rgba(250, 204, 21, 0.2) 0%, rgba(250, 204, 21, 0.1) 100%)",
                   }}
                 />
               </Tooltip>

--- a/src/components/dashboard/LiveCommitLog.tsx
+++ b/src/components/dashboard/LiveCommitLog.tsx
@@ -222,10 +222,10 @@ const CommitLogItem: React.FC<{
                   label="Low Value"
                   size="small"
                   sx={{
-                    color: "#facc15",
-                    borderColor: alpha("#facc15", 0.4),
+                    color: "rgba(156, 163, 175, 0.9)",
+                    borderColor: "rgba(156, 163, 175, 0.4)",
                     background:
-                      "linear-gradient(135deg, rgba(250, 204, 21, 0.2) 0%, rgba(250, 204, 21, 0.1) 100%)",
+                      "linear-gradient(135deg, rgba(156, 163, 175, 0.2) 0%, rgba(156, 163, 175, 0.1) 100%)",
                   }}
                 />
               </Tooltip>

--- a/src/components/dashboard/LiveCommitLog.tsx
+++ b/src/components/dashboard/LiveCommitLog.tsx
@@ -10,6 +10,7 @@ import {
   alpha,
   Avatar,
   Chip,
+  Tooltip,
 } from "@mui/material";
 import { useNavigate } from "react-router-dom";
 import theme from "../../theme";
@@ -33,6 +34,7 @@ interface CommitLogEntry {
   author: string;
   score: string;
   isNew?: boolean;
+  lowValuePr?: boolean;
 }
 
 const getScoreColor = (score: string) => {
@@ -79,7 +81,10 @@ const CommitLogItem: React.FC<{
     ? dayjs(timestampRaw).utc().format("MMM D, HH:mm:ss UTC")
     : "Loading...";
 
-  return (
+  // Use lowValuePr from hydrated details if available, fallback to entry data
+  const isLowValue = details?.lowValuePr === true || entry.lowValuePr === true;
+
+  const content = (
     <Box
       ref={innerRef}
       onClick={() =>
@@ -187,6 +192,43 @@ const CommitLogItem: React.FC<{
                 backgroundColor: alpha(status.color, 0.1),
               }}
             />
+            {isLowValue && (
+              <Tooltip
+                title="This PR is marked as low value due to minimal code changes, documentation-only updates, or other factors that reduce its scoring weight. Low value PRs do not count towards score or tier unlock requirements."
+                arrow
+                placement="top"
+                slotProps={{
+                  tooltip: {
+                    sx: {
+                      backgroundColor: "rgba(30, 30, 30, 0.95)",
+                      color: "#ffffff",
+                      fontSize: "0.75rem",
+                      fontFamily: '"JetBrains Mono", monospace',
+                      padding: "12px 16px",
+                      borderRadius: "8px",
+                      border: "1px solid rgba(255, 255, 255, 0.1)",
+                      maxWidth: 300,
+                    },
+                  },
+                  arrow: {
+                    sx: {
+                      color: "rgba(30, 30, 30, 0.95)",
+                    },
+                  },
+                }}
+              >
+                <Chip
+                  variant="status"
+                  label="Low Value"
+                  size="small"
+                  sx={{
+                    color: "#facc15",
+                    borderColor: alpha("#facc15", 0.4),
+                    background: "linear-gradient(135deg, rgba(250, 204, 21, 0.2) 0%, rgba(250, 204, 21, 0.1) 100%)",
+                  }}
+                />
+              </Tooltip>
+            )}
             <Typography variant="caption" sx={{ color: "text.secondary" }}>
               {timestamp}
             </Typography>
@@ -250,6 +292,8 @@ const CommitLogItem: React.FC<{
       </Stack>
     </Box>
   );
+
+  return content;
 };
 
 const LiveCommitLog: React.FC = () => {

--- a/src/components/leaderboard/TopPRsTable.tsx
+++ b/src/components/leaderboard/TopPRsTable.tsx
@@ -845,7 +845,9 @@ const TopPRsTable: React.FC<TopPRsTableProps> = ({
           <TableBody>
             {filteredPRs
               .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
-              .map((pr) => (
+              .map((pr) => {
+                const isLowValue = pr.lowValuePr === true;
+                const rowContent = (
                 <TableRow
                   key={`${pr.repository}-${pr.pullRequestNumber}`}
                   hover
@@ -854,8 +856,14 @@ const TopPRsTable: React.FC<TopPRsTableProps> = ({
                   }
                   sx={{
                     cursor: "pointer",
+                    ...(isLowValue && {
+                      backgroundColor: "rgba(250, 204, 21, 0.10)",
+                      borderLeft: "3px solid rgba(250, 204, 21, 0.5)",
+                    }),
                     "&:hover": {
-                      backgroundColor: "rgba(255, 255, 255, 0.05)",
+                      backgroundColor: isLowValue
+                        ? "rgba(250, 204, 21, 0.15)"
+                        : "rgba(255, 255, 255, 0.05)",
                     },
                     transition: "background-color 0.2s",
                   }}
@@ -874,8 +882,7 @@ const TopPRsTable: React.FC<TopPRsTableProps> = ({
                           overflow: "hidden",
                           textOverflow: "ellipsis",
                           whiteSpace: "nowrap",
-                          maxWidth: "100%",
-                          display: "inline-block",
+                          display: "block",
                           "&:hover": {
                             color: "primary.main",
                             textDecoration: "underline",
@@ -1095,7 +1102,37 @@ const TopPRsTable: React.FC<TopPRsTableProps> = ({
                     </Box>
                   </TableCell>
                 </TableRow>
-              ))}
+                );
+                return isLowValue ? (
+                  <Tooltip
+                    key={`${pr.repository}-${pr.pullRequestNumber}`}
+                    title="This PR is marked as low value due to minimal code changes, documentation-only updates, or other factors that reduce its scoring weight. Low value PRs do not count towards score or tier unlock requirements."
+                    arrow
+                    placement="top"
+                    slotProps={{
+                      tooltip: {
+                        sx: {
+                          backgroundColor: "rgba(30, 30, 30, 0.95)",
+                          color: "#ffffff",
+                          fontSize: "0.75rem",
+                          fontFamily: '"JetBrains Mono", monospace',
+                          padding: "12px 16px",
+                          borderRadius: "8px",
+                          border: "1px solid rgba(255, 255, 255, 0.1)",
+                          maxWidth: 300,
+                        },
+                      },
+                      arrow: {
+                        sx: {
+                          color: "rgba(30, 30, 30, 0.95)",
+                        },
+                      },
+                    }}
+                  >
+                    {rowContent}
+                  </Tooltip>
+                ) : rowContent;
+              })}
           </TableBody>
         </Table>
       </TableContainer>

--- a/src/components/leaderboard/TopPRsTable.tsx
+++ b/src/components/leaderboard/TopPRsTable.tsx
@@ -857,15 +857,18 @@ const TopPRsTable: React.FC<TopPRsTableProps> = ({
                     sx={{
                       cursor: "pointer",
                       ...(isLowValue && {
-                        backgroundColor: "rgba(250, 204, 21, 0.10)",
-                        borderLeft: "3px solid rgba(250, 204, 21, 0.5)",
+                        opacity: 0.5,
+                        "& .MuiTableCell-root": {
+                          color: "rgba(255, 255, 255, 0.5)",
+                        },
                       }),
                       "&:hover": {
-                        backgroundColor: isLowValue
-                          ? "rgba(250, 204, 21, 0.15)"
-                          : "rgba(255, 255, 255, 0.05)",
+                        backgroundColor: "rgba(255, 255, 255, 0.05)",
+                        ...(isLowValue && {
+                          opacity: 0.7,
+                        }),
                       },
-                      transition: "background-color 0.2s",
+                      transition: "all 0.2s",
                     }}
                   >
                     <TableCell sx={{ ...bodyCellStyle, width: "80px" }}>
@@ -1114,6 +1117,7 @@ const TopPRsTable: React.FC<TopPRsTableProps> = ({
                     title="This PR is marked as low value due to minimal code changes, documentation-only updates, or other factors that reduce its scoring weight. Low value PRs do not count towards score or tier unlock requirements."
                     arrow
                     placement="top"
+                    followCursor
                     slotProps={{
                       tooltip: {
                         sx: {

--- a/src/components/leaderboard/TopPRsTable.tsx
+++ b/src/components/leaderboard/TopPRsTable.tsx
@@ -848,260 +848,265 @@ const TopPRsTable: React.FC<TopPRsTableProps> = ({
               .map((pr) => {
                 const isLowValue = pr.lowValuePr === true;
                 const rowContent = (
-                <TableRow
-                  key={`${pr.repository}-${pr.pullRequestNumber}`}
-                  hover
-                  onClick={() =>
-                    onSelectPR(pr.repository || "", pr.pullRequestNumber)
-                  }
-                  sx={{
-                    cursor: "pointer",
-                    ...(isLowValue && {
-                      backgroundColor: "rgba(250, 204, 21, 0.10)",
-                      borderLeft: "3px solid rgba(250, 204, 21, 0.5)",
-                    }),
-                    "&:hover": {
-                      backgroundColor: isLowValue
-                        ? "rgba(250, 204, 21, 0.15)"
-                        : "rgba(255, 255, 255, 0.05)",
-                    },
-                    transition: "background-color 0.2s",
-                  }}
-                >
-                  <TableCell sx={{ ...bodyCellStyle, width: "80px" }}>
-                    {getRankIcon(pr.rank || 0)}
-                  </TableCell>
-                  <TableCell sx={{ ...bodyCellStyle, width: "40%" }}>
-                    <Tooltip title={pr.pullRequestTitle || ""} placement="top">
-                      <Typography
-                        component="span"
-                        sx={{
-                          color: "#ffffff",
-                          fontWeight: 500,
-                          cursor: "pointer",
-                          overflow: "hidden",
-                          textOverflow: "ellipsis",
-                          whiteSpace: "nowrap",
-                          display: "block",
-                          "&:hover": {
-                            color: "primary.main",
-                            textDecoration: "underline",
-                          },
-                        }}
+                  <TableRow
+                    key={`${pr.repository}-${pr.pullRequestNumber}`}
+                    hover
+                    onClick={() =>
+                      onSelectPR(pr.repository || "", pr.pullRequestNumber)
+                    }
+                    sx={{
+                      cursor: "pointer",
+                      ...(isLowValue && {
+                        backgroundColor: "rgba(250, 204, 21, 0.10)",
+                        borderLeft: "3px solid rgba(250, 204, 21, 0.5)",
+                      }),
+                      "&:hover": {
+                        backgroundColor: isLowValue
+                          ? "rgba(250, 204, 21, 0.15)"
+                          : "rgba(255, 255, 255, 0.05)",
+                      },
+                      transition: "background-color 0.2s",
+                    }}
+                  >
+                    <TableCell sx={{ ...bodyCellStyle, width: "80px" }}>
+                      {getRankIcon(pr.rank || 0)}
+                    </TableCell>
+                    <TableCell sx={{ ...bodyCellStyle, width: "40%" }}>
+                      <Tooltip
+                        title={pr.pullRequestTitle || ""}
+                        placement="top"
                       >
-                        {truncateText(pr.pullRequestTitle || "", 50)}
-                      </Typography>
-                    </Tooltip>
-                  </TableCell>
-                  <TableCell sx={{ ...bodyCellStyle, width: "20%" }}>
-                    <Box
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        onSelectMiner(pr.githubId || pr.author || "");
-                      }}
-                      sx={{
-                        display: "flex",
-                        alignItems: "center",
-                        gap: 1,
-                        cursor: "pointer",
-                        "&:hover": {
-                          "& .MuiTypography-root": {
-                            color: "primary.main",
-                            textDecoration: "underline",
-                          },
-                        },
-                      }}
-                    >
-                      <Avatar
-                        src={`https://avatars.githubusercontent.com/${pr.author}`}
-                        sx={{ width: 20, height: 20 }}
-                      />
-                      <Tooltip title={pr.author || ""} placement="top">
-                        <Typography
-                          component="span"
-                          sx={{
-                            fontFamily: '"JetBrains Mono", monospace',
-                            fontSize: "0.85rem",
-                            transition: "color 0.2s",
-                            overflow: "hidden",
-                            textOverflow: "ellipsis",
-                            whiteSpace: "nowrap",
-                            maxWidth: "100%",
-                            display: "inline-block",
-                          }}
-                        >
-                          {truncateText(pr.author || "", 20)}
-                        </Typography>
-                      </Tooltip>
-                    </Box>
-                  </TableCell>
-                  <TableCell sx={{ ...bodyCellStyle, width: "20%" }}>
-                    <Box
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        onSelectRepository(pr.repository || "");
-                      }}
-                      sx={{
-                        display: "flex",
-                        alignItems: "center",
-                        gap: 1.5,
-                        cursor: "pointer",
-                        "&:hover": {
-                          "& .MuiTypography-root": {
-                            color: "primary.main",
-                            textDecoration: "underline",
-                          },
-                        },
-                      }}
-                    >
-                      <Avatar
-                        src={`https://avatars.githubusercontent.com/${(pr.repository || "").split("/")[0]}`}
-                        alt={(pr.repository || "").split("/")[0]}
-                        sx={{
-                          width: 20,
-                          height: 20,
-                          border: "1px solid rgba(255, 255, 255, 0.2)",
-                          backgroundColor:
-                            (pr.repository || "").split("/")[0] === "opentensor"
-                              ? "#ffffff"
-                              : (pr.repository || "").split("/")[0] ===
-                                  "bitcoin"
-                                ? "#F7931A"
-                                : "transparent",
-                        }}
-                      />
-                      <Tooltip title={pr.repository || ""} placement="top">
                         <Typography
                           component="span"
                           sx={{
                             color: "#ffffff",
                             fontWeight: 500,
-                            transition: "color 0.2s",
+                            cursor: "pointer",
                             overflow: "hidden",
                             textOverflow: "ellipsis",
                             whiteSpace: "nowrap",
-                            maxWidth: "100%",
-                            display: "inline-block",
+                            display: "block",
+                            "&:hover": {
+                              color: "primary.main",
+                              textDecoration: "underline",
+                            },
                           }}
                         >
-                          {truncateText(pr.repository || "", 30)}
+                          {truncateText(pr.pullRequestTitle || "", 50)}
                         </Typography>
                       </Tooltip>
-                      <Chip
-                        variant="tier"
-                        label={pr.tier || "N/A"}
-                        sx={{
-                          ml: 1,
-                          color: getTierColor(pr.tier || ""),
-                          borderColor: getTierColor(pr.tier || ""),
+                    </TableCell>
+                    <TableCell sx={{ ...bodyCellStyle, width: "20%" }}>
+                      <Box
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          onSelectMiner(pr.githubId || pr.author || "");
                         }}
-                      />
-                    </Box>
-                  </TableCell>
-                  <TableCell sx={{ ...bodyCellStyle, width: "10%" }}>
-                    {(() => {
-                      const state =
-                        pr.prState?.toUpperCase() ||
-                        (pr.mergedAt ? "MERGED" : "OPEN");
-                      let color = theme.palette.status.neutral;
-                      let label = state;
-
-                      if (state === "MERGED") {
-                        color = theme.palette.status.merged;
-                      } else if (state === "OPEN") {
-                        color = theme.palette.status.open;
-                      } else if (state === "CLOSED") {
-                        color = theme.palette.status.closed;
-                      }
-
-                      return (
-                        <Chip
-                          variant="status"
-                          label={label}
-                          sx={{
-                            color: color,
-                            borderColor: color,
-                          }}
-                        />
-                      );
-                    })()}
-                  </TableCell>
-                  <TableCell
-                    align="right"
-                    sx={{ ...bodyCellStyle, width: "15%" }}
-                  >
-                    <Box
-                      sx={{
-                        display: "flex",
-                        flexDirection: "column",
-                        alignItems: "flex-end",
-                        gap: 0.25,
-                      }}
-                    >
-                      <Typography
                         sx={{
-                          fontFamily: '"JetBrains Mono", monospace',
-                          fontSize: "0.8rem",
-                          fontWeight: 600,
-                          color: "#ffffff",
-                          lineHeight: 1.2,
+                          display: "flex",
+                          alignItems: "center",
+                          gap: 1,
+                          cursor: "pointer",
+                          "&:hover": {
+                            "& .MuiTypography-root": {
+                              color: "primary.main",
+                              textDecoration: "underline",
+                            },
+                          },
                         }}
                       >
-                        {parseFloat(pr.score || "0").toFixed(4)}
-                      </Typography>
-                      {(pr.prState === "MERGED" || pr.mergedAt) &&
-                        formatUsdEstimate(pr.predictedUsdPerDay, {
-                          includeApproxPrefix: true,
-                        }) && (
-                          <Tooltip
-                            title="This is an estimation. Actual payouts depend on validator consensus, network incentive distribution, and other miners' scores."
-                            arrow
-                            placement="bottom"
-                            slotProps={{
-                              tooltip: {
-                                sx: {
-                                  backgroundColor: "rgba(15, 15, 17, 0.98)",
-                                  color: "rgba(255, 255, 255, 0.85)",
-                                  fontSize: "0.7rem",
-                                  fontFamily: '"JetBrains Mono", monospace',
-                                  padding: "8px 12px",
-                                  borderRadius: "6px",
-                                  border: "1px solid rgba(255, 255, 255, 0.08)",
-                                  boxShadow: "0 8px 24px rgba(0, 0, 0, 0.4)",
-                                },
-                              },
-                              arrow: {
-                                sx: {
-                                  color: "rgba(15, 15, 17, 0.98)",
-                                },
-                              },
+                        <Avatar
+                          src={`https://avatars.githubusercontent.com/${pr.author}`}
+                          sx={{ width: 20, height: 20 }}
+                        />
+                        <Tooltip title={pr.author || ""} placement="top">
+                          <Typography
+                            component="span"
+                            sx={{
+                              fontFamily: '"JetBrains Mono", monospace',
+                              fontSize: "0.85rem",
+                              transition: "color 0.2s",
+                              overflow: "hidden",
+                              textOverflow: "ellipsis",
+                              whiteSpace: "nowrap",
+                              maxWidth: "100%",
+                              display: "inline-block",
                             }}
                           >
-                            <Typography
-                              component="span"
-                              sx={{
-                                fontFamily: '"JetBrains Mono", monospace',
-                                fontSize: "0.65rem",
-                                fontWeight: 500,
-                                color: "rgba(74, 222, 128, 0.7)",
-                                cursor: "pointer",
-                                lineHeight: 1,
-                                transition: "color 0.15s ease",
-                                "&:hover": {
-                                  color: "rgba(74, 222, 128, 0.95)",
+                            {truncateText(pr.author || "", 20)}
+                          </Typography>
+                        </Tooltip>
+                      </Box>
+                    </TableCell>
+                    <TableCell sx={{ ...bodyCellStyle, width: "20%" }}>
+                      <Box
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          onSelectRepository(pr.repository || "");
+                        }}
+                        sx={{
+                          display: "flex",
+                          alignItems: "center",
+                          gap: 1.5,
+                          cursor: "pointer",
+                          "&:hover": {
+                            "& .MuiTypography-root": {
+                              color: "primary.main",
+                              textDecoration: "underline",
+                            },
+                          },
+                        }}
+                      >
+                        <Avatar
+                          src={`https://avatars.githubusercontent.com/${(pr.repository || "").split("/")[0]}`}
+                          alt={(pr.repository || "").split("/")[0]}
+                          sx={{
+                            width: 20,
+                            height: 20,
+                            border: "1px solid rgba(255, 255, 255, 0.2)",
+                            backgroundColor:
+                              (pr.repository || "").split("/")[0] ===
+                              "opentensor"
+                                ? "#ffffff"
+                                : (pr.repository || "").split("/")[0] ===
+                                    "bitcoin"
+                                  ? "#F7931A"
+                                  : "transparent",
+                          }}
+                        />
+                        <Tooltip title={pr.repository || ""} placement="top">
+                          <Typography
+                            component="span"
+                            sx={{
+                              color: "#ffffff",
+                              fontWeight: 500,
+                              transition: "color 0.2s",
+                              overflow: "hidden",
+                              textOverflow: "ellipsis",
+                              whiteSpace: "nowrap",
+                              maxWidth: "100%",
+                              display: "inline-block",
+                            }}
+                          >
+                            {truncateText(pr.repository || "", 30)}
+                          </Typography>
+                        </Tooltip>
+                        <Chip
+                          variant="tier"
+                          label={pr.tier || "N/A"}
+                          sx={{
+                            ml: 1,
+                            color: getTierColor(pr.tier || ""),
+                            borderColor: getTierColor(pr.tier || ""),
+                          }}
+                        />
+                      </Box>
+                    </TableCell>
+                    <TableCell sx={{ ...bodyCellStyle, width: "10%" }}>
+                      {(() => {
+                        const state =
+                          pr.prState?.toUpperCase() ||
+                          (pr.mergedAt ? "MERGED" : "OPEN");
+                        let color = theme.palette.status.neutral;
+                        let label = state;
+
+                        if (state === "MERGED") {
+                          color = theme.palette.status.merged;
+                        } else if (state === "OPEN") {
+                          color = theme.palette.status.open;
+                        } else if (state === "CLOSED") {
+                          color = theme.palette.status.closed;
+                        }
+
+                        return (
+                          <Chip
+                            variant="status"
+                            label={label}
+                            sx={{
+                              color: color,
+                              borderColor: color,
+                            }}
+                          />
+                        );
+                      })()}
+                    </TableCell>
+                    <TableCell
+                      align="right"
+                      sx={{ ...bodyCellStyle, width: "15%" }}
+                    >
+                      <Box
+                        sx={{
+                          display: "flex",
+                          flexDirection: "column",
+                          alignItems: "flex-end",
+                          gap: 0.25,
+                        }}
+                      >
+                        <Typography
+                          sx={{
+                            fontFamily: '"JetBrains Mono", monospace',
+                            fontSize: "0.8rem",
+                            fontWeight: 600,
+                            color: "#ffffff",
+                            lineHeight: 1.2,
+                          }}
+                        >
+                          {parseFloat(pr.score || "0").toFixed(4)}
+                        </Typography>
+                        {(pr.prState === "MERGED" || pr.mergedAt) &&
+                          formatUsdEstimate(pr.predictedUsdPerDay, {
+                            includeApproxPrefix: true,
+                          }) && (
+                            <Tooltip
+                              title="This is an estimation. Actual payouts depend on validator consensus, network incentive distribution, and other miners' scores."
+                              arrow
+                              placement="bottom"
+                              slotProps={{
+                                tooltip: {
+                                  sx: {
+                                    backgroundColor: "rgba(15, 15, 17, 0.98)",
+                                    color: "rgba(255, 255, 255, 0.85)",
+                                    fontSize: "0.7rem",
+                                    fontFamily: '"JetBrains Mono", monospace',
+                                    padding: "8px 12px",
+                                    borderRadius: "6px",
+                                    border:
+                                      "1px solid rgba(255, 255, 255, 0.08)",
+                                    boxShadow: "0 8px 24px rgba(0, 0, 0, 0.4)",
+                                  },
+                                },
+                                arrow: {
+                                  sx: {
+                                    color: "rgba(15, 15, 17, 0.98)",
+                                  },
                                 },
                               }}
                             >
-                              {formatUsdEstimate(pr.predictedUsdPerDay, {
-                                includeApproxPrefix: true,
-                              })}
-                              /d
-                            </Typography>
-                          </Tooltip>
-                        )}
-                    </Box>
-                  </TableCell>
-                </TableRow>
+                              <Typography
+                                component="span"
+                                sx={{
+                                  fontFamily: '"JetBrains Mono", monospace',
+                                  fontSize: "0.65rem",
+                                  fontWeight: 500,
+                                  color: "rgba(74, 222, 128, 0.7)",
+                                  cursor: "pointer",
+                                  lineHeight: 1,
+                                  transition: "color 0.15s ease",
+                                  "&:hover": {
+                                    color: "rgba(74, 222, 128, 0.95)",
+                                  },
+                                }}
+                              >
+                                {formatUsdEstimate(pr.predictedUsdPerDay, {
+                                  includeApproxPrefix: true,
+                                })}
+                                /d
+                              </Typography>
+                            </Tooltip>
+                          )}
+                      </Box>
+                    </TableCell>
+                  </TableRow>
                 );
                 return isLowValue ? (
                   <Tooltip
@@ -1131,7 +1136,9 @@ const TopPRsTable: React.FC<TopPRsTableProps> = ({
                   >
                     {rowContent}
                   </Tooltip>
-                ) : rowContent;
+                ) : (
+                  rowContent
+                );
               })}
           </TableBody>
         </Table>

--- a/src/components/miners/MinerPRsTable.tsx
+++ b/src/components/miners/MinerPRsTable.tsx
@@ -319,15 +319,18 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
                     sx={{
                       cursor: "pointer",
                       ...(isLowValue && {
-                        backgroundColor: "rgba(250, 204, 21, 0.10)",
-                        borderLeft: "3px solid rgba(250, 204, 21, 0.5)",
+                        opacity: 0.5,
+                        "& .MuiTableCell-root": {
+                          color: "rgba(255, 255, 255, 0.5)",
+                        },
                       }),
                       "&:hover": {
-                        backgroundColor: isLowValue
-                          ? "rgba(250, 204, 21, 0.15)"
-                          : "rgba(255, 255, 255, 0.05)",
+                        backgroundColor: "rgba(255, 255, 255, 0.05)",
+                        ...(isLowValue && {
+                          opacity: 0.7,
+                        }),
                       },
-                      transition: "background-color 0.2s",
+                      transition: "all 0.2s",
                     }}
                   >
                     <TableCell
@@ -513,6 +516,7 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
                     title="This PR is marked as low value due to minimal code changes, documentation-only updates, or other factors that reduce its scoring weight. Low value PRs do not count towards score or tier unlock requirements."
                     arrow
                     placement="top"
+                    followCursor
                     slotProps={{
                       tooltip: {
                         sx: {

--- a/src/components/miners/MinerPRsTable.tsx
+++ b/src/components/miners/MinerPRsTable.tsx
@@ -309,203 +309,203 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
               {filteredPRs.map((pr, index) => {
                 const isLowValue = pr.lowValuePr === true;
                 const rowContent = (
-                <TableRow
-                  key={`${pr.repository}-${pr.pullRequestNumber}-${index}`}
-                  onClick={() => {
-                    navigate(
-                      `/miners/pr?repo=${encodeURIComponent(pr.repository)}&number=${pr.pullRequestNumber}`,
-                    );
-                  }}
-                  sx={{
-                    cursor: "pointer",
-                    ...(isLowValue && {
-                      backgroundColor: "rgba(250, 204, 21, 0.10)",
-                      borderLeft: "3px solid rgba(250, 204, 21, 0.5)",
-                    }),
-                    "&:hover": {
-                      backgroundColor: isLowValue
-                        ? "rgba(250, 204, 21, 0.15)"
-                        : "rgba(255, 255, 255, 0.05)",
-                    },
-                    transition: "background-color 0.2s",
-                  }}
-                >
-                  <TableCell
+                  <TableRow
+                    key={`${pr.repository}-${pr.pullRequestNumber}-${index}`}
+                    onClick={() => {
+                      navigate(
+                        `/miners/pr?repo=${encodeURIComponent(pr.repository)}&number=${pr.pullRequestNumber}`,
+                      );
+                    }}
                     sx={{
-                      ...bodyCellStyle,
-                      width: { xs: "20%", sm: "10%" },
-                      fontSize: { xs: "0.75rem", sm: "0.85rem" },
+                      cursor: "pointer",
+                      ...(isLowValue && {
+                        backgroundColor: "rgba(250, 204, 21, 0.10)",
+                        borderLeft: "3px solid rgba(250, 204, 21, 0.5)",
+                      }),
+                      "&:hover": {
+                        backgroundColor: isLowValue
+                          ? "rgba(250, 204, 21, 0.15)"
+                          : "rgba(255, 255, 255, 0.05)",
+                      },
+                      transition: "background-color 0.2s",
                     }}
                   >
-                    <a
-                      href={`https://github.com/${pr.repository}/pull/${pr.pullRequestNumber}`}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      style={{
-                        color: "#ffffff",
-                        textDecoration: "none",
-                        fontWeight: 500,
-                      }}
-                    >
-                      #{pr.pullRequestNumber}
-                    </a>
-                  </TableCell>
-                  <TableCell
-                    sx={{
-                      ...bodyCellStyle,
-                      width: { xs: "55%", sm: "30%" },
-                      fontSize: { xs: "0.75rem", sm: "0.85rem" },
-                    }}
-                  >
-                    <Box
+                    <TableCell
                       sx={{
-                        overflow: "hidden",
-                        textOverflow: "ellipsis",
-                        whiteSpace: "nowrap",
+                        ...bodyCellStyle,
+                        width: { xs: "20%", sm: "10%" },
+                        fontSize: { xs: "0.75rem", sm: "0.85rem" },
                       }}
                     >
-                      {pr.pullRequestTitle}
-                    </Box>
-                  </TableCell>
-                  <TableCell
-                    sx={{
-                      ...bodyCellStyle,
-                      width: "20%",
-                      display: { xs: "none", sm: "table-cell" },
-                    }}
-                  >
-                    <Box
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        setSelectedRepo(pr.repository);
-                      }}
-                      sx={{
-                        display: "flex",
-                        alignItems: "center",
-                        gap: 1.5,
-                        cursor: "pointer",
-                        "&:hover": {
-                          color: "primary.main",
-                        },
-                        transition: "color 0.2s",
-                      }}
-                    >
-                      <Avatar
-                        src={`https://avatars.githubusercontent.com/${pr.repository.split("/")[0]}`}
-                        alt={pr.repository.split("/")[0]}
-                        sx={{
-                          width: 20,
-                          height: 20,
-                          border: "1px solid rgba(255, 255, 255, 0.2)",
-                          backgroundColor:
-                            pr.repository.split("/")[0] === "opentensor"
-                              ? "#ffffff"
-                              : pr.repository.split("/")[0] === "bitcoin"
-                                ? "#F7931A"
-                                : "transparent",
+                      <a
+                        href={`https://github.com/${pr.repository}/pull/${pr.pullRequestNumber}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        style={{
+                          color: "#ffffff",
+                          textDecoration: "none",
+                          fontWeight: 500,
                         }}
-                      />
-                      {pr.repository}
-                    </Box>
-                  </TableCell>
-                  <TableCell
-                    align="right"
-                    sx={{
-                      ...bodyCellStyle,
-                      width: "15%",
-                      display: { xs: "none", md: "table-cell" },
-                    }}
-                  >
-                    <Box
-                      component="span"
+                      >
+                        #{pr.pullRequestNumber}
+                      </a>
+                    </TableCell>
+                    <TableCell
                       sx={{
-                        color: theme.palette.diff.additions,
-                        mr: 1,
-                        fontFamily: '"JetBrains Mono", monospace',
+                        ...bodyCellStyle,
+                        width: { xs: "55%", sm: "30%" },
+                        fontSize: { xs: "0.75rem", sm: "0.85rem" },
                       }}
                     >
-                      +{pr.additions}
-                    </Box>
-                    <Box
-                      component="span"
+                      <Box
+                        sx={{
+                          overflow: "hidden",
+                          textOverflow: "ellipsis",
+                          whiteSpace: "nowrap",
+                        }}
+                      >
+                        {pr.pullRequestTitle}
+                      </Box>
+                    </TableCell>
+                    <TableCell
                       sx={{
-                        color: theme.palette.diff.deletions,
-                        fontFamily: '"JetBrains Mono", monospace',
+                        ...bodyCellStyle,
+                        width: "20%",
+                        display: { xs: "none", sm: "table-cell" },
                       }}
                     >
-                      -{pr.deletions}
-                    </Box>
-                  </TableCell>
-                  <TableCell
-                    align="right"
-                    sx={{ ...bodyCellStyle, width: { xs: "25%", sm: "10%" } }}
-                  >
-                    <Box>
-                      {pr.prState === "CLOSED" && !pr.mergedAt ? (
-                        <Typography
+                      <Box
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setSelectedRepo(pr.repository);
+                        }}
+                        sx={{
+                          display: "flex",
+                          alignItems: "center",
+                          gap: 1.5,
+                          cursor: "pointer",
+                          "&:hover": {
+                            color: "primary.main",
+                          },
+                          transition: "color 0.2s",
+                        }}
+                      >
+                        <Avatar
+                          src={`https://avatars.githubusercontent.com/${pr.repository.split("/")[0]}`}
+                          alt={pr.repository.split("/")[0]}
                           sx={{
-                            fontFamily: '"JetBrains Mono", monospace',
-                            fontSize: { xs: "0.7rem", sm: "0.75rem" },
-                            fontWeight: 600,
-                            color: "rgba(255, 255, 255, 0.3)",
+                            width: 20,
+                            height: 20,
+                            border: "1px solid rgba(255, 255, 255, 0.2)",
+                            backgroundColor:
+                              pr.repository.split("/")[0] === "opentensor"
+                                ? "#ffffff"
+                                : pr.repository.split("/")[0] === "bitcoin"
+                                  ? "#F7931A"
+                                  : "transparent",
                           }}
-                        >
-                          -
-                        </Typography>
-                      ) : !pr.mergedAt && pr.collateralScore ? (
-                        <Typography
-                          sx={{
-                            fontFamily: '"JetBrains Mono", monospace',
-                            fontSize: { xs: "0.7rem", sm: "0.75rem" },
-                            fontWeight: 600,
-                            color: "#fb923c",
-                          }}
-                        >
-                          {parseFloat(pr.collateralScore).toFixed(4)}
-                        </Typography>
-                      ) : (
-                        <Typography
-                          sx={{
-                            fontFamily: '"JetBrains Mono", monospace',
-                            fontSize: { xs: "0.7rem", sm: "0.75rem" },
-                            fontWeight: 600,
-                          }}
-                        >
-                          {parseFloat(pr.score).toFixed(4)}
-                        </Typography>
-                      )}
-                      {!pr.mergedAt &&
-                        pr.collateralScore &&
-                        pr.prState !== "CLOSED" && (
+                        />
+                        {pr.repository}
+                      </Box>
+                    </TableCell>
+                    <TableCell
+                      align="right"
+                      sx={{
+                        ...bodyCellStyle,
+                        width: "15%",
+                        display: { xs: "none", md: "table-cell" },
+                      }}
+                    >
+                      <Box
+                        component="span"
+                        sx={{
+                          color: theme.palette.diff.additions,
+                          mr: 1,
+                          fontFamily: '"JetBrains Mono", monospace',
+                        }}
+                      >
+                        +{pr.additions}
+                      </Box>
+                      <Box
+                        component="span"
+                        sx={{
+                          color: theme.palette.diff.deletions,
+                          fontFamily: '"JetBrains Mono", monospace',
+                        }}
+                      >
+                        -{pr.deletions}
+                      </Box>
+                    </TableCell>
+                    <TableCell
+                      align="right"
+                      sx={{ ...bodyCellStyle, width: { xs: "25%", sm: "10%" } }}
+                    >
+                      <Box>
+                        {pr.prState === "CLOSED" && !pr.mergedAt ? (
                           <Typography
                             sx={{
                               fontFamily: '"JetBrains Mono", monospace',
-                              fontSize: "0.6rem",
-                              color: "rgba(255,255,255,0.5)",
+                              fontSize: { xs: "0.7rem", sm: "0.75rem" },
+                              fontWeight: 600,
+                              color: "rgba(255, 255, 255, 0.3)",
                             }}
                           >
-                            Collateral
+                            -
+                          </Typography>
+                        ) : !pr.mergedAt && pr.collateralScore ? (
+                          <Typography
+                            sx={{
+                              fontFamily: '"JetBrains Mono", monospace',
+                              fontSize: { xs: "0.7rem", sm: "0.75rem" },
+                              fontWeight: 600,
+                              color: "#fb923c",
+                            }}
+                          >
+                            {parseFloat(pr.collateralScore).toFixed(4)}
+                          </Typography>
+                        ) : (
+                          <Typography
+                            sx={{
+                              fontFamily: '"JetBrains Mono", monospace',
+                              fontSize: { xs: "0.7rem", sm: "0.75rem" },
+                              fontWeight: 600,
+                            }}
+                          >
+                            {parseFloat(pr.score).toFixed(4)}
                           </Typography>
                         )}
-                    </Box>
-                  </TableCell>
-                  <TableCell
-                    align="right"
-                    sx={{
-                      ...bodyCellStyle,
-                      width: "15%",
-                      display: { xs: "none", sm: "table-cell" },
-                      fontSize: { xs: "0.75rem", sm: "0.85rem" },
-                      color: "rgba(255,255,255,0.7)",
-                    }}
-                  >
-                    {pr.mergedAt
-                      ? new Date(pr.mergedAt).toLocaleDateString()
-                      : pr.prState === "CLOSED"
-                        ? "Closed"
-                        : "Open"}
-                  </TableCell>
-                </TableRow>
+                        {!pr.mergedAt &&
+                          pr.collateralScore &&
+                          pr.prState !== "CLOSED" && (
+                            <Typography
+                              sx={{
+                                fontFamily: '"JetBrains Mono", monospace',
+                                fontSize: "0.6rem",
+                                color: "rgba(255,255,255,0.5)",
+                              }}
+                            >
+                              Collateral
+                            </Typography>
+                          )}
+                      </Box>
+                    </TableCell>
+                    <TableCell
+                      align="right"
+                      sx={{
+                        ...bodyCellStyle,
+                        width: "15%",
+                        display: { xs: "none", sm: "table-cell" },
+                        fontSize: { xs: "0.75rem", sm: "0.85rem" },
+                        color: "rgba(255,255,255,0.7)",
+                      }}
+                    >
+                      {pr.mergedAt
+                        ? new Date(pr.mergedAt).toLocaleDateString()
+                        : pr.prState === "CLOSED"
+                          ? "Closed"
+                          : "Open"}
+                    </TableCell>
+                  </TableRow>
                 );
                 return isLowValue ? (
                   <Tooltip
@@ -535,7 +535,9 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
                   >
                     {rowContent}
                   </Tooltip>
-                ) : rowContent;
+                ) : (
+                  rowContent
+                );
               })}
             </TableBody>
           </Table>

--- a/src/components/miners/MinerPRsTable.tsx
+++ b/src/components/miners/MinerPRsTable.tsx
@@ -13,6 +13,7 @@ import {
   Avatar,
   Chip,
   Button,
+  Tooltip,
 } from "@mui/material";
 import { useMinerPRs } from "../../api";
 import { useNavigate } from "react-router-dom";
@@ -305,7 +306,9 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
               </TableRow>
             </TableHead>
             <TableBody>
-              {filteredPRs.map((pr, index) => (
+              {filteredPRs.map((pr, index) => {
+                const isLowValue = pr.lowValuePr === true;
+                const rowContent = (
                 <TableRow
                   key={`${pr.repository}-${pr.pullRequestNumber}-${index}`}
                   onClick={() => {
@@ -315,8 +318,14 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
                   }}
                   sx={{
                     cursor: "pointer",
+                    ...(isLowValue && {
+                      backgroundColor: "rgba(250, 204, 21, 0.10)",
+                      borderLeft: "3px solid rgba(250, 204, 21, 0.5)",
+                    }),
                     "&:hover": {
-                      backgroundColor: "rgba(255, 255, 255, 0.05)",
+                      backgroundColor: isLowValue
+                        ? "rgba(250, 204, 21, 0.15)"
+                        : "rgba(255, 255, 255, 0.05)",
                     },
                     transition: "background-color 0.2s",
                   }}
@@ -350,7 +359,6 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
                   >
                     <Box
                       sx={{
-                        maxWidth: "100%",
                         overflow: "hidden",
                         textOverflow: "ellipsis",
                         whiteSpace: "nowrap",
@@ -498,7 +506,37 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
                         : "Open"}
                   </TableCell>
                 </TableRow>
-              ))}
+                );
+                return isLowValue ? (
+                  <Tooltip
+                    key={`${pr.repository}-${pr.pullRequestNumber}-${index}`}
+                    title="This PR is marked as low value due to minimal code changes, documentation-only updates, or other factors that reduce its scoring weight. Low value PRs do not count towards score or tier unlock requirements."
+                    arrow
+                    placement="top"
+                    slotProps={{
+                      tooltip: {
+                        sx: {
+                          backgroundColor: "rgba(30, 30, 30, 0.95)",
+                          color: "#ffffff",
+                          fontSize: "0.75rem",
+                          fontFamily: '"JetBrains Mono", monospace',
+                          padding: "12px 16px",
+                          borderRadius: "8px",
+                          border: "1px solid rgba(255, 255, 255, 0.1)",
+                          maxWidth: 300,
+                        },
+                      },
+                      arrow: {
+                        sx: {
+                          color: "rgba(30, 30, 30, 0.95)",
+                        },
+                      },
+                    }}
+                  >
+                    {rowContent}
+                  </Tooltip>
+                ) : rowContent;
+              })}
             </TableBody>
           </Table>
         </TableContainer>

--- a/src/components/repositories/RepositoryContributorsTable.tsx
+++ b/src/components/repositories/RepositoryContributorsTable.tsx
@@ -36,12 +36,15 @@ const RepositoryContributorsTable: React.FC<
     return map;
   }, [allMinersStats]);
 
-  // Get contributors for this repository
+  // Get contributors for this repository - only count merged PRs
   const contributors = useMemo(() => {
     if (!allPRs) return [];
 
     const allRepoPRs = allPRs.filter(
-      (pr) => pr.repository === repositoryFullName && pr.githubId,
+      (pr) =>
+        pr.repository === repositoryFullName &&
+        pr.githubId &&
+        pr.prState === "MERGED",
     );
 
     const contributorsMap = new Map<

--- a/src/components/repositories/RepositoryIssuesTable.tsx
+++ b/src/components/repositories/RepositoryIssuesTable.tsx
@@ -166,13 +166,13 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
             label="Open"
             value="open"
             count={counts.open}
-            color="#3fb950"
+            color="#8b949e"
           />
           <FilterButton
             label="Closed"
             value="closed"
             count={counts.closed}
-            color="#a371f7"
+            color="#3fb950"
           />
         </Stack>
       </Box>
@@ -284,8 +284,8 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
                         }
                         label={isOpen ? "OPEN" : "CLOSED"}
                         sx={{
-                          color: isOpen ? "#3fb950" : "#a371f7",
-                          borderColor: isOpen ? "#3fb950" : "#a371f7",
+                          color: isOpen ? "#8b949e" : "#3fb950",
+                          borderColor: isOpen ? "#8b949e" : "#3fb950",
                           "& .MuiChip-icon": { color: "inherit" },
                         }}
                       />

--- a/src/components/repositories/RepositoryStats.tsx
+++ b/src/components/repositories/RepositoryStats.tsx
@@ -23,8 +23,7 @@ const RepositoryStats: React.FC<RepositoryStatsProps> = ({
 
     // Filter PRs for this repo - only count merged PRs
     const repoPRs = allPRs.filter(
-      (pr) =>
-        pr.repository === repositoryFullName && pr.prState === "MERGED",
+      (pr) => pr.repository === repositoryFullName && pr.prState === "MERGED",
     );
     const totalScore = repoPRs.reduce(
       (acc, pr) => acc + parseFloat(pr.score || "0"),

--- a/src/components/repositories/RepositoryStats.tsx
+++ b/src/components/repositories/RepositoryStats.tsx
@@ -19,17 +19,20 @@ const RepositoryStats: React.FC<RepositoryStatsProps> = ({
   }, [repos, repositoryFullName]);
 
   const stats = useMemo(() => {
-    if (!allPRs) return { totalPRs: 0, totalScore: 0 };
+    if (!allPRs) return { mergedPRs: 0, totalScore: 0 };
 
-    // Filter PRs for this repo
-    const repoPRs = allPRs.filter((pr) => pr.repository === repositoryFullName);
+    // Filter PRs for this repo - only count merged PRs
+    const repoPRs = allPRs.filter(
+      (pr) =>
+        pr.repository === repositoryFullName && pr.prState === "MERGED",
+    );
     const totalScore = repoPRs.reduce(
       (acc, pr) => acc + parseFloat(pr.score || "0"),
       0,
     );
 
     return {
-      totalPRs: repoPRs.length,
+      mergedPRs: repoPRs.length,
       totalScore,
     };
   }, [allPRs, repositoryFullName]);
@@ -193,7 +196,7 @@ const RepositoryStats: React.FC<RepositoryStatsProps> = ({
               fontSize: "13px",
             }}
           >
-            {stats.totalPRs}
+            {stats.mergedPRs}
           </Typography>
         </Box>
 


### PR DESCRIPTION
Been DM'd 3+ times asking about low value prs. Pretty sure it's because many miners / users just look at the table level views, see merges and are like "How's that not 3 merges? How's that not 3 unique repos? etc.".. Answer is usually because 1/3 of them was low value. But they don't know that because they never click into the [PR page](https://gittensor.io/miners/pr?repo=is-a-dev%2Fregister&number=31260) itself (like that linked example) to see that it's low value PR
---
Proposal:
<img width="397" height="678" alt="image" src="https://github.com/user-attachments/assets/a408646b-f21d-42a9-b849-9f259b533aec" />

<img width="1527" height="630" alt="image" src="https://github.com/user-attachments/assets/e3ee78a0-6241-42c4-9272-1d33d5e47c50" />

<img width="1581" height="909" alt="image" src="https://github.com/user-attachments/assets/293d7245-4a8f-4983-9045-830f40efe69e" />
