### PR TITLE
adjust format.yml for external PRs

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.head_ref || '' }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node.js
@@ -27,10 +27,10 @@ jobs:
         run: npm ci
 
       - name: Run Prettier
-        run: npx prettier --write "src/**/*.{ts,tsx,js,jsx,json,css,scss,md}"
+        run: npm run format
 
       - name: Run ESLint Fix
-        run: npx eslint --fix "src/**/*.{ts,tsx}"
+        run: npm run lint:fix
 
       - name: Check for changes
         id: changes
@@ -41,8 +41,9 @@ jobs:
             echo "has_changes=false" >> $GITHUB_OUTPUT
           fi
 
+      # Auto-commit for internal PRs
       - name: Commit formatting changes
-        if: steps.changes.outputs.has_changes == 'true'
+        if: steps.changes.outputs.has_changes == 'true' && github.event.pull_request.head.repo.full_name == github.repository
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
@@ -51,3 +52,12 @@ jobs:
 
           🤖 Automated formatting by GitHub Actions"
           git push
+
+      # Fail for fork PRs so contributors know to run formatting locally
+      - name: Require formatted code (fork PRs)
+        if: steps.changes.outputs.has_changes == 'true' && github.event.pull_request.head.repo.full_name != github.repository
+        run: |
+          echo "::error::Code is not formatted. Please run these commands locally and push:"
+          echo "  npm run format"
+          echo "  npm run lint:fix"
+          exit 1


### PR DESCRIPTION
## Summary

- external contributors would always fail our `format` CI pipeline because it's not configured for forked branches. this PR adjusts that so it can edit only if it's an internal PR, and fail if it's an unformatted external PR.
- change npx commands to the `package.json` defined commands

## Related Issues

n/a

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Checklist

n/a