### PR TITLE
feat: tier detail page

### DIFF
--- a/src/components/miners/MinerPRsTable.tsx
+++ b/src/components/miners/MinerPRsTable.tsx
@@ -36,7 +36,8 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({
 
   const headerCellStyle = useMemo(
     () => ({
-      backgroundColor: theme.palette.surface?.elevated ?? theme.palette.background.paper,
+      backgroundColor:
+        theme.palette.surface?.elevated ?? theme.palette.background.paper,
       backdropFilter: 'blur(8px)',
       color: alpha(theme.palette.text.primary, 0.7),
       fontFamily: '"JetBrains Mono", monospace',
@@ -317,10 +318,12 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({
               backgroundColor: 'transparent',
             },
             '&::-webkit-scrollbar-thumb': {
-              backgroundColor: (t) => t.palette.border?.light ?? t.palette.divider,
+              backgroundColor: (t) =>
+                t.palette.border?.light ?? t.palette.divider,
               borderRadius: '4px',
               '&:hover': {
-                backgroundColor: (t) => t.palette.border?.medium ?? t.palette.divider,
+                backgroundColor: (t) =>
+                  t.palette.border?.medium ?? t.palette.divider,
               },
             },
           }}
@@ -581,28 +584,30 @@ const FilterButton: React.FC<{
   onClick: () => void;
 }> = ({ label, count, color, selected, onClick }) => (
   <Button
-      size="small"
-      onClick={onClick}
-      sx={{
-        color: selected ? 'text.primary' : (t) => alpha(t.palette.text.primary, 0.5),
-        backgroundColor: selected ? 'surface.light' : 'transparent',
-        borderRadius: '6px',
-        px: 1.5,
-        minWidth: 'auto',
-        textTransform: 'none',
-        fontFamily: '"JetBrains Mono", monospace',
-        fontSize: '0.75rem',
-        border: selected ? `1px solid ${color}` : '1px solid transparent',
-        '&:hover': {
-          backgroundColor: (t) => alpha(t.palette.text.primary, 0.15),
-        },
-      }}
-    >
-      {label}{' '}
-      <span style={{ opacity: 0.6, marginLeft: '6px', fontSize: '0.7rem' }}>
-        {count}
-      </span>
-    </Button>
+    size="small"
+    onClick={onClick}
+    sx={{
+      color: selected
+        ? 'text.primary'
+        : (t) => alpha(t.palette.text.primary, 0.5),
+      backgroundColor: selected ? 'surface.light' : 'transparent',
+      borderRadius: '6px',
+      px: 1.5,
+      minWidth: 'auto',
+      textTransform: 'none',
+      fontFamily: '"JetBrains Mono", monospace',
+      fontSize: '0.75rem',
+      border: selected ? `1px solid ${color}` : '1px solid transparent',
+      '&:hover': {
+        backgroundColor: (t) => alpha(t.palette.text.primary, 0.15),
+      },
+    }}
+  >
+    {label}{' '}
+    <span style={{ opacity: 0.6, marginLeft: '6px', fontSize: '0.7rem' }}>
+      {count}
+    </span>
+  </Button>
 );
 
 export default MinerPRsTable;

--- a/src/components/miners/MinerPRsTable.tsx
+++ b/src/components/miners/MinerPRsTable.tsx
@@ -91,12 +91,10 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({
       open: prsInTier.filter(
         (pr) => pr.prState === 'OPEN' || (!pr.prState && !pr.mergedAt),
       ).length,
-      merged: prsInTier.filter(
-        (pr) => pr.mergedAt || pr.prState === 'MERGED',
-      ).length,
-      closed: prsInTier.filter(
-        (pr) => pr.prState === 'CLOSED' && !pr.mergedAt,
-      ).length,
+      merged: prsInTier.filter((pr) => pr.mergedAt || pr.prState === 'MERGED')
+        .length,
+      closed: prsInTier.filter((pr) => pr.prState === 'CLOSED' && !pr.mergedAt)
+        .length,
     };
   }, [prsInTier]);
 

--- a/src/components/miners/MinerPRsTable.tsx
+++ b/src/components/miners/MinerPRsTable.tsx
@@ -14,27 +14,54 @@ import {
   Chip,
   Button,
 } from '@mui/material';
-import { useMinerPRs } from '../../api';
+import { useMinerPRs, useReposAndWeights } from '../../api';
 import { useNavigate } from 'react-router-dom';
 import theme from '../../theme';
 
 interface MinerPRsTableProps {
   githubId: string;
+  /** When set, only PRs in repositories of this tier are shown (e.g. "Bronze", "Silver", "Gold"). */
+  tierFilter?: string;
 }
 
-const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
+const MinerPRsTable: React.FC<MinerPRsTableProps> = ({
+  githubId,
+  tierFilter,
+}) => {
   const navigate = useNavigate();
   const { data: prs, isLoading } = useMinerPRs(githubId);
+  const { data: repos } = useReposAndWeights();
   const [selectedRepo, setSelectedRepo] = useState<string | null>(null);
   const [selectedAuthor, setSelectedAuthor] = useState<string | null>(null);
   const [statusFilter, setStatusFilter] = useState<
     'all' | 'open' | 'merged' | 'closed'
   >('all');
 
-  // Filter PRs by selected repository, author, and status
+  const repoTiers = useMemo(() => {
+    const map = new Map<string, string>();
+    if (Array.isArray(repos)) {
+      repos.forEach((repo) => {
+        if (repo?.fullName) map.set(repo.fullName, repo.tier || '');
+      });
+    }
+    return map;
+  }, [repos]);
+
+  const tierFilterLower = tierFilter?.toLowerCase();
+
+  const prsInTier = useMemo(() => {
+    if (!prs || !tierFilterLower) return prs;
+    return prs.filter((pr) => {
+      const prTier = pr.tier?.toLowerCase();
+      const repoTier = repoTiers.get(pr.repository)?.toLowerCase();
+      return prTier === tierFilterLower || repoTier === tierFilterLower;
+    });
+  }, [prs, tierFilterLower, repoTiers]);
+
+  // Filter PRs by selected repository, author, and status (and tier when tierFilter is set)
   const filteredPRs = useMemo(() => {
-    if (!prs) return [];
-    let filtered = prs;
+    if (!prsInTier) return [];
+    let filtered = prsInTier;
     if (selectedRepo) {
       filtered = filtered.filter((pr) => pr.repository === selectedRepo);
     }
@@ -55,20 +82,23 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
       );
     }
     return filtered;
-  }, [prs, selectedRepo, selectedAuthor, statusFilter]);
+  }, [prsInTier, selectedRepo, selectedAuthor, statusFilter]);
 
   const statusCounts = useMemo(() => {
-    if (!prs) return { all: 0, open: 0, merged: 0, closed: 0 };
+    if (!prsInTier) return { all: 0, open: 0, merged: 0, closed: 0 };
     return {
-      all: prs.length,
-      open: prs.filter(
+      all: prsInTier.length,
+      open: prsInTier.filter(
         (pr) => pr.prState === 'OPEN' || (!pr.prState && !pr.mergedAt),
       ).length,
-      merged: prs.filter((pr) => pr.mergedAt || pr.prState === 'MERGED').length,
-      closed: prs.filter((pr) => pr.prState === 'CLOSED' && !pr.mergedAt)
-        .length,
+      merged: prsInTier.filter(
+        (pr) => pr.mergedAt || pr.prState === 'MERGED',
+      ).length,
+      closed: prsInTier.filter(
+        (pr) => pr.prState === 'CLOSED' && !pr.mergedAt,
+      ).length,
     };
-  }, [prs]);
+  }, [prsInTier]);
 
   if (isLoading) {
     return (
@@ -136,8 +166,11 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
               }}
             >
               ({filteredPRs.length}
-              {selectedRepo || selectedAuthor || statusFilter !== 'all'
-                ? ` of ${prs?.length || 0}`
+              {selectedRepo ||
+              selectedAuthor ||
+              statusFilter !== 'all' ||
+              tierFilter
+                ? ` of ${(tierFilter ? (prsInTier ?? []) : prs)?.length || 0}`
                 : ''}
               )
             </Typography>
@@ -211,6 +244,18 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
             }}
           >
             No PRs found
