### PR TITLE
fix: case-insensitive repository matching for URL params

### DIFF
--- a/src/components/repositories/RepositoryContributorsTable.tsx
+++ b/src/components/repositories/RepositoryContributorsTable.tsx
@@ -42,7 +42,7 @@ const RepositoryContributorsTable: React.FC<
 
     const allRepoPRs = allPRs.filter(
       (pr) =>
-        pr.repository === repositoryFullName &&
+        pr.repository.toLowerCase() === repositoryFullName.toLowerCase() &&
         pr.githubId &&
         pr.prState === "MERGED",
     );

--- a/src/components/repositories/RepositoryPRsTable.tsx
+++ b/src/components/repositories/RepositoryPRsTable.tsx
@@ -54,7 +54,9 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
 
   const allPRs = useMemo(() => {
     if (!allMinerPRs) return [];
-    return allMinerPRs.filter((pr) => pr.repository === repositoryFullName);
+    return allMinerPRs.filter(
+      (pr) => pr.repository.toLowerCase() === repositoryFullName.toLowerCase(),
+    );
   }, [allMinerPRs, repositoryFullName]);
 
   const counts = useMemo(() => {

--- a/src/components/repositories/RepositoryScoreCard.tsx
+++ b/src/components/repositories/RepositoryScoreCard.tsx
@@ -92,40 +92,35 @@ const RepositoryScoreCard: React.FC<RepositoryScoreCardProps> = ({
       allRepos
         .sort((a, b) => b[1].totalScore - a[1].totalScore)
         .findIndex(
-          ([repo]) =>
-            repo.toLowerCase() === repositoryFullName.toLowerCase(),
+          ([repo]) => repo.toLowerCase() === repositoryFullName.toLowerCase(),
         ) + 1;
 
     const prsRank =
       allRepos
         .sort((a, b) => b[1].totalPRs - a[1].totalPRs)
         .findIndex(
-          ([repo]) =>
-            repo.toLowerCase() === repositoryFullName.toLowerCase(),
+          ([repo]) => repo.toLowerCase() === repositoryFullName.toLowerCase(),
         ) + 1;
 
     const contributorsRank =
       allRepos
         .sort((a, b) => b[1].uniqueContributors - a[1].uniqueContributors)
         .findIndex(
-          ([repo]) =>
-            repo.toLowerCase() === repositoryFullName.toLowerCase(),
+          ([repo]) => repo.toLowerCase() === repositoryFullName.toLowerCase(),
         ) + 1;
 
     const linesRank =
       allRepos
         .sort((a, b) => b[1].totalLines - a[1].totalLines)
         .findIndex(
-          ([repo]) =>
-            repo.toLowerCase() === repositoryFullName.toLowerCase(),
+          ([repo]) => repo.toLowerCase() === repositoryFullName.toLowerCase(),
         ) + 1;
 
     const commitsRank =
       allRepos
         .sort((a, b) => b[1].totalCommits - a[1].totalCommits)
         .findIndex(
-          ([repo]) =>
-            repo.toLowerCase() === repositoryFullName.toLowerCase(),
+          ([repo]) => repo.toLowerCase() === repositoryFullName.toLowerCase(),
         ) + 1;
 
     return {

--- a/src/components/repositories/RepositoryScoreCard.tsx
+++ b/src/components/repositories/RepositoryScoreCard.tsx
@@ -22,7 +22,7 @@ const RepositoryScoreCard: React.FC<RepositoryScoreCardProps> = ({
     if (!allPRs) return null;
 
     const allRepoPRs = allPRs.filter(
-      (pr) => pr.repository === repositoryFullName,
+      (pr) => pr.repository.toLowerCase() === repositoryFullName.toLowerCase(),
     );
 
     if (allRepoPRs.length === 0) return null;
@@ -91,27 +91,42 @@ const RepositoryScoreCard: React.FC<RepositoryScoreCardProps> = ({
     const scoreRank =
       allRepos
         .sort((a, b) => b[1].totalScore - a[1].totalScore)
-        .findIndex(([repo]) => repo === repositoryFullName) + 1;
+        .findIndex(
+          ([repo]) =>
+            repo.toLowerCase() === repositoryFullName.toLowerCase(),
+        ) + 1;
 
     const prsRank =
       allRepos
         .sort((a, b) => b[1].totalPRs - a[1].totalPRs)
-        .findIndex(([repo]) => repo === repositoryFullName) + 1;
+        .findIndex(
+          ([repo]) =>
+            repo.toLowerCase() === repositoryFullName.toLowerCase(),
+        ) + 1;
 
     const contributorsRank =
       allRepos
         .sort((a, b) => b[1].uniqueContributors - a[1].uniqueContributors)
-        .findIndex(([repo]) => repo === repositoryFullName) + 1;
+        .findIndex(
+          ([repo]) =>
+            repo.toLowerCase() === repositoryFullName.toLowerCase(),
+        ) + 1;
 
     const linesRank =
       allRepos
         .sort((a, b) => b[1].totalLines - a[1].totalLines)
-        .findIndex(([repo]) => repo === repositoryFullName) + 1;
+        .findIndex(
+          ([repo]) =>
+            repo.toLowerCase() === repositoryFullName.toLowerCase(),
+        ) + 1;
 
     const commitsRank =
       allRepos
         .sort((a, b) => b[1].totalCommits - a[1].totalCommits)
-        .findIndex(([repo]) => repo === repositoryFullName) + 1;
+        .findIndex(
+          ([repo]) =>
+            repo.toLowerCase() === repositoryFullName.toLowerCase(),
+        ) + 1;
 
     return {
       totalScore,

--- a/src/components/repositories/RepositoryStats.tsx
+++ b/src/components/repositories/RepositoryStats.tsx
@@ -15,15 +15,18 @@ const RepositoryStats: React.FC<RepositoryStatsProps> = ({
     useRepositoryIssues(repositoryFullName);
 
   const repository = useMemo(() => {
-    return repos?.find((r) => r.fullName === repositoryFullName);
+    return repos?.find(
+      (r) => r.fullName.toLowerCase() === repositoryFullName.toLowerCase(),
+    );
   }, [repos, repositoryFullName]);
 
   const stats = useMemo(() => {
     if (!allPRs) return { mergedPRs: 0, totalScore: 0 };
 
-    // Filter PRs for this repo - only count merged PRs
     const repoPRs = allPRs.filter(
-      (pr) => pr.repository === repositoryFullName && pr.prState === "MERGED",
+      (pr) =>
+        pr.repository.toLowerCase() === repositoryFullName.toLowerCase() &&
+        pr.prState === "MERGED",
     );
     const totalScore = repoPRs.reduce(
       (acc, pr) => acc + parseFloat(pr.score || "0"),


### PR DESCRIPTION
The URL can contain repository names with different casing than what's stored in the API (e.g., platformnetwork/platform vs PlatformNetwork/platform).

This caused the Repository Stats panel and related components to not render because the exact string matching failed.

Fixed by using toLowerCase() comparisons in:
- RepositoryStats.tsx (repo lookup + PR filtering)
- RepositoryContributorsTable.tsx (PR filtering)
- RepositoryScoreCard.tsx (PR filtering + ranking calculations)
- RepositoryPRsTable.tsx (PR filtering)

addresses: Weights are incorrect for niche repos (lingering casing bug issue?)
