### PR TITLE
feat: Add Docs link to sidebar footer

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -131,6 +131,31 @@ const Sidebar: React.FC<SidebarProps> = ({ onNavigate }) => {
               color="#ffffff"
               variant="caption"
               component="a"
+              href="https://docs.gittensor.io"
+              target="_blank"
+              rel="noopener noreferrer"
+              sx={{
+                fontSize: '0.65rem',
+                textDecoration: 'none',
+                '&:hover': { textDecoration: 'underline' },
+              }}
+            >
+              Docs
+            </Typography>
+            <Divider
+              orientation="vertical"
+              flexItem
+              sx={{
+                borderColor: '#3d3d3d',
+                mx: 0.5,
+                height: '12px',
+                alignSelf: 'center',
+              }}
+            />
+            <Typography
+              color="#ffffff"
+              variant="caption"
+              component="a"
               href="https://docs.learnbittensor.org/resources/community-links"
               target="_blank"
               rel="noopener noreferrer"


### PR DESCRIPTION
Adds a link to docs.gittensor.io in the sidebar footer alongside Community, Github, and X.
<img width="260" height="107" alt="image" src="https://github.com/user-attachments/assets/6c0719f1-2f2d-4825-ac94-a9bf3395a04c" />
<img width="1728" height="1117" alt="image" src="https://github.com/user-attachments/assets/83e46e69-2e8c-4c35-b714-70e358f697d2" />
