### PR TITLE
Update PR display to handle null payout values

### DIFF
--- a/src/api/models/Dashboard.ts
+++ b/src/api/models/Dashboard.ts
@@ -96,10 +96,11 @@ export type CommitLog = {
 
   // TODO: these values do not come in the /dash/commits endpoint, refactor to perhaps make a new model to include these attributes
   // Payout predictions (from /miners/all/prs endpoint)
+  // Note: dollar values are null for open PRs, only calculated for merged PRs
   potentialScore?: number;
-  predictedAlphaPerDay?: number;
-  predictedTaoPerDay?: number;
-  predictedUsdPerDay?: number;
+  predictedAlphaPerDay?: number | null;
+  predictedTaoPerDay?: number | null;
+  predictedUsdPerDay?: number | null;
 
   // Low value PR indicator
   lowValuePr?: boolean;
@@ -228,10 +229,11 @@ export type PullRequestDetails = {
   updatedAt: string;
   tier: string; // Bronze, Silver, Gold
   // Predicted daily payouts based on potential score
+  // Note: dollar values are null for open PRs, only calculated for merged PRs
   potentialScore?: number;
-  predictedAlphaPerDay?: number;
-  predictedTaoPerDay?: number;
-  predictedUsdPerDay?: number;
+  predictedAlphaPerDay?: number | null;
+  predictedTaoPerDay?: number | null;
+  predictedUsdPerDay?: number | null;
   // Low value PR indicator
   lowValuePr?: boolean;
 };

--- a/src/components/prs/PRHeader.tsx
+++ b/src/components/prs/PRHeader.tsx
@@ -37,7 +37,7 @@ const PRHeader: React.FC<PRHeaderProps> = ({
   const isClosed = prDetails.prState === "CLOSED";
   const collateralScore = parseFloat(prDetails.collateralScore || "0");
   const earnedScore = parseFloat(prDetails.earnedScore || "0");
-  const predictedUsdPerDay = prDetails.predictedUsdPerDay || 0;
+  const predictedUsdPerDay = prDetails.predictedUsdPerDay;
 
   // Low value PR - use the field from API directly
   const isLowValuePR = prDetails.lowValuePr === true;
@@ -230,45 +230,6 @@ const PRHeader: React.FC<PRHeaderProps> = ({
               >
                 {(collateralScore * 5).toFixed(2)}
               </Typography>
-              {predictedUsdPerDay > 0 && (
-                <Tooltip
-                  title="This is an estimation. Actual payouts depend on validator consensus, network incentive distribution, and other miners' scores."
-                  arrow
-                  placement="bottom"
-                  slotProps={{
-                    tooltip: {
-                      sx: {
-                        backgroundColor: "rgba(30, 30, 30, 0.95)",
-                        color: "#ffffff",
-                        fontSize: "0.75rem",
-                        fontFamily: '"JetBrains Mono", monospace',
-                        padding: "8px 12px",
-                        borderRadius: "6px",
-                        border: "1px solid rgba(255, 255, 255, 0.1)",
-                        maxWidth: 280,
-                      },
-                    },
-                    arrow: {
-                      sx: {
-                        color: "rgba(30, 30, 30, 0.95)",
-                      },
-                    },
-                  }}
-                >
-                  <Typography
-                    sx={{
-                      fontFamily: '"JetBrains Mono", monospace',
-                      fontSize: "0.95rem",
-                      color: "rgba(74, 222, 128, 0.8)",
-                      mt: 0.5,
-                      cursor: "pointer",
-                    }}
-                  >
-                    ~{formatUsdEstimate(predictedUsdPerDay, { showZero: true })}
-                    /day
-                  </Typography>
-                </Tooltip>
-              )}
             </Box>
 
             {/* Divider */}
@@ -370,7 +331,7 @@ const PRHeader: React.FC<PRHeaderProps> = ({
             >
               {earnedScore.toFixed(2)}
             </Typography>
-            {!isClosed && predictedUsdPerDay > 0 && (
+            {!isClosed && predictedUsdPerDay != null && predictedUsdPerDay > 0 && (
               <Tooltip
                 title="This is an estimation. Actual payouts depend on validator consensus, network incentive distribution, and other miners' scores."
                 arrow

--- a/src/components/prs/PRHeader.tsx
+++ b/src/components/prs/PRHeader.tsx
@@ -331,45 +331,47 @@ const PRHeader: React.FC<PRHeaderProps> = ({
             >
               {earnedScore.toFixed(2)}
             </Typography>
-            {!isClosed && predictedUsdPerDay != null && predictedUsdPerDay > 0 && (
-              <Tooltip
-                title="This is an estimation. Actual payouts depend on validator consensus, network incentive distribution, and other miners' scores."
-                arrow
-                placement="bottom"
-                slotProps={{
-                  tooltip: {
-                    sx: {
-                      backgroundColor: "rgba(30, 30, 30, 0.95)",
-                      color: "#ffffff",
-                      fontSize: "0.75rem",
-                      fontFamily: '"JetBrains Mono", monospace',
-                      padding: "8px 12px",
-                      borderRadius: "6px",
-                      border: "1px solid rgba(255, 255, 255, 0.1)",
-                      maxWidth: 280,
+            {!isClosed &&
+              predictedUsdPerDay != null &&
+              predictedUsdPerDay > 0 && (
+                <Tooltip
+                  title="This is an estimation. Actual payouts depend on validator consensus, network incentive distribution, and other miners' scores."
+                  arrow
+                  placement="bottom"
+                  slotProps={{
+                    tooltip: {
+                      sx: {
+                        backgroundColor: "rgba(30, 30, 30, 0.95)",
+                        color: "#ffffff",
+                        fontSize: "0.75rem",
+                        fontFamily: '"JetBrains Mono", monospace',
+                        padding: "8px 12px",
+                        borderRadius: "6px",
+                        border: "1px solid rgba(255, 255, 255, 0.1)",
+                        maxWidth: 280,
+                      },
                     },
-                  },
-                  arrow: {
-                    sx: {
-                      color: "rgba(30, 30, 30, 0.95)",
+                    arrow: {
+                      sx: {
+                        color: "rgba(30, 30, 30, 0.95)",
+                      },
                     },
-                  },
-                }}
-              >
-                <Typography
-                  sx={{
-                    fontFamily: '"JetBrains Mono", monospace',
-                    fontSize: "0.95rem",
-                    color: "rgba(74, 222, 128, 0.8)",
-                    mt: 0.5,
-                    cursor: "pointer",
                   }}
                 >
-                  ~{formatUsdEstimate(predictedUsdPerDay, { showZero: true })}
-                  /day
-                </Typography>
-              </Tooltip>
-            )}
+                  <Typography
+                    sx={{
+                      fontFamily: '"JetBrains Mono", monospace',
+                      fontSize: "0.95rem",
+                      color: "rgba(74, 222, 128, 0.8)",
+                      mt: 0.5,
+                      cursor: "pointer",
+                    }}
+                  >
+                    ~{formatUsdEstimate(predictedUsdPerDay, { showZero: true })}
+                    /day
+                  </Typography>
+                </Tooltip>
+              )}
           </Box>
         )}
 

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -8,7 +8,7 @@
  * @returns Formatted string like "$5", "<$1", or null if value is invalid/zero
  */
 export const formatUsdEstimate = (
-  value: number | undefined,
+  value: number | null | undefined,
   options?: { includeApproxPrefix?: boolean; showZero?: boolean },
 ): string | null => {
   const { includeApproxPrefix = false, showZero = false } = options ?? {};


### PR DESCRIPTION
- Remove USD estimate display for open PRs (API now returns null)
- Update type definitions to accept null for payout fields
- Add null check for merged PR USD display
- Update formatUsdEstimate to accept null type