+          </Typography>
+        </Box>
+      ) : tierFilter && (prsInTier ?? []).length === 0 ? (
+        <Box sx={{ textAlign: 'center', py: 8 }}>
+          <Typography
+            sx={{
+              color: 'rgba(255, 255, 255, 0.5)',
+              fontFamily: '"JetBrains Mono", monospace',
+              fontSize: '0.9rem',
+            }}
+          >
+            No PRs in this tier
           </Typography>
         </Box>
       ) : filteredPRs.length === 0 ? (

--- a/src/components/miners/MinerPRsTable.tsx
+++ b/src/components/miners/MinerPRsTable.tsx
@@ -271,7 +271,7 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({
         <Box sx={{ textAlign: 'center', py: 8 }}>
           <Typography
             sx={{
-              color: 'rgba(255, 255, 255, 0.5)',
+              color: (t) => alpha(t.palette.text.primary, 0.5),
               fontFamily: '"JetBrains Mono", monospace',
               fontSize: '0.9rem',
             }}
@@ -283,7 +283,7 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({
         <Box sx={{ textAlign: 'center', py: 8 }}>
           <Typography
             sx={{
-              color: 'rgba(255, 255, 255, 0.5)',
+              color: (t) => alpha(t.palette.text.primary, 0.5),
               fontFamily: '"JetBrains Mono", monospace',
               fontSize: '0.9rem',
             }}
@@ -295,7 +295,7 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({
         <Box sx={{ textAlign: 'center', py: 8 }}>
           <Typography
             sx={{
-              color: 'rgba(255, 255, 255, 0.5)',
+              color: (t) => alpha(t.palette.text.primary, 0.5),
               fontFamily: '"JetBrains Mono", monospace',
               fontSize: '0.9rem',
             }}
@@ -317,10 +317,10 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({
               backgroundColor: 'transparent',
             },
             '&::-webkit-scrollbar-thumb': {
-              backgroundColor: 'rgba(255, 255, 255, 0.1)',
+              backgroundColor: (t) => t.palette.border?.light ?? t.palette.divider,
               borderRadius: '4px',
               '&:hover': {
-                backgroundColor: 'rgba(255, 255, 255, 0.2)',
+                backgroundColor: (t) => t.palette.border?.medium ?? t.palette.divider,
               },
             },
           }}
@@ -579,10 +579,8 @@ const FilterButton: React.FC<{
   color: string;
   selected: boolean;
   onClick: () => void;
-}> = ({ label, count, color, selected, onClick }) => {
-  const theme = useTheme();
-  return (
-    <Button
+}> = ({ label, count, color, selected, onClick }) => (
+  <Button
       size="small"
       onClick={onClick}
       sx={{
@@ -605,7 +603,6 @@ const FilterButton: React.FC<{
         {count}
       </span>
     </Button>
-  );
-};
+);
 
 export default MinerPRsTable;

--- a/src/components/miners/MinerPRsTable.tsx
+++ b/src/components/miners/MinerPRsTable.tsx
@@ -34,37 +34,31 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({
   const { data: prs, isLoading } = useMinerPRs(githubId);
   const { data: repos } = useReposAndWeights();
 
-  const headerCellStyle = useMemo(
-    () => ({
-      backgroundColor:
-        theme.palette.surface?.elevated ?? theme.palette.background.paper,
-      backdropFilter: 'blur(8px)',
-      color: alpha(theme.palette.text.primary, 0.7),
-      fontFamily: '"JetBrains Mono", monospace',
-      fontWeight: 500,
-      fontSize: { xs: '0.65rem', sm: '0.75rem' },
-      borderBottom: `1px solid ${theme.palette.border?.light ?? theme.palette.divider}`,
-      height: { xs: '48px', sm: '56px' },
-      py: { xs: 1, sm: 1.5 },
-      px: { xs: 0.5, sm: 2 },
-      textTransform: 'uppercase' as const,
-      letterSpacing: '0.5px',
-    }),
-    [theme],
-  );
+  const headerCellStyle = {
+    backgroundColor: theme.palette.surface.elevated,
+    backdropFilter: 'blur(8px)',
+    color: alpha(theme.palette.text.primary, 0.7),
+    fontFamily: '"JetBrains Mono", monospace',
+    fontWeight: 500,
+    fontSize: { xs: '0.65rem', sm: '0.75rem' },
+    borderBottom: `1px solid ${theme.palette.border.light}`,
+    height: { xs: '48px', sm: '56px' },
+    py: { xs: 1, sm: 1.5 },
+    px: { xs: 0.5, sm: 2 },
+    textTransform: 'uppercase' as const,
+    letterSpacing: '0.5px',
+  };
 
-  const bodyCellStyle = useMemo(
-    () => ({
-      color: theme.palette.text.primary,
-      fontFamily: '"JetBrains Mono", monospace',
-      borderBottom: `1px solid ${theme.palette.border?.light ?? theme.palette.divider}`,
-      fontSize: '0.85rem',
-      py: { xs: 0.75, sm: 1 },
-      px: { xs: 0.5, sm: 2 },
-      height: { xs: '52px', sm: '60px' },
-    }),
-    [theme],
-  );
+  const bodyCellStyle = {
+    color: theme.palette.text.primary,
+    fontFamily: '"JetBrains Mono", monospace',
+    borderBottom: `1px solid ${theme.palette.border.light}`,
+    fontSize: '0.85rem',
+    py: { xs: 0.75, sm: 1 },
+    px: { xs: 0.5, sm: 2 },
+    height: { xs: '52px', sm: '60px' },
+  };
+
   const [selectedRepo, setSelectedRepo] = useState<string | null>(null);
   const [selectedAuthor, setSelectedAuthor] = useState<string | null>(null);
   const [statusFilter, setStatusFilter] = useState<
@@ -318,12 +312,10 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({
               backgroundColor: 'transparent',
             },
             '&::-webkit-scrollbar-thumb': {
-              backgroundColor: (t) =>
-                t.palette.border?.light ?? t.palette.divider,
+              backgroundColor: (t) => t.palette.border.light,
               borderRadius: '4px',
               '&:hover': {
-                backgroundColor: (t) =>
-                  t.palette.border?.medium ?? t.palette.divider,
+                backgroundColor: (t) => t.palette.border.medium,
               },
             },
           }}

--- a/src/components/miners/MinerPRsTable.tsx
+++ b/src/components/miners/MinerPRsTable.tsx
@@ -13,10 +13,11 @@ import {
   Avatar,
   Chip,
   Button,
+  useTheme,
+  alpha,
 } from '@mui/material';
 import { useMinerPRs, useReposAndWeights } from '../../api';
 import { useNavigate } from 'react-router-dom';
-import theme from '../../theme';
 
 interface MinerPRsTableProps {
   githubId: string;
@@ -28,9 +29,41 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({
   githubId,
   tierFilter,
 }) => {
+  const theme = useTheme();
   const navigate = useNavigate();
   const { data: prs, isLoading } = useMinerPRs(githubId);
   const { data: repos } = useReposAndWeights();
+
+  const headerCellStyle = useMemo(
+    () => ({
+      backgroundColor: theme.palette.surface?.elevated ?? theme.palette.background.paper,
+      backdropFilter: 'blur(8px)',
+      color: alpha(theme.palette.text.primary, 0.7),
+      fontFamily: '"JetBrains Mono", monospace',
+      fontWeight: 500,
+      fontSize: { xs: '0.65rem', sm: '0.75rem' },
+      borderBottom: `1px solid ${theme.palette.border?.light ?? theme.palette.divider}`,
+      height: { xs: '48px', sm: '56px' },
+      py: { xs: 1, sm: 1.5 },
+      px: { xs: 0.5, sm: 2 },
+      textTransform: 'uppercase' as const,
+      letterSpacing: '0.5px',
+    }),
+    [theme],
+  );
+
+  const bodyCellStyle = useMemo(
+    () => ({
+      color: theme.palette.text.primary,
+      fontFamily: '"JetBrains Mono", monospace',
+      borderBottom: `1px solid ${theme.palette.border?.light ?? theme.palette.divider}`,
+      fontSize: '0.85rem',
+      py: { xs: 0.75, sm: 1 },
+      px: { xs: 0.5, sm: 2 },
+      height: { xs: '52px', sm: '60px' },
+    }),
+    [theme],
+  );
   const [selectedRepo, setSelectedRepo] = useState<string | null>(null);
   const [selectedAuthor, setSelectedAuthor] = useState<string | null>(null);
   const [statusFilter, setStatusFilter] = useState<
@@ -103,7 +136,8 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({
       <Card
         sx={{
           borderRadius: 3,
-          border: '1px solid rgba(255, 255, 255, 0.1)',
+          border: '1px solid',
+          borderColor: 'border.light',
           backgroundColor: 'transparent',
           p: 4,
           textAlign: 'center',
@@ -119,20 +153,21 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({
     <Card
       sx={{
         borderRadius: 3,
-        border: '1px solid rgba(255, 255, 255, 0.1)',
+        border: '1px solid',
+        borderColor: 'border.light',
         backgroundColor: 'transparent',
-        p: 0, // Remove padding to let table fill the card
+        p: 0,
         display: 'flex',
         flexDirection: 'column',
-        overflow: 'hidden', // Ensure rounded corners clip content
+        overflow: 'hidden',
       }}
       elevation={0}
     >
-      {/* Header */}
       <Box
         sx={{
           p: { xs: 2, sm: 3 },
-          borderBottom: '1px solid rgba(255, 255, 255, 0.1)',
+          borderBottom: '1px solid',
+          borderColor: 'border.light',
         }}
       >
         <Box
@@ -148,7 +183,7 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({
             <Typography
               variant="h6"
               sx={{
-                color: '#ffffff',
+                color: 'text.primary',
                 fontFamily: '"JetBrains Mono", monospace',
                 fontSize: { xs: '0.95rem', sm: '1.1rem' },
                 fontWeight: 500,
@@ -158,7 +193,7 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({
             </Typography>
             <Typography
               sx={{
-                color: 'rgba(255, 255, 255, 0.5)',
+                color: (t) => alpha(t.palette.text.primary, 0.5),
                 fontFamily: '"JetBrains Mono", monospace',
                 fontSize: '0.75rem',
               }}
@@ -346,7 +381,7 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({
                   sx={{
                     cursor: 'pointer',
                     '&:hover': {
-                      backgroundColor: 'rgba(255, 255, 255, 0.05)',
+                      backgroundColor: 'surface.light',
                     },
                     transition: 'all 0.2s',
                   }}
@@ -358,18 +393,19 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({
                       fontSize: { xs: '0.75rem', sm: '0.85rem' },
                     }}
                   >
-                    <a
+                    <Box
+                      component="a"
                       href={`https://github.com/${pr.repository}/pull/${pr.pullRequestNumber}`}
                       target="_blank"
                       rel="noopener noreferrer"
-                      style={{
-                        color: '#ffffff',
+                      sx={{
+                        color: 'text.primary',
                         textDecoration: 'none',
                         fontWeight: 500,
                       }}
                     >
                       #{pr.pullRequestNumber}
-                    </a>
+                    </Box>
                   </TableCell>
                   <TableCell
                     sx={{
@@ -417,12 +453,13 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({
                         sx={{
                           width: 20,
                           height: 20,
-                          border: '1px solid rgba(255, 255, 255, 0.2)',
+                          border: '1px solid',
+                          borderColor: 'border.medium',
                           backgroundColor:
                             pr.repository.split('/')[0] === 'opentensor'
-                              ? '#ffffff'
+                              ? 'text.primary'
                               : pr.repository.split('/')[0] === 'bitcoin'
-                                ? '#F7931A'
+                                ? 'status.warning'
                                 : 'transparent',
                         }}
                       />
@@ -468,7 +505,7 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({
                             fontFamily: '"JetBrains Mono", monospace',
                             fontSize: { xs: '0.7rem', sm: '0.75rem' },
                             fontWeight: 600,
-                            color: 'rgba(255, 255, 255, 0.3)',
+                            color: (t) => alpha(t.palette.text.primary, 0.3),
                           }}
                         >
                           -
@@ -479,7 +516,7 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({
                             fontFamily: '"JetBrains Mono", monospace',
                             fontSize: { xs: '0.7rem', sm: '0.75rem' },
                             fontWeight: 600,
-                            color: '#fb923c',
+                            color: 'status.warning',
                           }}
                         >
                           {parseFloat(pr.collateralScore).toFixed(4)}
@@ -502,7 +539,7 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({
                             sx={{
                               fontFamily: '"JetBrains Mono", monospace',
                               fontSize: '0.6rem',
-                              color: 'rgba(255,255,255,0.5)',
+                              color: (t) => alpha(t.palette.text.primary, 0.5),
                             }}
                           >
                             Collateral
@@ -517,7 +554,7 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({
                       width: '15%',
                       display: { xs: 'none', sm: 'table-cell' },
                       fontSize: { xs: '0.75rem', sm: '0.85rem' },
-                      color: 'rgba(255,255,255,0.7)',
+                      color: (t) => alpha(t.palette.text.primary, 0.7),
                     }}
                   >
                     {pr.mergedAt
@@ -536,61 +573,39 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({
   );
 };
 
-const headerCellStyle = {
-  backgroundColor: 'rgba(18, 18, 20, 0.95)',
-  backdropFilter: 'blur(8px)',
-  color: 'rgba(255, 255, 255, 0.7)',
-  fontFamily: '"JetBrains Mono", monospace',
-  fontWeight: 500,
-  fontSize: { xs: '0.65rem', sm: '0.75rem' },
-  borderBottom: '1px solid rgba(255, 255, 255, 0.1)',
-  height: { xs: '48px', sm: '56px' },
-  py: { xs: 1, sm: 1.5 },
-  px: { xs: 0.5, sm: 2 },
-  textTransform: 'uppercase' as const,
-  letterSpacing: '0.5px',
-};
-
-const bodyCellStyle = {
-  color: '#ffffff',
-  fontFamily: '"JetBrains Mono", monospace',
-  borderBottom: '1px solid rgba(255, 255, 255, 0.1)',
-  fontSize: '0.85rem',
-  py: { xs: 0.75, sm: 1 },
-  px: { xs: 0.5, sm: 2 },
-  height: { xs: '52px', sm: '60px' },
-};
-
 const FilterButton: React.FC<{
   label: string;
   count: number;
   color: string;
   selected: boolean;
   onClick: () => void;
-}> = ({ label, count, color, selected, onClick }) => (
-  <Button
-    size="small"
-    onClick={onClick}
-    sx={{
-      color: selected ? '#fff' : 'rgba(255,255,255,0.5)',
-      backgroundColor: selected ? 'rgba(255,255,255,0.1)' : 'transparent',
-      borderRadius: '6px',
-      px: 1.5,
-      minWidth: 'auto',
-      textTransform: 'none',
-      fontFamily: '"JetBrains Mono", monospace',
-      fontSize: '0.75rem',
-      border: selected ? `1px solid ${color}` : '1px solid transparent',
-      '&:hover': {
-        backgroundColor: 'rgba(255,255,255,0.15)',
-      },
-    }}
-  >
-    {label}{' '}
-    <span style={{ opacity: 0.6, marginLeft: '6px', fontSize: '0.7rem' }}>
-      {count}
-    </span>
-  </Button>
-);
+}> = ({ label, count, color, selected, onClick }) => {
+  const theme = useTheme();
+  return (
+    <Button
+      size="small"
+      onClick={onClick}
+      sx={{
+        color: selected ? 'text.primary' : (t) => alpha(t.palette.text.primary, 0.5),
+        backgroundColor: selected ? 'surface.light' : 'transparent',
+        borderRadius: '6px',
+        px: 1.5,
+        minWidth: 'auto',
+        textTransform: 'none',
+        fontFamily: '"JetBrains Mono", monospace',
+        fontSize: '0.75rem',
+        border: selected ? `1px solid ${color}` : '1px solid transparent',
+        '&:hover': {
+          backgroundColor: (t) => alpha(t.palette.text.primary, 0.15),
+        },
+      }}
+    >
+      {label}{' '}
+      <span style={{ opacity: 0.6, marginLeft: '6px', fontSize: '0.7rem' }}>
+        {count}
+      </span>
+    </Button>
+  );
+};
 
 export default MinerPRsTable;

--- a/src/components/miners/MinerRepositoriesTable.tsx
+++ b/src/components/miners/MinerRepositoriesTable.tsx
@@ -20,6 +20,8 @@ import { TIER_COLORS } from '../../theme';
 
 interface MinerRepositoriesTableProps {
   githubId: string;
+  /** When set, only repositories in this tier are shown (e.g. "Bronze", "Silver", "Gold"). */
+  tierFilter?: string;
 }
 
 interface RepoStats {
@@ -48,6 +50,7 @@ const getTierColor = (tier: string): string => {
 
 const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
   githubId,
+  tierFilter,
 }) => {
   const navigate = useNavigate();
   const { data: prs, isLoading: isLoadingPRs } = useMinerPRs(githubId);
@@ -102,9 +105,18 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
     return Array.from(statsMap.values());
   }, [prs, repoWeights, repoTiers]);
 
+  // Filter by tier when tierFilter is set (case-insensitive)
+  const filteredRepoStats = useMemo(() => {
+    if (!tierFilter) return repoStats;
+    const tierLower = tierFilter.toLowerCase();
+    return repoStats.filter(
+      (r) => r.tier && r.tier.toLowerCase() === tierLower,
+    );
+  }, [repoStats, tierFilter]);
+
   // Sort repository stats
   const sortedRepoStats = useMemo(() => {
-    const sorted = [...repoStats];
+    const sorted = [...filteredRepoStats];
     sorted.sort((a, b) => {
       let compareValue = 0;
 
@@ -130,7 +142,7 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
       return sortOrder === 'asc' ? compareValue : -compareValue;
     });
     return sorted;
-  }, [repoStats, sortField, sortOrder]);
+  }, [filteredRepoStats, sortField, sortOrder]);
 
   const handleSort = (field: SortField) => {
     if (sortField === field) {
@@ -160,7 +172,7 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
     );
   }
 
-  if (!prs || prs.length === 0 || repoStats.length === 0) {
+  if (!prs || prs.length === 0) {
     return (
       <Card
         sx={{
@@ -180,6 +192,56 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
           }}
         >
           No repository contributions found
+        </Typography>
+      </Card>
+    );
+  }
+
+  if (!tierFilter && repoStats.length === 0) {
+    return (
+      <Card
+        sx={{
+          borderRadius: 3,
+          border: '1px solid rgba(255, 255, 255, 0.1)',
+          backgroundColor: 'transparent',
+          p: 4,
+        }}
+        elevation={0}
+      >
+        <Typography
+          sx={{
+            color: 'rgba(255, 255, 255, 0.5)',
+            fontFamily: '"JetBrains Mono", monospace',
+            fontSize: '0.9rem',
+            textAlign: 'center',
+          }}
+        >
+          No repository contributions found
+        </Typography>
+      </Card>
+    );
+  }
+
+  if (tierFilter && filteredRepoStats.length === 0) {
+    return (
+      <Card
+        sx={{
+          borderRadius: 3,
+          border: '1px solid rgba(255, 255, 255, 0.1)',
+          backgroundColor: 'transparent',
+          p: 4,
+        }}
+        elevation={0}
+      >
+        <Typography
+          sx={{
+            color: 'rgba(255, 255, 255, 0.5)',
+            fontFamily: '"JetBrains Mono", monospace',
+            fontSize: '0.9rem',
+            textAlign: 'center',
+          }}
+        >
+          No repositories in this tier
         </Typography>
       </Card>
     );

--- a/src/components/miners/MinerRepositoriesTable.tsx
+++ b/src/components/miners/MinerRepositoriesTable.tsx
@@ -62,7 +62,8 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
 
   const headerCellStyle = useMemo(
     () => ({
-      backgroundColor: theme.palette.surface?.elevated ?? theme.palette.background.paper,
+      backgroundColor:
+        theme.palette.surface?.elevated ?? theme.palette.background.paper,
       backdropFilter: 'blur(8px)',
       color: alpha(theme.palette.text.primary, 0.7),
       fontFamily: '"JetBrains Mono", monospace',
@@ -321,13 +322,16 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
                   active={sortField === 'rank'}
                   direction={sortField === 'rank' ? sortOrder : 'desc'}
                   onClick={() => handleSort('rank')}
-                    sx={{
+                  sx={{
                     color: 'inherit',
-                    '&:hover': { color: (t) => alpha(t.palette.text.primary, 0.9) },
+                    '&:hover': {
+                      color: (t) => alpha(t.palette.text.primary, 0.9),
+                    },
                     '&.Mui-active': {
                       color: (t) => alpha(t.palette.text.primary, 0.9),
                       '& .MuiTableSortLabel-icon': {
-                        color: (t) => `${alpha(t.palette.text.primary, 0.9)} !important`,
+                        color: (t) =>
+                          `${alpha(t.palette.text.primary, 0.9)} !important`,
                       },
                     },
                   }}
@@ -340,13 +344,16 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
                   active={sortField === 'repository'}
                   direction={sortField === 'repository' ? sortOrder : 'asc'}
                   onClick={() => handleSort('repository')}
-                    sx={{
+                  sx={{
                     color: 'inherit',
-                    '&:hover': { color: (t) => alpha(t.palette.text.primary, 0.9) },
+                    '&:hover': {
+                      color: (t) => alpha(t.palette.text.primary, 0.9),
+                    },
                     '&.Mui-active': {
                       color: (t) => alpha(t.palette.text.primary, 0.9),
                       '& .MuiTableSortLabel-icon': {
-                        color: (t) => `${alpha(t.palette.text.primary, 0.9)} !important`,
+                        color: (t) =>
+                          `${alpha(t.palette.text.primary, 0.9)} !important`,
                       },
                     },
                   }}
@@ -359,13 +366,16 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
                   active={sortField === 'prs'}
                   direction={sortField === 'prs' ? sortOrder : 'desc'}
                   onClick={() => handleSort('prs')}
-                    sx={{
+                  sx={{
                     color: 'inherit',
-                    '&:hover': { color: (t) => alpha(t.palette.text.primary, 0.9) },
+                    '&:hover': {
+                      color: (t) => alpha(t.palette.text.primary, 0.9),
+                    },
                     '&.Mui-active': {
                       color: (t) => alpha(t.palette.text.primary, 0.9),
                       '& .MuiTableSortLabel-icon': {
-                        color: (t) => `${alpha(t.palette.text.primary, 0.9)} !important`,
+                        color: (t) =>
+                          `${alpha(t.palette.text.primary, 0.9)} !important`,
                       },
                     },
                   }}
@@ -378,13 +388,16 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
                   active={sortField === 'score'}
                   direction={sortField === 'score' ? sortOrder : 'desc'}
                   onClick={() => handleSort('score')}
-                    sx={{
+                  sx={{
                     color: 'inherit',
-                    '&:hover': { color: (t) => alpha(t.palette.text.primary, 0.9) },
+                    '&:hover': {
+                      color: (t) => alpha(t.palette.text.primary, 0.9),
+                    },
                     '&.Mui-active': {
                       color: (t) => alpha(t.palette.text.primary, 0.9),
                       '& .MuiTableSortLabel-icon': {
-                        color: (t) => `${alpha(t.palette.text.primary, 0.9)} !important`,
+                        color: (t) =>
+                          `${alpha(t.palette.text.primary, 0.9)} !important`,
                       },
                     },
                   }}
@@ -397,13 +410,16 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
                   active={sortField === 'weight'}
                   direction={sortField === 'weight' ? sortOrder : 'desc'}
                   onClick={() => handleSort('weight')}
-                    sx={{
+                  sx={{
                     color: 'inherit',
-                    '&:hover': { color: (t) => alpha(t.palette.text.primary, 0.9) },
+                    '&:hover': {
+                      color: (t) => alpha(t.palette.text.primary, 0.9),
+                    },
                     '&.Mui-active': {
                       color: (t) => alpha(t.palette.text.primary, 0.9),
                       '& .MuiTableSortLabel-icon': {
-                        color: (t) => `${alpha(t.palette.text.primary, 0.9)} !important`,
+                        color: (t) =>
+                          `${alpha(t.palette.text.primary, 0.9)} !important`,
                       },
                     },
                   }}

--- a/src/components/miners/MinerRepositoriesTable.tsx
+++ b/src/components/miners/MinerRepositoriesTable.tsx
@@ -60,31 +60,24 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
   const [sortField, setSortField] = useState<SortField>('score');
   const [sortOrder, setSortOrder] = useState<SortOrder>('desc');
 
-  const headerCellStyle = useMemo(
-    () => ({
-      backgroundColor:
-        theme.palette.surface?.elevated ?? theme.palette.background.paper,
-      backdropFilter: 'blur(8px)',
-      color: alpha(theme.palette.text.primary, 0.7),
-      fontFamily: '"JetBrains Mono", monospace',
-      fontWeight: 500,
-      fontSize: '0.75rem',
-      borderBottom: `1px solid ${theme.palette.border?.light ?? theme.palette.divider}`,
-      textTransform: 'uppercase' as const,
-      letterSpacing: '0.5px',
-    }),
-    [theme],
-  );
+  const headerCellStyle = {
+    backgroundColor: theme.palette.surface.elevated,
+    backdropFilter: 'blur(8px)',
+    color: alpha(theme.palette.text.primary, 0.7),
+    fontFamily: '"JetBrains Mono", monospace',
+    fontWeight: 500,
+    fontSize: '0.75rem',
+    borderBottom: `1px solid ${theme.palette.border.light}`,
+    textTransform: 'uppercase' as const,
+    letterSpacing: '0.5px',
+  };
 
-  const bodyCellStyle = useMemo(
-    () => ({
-      color: theme.palette.text.primary,
-      fontFamily: '"JetBrains Mono", monospace',
-      borderBottom: `1px solid ${theme.palette.border?.light ?? theme.palette.divider}`,
-      fontSize: '0.85rem',
-    }),
-    [theme],
-  );
+  const bodyCellStyle = {
+    color: theme.palette.text.primary,
+    fontFamily: '"JetBrains Mono", monospace',
+    borderBottom: `1px solid ${theme.palette.border.light}`,
+    fontSize: '0.85rem',
+  };
 
   // Build repository weights and tiers maps
   const repoWeights = useMemo(() => {

--- a/src/components/miners/MinerRepositoriesTable.tsx
+++ b/src/components/miners/MinerRepositoriesTable.tsx
@@ -13,6 +13,7 @@ import {
   Avatar,
   TableSortLabel,
   alpha,
+  useTheme,
 } from '@mui/material';
 import { useMinerPRs, useReposAndWeights } from '../../api';
 import { useNavigate } from 'react-router-dom';
@@ -52,11 +53,37 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
   githubId,
   tierFilter,
 }) => {
+  const theme = useTheme();
   const navigate = useNavigate();
   const { data: prs, isLoading: isLoadingPRs } = useMinerPRs(githubId);
   const { data: repos, isLoading: isLoadingRepos } = useReposAndWeights();
   const [sortField, setSortField] = useState<SortField>('score');
   const [sortOrder, setSortOrder] = useState<SortOrder>('desc');
+
+  const headerCellStyle = useMemo(
+    () => ({
+      backgroundColor: theme.palette.surface?.elevated ?? theme.palette.background.paper,
+      backdropFilter: 'blur(8px)',
+      color: alpha(theme.palette.text.primary, 0.7),
+      fontFamily: '"JetBrains Mono", monospace',
+      fontWeight: 500,
+      fontSize: '0.75rem',
+      borderBottom: `1px solid ${theme.palette.border?.light ?? theme.palette.divider}`,
+      textTransform: 'uppercase' as const,
+      letterSpacing: '0.5px',
+    }),
+    [theme],
+  );
+
+  const bodyCellStyle = useMemo(
+    () => ({
+      color: theme.palette.text.primary,
+      fontFamily: '"JetBrains Mono", monospace',
+      borderBottom: `1px solid ${theme.palette.border?.light ?? theme.palette.divider}`,
+      fontSize: '0.85rem',
+    }),
+    [theme],
+  );
 
   // Build repository weights and tiers maps
   const repoWeights = useMemo(() => {
@@ -160,7 +187,8 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
       <Card
         sx={{
           borderRadius: 3,
-          border: '1px solid rgba(255, 255, 255, 0.1)',
+          border: '1px solid',
+          borderColor: 'border.light',
           backgroundColor: 'transparent',
           p: 4,
           textAlign: 'center',
@@ -177,7 +205,8 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
       <Card
         sx={{
           borderRadius: 3,
-          border: '1px solid rgba(255, 255, 255, 0.1)',
+          border: '1px solid',
+          borderColor: 'border.light',
           backgroundColor: 'transparent',
           p: 4,
         }}
@@ -185,7 +214,7 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
       >
         <Typography
           sx={{
-            color: 'rgba(255, 255, 255, 0.5)',
+            color: (t) => alpha(t.palette.text.primary, 0.5),
             fontFamily: '"JetBrains Mono", monospace',
             fontSize: '0.9rem',
             textAlign: 'center',
@@ -202,7 +231,8 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
       <Card
         sx={{
           borderRadius: 3,
-          border: '1px solid rgba(255, 255, 255, 0.1)',
+          border: '1px solid',
+          borderColor: 'border.light',
           backgroundColor: 'transparent',
           p: 4,
         }}
@@ -210,7 +240,7 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
       >
         <Typography
           sx={{
-            color: 'rgba(255, 255, 255, 0.5)',
+            color: (t) => alpha(t.palette.text.primary, 0.5),
             fontFamily: '"JetBrains Mono", monospace',
             fontSize: '0.9rem',
             textAlign: 'center',
@@ -227,7 +257,8 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
       <Card
         sx={{
           borderRadius: 3,
-          border: '1px solid rgba(255, 255, 255, 0.1)',
+          border: '1px solid',
+          borderColor: 'border.light',
           backgroundColor: 'transparent',
           p: 4,
         }}
@@ -235,7 +266,7 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
       >
         <Typography
           sx={{
-            color: 'rgba(255, 255, 255, 0.5)',
+            color: (t) => alpha(t.palette.text.primary, 0.5),
             fontFamily: '"JetBrains Mono", monospace',
             fontSize: '0.9rem',
             textAlign: 'center',
@@ -251,7 +282,8 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
     <Card
       sx={{
         borderRadius: 3,
-        border: '1px solid rgba(255, 255, 255, 0.1)',
+        border: '1px solid',
+        borderColor: 'border.light',
         backgroundColor: 'transparent',
         p: 0,
         display: 'flex',
@@ -263,13 +295,14 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
       <Box
         sx={{
           p: 3,
-          borderBottom: '1px solid rgba(255, 255, 255, 0.1)',
+          borderBottom: '1px solid',
+          borderColor: 'border.light',
         }}
       >
         <Typography
           variant="h6"
           sx={{
-            color: '#ffffff',
+            color: 'text.primary',
             fontFamily: '"JetBrains Mono", monospace',
             fontSize: '1.1rem',
             fontWeight: 500,
@@ -288,13 +321,13 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
                   active={sortField === 'rank'}
                   direction={sortField === 'rank' ? sortOrder : 'desc'}
                   onClick={() => handleSort('rank')}
-                  sx={{
+                    sx={{
                     color: 'inherit',
-                    '&:hover': { color: 'rgba(255, 255, 255, 0.9)' },
+                    '&:hover': { color: (t) => alpha(t.palette.text.primary, 0.9) },
                     '&.Mui-active': {
-                      color: 'rgba(255, 255, 255, 0.9)',
+                      color: (t) => alpha(t.palette.text.primary, 0.9),
                       '& .MuiTableSortLabel-icon': {
-                        color: 'rgba(255, 255, 255, 0.9) !important',
+                        color: (t) => `${alpha(t.palette.text.primary, 0.9)} !important`,
                       },
                     },
                   }}
@@ -307,13 +340,13 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
                   active={sortField === 'repository'}
                   direction={sortField === 'repository' ? sortOrder : 'asc'}
                   onClick={() => handleSort('repository')}
-                  sx={{
+                    sx={{
                     color: 'inherit',
-                    '&:hover': { color: 'rgba(255, 255, 255, 0.9)' },
+                    '&:hover': { color: (t) => alpha(t.palette.text.primary, 0.9) },
                     '&.Mui-active': {
-                      color: 'rgba(255, 255, 255, 0.9)',
+                      color: (t) => alpha(t.palette.text.primary, 0.9),
                       '& .MuiTableSortLabel-icon': {
-                        color: 'rgba(255, 255, 255, 0.9) !important',
+                        color: (t) => `${alpha(t.palette.text.primary, 0.9)} !important`,
                       },
                     },
                   }}
@@ -326,13 +359,13 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
                   active={sortField === 'prs'}
                   direction={sortField === 'prs' ? sortOrder : 'desc'}
                   onClick={() => handleSort('prs')}
-                  sx={{
+                    sx={{
                     color: 'inherit',
-                    '&:hover': { color: 'rgba(255, 255, 255, 0.9)' },
+                    '&:hover': { color: (t) => alpha(t.palette.text.primary, 0.9) },
                     '&.Mui-active': {
-                      color: 'rgba(255, 255, 255, 0.9)',
+                      color: (t) => alpha(t.palette.text.primary, 0.9),
                       '& .MuiTableSortLabel-icon': {
-                        color: 'rgba(255, 255, 255, 0.9) !important',
+                        color: (t) => `${alpha(t.palette.text.primary, 0.9)} !important`,
                       },
                     },
                   }}
@@ -345,13 +378,13 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
                   active={sortField === 'score'}
                   direction={sortField === 'score' ? sortOrder : 'desc'}
                   onClick={() => handleSort('score')}
-                  sx={{
+                    sx={{
                     color: 'inherit',
-                    '&:hover': { color: 'rgba(255, 255, 255, 0.9)' },
+                    '&:hover': { color: (t) => alpha(t.palette.text.primary, 0.9) },
                     '&.Mui-active': {
-                      color: 'rgba(255, 255, 255, 0.9)',
+                      color: (t) => alpha(t.palette.text.primary, 0.9),
                       '& .MuiTableSortLabel-icon': {
-                        color: 'rgba(255, 255, 255, 0.9) !important',
+                        color: (t) => `${alpha(t.palette.text.primary, 0.9)} !important`,
                       },
                     },
                   }}
@@ -364,13 +397,13 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
                   active={sortField === 'weight'}
                   direction={sortField === 'weight' ? sortOrder : 'desc'}
                   onClick={() => handleSort('weight')}
-                  sx={{
+                    sx={{
                     color: 'inherit',
-                    '&:hover': { color: 'rgba(255, 255, 255, 0.9)' },
+                    '&:hover': { color: (t) => alpha(t.palette.text.primary, 0.9) },
                     '&.Mui-active': {
-                      color: 'rgba(255, 255, 255, 0.9)',
+                      color: (t) => alpha(t.palette.text.primary, 0.9),
                       '& .MuiTableSortLabel-icon': {
-                        color: 'rgba(255, 255, 255, 0.9) !important',
+                        color: (t) => `${alpha(t.palette.text.primary, 0.9)} !important`,
                       },
                     },
                   }}
@@ -386,7 +419,7 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
                 key={repo.repository}
                 sx={{
                   '&:hover': {
-                    backgroundColor: 'rgba(255, 255, 255, 0.05)',
+                    backgroundColor: 'surface.light',
                   },
                   transition: 'background-color 0.2s',
                 }}
@@ -394,7 +427,7 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
                 <TableCell sx={bodyCellStyle}>
                   <Box
                     sx={{
-                      backgroundColor: '#000000',
+                      backgroundColor: 'background.default',
                       borderRadius: '2px',
                       width: '28px',
                       height: '28px',
@@ -403,14 +436,14 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
                       justifyContent: 'center',
                       flexShrink: 0,
                       border: '1px solid',
-                      borderColor:
+                      borderColor: (t) =>
                         index === 0
                           ? alpha(TIER_COLORS.gold, 0.4)
                           : index === 1
                             ? alpha(TIER_COLORS.silver, 0.4)
                             : index === 2
                               ? alpha(TIER_COLORS.bronze, 0.4)
-                              : 'rgba(255, 255, 255, 0.15)',
+                              : alpha(t.palette.text.primary, 0.15),
                       boxShadow:
                         index === 0
                           ? `0 0 12px ${alpha(TIER_COLORS.gold, 0.4)}, 0 0 4px ${alpha(TIER_COLORS.gold, 0.2)}`
@@ -424,14 +457,14 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
                     <Typography
                       component="span"
                       sx={{
-                        color:
+                        color: (t) =>
                           index === 0
                             ? TIER_COLORS.gold
                             : index === 1
                               ? TIER_COLORS.silver
                               : index === 2
                                 ? TIER_COLORS.bronze
-                                : 'rgba(255, 255, 255, 0.6)',
+                                : alpha(t.palette.text.primary, 0.6),
                         fontFamily: '"JetBrains Mono", monospace',
                         fontSize: '0.7rem',
                         fontWeight: 600,
@@ -477,12 +510,13 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
                       sx={{
                         width: 24,
                         height: 24,
-                        border: '1px solid rgba(255, 255, 255, 0.2)',
+                        border: '1px solid',
+                        borderColor: 'border.medium',
                         backgroundColor:
                           repo.repository.split('/')[0] === 'opentensor'
-                            ? '#ffffff'
+                            ? 'text.primary'
                             : repo.repository.split('/')[0] === 'bitcoin'
-                              ? '#F7931A'
+                              ? 'status.warning'
                               : 'transparent',
                       }}
                     />
@@ -526,25 +560,6 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
       </TableContainer>
     </Card>
   );
-};
-
-const headerCellStyle = {
-  backgroundColor: 'rgba(18, 18, 20, 0.95)',
-  backdropFilter: 'blur(8px)',
-  color: 'rgba(255, 255, 255, 0.7)',
-  fontFamily: '"JetBrains Mono", monospace',
-  fontWeight: 500,
-  fontSize: '0.75rem',
-  borderBottom: '1px solid rgba(255, 255, 255, 0.1)',
-  textTransform: 'uppercase' as const,
-  letterSpacing: '0.5px',
-};
-
-const bodyCellStyle = {
-  color: '#ffffff',
-  fontFamily: '"JetBrains Mono", monospace',
-  borderBottom: '1px solid rgba(255, 255, 255, 0.1)',
-  fontSize: '0.85rem',
 };
 
 export default MinerRepositoriesTable;

--- a/src/components/miners/MinerTierPerformance.tsx
+++ b/src/components/miners/MinerTierPerformance.tsx
@@ -7,6 +7,7 @@ import {
   CircularProgress,
   alpha,
 } from '@mui/material';
+import { useNavigate } from 'react-router-dom';
 import {
   useMinerStats,
   useTierConfigurations,
@@ -74,8 +75,16 @@ interface MinerTierPerformanceProps {
 const MinerTierPerformance: React.FC<MinerTierPerformanceProps> = ({
   githubId,
 }) => {
+  const navigate = useNavigate();
   const { data: minerStats, isLoading, error } = useMinerStats(githubId);
   const { data: tierConfigData } = useTierConfigurations();
+
+  const handleTierClick = (tierName: string) => {
+    navigate(
+      `/miners/tier-details?githubId=${encodeURIComponent(githubId)}&tier=${encodeURIComponent(tierName)}`,
+      { state: { backLabel: 'Back to Miner' } },
+    );
+  };
 
   if (isLoading) {
     return (
@@ -227,26 +236,35 @@ const MinerTierPerformance: React.FC<MinerTierPerformanceProps> = ({
 
           return (
             <Grid item xs={12} md={4} key={tier.name}>
-              <TierCard
-                name={tier.name}
-                color={tier.color}
-                bgColor={tier.bgColor}
-                borderColor={tier.borderColor}
-                stats={tier.stats}
-                isLocked={isLocked}
-                isNextTier={isNextTier}
-                tooltipMessage={
-                  isLocked
-                    ? getTooltipMessage(
-                        tier.name,
-                        tier.level,
-                        isNextTier,
-                        config,
-                      )
-                    : undefined
-                }
-                unlockProgress={unlockProgress}
-              />
+              <Box
+                onClick={() => handleTierClick(tier.name)}
+                sx={{
+                  cursor: 'pointer',
+                  height: '100%',
+                  '&:hover': { opacity: 0.95 },
+                }}
+              >
+                <TierCard
+                  name={tier.name}
+                  color={tier.color}
+                  bgColor={tier.bgColor}
+                  borderColor={tier.borderColor}
+                  stats={tier.stats}
+                  isLocked={isLocked}
+                  isNextTier={isNextTier}
+                  tooltipMessage={
+                    isLocked
+                      ? getTooltipMessage(
+                          tier.name,
+                          tier.level,
+                          isNextTier,
+                          config,
+                        )
+                      : undefined
+                  }
+                  unlockProgress={unlockProgress}
+                />
+              </Box>
             </Grid>
           );
         })}

--- a/src/pages/TierDetailsPage.tsx
+++ b/src/pages/TierDetailsPage.tsx
@@ -73,12 +73,9 @@ const TierDetailsPage: React.FC = () => {
           />
 
           <Typography
-            variant="h6"
+            variant="sectionTitle"
             sx={{
-              color: '#ffffff',
-              fontFamily: '"JetBrains Mono", monospace',
               fontSize: '1.1rem',
-              fontWeight: 600,
               display: 'flex',
               alignItems: 'center',
               gap: 1.5,
@@ -96,12 +93,9 @@ const TierDetailsPage: React.FC = () => {
           <MinerRepositoriesTable githubId={githubId} tierFilter={tier} />
 
           <Typography
-            variant="h6"
+            variant="sectionTitle"
             sx={{
-              color: '#ffffff',
-              fontFamily: '"JetBrains Mono", monospace',
               fontSize: '1.1rem',
-              fontWeight: 600,
               display: 'flex',
               alignItems: 'center',
               gap: 1.5,
@@ -186,6 +180,8 @@ const TierSummaryCard: React.FC<TierSummaryCardProps> = ({
   return (
     <Card
       sx={{
+        display: 'flex',
+        flexDirection: 'column',
         borderRadius: 3,
         border: `1px solid ${borderColor}`,
         backgroundColor: bgColor,
@@ -195,12 +191,11 @@ const TierSummaryCard: React.FC<TierSummaryCardProps> = ({
       elevation={0}
     >
       <Typography
+        variant="sectionTitle"
         sx={{
           color,
-          fontFamily: '"JetBrains Mono", monospace',
           fontSize: '1rem',
           fontWeight: 700,
-          textTransform: 'uppercase',
           letterSpacing: '1px',
           mb: 2,
           pb: 1.5,
@@ -209,141 +204,52 @@ const TierSummaryCard: React.FC<TierSummaryCardProps> = ({
       >
         {tier} Tier Summary
       </Typography>
-      <Stack direction="row" flexWrap="wrap" gap={3} useFlexGap>
-        <Box>
-          <Typography
-            sx={{
-              color: 'rgba(255, 255, 255, 0.5)',
-              fontSize: '0.7rem',
-              fontFamily: '"JetBrains Mono", monospace',
-              textTransform: 'uppercase',
-            }}
-          >
-            Score
-          </Typography>
-          <Typography
-            sx={{
-              color: '#ffffff',
-              fontSize: '1.1rem',
-              fontFamily: '"JetBrains Mono", monospace',
-              fontWeight: 600,
-            }}
-          >
+      <Stack
+        direction="row"
+        flexWrap="wrap"
+        gap={4}
+        useFlexGap
+        sx={{
+          '& > *': { minWidth: 0 },
+          '& .MuiTypography-root': {
+            border: 'none',
+            borderBottom: 'none',
+            textDecoration: 'none',
+            margin: 0,
+            padding: 0,
+          },
+        }}
+      >
+        <Stack direction="column" gap={0.5} sx={{ minWidth: '4.5rem' }}>
+          <Typography variant="statLabel" component="span">Score</Typography>
+          <Typography variant="statValue" component="span">
             {score != null ? Number(score).toFixed(4) : '0.0000'}
           </Typography>
-        </Box>
-        <Box>
-          <Typography
-            sx={{
-              color: 'rgba(255, 255, 255, 0.5)',
-              fontSize: '0.7rem',
-              fontFamily: '"JetBrains Mono", monospace',
-              textTransform: 'uppercase',
-            }}
-          >
-            Credibility
-          </Typography>
-          <Typography
-            sx={{
-              color: '#ffffff',
-              fontSize: '1.1rem',
-              fontFamily: '"JetBrains Mono", monospace',
-              fontWeight: 600,
-            }}
-          >
+        </Stack>
+        <Stack direction="column" gap={0.5} sx={{ minWidth: '4.5rem' }}>
+          <Typography variant="statLabel" component="span">Credibility</Typography>
+          <Typography variant="statValue" component="span">
             {credibility != null
               ? `${(Number(credibility) * 100).toFixed(1)}%`
               : 'N/A'}
           </Typography>
-        </Box>
-        <Box>
-          <Typography
-            sx={{
-              color: 'rgba(255, 255, 255, 0.5)',
-              fontSize: '0.7rem',
-              fontFamily: '"JetBrains Mono", monospace',
-              textTransform: 'uppercase',
-            }}
-          >
-            PRs Merged
-          </Typography>
-          <Typography
-            sx={{
-              color: '#ffffff',
-              fontSize: '1.1rem',
-              fontFamily: '"JetBrains Mono", monospace',
-              fontWeight: 600,
-            }}
-          >
-            {merged ?? 0}
-          </Typography>
-        </Box>
-        <Box>
-          <Typography
-            sx={{
-              color: 'rgba(255, 255, 255, 0.5)',
-              fontSize: '0.7rem',
-              fontFamily: '"JetBrains Mono", monospace',
-              textTransform: 'uppercase',
-            }}
-          >
-            PRs Open
-          </Typography>
-          <Typography
-            sx={{
-              color: '#ffffff',
-              fontSize: '1.1rem',
-              fontFamily: '"JetBrains Mono", monospace',
-              fontWeight: 600,
-            }}
-          >
-            {opened}
-          </Typography>
-        </Box>
-        <Box>
-          <Typography
-            sx={{
-              color: 'rgba(255, 255, 255, 0.5)',
-              fontSize: '0.7rem',
-              fontFamily: '"JetBrains Mono", monospace',
-              textTransform: 'uppercase',
-            }}
-          >
-            PRs Closed
-          </Typography>
-          <Typography
-            sx={{
-              color: '#ffffff',
-              fontSize: '1.1rem',
-              fontFamily: '"JetBrains Mono", monospace',
-              fontWeight: 600,
-            }}
-          >
-            {closed ?? 0}
-          </Typography>
-        </Box>
-        <Box>
-          <Typography
-            sx={{
-              color: 'rgba(255, 255, 255, 0.5)',
-              fontSize: '0.7rem',
-              fontFamily: '"JetBrains Mono", monospace',
-              textTransform: 'uppercase',
-            }}
-          >
-            Unique Repos
-          </Typography>
-          <Typography
-            sx={{
-              color: '#ffffff',
-              fontSize: '1.1rem',
-              fontFamily: '"JetBrains Mono", monospace',
-              fontWeight: 600,
-            }}
-          >
-            {uniqueRepos ?? 0}
-          </Typography>
-        </Box>
+        </Stack>
+        <Stack direction="column" gap={0.5} sx={{ minWidth: '4.5rem' }}>
+          <Typography variant="statLabel" component="span">PRs Merged</Typography>
+          <Typography variant="statValue" component="span">{merged ?? 0}</Typography>
+        </Stack>
+        <Stack direction="column" gap={0.5} sx={{ minWidth: '4.5rem' }}>
+          <Typography variant="statLabel" component="span">PRs Open</Typography>
+          <Typography variant="statValue" component="span">{opened}</Typography>
+        </Stack>
+        <Stack direction="column" gap={0.5} sx={{ minWidth: '4.5rem' }}>
+          <Typography variant="statLabel" component="span">PRs Closed</Typography>
+          <Typography variant="statValue" component="span">{closed ?? 0}</Typography>
+        </Stack>
+        <Stack direction="column" gap={0.5} sx={{ minWidth: '4.5rem' }}>
+          <Typography variant="statLabel" component="span">Unique Repos</Typography>
+          <Typography variant="statValue" component="span">{uniqueRepos ?? 0}</Typography>
+        </Stack>
       </Stack>
     </Card>
   );

--- a/src/pages/TierDetailsPage.tsx
+++ b/src/pages/TierDetailsPage.tsx
@@ -221,13 +221,17 @@ const TierSummaryCard: React.FC<TierSummaryCardProps> = ({
         }}
       >
         <Stack direction="column" gap={0.5} sx={{ minWidth: '4.5rem' }}>
-          <Typography variant="statLabel" component="span">Score</Typography>
+          <Typography variant="statLabel" component="span">
+            Score
+          </Typography>
           <Typography variant="statValue" component="span">
             {score != null ? Number(score).toFixed(4) : '0.0000'}
           </Typography>
         </Stack>
         <Stack direction="column" gap={0.5} sx={{ minWidth: '4.5rem' }}>
-          <Typography variant="statLabel" component="span">Credibility</Typography>
+          <Typography variant="statLabel" component="span">
+            Credibility
+          </Typography>
           <Typography variant="statValue" component="span">
             {credibility != null
               ? `${(Number(credibility) * 100).toFixed(1)}%`
@@ -235,20 +239,36 @@ const TierSummaryCard: React.FC<TierSummaryCardProps> = ({
           </Typography>
         </Stack>
         <Stack direction="column" gap={0.5} sx={{ minWidth: '4.5rem' }}>
-          <Typography variant="statLabel" component="span">PRs Merged</Typography>
-          <Typography variant="statValue" component="span">{merged ?? 0}</Typography>
+          <Typography variant="statLabel" component="span">
+            PRs Merged
+          </Typography>
+          <Typography variant="statValue" component="span">
+            {merged ?? 0}
+          </Typography>
         </Stack>
         <Stack direction="column" gap={0.5} sx={{ minWidth: '4.5rem' }}>
-          <Typography variant="statLabel" component="span">PRs Open</Typography>
-          <Typography variant="statValue" component="span">{opened}</Typography>
+          <Typography variant="statLabel" component="span">
+            PRs Open
+          </Typography>
+          <Typography variant="statValue" component="span">
+            {opened}
+          </Typography>
         </Stack>
         <Stack direction="column" gap={0.5} sx={{ minWidth: '4.5rem' }}>
-          <Typography variant="statLabel" component="span">PRs Closed</Typography>
-          <Typography variant="statValue" component="span">{closed ?? 0}</Typography>
+          <Typography variant="statLabel" component="span">
+            PRs Closed
+          </Typography>
+          <Typography variant="statValue" component="span">
+            {closed ?? 0}
+          </Typography>
         </Stack>
         <Stack direction="column" gap={0.5} sx={{ minWidth: '4.5rem' }}>
-          <Typography variant="statLabel" component="span">Unique Repos</Typography>
-          <Typography variant="statValue" component="span">{uniqueRepos ?? 0}</Typography>
+          <Typography variant="statLabel" component="span">
+            Unique Repos
+          </Typography>
+          <Typography variant="statValue" component="span">
+            {uniqueRepos ?? 0}
+          </Typography>
         </Stack>
       </Stack>
     </Card>

--- a/src/pages/TierDetailsPage.tsx
+++ b/src/pages/TierDetailsPage.tsx
@@ -1,0 +1,352 @@
+import React from 'react';
+import { useSearchParams, useNavigate } from 'react-router-dom';
+import { Box, Card, Typography, Stack, alpha } from '@mui/material';
+import { Page } from '../components/layout';
+import {
+  MinerRepositoriesTable,
+  MinerPRsTable,
+  BackButton,
+  SEO,
+} from '../components';
+import { useMinerStats } from '../api';
+import { TIER_COLORS } from '../theme';
+
+const VALID_TIERS = ['Bronze', 'Silver', 'Gold'];
+
+const TierDetailsPage: React.FC = () => {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const githubId = searchParams.get('githubId');
+  const tierParam = searchParams.get('tier') || '';
+  const tier =
+    VALID_TIERS.find((t) => t.toLowerCase() === tierParam.toLowerCase()) ||
+    'Bronze';
+
+  if (!githubId) {
+    navigate('/top-miners');
+    return null;
+  }
+
+  const tierKey = tier.toLowerCase() as 'bronze' | 'silver' | 'gold';
+  const color = TIER_COLORS[tierKey];
+  const bgColor = alpha(color, 0.08);
+  const borderColor = alpha(color, 0.25);
+
+  return (
+    <Page title={`${tier} Tier Details`}>
+      <SEO
+        title={`${tier} Tier - ${githubId} | Gittensor`}
+        description={`Repositories and pull requests (merged, open, closed) for ${githubId} in the ${tier} tier on Gittensor.`}
+        type="website"
+      />
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          minHeight: { xs: 'auto', md: 'calc(100vh - 80px)' },
+          width: '100%',
+          py: { xs: 2, sm: 0 },
+        }}
+      >
+        <Box
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 3,
+            maxWidth: 1200,
+            width: '100%',
+            px: { xs: 2, sm: 2, md: 0 },
+          }}
+        >
+          <BackButton
+            to={`/miners/details?githubId=${encodeURIComponent(githubId)}`}
+            label="Back to Miner"
+          />
+
+          <TierSummaryCard
+            githubId={githubId}
+            tier={tier}
+            color={color}
+            bgColor={bgColor}
+            borderColor={borderColor}
+          />
+
+          <Typography
+            variant="h6"
+            sx={{
+              color: '#ffffff',
+              fontFamily: '"JetBrains Mono", monospace',
+              fontSize: '1.1rem',
+              fontWeight: 600,
+              display: 'flex',
+              alignItems: 'center',
+              gap: 1.5,
+              '&::before': {
+                content: '""',
+                width: '4px',
+                height: '20px',
+                backgroundColor: color,
+                borderRadius: '2px',
+              },
+            }}
+          >
+            Repositories in {tier} Tier
+          </Typography>
+          <MinerRepositoriesTable githubId={githubId} tierFilter={tier} />
+
+          <Typography
+            variant="h6"
+            sx={{
+              color: '#ffffff',
+              fontFamily: '"JetBrains Mono", monospace',
+              fontSize: '1.1rem',
+              fontWeight: 600,
+              display: 'flex',
+              alignItems: 'center',
+              gap: 1.5,
+              '&::before': {
+                content: '""',
+                width: '4px',
+                height: '20px',
+                backgroundColor: color,
+                borderRadius: '2px',
+              },
+            }}
+          >
+            Pull Requests in {tier} Tier
+          </Typography>
+          <MinerPRsTable githubId={githubId} tierFilter={tier} />
+        </Box>
+      </Box>
+    </Page>
+  );
+};
+
+interface TierSummaryCardProps {
+  githubId: string;
+  tier: string;
+  color: string;
+  bgColor: string;
+  borderColor: string;
+}
+
+const TierSummaryCard: React.FC<TierSummaryCardProps> = ({
+  githubId,
+  tier,
+  color,
+  bgColor,
+  borderColor,
+}) => {
+  const { data: minerStats, isLoading } = useMinerStats(githubId);
+
+  const tierKey = tier.toLowerCase() as 'bronze' | 'silver' | 'gold';
+  const score =
+    tierKey === 'bronze'
+      ? minerStats?.bronzeScore
+      : tierKey === 'silver'
+        ? minerStats?.silverScore
+        : minerStats?.goldScore;
+  const credibility =
+    tierKey === 'bronze'
+      ? minerStats?.bronzeCredibility
+      : tierKey === 'silver'
+        ? minerStats?.silverCredibility
+        : minerStats?.goldCredibility;
+  const merged =
+    tierKey === 'bronze'
+      ? minerStats?.bronzeMergedPrs
+      : tierKey === 'silver'
+        ? minerStats?.silverMergedPrs
+        : minerStats?.goldMergedPrs;
+  const closed =
+    tierKey === 'bronze'
+      ? minerStats?.bronzeClosedPrs
+      : tierKey === 'silver'
+        ? minerStats?.silverClosedPrs
+        : minerStats?.goldClosedPrs;
+  const total =
+    tierKey === 'bronze'
+      ? minerStats?.bronzeTotalPrs
+      : tierKey === 'silver'
+        ? minerStats?.silverTotalPrs
+        : minerStats?.goldTotalPrs;
+  const opened = (total ?? 0) - (merged ?? 0) - (closed ?? 0);
+  const uniqueRepos =
+    tierKey === 'bronze'
+      ? minerStats?.bronzeUniqueRepos
+      : tierKey === 'silver'
+        ? minerStats?.silverUniqueRepos
+        : minerStats?.goldUniqueRepos;
+
+  if (isLoading) {
+    return null;
+  }
+
+  return (
+    <Card
+      sx={{
+        borderRadius: 3,
+        border: `1px solid ${borderColor}`,
+        backgroundColor: bgColor,
+        p: 3,
+        elevation: 0,
+      }}
+      elevation={0}
+    >
+      <Typography
+        sx={{
+          color,
+          fontFamily: '"JetBrains Mono", monospace',
+          fontSize: '1rem',
+          fontWeight: 700,
+          textTransform: 'uppercase',
+          letterSpacing: '1px',
+          mb: 2,
+          pb: 1.5,
+          borderBottom: `1px solid ${borderColor}`,
+        }}
+      >
+        {tier} Tier Summary
+      </Typography>
+      <Stack direction="row" flexWrap="wrap" gap={3} useFlexGap>
+        <Box>
+          <Typography
+            sx={{
+              color: 'rgba(255, 255, 255, 0.5)',
+              fontSize: '0.7rem',
+              fontFamily: '"JetBrains Mono", monospace',
+              textTransform: 'uppercase',
+            }}
+          >
+            Score
+          </Typography>
+          <Typography
+            sx={{
+              color: '#ffffff',
+              fontSize: '1.1rem',
+              fontFamily: '"JetBrains Mono", monospace',
+              fontWeight: 600,
+            }}
+          >
+            {score != null ? Number(score).toFixed(4) : '0.0000'}
+          </Typography>
+        </Box>
+        <Box>
+          <Typography
+            sx={{
+              color: 'rgba(255, 255, 255, 0.5)',
+              fontSize: '0.7rem',
+              fontFamily: '"JetBrains Mono", monospace',
+              textTransform: 'uppercase',
+            }}
+          >
+            Credibility
+          </Typography>
+          <Typography
+            sx={{
+              color: '#ffffff',
+              fontSize: '1.1rem',
+              fontFamily: '"JetBrains Mono", monospace',
+              fontWeight: 600,
+            }}
+          >
+            {credibility != null
+              ? `${(Number(credibility) * 100).toFixed(1)}%`
+              : 'N/A'}
+          </Typography>
+        </Box>
+        <Box>
+          <Typography
+            sx={{
+              color: 'rgba(255, 255, 255, 0.5)',
+              fontSize: '0.7rem',
+              fontFamily: '"JetBrains Mono", monospace',
+              textTransform: 'uppercase',
+            }}
+          >
+            PRs Merged
+          </Typography>
+          <Typography
+            sx={{
+              color: '#ffffff',
+              fontSize: '1.1rem',
+              fontFamily: '"JetBrains Mono", monospace',
+              fontWeight: 600,
+            }}
+          >
+            {merged ?? 0}
+          </Typography>
+        </Box>
+        <Box>
+          <Typography
+            sx={{
+              color: 'rgba(255, 255, 255, 0.5)',
+              fontSize: '0.7rem',
+              fontFamily: '"JetBrains Mono", monospace',
+              textTransform: 'uppercase',
+            }}
+          >
+            PRs Open
+          </Typography>
+          <Typography
+            sx={{
+              color: '#ffffff',
+              fontSize: '1.1rem',
+              fontFamily: '"JetBrains Mono", monospace',
+              fontWeight: 600,
+            }}
+          >
+            {opened}
+          </Typography>
+        </Box>
+        <Box>
+          <Typography
+            sx={{
+              color: 'rgba(255, 255, 255, 0.5)',
+              fontSize: '0.7rem',
+              fontFamily: '"JetBrains Mono", monospace',
+              textTransform: 'uppercase',
+            }}
+          >
+            PRs Closed
+          </Typography>
+          <Typography
+            sx={{
+              color: '#ffffff',
+              fontSize: '1.1rem',
+              fontFamily: '"JetBrains Mono", monospace',
+              fontWeight: 600,
+            }}
+          >
+            {closed ?? 0}
+          </Typography>
+        </Box>
+        <Box>
+          <Typography
+            sx={{
+              color: 'rgba(255, 255, 255, 0.5)',
+              fontSize: '0.7rem',
+              fontFamily: '"JetBrains Mono", monospace',
+              textTransform: 'uppercase',
+            }}
+          >
+            Unique Repos
+          </Typography>
+          <Typography
+            sx={{
+              color: '#ffffff',
+              fontSize: '1.1rem',
+              fontFamily: '"JetBrains Mono", monospace',
+              fontWeight: 600,
+            }}
+          >
+            {uniqueRepos ?? 0}
+          </Typography>
+        </Box>
+      </Stack>
+    </Card>
+  );
+};
+
+export default TierDetailsPage;

--- a/src/pages/TierDetailsPage.tsx
+++ b/src/pages/TierDetailsPage.tsx
@@ -13,6 +13,22 @@ import { TIER_COLORS } from '../theme';
 
 const VALID_TIERS = ['Bronze', 'Silver', 'Gold'];
 
+interface TierStatItemProps {
+  label: string;
+  value: React.ReactNode;
+}
+
+const TierStatItem: React.FC<TierStatItemProps> = ({ label, value }) => (
+  <Stack direction="column" gap={0.5} sx={{ minWidth: '4.5rem' }}>
+    <Typography variant="statLabel" component="span">
+      {label}
+    </Typography>
+    <Typography variant="statValue" component="span">
+      {value}
+    </Typography>
+  </Stack>
+);
+
 const TierDetailsPage: React.FC = () => {
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
@@ -220,56 +236,22 @@ const TierSummaryCard: React.FC<TierSummaryCardProps> = ({
           },
         }}
       >
-        <Stack direction="column" gap={0.5} sx={{ minWidth: '4.5rem' }}>
-          <Typography variant="statLabel" component="span">
-            Score
-          </Typography>
-          <Typography variant="statValue" component="span">
-            {score != null ? Number(score).toFixed(4) : '0.0000'}
-          </Typography>
-        </Stack>
-        <Stack direction="column" gap={0.5} sx={{ minWidth: '4.5rem' }}>
-          <Typography variant="statLabel" component="span">
-            Credibility
-          </Typography>
-          <Typography variant="statValue" component="span">
-            {credibility != null
+        <TierStatItem
+          label="Score"
+          value={score != null ? Number(score).toFixed(4) : '0.0000'}
+        />
+        <TierStatItem
+          label="Credibility"
+          value={
+            credibility != null
               ? `${(Number(credibility) * 100).toFixed(1)}%`
-              : 'N/A'}
-          </Typography>
-        </Stack>
-        <Stack direction="column" gap={0.5} sx={{ minWidth: '4.5rem' }}>
-          <Typography variant="statLabel" component="span">
-            PRs Merged
-          </Typography>
-          <Typography variant="statValue" component="span">
-            {merged ?? 0}
-          </Typography>
-        </Stack>
-        <Stack direction="column" gap={0.5} sx={{ minWidth: '4.5rem' }}>
-          <Typography variant="statLabel" component="span">
-            PRs Open
-          </Typography>
-          <Typography variant="statValue" component="span">
-            {opened}
-          </Typography>
-        </Stack>
-        <Stack direction="column" gap={0.5} sx={{ minWidth: '4.5rem' }}>
-          <Typography variant="statLabel" component="span">
-            PRs Closed
-          </Typography>
-          <Typography variant="statValue" component="span">
-            {closed ?? 0}
-          </Typography>
-        </Stack>
-        <Stack direction="column" gap={0.5} sx={{ minWidth: '4.5rem' }}>
-          <Typography variant="statLabel" component="span">
-            Unique Repos
-          </Typography>
-          <Typography variant="statValue" component="span">
-            {uniqueRepos ?? 0}
-          </Typography>
-        </Stack>
+              : 'N/A'
+          }
+        />
+        <TierStatItem label="PRs Merged" value={merged ?? 0} />
+        <TierStatItem label="PRs Open" value={opened} />
+        <TierStatItem label="PRs Closed" value={closed ?? 0} />
+        <TierStatItem label="Unique Repos" value={uniqueRepos ?? 0} />
       </Stack>
     </Card>
   );

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -13,6 +13,9 @@ export * from './NotFoundPage';
 export { default as MinerDetailsPage } from './MinerDetailsPage';
 export * from './MinerDetailsPage';
 
+export { default as TierDetailsPage } from './TierDetailsPage';
+export * from './TierDetailsPage';
+
 export { default as RepositoryDetailsPage } from './RepositoryDetailsPage';
 export * from './RepositoryDetailsPage';
 

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -16,6 +16,7 @@ const IssueDetailsPage = React.lazy(() => import('./pages/IssueDetailsPage'));
 const TopMinersPage = React.lazy(() => import('./pages/TopMinersPage'));
 const RepositoriesPage = React.lazy(() => import('./pages/RepositoriesPage'));
 const MinerDetailsPage = React.lazy(() => import('./pages/MinerDetailsPage'));
+const TierDetailsPage = React.lazy(() => import('./pages/TierDetailsPage'));
 const RepositoryDetailsPage = React.lazy(
   () => import('./pages/RepositoryDetailsPage'),
 );
@@ -44,6 +45,11 @@ const routesArray: AppRoute[] = [
     name: 'miner-details',
     path: '/miners/details',
     element: <MinerDetailsPage />,
+  },
+  {
+    name: 'tier-details',
+    path: '/miners/tier-details',
+    element: <TierDetailsPage />,
   },
   {
     name: 'repository-details',


### PR DESCRIPTION
## Summary

Adds a dedicated Tier detail page so users can see which repos and PRs (merged, open, closed) count toward each tier for a miner. Tier cards on the miner detail page are now clickable and navigate to this page.

## Motivation
On the miner detail page there was no way to see which repositories and pull requests belonged to each tier (Bronze, Silver, Gold). This made it hard to understand how tier stats were earned and to inspect tier-specific activity.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

<img width="2082" height="1220" alt="image" src="https://github.com/user-attachments/assets/83be2f56-38d3-423f-bf40-f3940223b142" />
<img width="2085" height="1226" alt="image" src="https://github.com/user-attachments/assets/58c83118-14d0-4a97-95c3-3066fada5135" />
<img width="1072" height="1076" alt="image" src="https://github.com/user-attachments/assets/9a84fc13-67af-49f0-b8ab-771005b60a3b" />
<img width="1069" height="1069" alt="image" src="https://github.com/user-attachments/assets/aee180c2-3339-43be-8812-d69152578f81" />

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
