### PR TITLE
fix: use mergedAt for trending repos date bucketing

### DIFF
--- a/src/pages/RepositoriesPage.tsx
+++ b/src/pages/RepositoriesPage.tsx
@@ -198,7 +198,7 @@ const RepositoriesPage: React.FC = () => {
     >();
 
     allPRs.forEach((pr: CommitLog) => {
-      const prDate = pr.prCreatedAt || pr.mergedAt;
+      const prDate = pr.mergedAt;
       if (!pr?.repository || !prDate) return;
       const score = parseFloat(pr.score || '0');
 


### PR DESCRIPTION
Previously used prCreatedAt which caused repos to be excluded from trending when PRs were created outside the 7-day window but merged within it. Using mergedAt better reflects when work was accepted.