### PR TITLE
feat: Redesign miner detail page

### DIFF
--- a/src/components/miners/MinerActivity.tsx
+++ b/src/components/miners/MinerActivity.tsx
@@ -155,8 +155,10 @@ const MinerActivity: React.FC<MinerActivityProps> = ({ githubId }) => {
           borderBottom: '1px solid rgba(255, 255, 255, 0.1)',
           backgroundColor: 'rgba(255, 255, 255, 0.02)',
           display: 'flex',
+          flexDirection: { xs: 'column', sm: 'row' },
           justifyContent: 'space-between',
-          alignItems: 'center',
+          alignItems: { xs: 'flex-start', sm: 'center' },
+          gap: { xs: 1.5, sm: 0 },
         }}
       >
         <Typography variant="sectionTitle">Developer Activity</Typography>

--- a/src/components/miners/MinerDashboardHero.tsx
+++ b/src/components/miners/MinerDashboardHero.tsx
@@ -71,13 +71,9 @@ const MinerDashboardHero: React.FC<MinerDashboardHeroProps> = ({
   const { data: githubData } = useMinerGithubData(githubId);
   const { data: generalConfig } = useGeneralConfig();
 
-  const username =
-    githubData?.login || prs?.[0]?.author || githubId;
+  const username = githubData?.login || prs?.[0]?.author || githubId;
   const openPrThreshold = minerStats
-    ? calculateDynamicThreshold(
-        minerStats,
-        generalConfig?.repositoryPrScoring,
-      )
+    ? calculateDynamicThreshold(minerStats, generalConfig?.repositoryPrScoring)
     : 10;
   const openPrs = Number(minerStats?.totalOpenPrs || 0);
   const openRiskColor =
@@ -323,7 +319,9 @@ const MinerDashboardHero: React.FC<MinerDashboardHeroProps> = ({
             label="Est. daily"
             value={`$${Math.round(minerStats.usdPerDay ?? 0).toLocaleString()}`}
             valueColor={
-              (minerStats.usdPerDay ?? 0) > 0 ? STATUS_COLORS.success : undefined
+              (minerStats.usdPerDay ?? 0) > 0
+                ? STATUS_COLORS.success
+                : undefined
             }
           />
         </Box>

--- a/src/components/miners/MinerDashboardHero.tsx
+++ b/src/components/miners/MinerDashboardHero.tsx
@@ -10,6 +10,9 @@ import {
 } from '@mui/material';
 import GitHubIcon from '@mui/icons-material/GitHub';
 import UpdateIcon from '@mui/icons-material/Update';
+import LocationOnIcon from '@mui/icons-material/LocationOn';
+import WorkOutlineIcon from '@mui/icons-material/WorkOutline';
+import PeopleIcon from '@mui/icons-material/People';
 import {
   useMinerStats,
   useMinerPRs,
@@ -258,6 +261,67 @@ const MinerDashboardHero: React.FC<MinerDashboardHeroProps> = ({
             Hotkey: {minerStats.hotkey}
           </Typography>
         )}
+
+        {githubData &&
+          (githubData.location ||
+            githubData.hireable ||
+            githubData.followers != null) && (
+            <Box
+              sx={{
+                display: 'flex',
+                flexWrap: 'wrap',
+                gap: 1,
+                alignItems: 'center',
+                width: '100%',
+              }}
+            >
+              {githubData.location && (
+                <Chip
+                  size="small"
+                  icon={<LocationOnIcon sx={{ fontSize: '0.9rem' }} />}
+                  label={githubData.location}
+                  variant="outlined"
+                  sx={{
+                    fontFamily: '"JetBrains Mono", monospace',
+                    fontSize: '0.7rem',
+                    color: 'rgba(255,255,255,0.7)',
+                    borderColor: 'rgba(255,255,255,0.2)',
+                    '& .MuiChip-icon': { color: 'rgba(255,255,255,0.5)' },
+                  }}
+                />
+              )}
+              {githubData.hireable && (
+                <Chip
+                  size="small"
+                  icon={<WorkOutlineIcon sx={{ fontSize: '0.9rem' }} />}
+                  label="Open to Work"
+                  variant="outlined"
+                  sx={{
+                    fontFamily: '"JetBrains Mono", monospace',
+                    fontSize: '0.7rem',
+                    color: STATUS_COLORS.success,
+                    borderColor: alpha(STATUS_COLORS.success, 0.4),
+                    '& .MuiChip-icon': { color: STATUS_COLORS.success },
+                  }}
+                />
+              )}
+              {githubData.followers != null && (
+                <Chip
+                  size="small"
+                  icon={<PeopleIcon sx={{ fontSize: '0.9rem' }} />}
+                  label={`${githubData.followers} followers`}
+                  variant="outlined"
+                  sx={{
+                    fontFamily: '"JetBrains Mono", monospace',
+                    fontSize: '0.7rem',
+                    color: 'rgba(255,255,255,0.7)',
+                    borderColor: 'rgba(255,255,255,0.2)',
+                    '& .MuiChip-icon': { color: 'rgba(255,255,255,0.5)' },
+                  }}
+                />
+              )}
+            </Box>
+          )}
 
         <Box
           sx={{

--- a/src/components/miners/MinerDashboardHero.tsx
+++ b/src/components/miners/MinerDashboardHero.tsx
@@ -1,0 +1,373 @@
+import React from 'react';
+import {
+  Box,
+  Typography,
+  Avatar,
+  Chip,
+  alpha,
+  CircularProgress,
+  Tooltip,
+} from '@mui/material';
+import GitHubIcon from '@mui/icons-material/GitHub';
+import UpdateIcon from '@mui/icons-material/Update';
+import {
+  useMinerStats,
+  useMinerPRs,
+  useMinerGithubData,
+  useGeneralConfig,
+  type MinerEvaluation,
+  type RepositoryPrScoring,
+} from '../../api';
+import { TIER_COLORS, STATUS_COLORS } from '../../theme';
+
+const TIER_LEVELS: Record<string, number> = {
+  bronze: 1,
+  silver: 2,
+  gold: 3,
+};
+
+const calculateDynamicThreshold = (
+  minerStats: MinerEvaluation,
+  prScoring: RepositoryPrScoring | undefined,
+): number => {
+  const baseThreshold = prScoring?.excessivePrPenaltyThreshold ?? 10;
+  const tokenScorePer = prScoring?.openPrThresholdTokenScore ?? 500;
+  const maxThreshold = prScoring?.maxOpenPrThreshold ?? 30;
+  const currentTierLevel =
+    TIER_LEVELS[(minerStats.currentTier || '').toLowerCase()] || 0;
+  let unlockedTokenScore = 0;
+  if (currentTierLevel >= 1)
+    unlockedTokenScore += Number(minerStats.bronzeTokenScore || 0);
+  if (currentTierLevel >= 2)
+    unlockedTokenScore += Number(minerStats.silverTokenScore || 0);
+  if (currentTierLevel >= 3)
+    unlockedTokenScore += Number(minerStats.goldTokenScore || 0);
+  const bonus = Math.floor(unlockedTokenScore / tokenScorePer);
+  return Math.min(baseThreshold + bonus, maxThreshold);
+};
+
+const formatTimeAgo = (date: Date): string => {
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffMins = Math.floor(diffMs / (1000 * 60));
+  const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+  if (diffMins < 1) return 'just now';
+  if (diffMins < 60) return `${diffMins}m ago`;
+  if (diffHours < 24) return `${diffHours}h ago`;
+  if (diffDays === 1) return '1 day ago';
+  return `${diffDays}d ago`;
+};
+
+interface MinerDashboardHeroProps {
+  githubId: string;
+}
+
+const MinerDashboardHero: React.FC<MinerDashboardHeroProps> = ({
+  githubId,
+}) => {
+  const { data: minerStats, isLoading, error } = useMinerStats(githubId);
+  const { data: prs } = useMinerPRs(githubId);
+  const { data: githubData } = useMinerGithubData(githubId);
+  const { data: generalConfig } = useGeneralConfig();
+
+  const username =
+    githubData?.login || prs?.[0]?.author || githubId;
+  const openPrThreshold = minerStats
+    ? calculateDynamicThreshold(
+        minerStats,
+        generalConfig?.repositoryPrScoring,
+      )
+    : 10;
+  const openPrs = Number(minerStats?.totalOpenPrs || 0);
+  const openRiskColor =
+    openPrs >= openPrThreshold
+      ? STATUS_COLORS.error
+      : openPrs >= openPrThreshold - 2
+        ? '#f59e0b'
+        : undefined;
+
+  if (isLoading) {
+    return (
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          minHeight: 120,
+          border: '1px solid rgba(255,255,255,0.1)',
+          borderRadius: 3,
+        }}
+      >
+        <CircularProgress size={36} sx={{ color: 'primary.main' }} />
+      </Box>
+    );
+  }
+
+  if (error || !minerStats) {
+    return (
+      <Box
+        sx={{
+          p: 3,
+          border: '1px solid rgba(255,255,255,0.1)',
+          borderRadius: 3,
+          color: alpha(STATUS_COLORS.error, 0.9),
+          fontFamily: '"JetBrains Mono", monospace',
+          fontSize: '0.9rem',
+        }}
+      >
+        No data found for GitHub user: {githubId}
+      </Box>
+    );
+  }
+
+  const tierColor =
+    minerStats.currentTier === 'Gold'
+      ? TIER_COLORS.gold
+      : minerStats.currentTier === 'Silver'
+        ? TIER_COLORS.silver
+        : minerStats.currentTier === 'Bronze'
+          ? TIER_COLORS.bronze
+          : 'rgba(255,255,255,0.4)';
+
+  return (
+    <Box
+      sx={{
+        borderRadius: 3,
+        border: '1px solid rgba(255, 255, 255, 0.1)',
+        backgroundColor: 'rgba(255, 255, 255, 0.02)',
+        p: { xs: 2, sm: 3 },
+        position: 'relative',
+        display: 'flex',
+        flexDirection: 'column',
+      }}
+    >
+      {minerStats.updatedAt && (
+        <Chip
+          icon={<UpdateIcon sx={{ fontSize: '0.8rem' }} />}
+          label={`Updated ${formatTimeAgo(new Date(minerStats.updatedAt))}`}
+          size="small"
+          sx={{
+            position: { xs: 'static', sm: 'absolute' },
+            top: { sm: 12 },
+            right: { sm: 12 },
+            alignSelf: { xs: 'flex-start', sm: 'auto' },
+            order: { xs: 2, sm: 'unset' },
+            mt: { xs: 1, sm: 0 },
+            fontFamily: '"JetBrains Mono", monospace',
+            fontSize: '0.65rem',
+            color: 'rgba(255, 255, 255, 0.5)',
+            border: '1px solid rgba(255, 255, 255, 0.1)',
+            backgroundColor: 'rgba(0,0,0,0.3)',
+            '& .MuiChip-icon': { color: 'rgba(255, 255, 255, 0.4)' },
+          }}
+        />
+      )}
+
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: { xs: 'column', sm: 'row' },
+          alignItems: { xs: 'flex-start', sm: 'center' },
+          gap: { xs: 2, sm: 3 },
+          flexWrap: 'wrap',
+          order: { xs: 1, sm: 'unset' },
+        }}
+      >
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+          <Avatar
+            src={`https://avatars.githubusercontent.com/${username}`}
+            alt={username}
+            sx={{
+              width: 56,
+              height: 56,
+              border: `2px solid ${alpha(tierColor, 0.5)}`,
+            }}
+          />
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                flexWrap: 'wrap',
+                gap: 1,
+                alignSelf: 'flex-start',
+              }}
+            >
+              <Typography
+                sx={{
+                  color: '#fff',
+                  fontFamily: '"JetBrains Mono", monospace',
+                  fontWeight: 700,
+                  fontSize: '1.15rem',
+                }}
+              >
+                {githubData?.name || username}
+              </Typography>
+              <Box
+                sx={{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  px: 1.25,
+                  py: 0.25,
+                  borderRadius: 1,
+                  border: `1px solid ${alpha(tierColor, 0.4)}`,
+                  backgroundColor: alpha(tierColor, 0.08),
+                }}
+              >
+                <Typography
+                  sx={{
+                    fontFamily: '"JetBrains Mono", monospace',
+                    fontSize: '0.7rem',
+                    fontWeight: 600,
+                    color: tierColor,
+                    textTransform: 'uppercase',
+                    letterSpacing: '0.5px',
+                  }}
+                >
+                  {minerStats.currentTier || 'Unranked'} Tier
+                </Typography>
+              </Box>
+            </Box>
+            <Typography
+              component="a"
+              href={`https://github.com/${username}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              sx={{
+                color: 'primary.main',
+                fontFamily: '"JetBrains Mono", monospace',
+                fontSize: '0.9rem',
+                textDecoration: 'none',
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: 0.5,
+                '&:hover': { textDecoration: 'underline' },
+              }}
+            >
+              <GitHubIcon sx={{ fontSize: '1rem' }} /> @{username}
+            </Typography>
+          </Box>
+        </Box>
+
+        {minerStats.hotkey && (
+          <Typography
+            sx={{
+              width: '100%',
+              color: 'rgba(255,255,255,0.4)',
+              fontFamily: '"JetBrains Mono", monospace',
+              fontSize: '0.7rem',
+            }}
+          >
+            Hotkey: {minerStats.hotkey}
+          </Typography>
+        )}
+
+        <Box
+          sx={{
+            display: 'flex',
+            flexWrap: 'wrap',
+            gap: { xs: 1.5, sm: 2 },
+            alignItems: 'center',
+          }}
+        >
+          <StatPill
+            label="Score"
+            value={Number(minerStats.totalScore).toFixed(2)}
+          />
+          <Tooltip
+            title="Merged PRs ÷ total attempts. Higher credibility increases your score multiplier."
+            arrow
+            slotProps={{
+              tooltip: {
+                sx: {
+                  fontFamily: '"JetBrains Mono", monospace',
+                  fontSize: '0.75rem',
+                },
+              },
+            }}
+          >
+            <Box>
+              <StatPill
+                label="Credibility"
+                value={`${(Number(minerStats.credibility || 0) * 100).toFixed(0)}%`}
+                valueColor={
+                  (minerStats.credibility || 0) >= 0.7
+                    ? STATUS_COLORS.success
+                    : undefined
+                }
+              />
+            </Box>
+          </Tooltip>
+          <Tooltip
+            title={`Threshold: ${openPrThreshold} open PRs. Exceeding this reduces your score.`}
+            arrow
+            slotProps={{
+              tooltip: {
+                sx: {
+                  fontFamily: '"JetBrains Mono", monospace',
+                  fontSize: '0.75rem',
+                },
+              },
+            }}
+          >
+            <Box>
+              <StatPill
+                label="Open PRs"
+                value={`${openPrs} / ${openPrThreshold}`}
+                valueColor={openRiskColor}
+              />
+            </Box>
+          </Tooltip>
+          <StatPill
+            label="Est. daily"
+            value={`$${Math.round(minerStats.usdPerDay ?? 0).toLocaleString()}`}
+            valueColor={
+              (minerStats.usdPerDay ?? 0) > 0 ? STATUS_COLORS.success : undefined
+            }
+          />
+        </Box>
+      </Box>
+    </Box>
+  );
+};
+
+const StatPill: React.FC<{
+  label: string;
+  value: string;
+  valueColor?: string;
+}> = ({ label, value, valueColor }) => (
+  <Box
+    sx={{
+      px: 1.5,
+      py: 1,
+      borderRadius: 2,
+      backgroundColor: 'rgba(255,255,255,0.05)',
+      border: '1px solid rgba(255,255,255,0.08)',
+    }}
+  >
+    <Typography
+      sx={{
+        color: 'rgba(255,255,255,0.5)',
+        fontFamily: '"JetBrains Mono", monospace',
+        fontSize: '0.65rem',
+        textTransform: 'uppercase',
+        letterSpacing: '0.5px',
+      }}
+    >
+      {label}
+    </Typography>
+    <Typography
+      sx={{
+        color: valueColor || '#fff',
+        fontFamily: '"JetBrains Mono", monospace',
+        fontSize: '1rem',
+        fontWeight: 600,
+      }}
+    >
+      {value}
+    </Typography>
+  </Box>
+);
+
+export default MinerDashboardHero;

--- a/src/components/miners/MinerPRsTable.tsx
+++ b/src/components/miners/MinerPRsTable.tsx
@@ -23,7 +23,6 @@ import SearchIcon from '@mui/icons-material/Search';
 import { useMinerPRs } from '../../api';
 import { useNavigate } from 'react-router-dom';
 import theme from '../../theme';
-import type { CommitLog } from '../../api';
 
 interface MinerPRsTableProps {
   githubId: string;
@@ -59,22 +58,22 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({
     setPage(0);
   }, [searchQuery, selectedRepo, selectedAuthor, statusFilter]);
 
-  const matchesSearch = (pr: CommitLog) => {
-    if (!searchQuery) return true;
-    const title = (pr.pullRequestTitle || '').toLowerCase();
-    const repo = (pr.repository || '').toLowerCase();
-    const num = String(pr.pullRequestNumber);
-    return (
-      title.includes(searchQuery) ||
-      repo.includes(searchQuery) ||
-      num.includes(searchQuery)
-    );
-  };
-
   // Filter PRs by selected repository, author, status, and search
   const filteredPRs = useMemo(() => {
     if (!prs) return [];
-    let filtered = prs.filter(matchesSearch);
+    let filtered = prs;
+    if (searchQuery) {
+      filtered = filtered.filter((pr) => {
+        const title = (pr.pullRequestTitle || '').toLowerCase();
+        const repo = (pr.repository || '').toLowerCase();
+        const num = String(pr.pullRequestNumber);
+        return (
+          title.includes(searchQuery) ||
+          repo.includes(searchQuery) ||
+          num.includes(searchQuery)
+        );
+      });
+    }
     if (selectedRepo) {
       filtered = filtered.filter((pr) => pr.repository === selectedRepo);
     }
@@ -117,7 +116,9 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({
           break;
         }
         case 'title':
-          cmp = (a.pullRequestTitle || '').localeCompare(b.pullRequestTitle || '');
+          cmp = (a.pullRequestTitle || '').localeCompare(
+            b.pullRequestTitle || '',
+          );
           break;
         case 'repo':
           cmp = (a.repository || '').localeCompare(b.repository || '');
@@ -248,7 +249,12 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({
                 InputProps={{
                   startAdornment: (
                     <InputAdornment position="start">
-                      <SearchIcon sx={{ color: 'rgba(255,255,255,0.4)', fontSize: '1.1rem' }} />
+                      <SearchIcon
+                        sx={{
+                          color: 'rgba(255,255,255,0.4)',
+                          fontSize: '1.1rem',
+                        }}
+                      />
                     </InputAdornment>
                   ),
                   sx: {
@@ -371,7 +377,9 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({
           >
             <TableHead>
               <TableRow>
-                <TableCell sx={{ ...headerCellStyle, width: '10%' }}>PR #</TableCell>
+                <TableCell sx={{ ...headerCellStyle, width: '10%' }}>
+                  PR #
+                </TableCell>
                 <TableCell sx={{ ...headerCellStyle, width: '28%' }}>
                   <TableSortLabel
                     active={sortField === 'title'}
@@ -384,7 +392,10 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({
                           : 'asc',
                       );
                     }}
-                    sx={{ color: 'inherit', '&.Mui-active': { color: 'rgba(255,255,255,0.9)' } }}
+                    sx={{
+                      color: 'inherit',
+                      '&.Mui-active': { color: 'rgba(255,255,255,0.9)' },
+                    }}
                   >
                     Title
                   </TableSortLabel>
@@ -407,7 +418,10 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({
                           : 'asc',
                       );
                     }}
-                    sx={{ color: 'inherit', '&.Mui-active': { color: 'rgba(255,255,255,0.9)' } }}
+                    sx={{
+                      color: 'inherit',
+                      '&.Mui-active': { color: 'rgba(255,255,255,0.9)' },
+                    }}
                   >
                     Repository
                   </TableSortLabel>
@@ -431,12 +445,18 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({
                           : 'desc',
                       );
                     }}
-                    sx={{ color: 'inherit', '&.Mui-active': { color: 'rgba(255,255,255,0.9)' } }}
+                    sx={{
+                      color: 'inherit',
+                      '&.Mui-active': { color: 'rgba(255,255,255,0.9)' },
+                    }}
                   >
                     +/-
                   </TableSortLabel>
                 </TableCell>
-                <TableCell align="right" sx={{ ...headerCellStyle, width: '10%' }}>
+                <TableCell
+                  align="right"
+                  sx={{ ...headerCellStyle, width: '10%' }}
+                >
                   <TableSortLabel
                     active={sortField === 'score'}
                     direction={sortField === 'score' ? sortOrder : 'desc'}
@@ -448,7 +468,10 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({
                           : 'desc',
                       );
                     }}
-                    sx={{ color: 'inherit', '&.Mui-active': { color: 'rgba(255,255,255,0.9)' } }}
+                    sx={{
+                      color: 'inherit',
+                      '&.Mui-active': { color: 'rgba(255,255,255,0.9)' },
+                    }}
                   >
                     Score
                   </TableSortLabel>
@@ -471,7 +494,10 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({
                           : 'desc',
                       );
                     }}
-                    sx={{ color: 'inherit', '&.Mui-active': { color: 'rgba(255,255,255,0.9)' } }}
+                    sx={{
+                      color: 'inherit',
+                      '&.Mui-active': { color: 'rgba(255,255,255,0.9)' },
+                    }}
                   >
                     Merged
                   </TableSortLabel>
@@ -719,8 +745,8 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({
                       : pr.prState === 'CLOSED'
                         ? 'Closed'
                         : 'Open'}
-                </TableCell>
-              </TableRow>
+                  </TableCell>
+                </TableRow>
               ))}
             </TableBody>
           </Table>
@@ -741,8 +767,12 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({
                 color: 'rgba(255,255,255,0.7)',
                 fontFamily: '"JetBrains Mono", monospace',
                 fontSize: '0.8rem',
-                '& .MuiTablePagination-selectIcon': { color: 'rgba(255,255,255,0.7)' },
-                '& .MuiTablePagination-actions button': { color: 'rgba(255,255,255,0.7)' },
+                '& .MuiTablePagination-selectIcon': {
+                  color: 'rgba(255,255,255,0.7)',
+                },
+                '& .MuiTablePagination-actions button': {
+                  color: 'rgba(255,255,255,0.7)',
+                },
               }}
             />
           )}

--- a/src/components/miners/MinerPRsTable.tsx
+++ b/src/components/miners/MinerPRsTable.tsx
@@ -9,20 +9,36 @@ import {
   TableContainer,
   TableHead,
   TableRow,
+  TablePagination,
   CircularProgress,
   Avatar,
   Chip,
   Button,
+  TextField,
+  InputAdornment,
+  TableSortLabel,
+  Tooltip,
 } from '@mui/material';
+import SearchIcon from '@mui/icons-material/Search';
 import { useMinerPRs } from '../../api';
 import { useNavigate } from 'react-router-dom';
 import theme from '../../theme';
+import type { CommitLog } from '../../api';
 
 interface MinerPRsTableProps {
   githubId: string;
+  search?: string;
+  onSearchChange?: (value: string) => void;
 }
 
-const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
+type SortField = 'score' | 'merged' | 'changes' | 'title' | 'repo';
+type SortOrder = 'asc' | 'desc';
+
+const MinerPRsTable: React.FC<MinerPRsTableProps> = ({
+  githubId,
+  search: externalSearch,
+  onSearchChange,
+}) => {
   const navigate = useNavigate();
   const { data: prs, isLoading } = useMinerPRs(githubId);
   const [selectedRepo, setSelectedRepo] = useState<string | null>(null);
@@ -30,11 +46,35 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
   const [statusFilter, setStatusFilter] = useState<
     'all' | 'open' | 'merged' | 'closed'
   >('all');
+  const [internalSearch, setInternalSearch] = useState('');
+  const [sortField, setSortField] = useState<SortField>('score');
+  const [sortOrder, setSortOrder] = useState<SortOrder>('desc');
+  const [page, setPage] = useState(0);
+  const [rowsPerPage, setRowsPerPage] = useState(25);
 
-  // Filter PRs by selected repository, author, and status
+  const searchQuery = (externalSearch ?? internalSearch).trim().toLowerCase();
+
+  // Reset to first page when filters change
+  React.useEffect(() => {
+    setPage(0);
+  }, [searchQuery, selectedRepo, selectedAuthor, statusFilter]);
+
+  const matchesSearch = (pr: CommitLog) => {
+    if (!searchQuery) return true;
+    const title = (pr.pullRequestTitle || '').toLowerCase();
+    const repo = (pr.repository || '').toLowerCase();
+    const num = String(pr.pullRequestNumber);
+    return (
+      title.includes(searchQuery) ||
+      repo.includes(searchQuery) ||
+      num.includes(searchQuery)
+    );
+  };
+
+  // Filter PRs by selected repository, author, status, and search
   const filteredPRs = useMemo(() => {
     if (!prs) return [];
-    let filtered = prs;
+    let filtered = prs.filter(matchesSearch);
     if (selectedRepo) {
       filtered = filtered.filter((pr) => pr.repository === selectedRepo);
     }
@@ -54,8 +94,54 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
         (pr) => pr.prState === 'CLOSED' && !pr.mergedAt,
       );
     }
+    const dir = sortOrder === 'asc' ? 1 : -1;
+    filtered = [...filtered].sort((a, b) => {
+      let cmp = 0;
+      switch (sortField) {
+        case 'score': {
+          const sa = parseFloat(a.score || '0');
+          const sb = parseFloat(b.score || '0');
+          cmp = sa - sb;
+          break;
+        }
+        case 'merged': {
+          const ta = a.mergedAt ? new Date(a.mergedAt).getTime() : 0;
+          const tb = b.mergedAt ? new Date(b.mergedAt).getTime() : 0;
+          cmp = ta - tb;
+          break;
+        }
+        case 'changes': {
+          const ca = (a.additions || 0) + (a.deletions || 0);
+          const cb = (b.additions || 0) + (b.deletions || 0);
+          cmp = ca - cb;
+          break;
+        }
+        case 'title':
+          cmp = (a.pullRequestTitle || '').localeCompare(b.pullRequestTitle || '');
+          break;
+        case 'repo':
+          cmp = (a.repository || '').localeCompare(b.repository || '');
+          break;
+        default:
+          break;
+      }
+      return cmp * dir;
+    });
     return filtered;
-  }, [prs, selectedRepo, selectedAuthor, statusFilter]);
+  }, [
+    prs,
+    selectedRepo,
+    selectedAuthor,
+    statusFilter,
+    searchQuery,
+    sortField,
+    sortOrder,
+  ]);
+
+  const paginatedPRs = useMemo(() => {
+    const start = page * rowsPerPage;
+    return filteredPRs.slice(start, start + rowsPerPage);
+  }, [filteredPRs, page, rowsPerPage]);
 
   const statusCounts = useMemo(() => {
     if (!prs) return { all: 0, open: 0, merged: 0, closed: 0 };
@@ -139,6 +225,9 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
               {selectedRepo || selectedAuthor || statusFilter !== 'all'
                 ? ` of ${prs?.length || 0}`
                 : ''}
+              {filteredPRs.length > rowsPerPage
+                ? ` · page ${page + 1} of ${Math.ceil(filteredPRs.length / rowsPerPage)}`
+                : ''}
               )
             </Typography>
           </Box>
@@ -150,6 +239,34 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
               alignItems: 'center',
             }}
           >
+            {!onSearchChange && (
+              <TextField
+                size="small"
+                placeholder="Search PRs by title, repo, or #..."
+                value={internalSearch}
+                onChange={(e) => setInternalSearch(e.target.value)}
+                InputProps={{
+                  startAdornment: (
+                    <InputAdornment position="start">
+                      <SearchIcon sx={{ color: 'rgba(255,255,255,0.4)', fontSize: '1.1rem' }} />
+                    </InputAdornment>
+                  ),
+                  sx: {
+                    fontFamily: '"JetBrains Mono", monospace',
+                    fontSize: '0.8rem',
+                    color: '#fff',
+                    '& .MuiOutlinedInput-notchedOutline': {
+                      borderColor: 'rgba(255,255,255,0.2)',
+                    },
+                    '&:hover .MuiOutlinedInput-notchedOutline': {
+                      borderColor: 'rgba(255,255,255,0.35)',
+                    },
+                    maxWidth: 260,
+                  },
+                }}
+                sx={{ minWidth: 200 }}
+              />
+            )}
             {selectedRepo && (
               <Chip
                 variant="filter"
@@ -230,7 +347,8 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
           sx={{
             maxHeight: { xs: '400px', sm: '500px' },
             overflowY: 'auto',
-            overflowX: { xs: 'hidden', sm: 'auto' },
+            overflowX: 'auto',
+            WebkitOverflowScrolling: 'touch',
             '&::-webkit-scrollbar': {
               width: { xs: '6px', sm: '8px' },
               height: { xs: '6px', sm: '8px' },
@@ -249,45 +367,119 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
         >
           <Table
             stickyHeader
-            sx={{ tableLayout: 'fixed', minWidth: { xs: '100%', sm: '800px' } }}
+            sx={{ tableLayout: 'fixed', minWidth: { xs: 600, sm: 800 } }}
           >
             <TableHead>
               <TableRow>
-                <TableCell sx={headerCellStyle}>PR #</TableCell>
-                <TableCell sx={headerCellStyle}>Title</TableCell>
+                <TableCell sx={{ ...headerCellStyle, width: '10%' }}>PR #</TableCell>
+                <TableCell sx={{ ...headerCellStyle, width: '28%' }}>
+                  <TableSortLabel
+                    active={sortField === 'title'}
+                    direction={sortField === 'title' ? sortOrder : 'asc'}
+                    onClick={() => {
+                      setSortField('title');
+                      setSortOrder(
+                        sortField === 'title' && sortOrder === 'asc'
+                          ? 'desc'
+                          : 'asc',
+                      );
+                    }}
+                    sx={{ color: 'inherit', '&.Mui-active': { color: 'rgba(255,255,255,0.9)' } }}
+                  >
+                    Title
+                  </TableSortLabel>
+                </TableCell>
                 <TableCell
                   sx={{
                     ...headerCellStyle,
+                    width: '22%',
                     display: { xs: 'none', sm: 'table-cell' },
                   }}
                 >
-                  Repository
+                  <TableSortLabel
+                    active={sortField === 'repo'}
+                    direction={sortField === 'repo' ? sortOrder : 'asc'}
+                    onClick={() => {
+                      setSortField('repo');
+                      setSortOrder(
+                        sortField === 'repo' && sortOrder === 'asc'
+                          ? 'desc'
+                          : 'asc',
+                      );
+                    }}
+                    sx={{ color: 'inherit', '&.Mui-active': { color: 'rgba(255,255,255,0.9)' } }}
+                  >
+                    Repository
+                  </TableSortLabel>
                 </TableCell>
                 <TableCell
                   align="right"
                   sx={{
                     ...headerCellStyle,
+                    width: '10%',
                     display: { xs: 'none', md: 'table-cell' },
                   }}
                 >
-                  +/-
+                  <TableSortLabel
+                    active={sortField === 'changes'}
+                    direction={sortField === 'changes' ? sortOrder : 'desc'}
+                    onClick={() => {
+                      setSortField('changes');
+                      setSortOrder(
+                        sortField === 'changes' && sortOrder === 'desc'
+                          ? 'asc'
+                          : 'desc',
+                      );
+                    }}
+                    sx={{ color: 'inherit', '&.Mui-active': { color: 'rgba(255,255,255,0.9)' } }}
+                  >
+                    +/-
+                  </TableSortLabel>
                 </TableCell>
-                <TableCell align="right" sx={headerCellStyle}>
-                  Score
+                <TableCell align="right" sx={{ ...headerCellStyle, width: '10%' }}>
+                  <TableSortLabel
+                    active={sortField === 'score'}
+                    direction={sortField === 'score' ? sortOrder : 'desc'}
+                    onClick={() => {
+                      setSortField('score');
+                      setSortOrder(
+                        sortField === 'score' && sortOrder === 'desc'
+                          ? 'asc'
+                          : 'desc',
+                      );
+                    }}
+                    sx={{ color: 'inherit', '&.Mui-active': { color: 'rgba(255,255,255,0.9)' } }}
+                  >
+                    Score
+                  </TableSortLabel>
                 </TableCell>
                 <TableCell
                   align="right"
                   sx={{
                     ...headerCellStyle,
-                    display: { xs: 'none', sm: 'table-cell' },
+                    width: '10%',
                   }}
                 >
-                  Merged
+                  <TableSortLabel
+                    active={sortField === 'merged'}
+                    direction={sortField === 'merged' ? sortOrder : 'desc'}
+                    onClick={() => {
+                      setSortField('merged');
+                      setSortOrder(
+                        sortField === 'merged' && sortOrder === 'desc'
+                          ? 'asc'
+                          : 'desc',
+                      );
+                    }}
+                    sx={{ color: 'inherit', '&.Mui-active': { color: 'rgba(255,255,255,0.9)' } }}
+                  >
+                    Merged
+                  </TableSortLabel>
                 </TableCell>
               </TableRow>
             </TableHead>
             <TableBody>
-              {filteredPRs.map((pr, index) => (
+              {paginatedPRs.map((pr, index) => (
                 <TableRow
                   key={`${pr.repository}-${pr.pullRequestNumber}-${index}`}
                   onClick={() => {
@@ -331,60 +523,106 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
                   <TableCell
                     sx={{
                       ...bodyCellStyle,
-                      width: { xs: '55%', sm: '30%' },
+                      width: { xs: '45%', sm: '28%' },
                       fontSize: { xs: '0.75rem', sm: '0.85rem' },
                     }}
                   >
-                    <Box
-                      sx={{
-                        overflow: 'hidden',
-                        textOverflow: 'ellipsis',
-                        whiteSpace: 'nowrap',
+                    <Tooltip
+                      title={pr.pullRequestTitle}
+                      placement="top"
+                      enterDelay={300}
+                      slotProps={{
+                        tooltip: {
+                          sx: {
+                            fontFamily: '"JetBrains Mono", monospace',
+                            fontSize: '0.8rem',
+                            maxWidth: 360,
+                          },
+                        },
                       }}
                     >
-                      {pr.pullRequestTitle}
-                    </Box>
+                      <Box
+                        component="span"
+                        sx={{
+                          display: 'block',
+                          overflow: 'hidden',
+                          textOverflow: 'ellipsis',
+                          whiteSpace: 'nowrap',
+                          minWidth: 0,
+                        }}
+                      >
+                        {pr.pullRequestTitle}
+                      </Box>
+                    </Tooltip>
                   </TableCell>
                   <TableCell
                     sx={{
                       ...bodyCellStyle,
-                      width: '20%',
+                      width: '22%',
                       display: { xs: 'none', sm: 'table-cell' },
                     }}
                   >
-                    <Box
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        setSelectedRepo(pr.repository);
-                      }}
-                      sx={{
-                        display: 'flex',
-                        alignItems: 'center',
-                        gap: 1.5,
-                        cursor: 'pointer',
-                        '&:hover': {
-                          color: 'primary.main',
+                    <Tooltip
+                      title={pr.repository}
+                      placement="top"
+                      enterDelay={300}
+                      slotProps={{
+                        tooltip: {
+                          sx: {
+                            fontFamily: '"JetBrains Mono", monospace',
+                            fontSize: '0.8rem',
+                            maxWidth: 360,
+                          },
                         },
-                        transition: 'color 0.2s',
                       }}
                     >
-                      <Avatar
-                        src={`https://avatars.githubusercontent.com/${pr.repository.split('/')[0]}`}
-                        alt={pr.repository.split('/')[0]}
-                        sx={{
-                          width: 20,
-                          height: 20,
-                          border: '1px solid rgba(255, 255, 255, 0.2)',
-                          backgroundColor:
-                            pr.repository.split('/')[0] === 'opentensor'
-                              ? '#ffffff'
-                              : pr.repository.split('/')[0] === 'bitcoin'
-                                ? '#F7931A'
-                                : 'transparent',
+                      <Box
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setSelectedRepo(pr.repository);
                         }}
-                      />
-                      {pr.repository}
-                    </Box>
+                        sx={{
+                          display: 'flex',
+                          alignItems: 'center',
+                          gap: 1.5,
+                          cursor: 'pointer',
+                          minWidth: 0,
+                          overflow: 'hidden',
+                          '&:hover': {
+                            color: 'primary.main',
+                          },
+                          transition: 'color 0.2s',
+                        }}
+                      >
+                        <Avatar
+                          src={`https://avatars.githubusercontent.com/${pr.repository.split('/')[0]}`}
+                          alt={pr.repository.split('/')[0]}
+                          sx={{
+                            width: 20,
+                            height: 20,
+                            flexShrink: 0,
+                            border: '1px solid rgba(255, 255, 255, 0.2)',
+                            backgroundColor:
+                              pr.repository.split('/')[0] === 'opentensor'
+                                ? '#ffffff'
+                                : pr.repository.split('/')[0] === 'bitcoin'
+                                  ? '#F7931A'
+                                  : 'transparent',
+                          }}
+                        />
+                        <Box
+                          component="span"
+                          sx={{
+                            overflow: 'hidden',
+                            textOverflow: 'ellipsis',
+                            whiteSpace: 'nowrap',
+                            minWidth: 0,
+                          }}
+                        >
+                          {pr.repository}
+                        </Box>
+                      </Box>
+                    </Tooltip>
                   </TableCell>
                   <TableCell
                     align="right"
@@ -472,7 +710,6 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
                     sx={{
                       ...bodyCellStyle,
                       width: '15%',
-                      display: { xs: 'none', sm: 'table-cell' },
                       fontSize: { xs: '0.75rem', sm: '0.85rem' },
                       color: 'rgba(255,255,255,0.7)',
                     }}
@@ -482,11 +719,33 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
                       : pr.prState === 'CLOSED'
                         ? 'Closed'
                         : 'Open'}
-                  </TableCell>
-                </TableRow>
+                </TableCell>
+              </TableRow>
               ))}
             </TableBody>
           </Table>
+          {filteredPRs.length > 10 && (
+            <TablePagination
+              component="div"
+              count={filteredPRs.length}
+              page={page}
+              onPageChange={(_, newPage) => setPage(newPage)}
+              rowsPerPage={rowsPerPage}
+              onRowsPerPageChange={(e) => {
+                setRowsPerPage(parseInt(e.target.value, 10));
+                setPage(0);
+              }}
+              rowsPerPageOptions={[10, 25, 50, 100]}
+              sx={{
+                borderTop: '1px solid rgba(255,255,255,0.1)',
+                color: 'rgba(255,255,255,0.7)',
+                fontFamily: '"JetBrains Mono", monospace',
+                fontSize: '0.8rem',
+                '& .MuiTablePagination-selectIcon': { color: 'rgba(255,255,255,0.7)' },
+                '& .MuiTablePagination-actions button': { color: 'rgba(255,255,255,0.7)' },
+              }}
+            />
+          )}
         </TableContainer>
       )}
     </Card>
@@ -516,6 +775,7 @@ const bodyCellStyle = {
   py: { xs: 0.75, sm: 1 },
   px: { xs: 0.5, sm: 2 },
   height: { xs: '52px', sm: '60px' },
+  overflow: 'hidden' as const,
 };
 
 const FilterButton: React.FC<{

--- a/src/components/miners/MinerRepositoriesTable.tsx
+++ b/src/components/miners/MinerRepositoriesTable.tsx
@@ -245,7 +245,9 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
             InputProps={{
               startAdornment: (
                 <InputAdornment position="start">
-                  <SearchIcon sx={{ color: 'rgba(255,255,255,0.4)', fontSize: '1.1rem' }} />
+                  <SearchIcon
+                    sx={{ color: 'rgba(255,255,255,0.4)', fontSize: '1.1rem' }}
+                  />
                 </InputAdornment>
               ),
               sx: {
@@ -309,7 +311,9 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
                   Rank
                 </TableSortLabel>
               </TableCell>
-              <TableCell sx={{ ...headerCellStyle, width: '40%', overflow: 'hidden' }}>
+              <TableCell
+                sx={{ ...headerCellStyle, width: '40%', overflow: 'hidden' }}
+              >
                 <TableSortLabel
                   active={sortField === 'repository'}
                   direction={sortField === 'repository' ? sortOrder : 'asc'}
@@ -390,174 +394,189 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
           <TableBody>
             {sortedRepoStats.length === 0 && searchQuery ? (
               <TableRow>
-                <TableCell colSpan={5} sx={{ ...bodyCellStyle, textAlign: 'center', py: 4 }}>
-                  <Typography sx={{ color: 'rgba(255,255,255,0.5)', fontFamily: '"JetBrains Mono", monospace', fontSize: '0.9rem' }}>
+                <TableCell
+                  colSpan={5}
+                  sx={{ ...bodyCellStyle, textAlign: 'center', py: 4 }}
+                >
+                  <Typography
+                    sx={{
+                      color: 'rgba(255,255,255,0.5)',
+                      fontFamily: '"JetBrains Mono", monospace',
+                      fontSize: '0.9rem',
+                    }}
+                  >
                     No repositories match your search.
                   </Typography>
                 </TableCell>
               </TableRow>
             ) : (
               sortedRepoStats.map((repo, index) => (
-              <TableRow
-                key={repo.repository}
-                sx={{
-                  '&:hover': {
-                    backgroundColor: 'rgba(255, 255, 255, 0.05)',
-                  },
-                  transition: 'background-color 0.2s',
-                }}
-              >
-                <TableCell sx={{ ...bodyCellStyle, width: 56 }}>
-                  <Box
-                    sx={{
-                      backgroundColor: '#000000',
-                      borderRadius: '2px',
-                      width: '28px',
-                      height: '28px',
-                      display: 'inline-flex',
-                      alignItems: 'center',
-                      justifyContent: 'center',
-                      flexShrink: 0,
-                      border: '1px solid',
-                      borderColor:
-                        index === 0
-                          ? alpha(TIER_COLORS.gold, 0.4)
-                          : index === 1
-                            ? alpha(TIER_COLORS.silver, 0.4)
-                            : index === 2
-                              ? alpha(TIER_COLORS.bronze, 0.4)
-                              : 'rgba(255, 255, 255, 0.15)',
-                      boxShadow:
-                        index === 0
-                          ? `0 0 12px ${alpha(TIER_COLORS.gold, 0.4)}, 0 0 4px ${alpha(TIER_COLORS.gold, 0.2)}`
-                          : index === 1
-                            ? `0 0 12px ${alpha(TIER_COLORS.silver, 0.4)}, 0 0 4px ${alpha(TIER_COLORS.silver, 0.2)}`
-                            : index === 2
-                              ? `0 0 12px ${alpha(TIER_COLORS.bronze, 0.4)}, 0 0 4px ${alpha(TIER_COLORS.bronze, 0.2)}`
-                              : 'none',
-                    }}
-                  >
-                    <Typography
-                      component="span"
+                <TableRow
+                  key={repo.repository}
+                  sx={{
+                    '&:hover': {
+                      backgroundColor: 'rgba(255, 255, 255, 0.05)',
+                    },
+                    transition: 'background-color 0.2s',
+                  }}
+                >
+                  <TableCell sx={{ ...bodyCellStyle, width: 56 }}>
+                    <Box
                       sx={{
-                        color:
-                          index === 0
-                            ? TIER_COLORS.gold
-                            : index === 1
-                              ? TIER_COLORS.silver
-                              : index === 2
-                                ? TIER_COLORS.bronze
-                                : 'rgba(255, 255, 255, 0.6)',
-                        fontFamily: '"JetBrains Mono", monospace',
-                        fontSize: '0.7rem',
-                        fontWeight: 600,
-                        lineHeight: 1,
-                        display: 'flex',
+                        backgroundColor: '#000000',
+                        borderRadius: '2px',
+                        width: '28px',
+                        height: '28px',
+                        display: 'inline-flex',
                         alignItems: 'center',
                         justifyContent: 'center',
+                        flexShrink: 0,
+                        border: '1px solid',
+                        borderColor:
+                          index === 0
+                            ? alpha(TIER_COLORS.gold, 0.4)
+                            : index === 1
+                              ? alpha(TIER_COLORS.silver, 0.4)
+                              : index === 2
+                                ? alpha(TIER_COLORS.bronze, 0.4)
+                                : 'rgba(255, 255, 255, 0.15)',
+                        boxShadow:
+                          index === 0
+                            ? `0 0 12px ${alpha(TIER_COLORS.gold, 0.4)}, 0 0 4px ${alpha(TIER_COLORS.gold, 0.2)}`
+                            : index === 1
+                              ? `0 0 12px ${alpha(TIER_COLORS.silver, 0.4)}, 0 0 4px ${alpha(TIER_COLORS.silver, 0.2)}`
+                              : index === 2
+                                ? `0 0 12px ${alpha(TIER_COLORS.bronze, 0.4)}, 0 0 4px ${alpha(TIER_COLORS.bronze, 0.2)}`
+                                : 'none',
                       }}
                     >
-                      {index + 1}
-                    </Typography>
-                  </Box>
-                </TableCell>
-                <TableCell sx={{ ...bodyCellStyle, width: '40%' }}>
-                  <Tooltip
-                    title={repo.repository}
-                    placement="top"
-                    enterDelay={300}
-                    slotProps={{
-                      tooltip: {
-                        sx: {
-                          fontFamily: '"JetBrains Mono", monospace',
-                          fontSize: '0.8rem',
-                          maxWidth: 360,
-                        },
-                      },
-                    }}
-                  >
-                    <Box
-                      onClick={() =>
-                        navigate(
-                          `/miners/repository?name=${encodeURIComponent(repo.repository)}`,
-                          {
-                            state: {
-                              backLabel: `Back to ${prs?.[0]?.author || githubId}`,
-                            },
-                          },
-                        )
-                      }
-                      sx={{
-                        display: 'flex',
-                        alignItems: 'center',
-                        gap: 1.5,
-                        cursor: 'pointer',
-                        minWidth: 0,
-                        overflow: 'hidden',
-                        '&:hover': {
-                          color: 'primary.main',
-                          '& .MuiTypography-root': {
-                            textDecoration: 'underline',
-                          },
-                        },
-                        transition: 'color 0.2s',
-                      }}
-                    >
-                      <Avatar
-                        src={`https://avatars.githubusercontent.com/${repo.repository.split('/')[0]}`}
-                        alt={repo.repository.split('/')[0]}
-                        sx={{
-                          width: 24,
-                          height: 24,
-                          flexShrink: 0,
-                          border: '1px solid rgba(255, 255, 255, 0.2)',
-                          backgroundColor:
-                            repo.repository.split('/')[0] === 'opentensor'
-                              ? '#ffffff'
-                              : repo.repository.split('/')[0] === 'bitcoin'
-                                ? '#F7931A'
-                                : 'transparent',
-                        }}
-                      />
-                      {repo.tier && (
-                        <Box
-                          sx={{
-                            width: 6,
-                            height: 6,
-                            borderRadius: '50%',
-                            backgroundColor: getTierColor(repo.tier),
-                            flexShrink: 0,
-                          }}
-                          title={`${repo.tier} tier`}
-                        />
-                      )}
                       <Typography
                         component="span"
                         sx={{
+                          color:
+                            index === 0
+                              ? TIER_COLORS.gold
+                              : index === 1
+                                ? TIER_COLORS.silver
+                                : index === 2
+                                  ? TIER_COLORS.bronze
+                                  : 'rgba(255, 255, 255, 0.6)',
                           fontFamily: '"JetBrains Mono", monospace',
-                          fontSize: '0.85rem',
-                          transition: 'color 0.2s',
-                          overflow: 'hidden',
-                          textOverflow: 'ellipsis',
-                          whiteSpace: 'nowrap',
-                          minWidth: 0,
+                          fontSize: '0.7rem',
+                          fontWeight: 600,
+                          lineHeight: 1,
+                          display: 'flex',
+                          alignItems: 'center',
+                          justifyContent: 'center',
                         }}
                       >
-                        {repo.repository}
+                        {index + 1}
                       </Typography>
                     </Box>
-                  </Tooltip>
-                </TableCell>
-                <TableCell align="right" sx={{ ...bodyCellStyle, width: 80 }}>
-                  {repo.prs}
-                </TableCell>
-                <TableCell align="right" sx={{ ...bodyCellStyle, width: 100 }}>
-                  {repo.score.toFixed(4)}
-                </TableCell>
-                <TableCell align="right" sx={{ ...bodyCellStyle, width: 100 }}>
-                  {repo.weight.toFixed(4)}
-                </TableCell>
-              </TableRow>
+                  </TableCell>
+                  <TableCell sx={{ ...bodyCellStyle, width: '40%' }}>
+                    <Tooltip
+                      title={repo.repository}
+                      placement="top"
+                      enterDelay={300}
+                      slotProps={{
+                        tooltip: {
+                          sx: {
+                            fontFamily: '"JetBrains Mono", monospace',
+                            fontSize: '0.8rem',
+                            maxWidth: 360,
+                          },
+                        },
+                      }}
+                    >
+                      <Box
+                        onClick={() =>
+                          navigate(
+                            `/miners/repository?name=${encodeURIComponent(repo.repository)}`,
+                            {
+                              state: {
+                                backLabel: `Back to ${prs?.[0]?.author || githubId}`,
+                              },
+                            },
+                          )
+                        }
+                        sx={{
+                          display: 'flex',
+                          alignItems: 'center',
+                          gap: 1.5,
+                          cursor: 'pointer',
+                          minWidth: 0,
+                          overflow: 'hidden',
+                          '&:hover': {
+                            color: 'primary.main',
+                            '& .MuiTypography-root': {
+                              textDecoration: 'underline',
+                            },
+                          },
+                          transition: 'color 0.2s',
+                        }}
+                      >
+                        <Avatar
+                          src={`https://avatars.githubusercontent.com/${repo.repository.split('/')[0]}`}
+                          alt={repo.repository.split('/')[0]}
+                          sx={{
+                            width: 24,
+                            height: 24,
+                            flexShrink: 0,
+                            border: '1px solid rgba(255, 255, 255, 0.2)',
+                            backgroundColor:
+                              repo.repository.split('/')[0] === 'opentensor'
+                                ? '#ffffff'
+                                : repo.repository.split('/')[0] === 'bitcoin'
+                                  ? '#F7931A'
+                                  : 'transparent',
+                          }}
+                        />
+                        {repo.tier && (
+                          <Box
+                            sx={{
+                              width: 6,
+                              height: 6,
+                              borderRadius: '50%',
+                              backgroundColor: getTierColor(repo.tier),
+                              flexShrink: 0,
+                            }}
+                            title={`${repo.tier} tier`}
+                          />
+                        )}
+                        <Typography
+                          component="span"
+                          sx={{
+                            fontFamily: '"JetBrains Mono", monospace',
+                            fontSize: '0.85rem',
+                            transition: 'color 0.2s',
+                            overflow: 'hidden',
+                            textOverflow: 'ellipsis',
+                            whiteSpace: 'nowrap',
+                            minWidth: 0,
+                          }}
+                        >
+                          {repo.repository}
+                        </Typography>
+                      </Box>
+                    </Tooltip>
+                  </TableCell>
+                  <TableCell align="right" sx={{ ...bodyCellStyle, width: 80 }}>
+                    {repo.prs}
+                  </TableCell>
+                  <TableCell
+                    align="right"
+                    sx={{ ...bodyCellStyle, width: 100 }}
+                  >
+                    {repo.score.toFixed(4)}
+                  </TableCell>
+                  <TableCell
+                    align="right"
+                    sx={{ ...bodyCellStyle, width: 100 }}
+                  >
+                    {repo.weight.toFixed(4)}
+                  </TableCell>
+                </TableRow>
               ))
             )}
           </TableBody>

--- a/src/components/miners/MinerRepositoriesTable.tsx
+++ b/src/components/miners/MinerRepositoriesTable.tsx
@@ -13,13 +13,19 @@ import {
   Avatar,
   TableSortLabel,
   alpha,
+  TextField,
+  InputAdornment,
+  Tooltip,
 } from '@mui/material';
+import SearchIcon from '@mui/icons-material/Search';
 import { useMinerPRs, useReposAndWeights } from '../../api';
 import { useNavigate } from 'react-router-dom';
 import { TIER_COLORS } from '../../theme';
 
 interface MinerRepositoriesTableProps {
   githubId: string;
+  search?: string;
+  onSearchChange?: (value: string) => void;
 }
 
 interface RepoStats {
@@ -48,12 +54,16 @@ const getTierColor = (tier: string): string => {
 
 const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
   githubId,
+  search: externalSearch,
+  onSearchChange,
 }) => {
   const navigate = useNavigate();
   const { data: prs, isLoading: isLoadingPRs } = useMinerPRs(githubId);
   const { data: repos, isLoading: isLoadingRepos } = useReposAndWeights();
   const [sortField, setSortField] = useState<SortField>('score');
   const [sortOrder, setSortOrder] = useState<SortOrder>('desc');
+  const [internalSearch, setInternalSearch] = useState('');
+  const searchQuery = (externalSearch ?? internalSearch).trim().toLowerCase();
 
   // Build repository weights and tiers maps
   const repoWeights = useMemo(() => {
@@ -102,9 +112,16 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
     return Array.from(statsMap.values());
   }, [prs, repoWeights, repoTiers]);
 
+  const filteredRepoStats = useMemo(() => {
+    if (!searchQuery) return repoStats;
+    return repoStats.filter((r) =>
+      r.repository.toLowerCase().includes(searchQuery),
+    );
+  }, [repoStats, searchQuery]);
+
   // Sort repository stats
   const sortedRepoStats = useMemo(() => {
-    const sorted = [...repoStats];
+    const sorted = [...filteredRepoStats];
     sorted.sort((a, b) => {
       let compareValue = 0;
 
@@ -130,7 +147,7 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
       return sortOrder === 'asc' ? compareValue : -compareValue;
     });
     return sorted;
-  }, [repoStats, sortField, sortOrder]);
+  }, [filteredRepoStats, sortField, sortOrder]);
 
   const handleSort = (field: SortField) => {
     if (sortField === field) {
@@ -202,6 +219,10 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
         sx={{
           p: 3,
           borderBottom: '1px solid rgba(255, 255, 255, 0.1)',
+          display: 'flex',
+          flexWrap: 'wrap',
+          alignItems: 'center',
+          gap: 2,
         }}
       >
         <Typography
@@ -215,13 +236,61 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
         >
           Top Repositories
         </Typography>
+        {!onSearchChange && (
+          <TextField
+            size="small"
+            placeholder="Search repositories..."
+            value={internalSearch}
+            onChange={(e) => setInternalSearch(e.target.value)}
+            InputProps={{
+              startAdornment: (
+                <InputAdornment position="start">
+                  <SearchIcon sx={{ color: 'rgba(255,255,255,0.4)', fontSize: '1.1rem' }} />
+                </InputAdornment>
+              ),
+              sx: {
+                fontFamily: '"JetBrains Mono", monospace',
+                fontSize: '0.8rem',
+                color: '#fff',
+                '& .MuiOutlinedInput-notchedOutline': {
+                  borderColor: 'rgba(255,255,255,0.2)',
+                },
+                '&:hover .MuiOutlinedInput-notchedOutline': {
+                  borderColor: 'rgba(255,255,255,0.35)',
+                },
+                maxWidth: 240,
+              },
+            }}
+            sx={{ minWidth: 180 }}
+          />
+        )}
       </Box>
 
-      <TableContainer sx={{ maxHeight: '400px', overflow: 'auto' }}>
-        <Table stickyHeader>
+      <TableContainer
+        sx={{
+          maxHeight: '400px',
+          overflow: 'auto',
+          WebkitOverflowScrolling: 'touch',
+          '&::-webkit-scrollbar': {
+            width: '8px',
+            height: '8px',
+          },
+          '&::-webkit-scrollbar-track': {
+            backgroundColor: 'transparent',
+          },
+          '&::-webkit-scrollbar-thumb': {
+            backgroundColor: 'rgba(255, 255, 255, 0.1)',
+            borderRadius: '4px',
+            '&:hover': {
+              backgroundColor: 'rgba(255, 255, 255, 0.2)',
+            },
+          },
+        }}
+      >
+        <Table stickyHeader sx={{ tableLayout: 'fixed', minWidth: 600 }}>
           <TableHead>
             <TableRow>
-              <TableCell sx={headerCellStyle}>
+              <TableCell sx={{ ...headerCellStyle, width: 56 }}>
                 <TableSortLabel
                   active={sortField === 'rank'}
                   direction={sortField === 'rank' ? sortOrder : 'desc'}
@@ -240,7 +309,7 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
                   Rank
                 </TableSortLabel>
               </TableCell>
-              <TableCell sx={headerCellStyle}>
+              <TableCell sx={{ ...headerCellStyle, width: '40%', overflow: 'hidden' }}>
                 <TableSortLabel
                   active={sortField === 'repository'}
                   direction={sortField === 'repository' ? sortOrder : 'asc'}
@@ -278,7 +347,7 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
                   PRs
                 </TableSortLabel>
               </TableCell>
-              <TableCell align="right" sx={headerCellStyle}>
+              <TableCell align="right" sx={{ ...headerCellStyle, width: 100 }}>
                 <TableSortLabel
                   active={sortField === 'score'}
                   direction={sortField === 'score' ? sortOrder : 'desc'}
@@ -319,7 +388,16 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
             </TableRow>
           </TableHead>
           <TableBody>
-            {sortedRepoStats.map((repo, index) => (
+            {sortedRepoStats.length === 0 && searchQuery ? (
+              <TableRow>
+                <TableCell colSpan={5} sx={{ ...bodyCellStyle, textAlign: 'center', py: 4 }}>
+                  <Typography sx={{ color: 'rgba(255,255,255,0.5)', fontFamily: '"JetBrains Mono", monospace', fontSize: '0.9rem' }}>
+                    No repositories match your search.
+                  </Typography>
+                </TableCell>
+              </TableRow>
+            ) : (
+              sortedRepoStats.map((repo, index) => (
               <TableRow
                 key={repo.repository}
                 sx={{
@@ -329,7 +407,7 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
                   transition: 'background-color 0.2s',
                 }}
               >
-                <TableCell sx={bodyCellStyle}>
+                <TableCell sx={{ ...bodyCellStyle, width: 56 }}>
                   <Box
                     sx={{
                       backgroundColor: '#000000',
@@ -383,82 +461,105 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
                     </Typography>
                   </Box>
                 </TableCell>
-                <TableCell sx={bodyCellStyle}>
-                  <Box
-                    onClick={() =>
-                      navigate(
-                        `/miners/repository?name=${encodeURIComponent(repo.repository)}`,
-                        {
-                          state: {
-                            backLabel: `Back to ${prs?.[0]?.author || githubId}`,
-                          },
-                        },
-                      )
-                    }
-                    sx={{
-                      display: 'flex',
-                      alignItems: 'center',
-                      gap: 1.5,
-                      cursor: 'pointer',
-                      '&:hover': {
-                        color: 'primary.main',
-                        '& .MuiTypography-root': {
-                          textDecoration: 'underline',
+                <TableCell sx={{ ...bodyCellStyle, width: '40%' }}>
+                  <Tooltip
+                    title={repo.repository}
+                    placement="top"
+                    enterDelay={300}
+                    slotProps={{
+                      tooltip: {
+                        sx: {
+                          fontFamily: '"JetBrains Mono", monospace',
+                          fontSize: '0.8rem',
+                          maxWidth: 360,
                         },
                       },
-                      transition: 'color 0.2s',
                     }}
                   >
-                    <Avatar
-                      src={`https://avatars.githubusercontent.com/${repo.repository.split('/')[0]}`}
-                      alt={repo.repository.split('/')[0]}
+                    <Box
+                      onClick={() =>
+                        navigate(
+                          `/miners/repository?name=${encodeURIComponent(repo.repository)}`,
+                          {
+                            state: {
+                              backLabel: `Back to ${prs?.[0]?.author || githubId}`,
+                            },
+                          },
+                        )
+                      }
                       sx={{
-                        width: 24,
-                        height: 24,
-                        border: '1px solid rgba(255, 255, 255, 0.2)',
-                        backgroundColor:
-                          repo.repository.split('/')[0] === 'opentensor'
-                            ? '#ffffff'
-                            : repo.repository.split('/')[0] === 'bitcoin'
-                              ? '#F7931A'
-                              : 'transparent',
-                      }}
-                    />
-                    {repo.tier && (
-                      <Box
-                        sx={{
-                          width: 6,
-                          height: 6,
-                          borderRadius: '50%',
-                          backgroundColor: getTierColor(repo.tier),
-                          flexShrink: 0,
-                        }}
-                        title={`${repo.tier} tier`}
-                      />
-                    )}
-                    <Typography
-                      component="span"
-                      sx={{
-                        fontFamily: '"JetBrains Mono", monospace',
-                        fontSize: '0.85rem',
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: 1.5,
+                        cursor: 'pointer',
+                        minWidth: 0,
+                        overflow: 'hidden',
+                        '&:hover': {
+                          color: 'primary.main',
+                          '& .MuiTypography-root': {
+                            textDecoration: 'underline',
+                          },
+                        },
                         transition: 'color 0.2s',
                       }}
                     >
-                      {repo.repository}
-                    </Typography>
-                  </Box>
+                      <Avatar
+                        src={`https://avatars.githubusercontent.com/${repo.repository.split('/')[0]}`}
+                        alt={repo.repository.split('/')[0]}
+                        sx={{
+                          width: 24,
+                          height: 24,
+                          flexShrink: 0,
+                          border: '1px solid rgba(255, 255, 255, 0.2)',
+                          backgroundColor:
+                            repo.repository.split('/')[0] === 'opentensor'
+                              ? '#ffffff'
+                              : repo.repository.split('/')[0] === 'bitcoin'
+                                ? '#F7931A'
+                                : 'transparent',
+                        }}
+                      />
+                      {repo.tier && (
+                        <Box
+                          sx={{
+                            width: 6,
+                            height: 6,
+                            borderRadius: '50%',
+                            backgroundColor: getTierColor(repo.tier),
+                            flexShrink: 0,
+                          }}
+                          title={`${repo.tier} tier`}
+                        />
+                      )}
+                      <Typography
+                        component="span"
+                        sx={{
+                          fontFamily: '"JetBrains Mono", monospace',
+                          fontSize: '0.85rem',
+                          transition: 'color 0.2s',
+                          overflow: 'hidden',
+                          textOverflow: 'ellipsis',
+                          whiteSpace: 'nowrap',
+                          minWidth: 0,
+                        }}
+                      >
+                        {repo.repository}
+                      </Typography>
+                    </Box>
+                  </Tooltip>
                 </TableCell>
-                <TableCell align="right" sx={bodyCellStyle}>
+                <TableCell align="right" sx={{ ...bodyCellStyle, width: 80 }}>
                   {repo.prs}
                 </TableCell>
-                <TableCell align="right" sx={bodyCellStyle}>
+                <TableCell align="right" sx={{ ...bodyCellStyle, width: 100 }}>
                   {repo.score.toFixed(4)}
                 </TableCell>
-                <TableCell align="right" sx={bodyCellStyle}>
+                <TableCell align="right" sx={{ ...bodyCellStyle, width: 100 }}>
                   {repo.weight.toFixed(4)}
                 </TableCell>
               </TableRow>
-            ))}
+              ))
+            )}
           </TableBody>
         </Table>
       </TableContainer>
@@ -483,6 +584,7 @@ const bodyCellStyle = {
   fontFamily: '"JetBrains Mono", monospace',
   borderBottom: '1px solid rgba(255, 255, 255, 0.1)',
   fontSize: '0.85rem',
+  overflow: 'hidden' as const,
 };
 
 export default MinerRepositoriesTable;

--- a/src/components/miners/MinerTierPerformance.tsx
+++ b/src/components/miners/MinerTierPerformance.tsx
@@ -184,15 +184,11 @@ const MinerTierPerformance: React.FC<MinerTierPerformanceProps> = ({
           credibility: minerStats.bronzeCredibility || 0,
         };
   const progressStats = nextTierStats || bronzeStats;
-  const reqToken =
-    nextTierConfig?.requiredMinTokenScore ?? null;
+  const reqToken = nextTierConfig?.requiredMinTokenScore ?? null;
   const reqRepos = nextTierConfig?.requiredQualifiedUniqueRepos ?? 3;
   const reqCred = nextTierConfig?.requiredCredibility ?? 0.7;
   const tokenProgress = reqToken
-    ? Math.min(
-        ((progressStats?.tokenScore ?? 0) / reqToken) * 100,
-        100,
-      )
+    ? Math.min(((progressStats?.tokenScore ?? 0) / reqToken) * 100, 100)
     : 100;
   const reposProgress = Math.min(
     ((progressStats?.qualifiedRepos ?? 0) / reqRepos) * 100,

--- a/src/components/miners/MinerTierPerformance.tsx
+++ b/src/components/miners/MinerTierPerformance.tsx
@@ -149,6 +149,70 @@ const MinerTierPerformance: React.FC<MinerTierPerformanceProps> = ({
     },
   ];
 
+  const nextTierName =
+    currentTierLevel < 3
+      ? currentTierLevel === 0
+        ? 'Bronze'
+        : currentTierLevel === 1
+          ? 'Silver'
+          : 'Gold'
+      : null;
+  const nextTierConfig =
+    nextTierName && getTierConfig(nextTierName, tierConfigs);
+  const nextTierStats =
+    nextTierName === 'Bronze'
+      ? null
+      : nextTierName === 'Silver'
+        ? {
+            tokenScore: minerStats.silverTokenScore || 0,
+            qualifiedRepos: minerStats.silverQualifiedUniqueRepos || 0,
+            credibility: minerStats.silverCredibility || 0,
+          }
+        : nextTierName === 'Gold'
+          ? {
+              tokenScore: minerStats.goldTokenScore || 0,
+              qualifiedRepos: minerStats.goldQualifiedUniqueRepos || 0,
+              credibility: minerStats.goldCredibility || 0,
+            }
+          : null;
+  const bronzeStats =
+    currentTierLevel >= 1
+      ? null
+      : {
+          tokenScore: minerStats.bronzeTokenScore || 0,
+          qualifiedRepos: minerStats.bronzeQualifiedUniqueRepos || 0,
+          credibility: minerStats.bronzeCredibility || 0,
+        };
+  const progressStats = nextTierStats || bronzeStats;
+  const reqToken =
+    nextTierConfig?.requiredMinTokenScore ?? null;
+  const reqRepos = nextTierConfig?.requiredQualifiedUniqueRepos ?? 3;
+  const reqCred = nextTierConfig?.requiredCredibility ?? 0.7;
+  const tokenProgress = reqToken
+    ? Math.min(
+        ((progressStats?.tokenScore ?? 0) / reqToken) * 100,
+        100,
+      )
+    : 100;
+  const reposProgress = Math.min(
+    ((progressStats?.qualifiedRepos ?? 0) / reqRepos) * 100,
+    100,
+  );
+  const credProgress = Math.min(
+    ((progressStats?.credibility ?? 0) / reqCred) * 100,
+    100,
+  );
+  const overallProgress =
+    nextTierConfig && progressStats
+      ? (tokenProgress + reposProgress + credProgress) / 3
+      : 0;
+  const nextTierColor =
+    nextTierName === 'Gold'
+      ? TIER_COLORS.gold
+      : nextTierName === 'Silver'
+        ? TIER_COLORS.silver
+        : TIER_COLORS.bronze;
+
   return (
     <Card
       sx={{
@@ -160,28 +224,86 @@ const MinerTierPerformance: React.FC<MinerTierPerformanceProps> = ({
       }}
       elevation={0}
     >
-      <Typography
-        variant="h6"
-        sx={{
-          color: '#ffffff',
-          fontFamily: '"JetBrains Mono", monospace',
-          mb: 2.5,
-          fontWeight: 600,
-          fontSize: '1.1rem',
-          display: 'flex',
-          alignItems: 'center',
-          gap: 1.5,
-          '&::before': {
-            content: '""',
-            width: '4px',
-            height: '20px',
-            backgroundColor: 'primary.main',
-            borderRadius: '2px',
-          },
-        }}
-      >
-        Tier Performance
-      </Typography>
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, mb: 2.5 }}>
+        <Typography
+          variant="h6"
+          sx={{
+            color: '#ffffff',
+            fontFamily: '"JetBrains Mono", monospace',
+            fontWeight: 600,
+            fontSize: '1.1rem',
+            display: 'flex',
+            alignItems: 'center',
+            gap: 1.5,
+            '&::before': {
+              content: '""',
+              width: '4px',
+              height: '20px',
+              backgroundColor: 'primary.main',
+              borderRadius: '2px',
+            },
+          }}
+        >
+          Tier Performance
+        </Typography>
+        {nextTierName && currentTierLevel < 3 && nextTierConfig && (
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              flexWrap: 'wrap',
+              gap: 1.5,
+              py: 1.5,
+              px: 2,
+              borderRadius: 2,
+              border: `1px solid ${alpha(nextTierColor, 0.35)}`,
+              backgroundColor: alpha(nextTierColor, 0.06),
+            }}
+          >
+            <Typography
+              sx={{
+                fontFamily: '"JetBrains Mono", monospace',
+                fontSize: '0.8rem',
+                fontWeight: 600,
+                color: nextTierColor,
+                textTransform: 'uppercase',
+                letterSpacing: '0.5px',
+              }}
+            >
+              Next: Unlock {nextTierName}
+            </Typography>
+            <Box
+              sx={{
+                flex: 1,
+                minWidth: 120,
+                height: 6,
+                borderRadius: 3,
+                backgroundColor: 'rgba(255,255,255,0.1)',
+                overflow: 'hidden',
+              }}
+            >
+              <Box
+                sx={{
+                  height: '100%',
+                  width: `${overallProgress}%`,
+                  borderRadius: 3,
+                  backgroundColor: nextTierColor,
+                  transition: 'width 0.3s ease',
+                }}
+              />
+            </Box>
+            <Typography
+              sx={{
+                fontFamily: '"JetBrains Mono", monospace',
+                fontSize: '0.75rem',
+                color: 'rgba(255,255,255,0.6)',
+              }}
+            >
+              {Math.round(overallProgress)}% of requirements
+            </Typography>
+          </Box>
+        )}
+      </Box>
 
       <Grid container spacing={2}>
         {tiers.map((tier) => {

--- a/src/components/miners/ScoreBreakdownCard.tsx
+++ b/src/components/miners/ScoreBreakdownCard.tsx
@@ -1,11 +1,5 @@
 import React, { useState } from 'react';
-import {
-  Box,
-  Typography,
-  Collapse,
-  Button,
-  alpha,
-} from '@mui/material';
+import { Box, Typography, Collapse, Button, alpha } from '@mui/material';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ExpandLessIcon from '@mui/icons-material/ExpandLess';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';

--- a/src/components/miners/ScoreBreakdownCard.tsx
+++ b/src/components/miners/ScoreBreakdownCard.tsx
@@ -1,0 +1,105 @@
+import React, { useState } from 'react';
+import {
+  Box,
+  Typography,
+  Collapse,
+  Button,
+  alpha,
+} from '@mui/material';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import ExpandLessIcon from '@mui/icons-material/ExpandLess';
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
+import { STATUS_COLORS } from '../../theme';
+
+const summary =
+  'Your total score comes from each merged PR: base score × repo weight × credibility × issue bonus × uniqueness × time decay. Open PRs hold collateral (deducted if you exceed the open PR limit). ' +
+  'Your total is the sum of each merged PR’s earned score. Click any PR in the table below to see how that PR’s score was calculated.';
+
+const details = [
+  'Base score — starting points per merged PR.',
+  'Repo weight — higher for Gold/Silver/Bronze tier repos.',
+  'Credibility — your merge rate (merged ÷ total attempts) scales the multiplier.',
+  'Issue bonus — PRs linked to open issues get a boost.',
+  'Uniqueness — first contribution to a repo in a window gets a boost.',
+  'Time decay — newer merges count slightly more.',
+  'Token score — code is analyzed at the token level (structural vs leaf); details on each PR page.',
+];
+
+const ScoreBreakdownCard: React.FC = () => {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <Box
+      sx={{
+        borderRadius: 2,
+        border: '1px solid rgba(255, 255, 255, 0.1)',
+        backgroundColor: 'rgba(255, 255, 255, 0.02)',
+        p: 2,
+      }}
+    >
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'flex-start',
+          gap: 1,
+        }}
+      >
+        <InfoOutlinedIcon
+          sx={{
+            color: alpha(STATUS_COLORS.info, 0.9),
+            fontSize: '1.1rem',
+            mt: 0.2,
+          }}
+        />
+        <Box sx={{ flex: 1 }}>
+          <Typography
+            sx={{
+              color: 'rgba(255,255,255,0.9)',
+              fontFamily: '"JetBrains Mono", monospace',
+              fontSize: '0.85rem',
+              lineHeight: 1.5,
+            }}
+          >
+            {summary}
+          </Typography>
+          <Collapse in={expanded}>
+            <Box
+              component="ul"
+              sx={{
+                m: 0,
+                mt: 1.5,
+                pl: 2.5,
+                color: 'rgba(255,255,255,0.7)',
+                fontFamily: '"JetBrains Mono", monospace',
+                fontSize: '0.8rem',
+                lineHeight: 1.8,
+              }}
+            >
+              {details.map((line, i) => (
+                <li key={i}>{line}</li>
+              ))}
+            </Box>
+          </Collapse>
+          <Button
+            size="small"
+            onClick={() => setExpanded(!expanded)}
+            endIcon={expanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+            sx={{
+              color: 'primary.main',
+              fontFamily: '"JetBrains Mono", monospace',
+              fontSize: '0.75rem',
+              textTransform: 'none',
+              mt: 1,
+              minWidth: 'auto',
+              p: 0,
+            }}
+          >
+            {expanded ? 'Less' : 'How is my score calculated?'}
+          </Button>
+        </Box>
+      </Box>
+    </Box>
+  );
+};
+
+export default ScoreBreakdownCard;

--- a/src/components/miners/index.ts
+++ b/src/components/miners/index.ts
@@ -1,8 +1,10 @@
 export { default as CredibilityChart } from './CredibilityChart';
 export { default as MinerActivity } from './MinerActivity';
+export { default as MinerDashboardHero } from './MinerDashboardHero';
 export { default as MinerPRsTable } from './MinerPRsTable';
 export { default as MinerRepositoriesTable } from './MinerRepositoriesTable';
 export { default as MinerScoreCard } from './MinerScoreCard';
 export { default as MinerTierPerformance } from './MinerTierPerformance';
 export { default as PerformanceRadar } from './PerformanceRadar';
+export { default as ScoreBreakdownCard } from './ScoreBreakdownCard';
 export { default as TrustBadge, getRiskAssessment } from './TrustBadge';

--- a/src/pages/MinerDetailsPage.tsx
+++ b/src/pages/MinerDetailsPage.tsx
@@ -30,7 +30,9 @@ const MinerDetailsPage: React.FC = () => {
     <Page title="My Dashboard">
       <SEO
         title={`Miner Stats - ${githubId}`}
-        description={`View your Gittensor stats, tier progress, contributions, and earnings. Track scores and pull requests.`}
+        description={
+          'View your Gittensor stats, tier progress, contributions, and earnings. Track scores and pull requests.'
+        }
         type="website"
       />
       <Box
@@ -107,7 +109,10 @@ const MinerDetailsPage: React.FC = () => {
                 startAdornment: (
                   <InputAdornment position="start">
                     <SearchIcon
-                      sx={{ color: 'rgba(255,255,255,0.4)', fontSize: '1.1rem' }}
+                      sx={{
+                        color: 'rgba(255,255,255,0.4)',
+                        fontSize: '1.1rem',
+                      }}
                     />
                   </InputAdornment>
                 ),

--- a/src/pages/MinerDetailsPage.tsx
+++ b/src/pages/MinerDetailsPage.tsx
@@ -1,13 +1,15 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useSearchParams, useNavigate } from 'react-router-dom';
-import { Box } from '@mui/material';
+import { Box, Tabs, Tab, TextField, InputAdornment } from '@mui/material';
+import SearchIcon from '@mui/icons-material/Search';
 import { Page } from '../components/layout';
 import {
-  MinerScoreCard,
+  MinerDashboardHero,
   MinerActivity,
   MinerRepositoriesTable,
   MinerPRsTable,
   MinerTierPerformance,
+  ScoreBreakdownCard,
   BackButton,
   SEO,
 } from '../components';
@@ -16,56 +18,131 @@ const MinerDetailsPage: React.FC = () => {
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
   const githubId = searchParams.get('githubId');
+  const [contribTab, setContribTab] = useState<'prs' | 'repos'>('prs');
+  const [contribSearch, setContribSearch] = useState('');
 
-  // If no githubId is provided, redirect to miners page
   if (!githubId) {
-    navigate('/miners');
+    navigate('/top-miners');
     return null;
   }
 
   return (
-    <Page title="Miner Details">
+    <Page title="My Dashboard">
       <SEO
         title={`Miner Stats - ${githubId}`}
-        description={`View detailed statistics, contributions, and pull requests for ${githubId} on Gittensor. Track open source contributions and rewards.`}
+        description={`View your Gittensor stats, tier progress, contributions, and earnings. Track scores and pull requests.`}
         type="website"
       />
       <Box
         sx={{
           display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          minHeight: { xs: 'auto', md: 'calc(100vh - 80px)' },
+          flexDirection: 'column',
+          gap: 3,
+          maxWidth: 1200,
           width: '100%',
+          mx: 'auto',
+          px: { xs: 2, sm: 2, md: 0 },
           py: { xs: 2, sm: 0 },
+          minHeight: { xs: 'auto', md: 'calc(100vh - 80px)' },
         }}
       >
+        <BackButton to="/top-miners" />
+
+        <MinerDashboardHero githubId={githubId} />
+
+        <MinerTierPerformance githubId={githubId} />
+
+        <ScoreBreakdownCard />
+
+        <MinerActivity githubId={githubId} />
+
         <Box
           sx={{
-            display: 'flex',
-            flexDirection: 'column',
-            gap: 3,
-            maxWidth: 1200,
-            width: '100%',
-            px: { xs: 2, sm: 2, md: 0 },
+            borderRadius: 3,
+            border: '1px solid rgba(255, 255, 255, 0.1)',
+            overflow: 'hidden',
+            backgroundColor: 'transparent',
           }}
         >
-          <BackButton to="/top-miners" />
-
-          {/* Miner Score Card */}
-          <MinerScoreCard githubId={githubId} />
-
-          {/* Activity Visualization */}
-          <MinerActivity githubId={githubId} />
-
-          {/* Tier Performance */}
-          <MinerTierPerformance githubId={githubId} />
-
-          {/* Top Repositories */}
-          <MinerRepositoriesTable githubId={githubId} />
-
-          {/* Miner PRs Table */}
-          <MinerPRsTable githubId={githubId} />
+          <Box
+            sx={{
+              borderBottom: '1px solid rgba(255, 255, 255, 0.1)',
+              px: 2,
+              py: 1.5,
+              backgroundColor: 'rgba(255, 255, 255, 0.02)',
+              display: 'flex',
+              flexDirection: { xs: 'column', sm: 'row' },
+              alignItems: { xs: 'stretch', sm: 'center' },
+              gap: 2,
+            }}
+          >
+            <Tabs
+              value={contribTab}
+              onChange={(_, v: 'prs' | 'repos') => setContribTab(v)}
+              sx={{
+                minHeight: 44,
+                flex: { xs: '0 0 auto', sm: 1 },
+                width: { xs: '100%', sm: 'auto' },
+                '& .MuiTab-root': {
+                  fontFamily: '"JetBrains Mono", monospace',
+                  fontSize: { xs: '0.85rem', sm: '0.9rem' },
+                  textTransform: 'none',
+                },
+                '& .Mui-selected': { color: 'primary.main' },
+              }}
+            >
+              <Tab value="prs" label="Pull requests" />
+              <Tab value="repos" label="By repository" />
+            </Tabs>
+            <TextField
+              size="small"
+              placeholder={
+                contribTab === 'prs'
+                  ? 'Search by title, repo, or PR #...'
+                  : 'Search repositories...'
+              }
+              value={contribSearch}
+              onChange={(e) => setContribSearch(e.target.value)}
+              InputProps={{
+                startAdornment: (
+                  <InputAdornment position="start">
+                    <SearchIcon
+                      sx={{ color: 'rgba(255,255,255,0.4)', fontSize: '1.1rem' }}
+                    />
+                  </InputAdornment>
+                ),
+                sx: {
+                  fontFamily: '"JetBrains Mono", monospace',
+                  fontSize: '0.8rem',
+                  color: '#fff',
+                  '& .MuiOutlinedInput-notchedOutline': {
+                    borderColor: 'rgba(255,255,255,0.2)',
+                  },
+                  '&:hover .MuiOutlinedInput-notchedOutline': {
+                    borderColor: 'rgba(255,255,255,0.35)',
+                  },
+                  width: { xs: '100%', sm: 280 },
+                },
+              }}
+              sx={{ width: { xs: '100%', sm: 280 }, minWidth: 0 }}
+            />
+          </Box>
+          <Box sx={{ p: 0 }}>
+            {contribTab === 'prs' && (
+              <MinerPRsTable
+                githubId={githubId}
+                search={contribSearch}
+                onSearchChange={setContribSearch}
+              />
+            )}
+            {contribTab === 'repos' && (
+              <MinerRepositoriesTable
+                githubId={githubId}
+                search={contribSearch}
+                onSearchChange={setContribSearch}
+              />
+            )}
+          </Box>
         </Box>
       </Box>
     </Page>


### PR DESCRIPTION
# Pull Request: Miner Details Page Dashboard Redesign

## Summary

Redesign miner details page as a miner-focused dashboard: hero with identity and main KPIs, tier progress with "Next: Unlock", score breakdown, activity card, and a single Contributions section (tabs + search + sort + pagination). Responsive layout and mobile-specific tweaks (hotkey placement, TrustBadge under title, horizontal scroll for tables).

## Related Issues

Closes [#95](https://github.com/entrius/gittensor-ui/issues/95) — Redesigning Miner Details Page

## Design rationale

- **Hero first:** Identity (avatar, name, tier, GitHub link) and main KPIs (score, credibility, open PRs, est. daily) are at the top so miners see standing at a glance. Hotkey and profile chips (location, Open to Work, followers) sit in their own row so they don’t compete with the identity block.
- **Tier progress:** “Next: Unlock [Tier]” with a progress bar and percentage makes the path to the next tier obvious and motivating.
- **Score breakdown:** A short, expandable explanation ties the total score to per-PR scores and links to the table so miners can trace how scores are calculated.
- **Single Contributions area:** One section with tabs (Pull requests / By repository), shared search, and per-tab sort/pagination reduces duplication and keeps the page usable for both small and large contribution counts.
- **Activity:** Developer activity (heatmap, credibility, radar) stays in one card with a clear header; on mobile, TrustBadge stacks under the title for readability.

## Data completeness

- All metrics used on the page remain available: miner stats (score, credibility, open PRs, earnings, hotkey, tier), GitHub profile (name, location, hireable, followers), tier config, PR list, and repo stats. Nothing was removed from the API usage.
- The profile details that miners care about most — **location**, **Open to Work**, and **followers** — are now shown as chips in the hero. Full profile (bio, company, blog, Twitter, etc.) and the detailed stat grid still exist in `MinerScoreCard` and can be re-surfaced later (e.g. “View full profile”) if needed.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

<!-- Include before/after screenshots for every UI/visual change. -->
<img width="1264" height="887" alt="miner-detail-1" src="https://github.com/user-attachments/assets/254bfa0b-3a62-44a9-a55c-4e46da815e34" />
<img width="1264" height="887" alt="miner-detail-2" src="https://github.com/user-attachments/assets/0bae2251-7019-47cd-b9ff-4e3840c076a4" />
<img width="1265" height="885" alt="miner-detail-3" src="https://github.com/user-attachments/assets/4d6d7731-51ba-4312-bc47-d8f14689328f" />
<img width="1264" height="887" alt="miner-detail-4" src="https://github.com/user-attachments/assets/ef71e3c3-40cd-479f-8ff2-cfc6ee859d67" />
<img width="357" height="795" alt="miner-detail-5" src="https://github.com/user-attachments/assets/d7ea3598-f7bd-4423-ad15-edc6176d47a5" />
<img width="358" height="794" alt="miner-detail-6" src="https://github.com/user-attachments/assets/00e004ef-d09e-4474-8c4e-83364326ab0c" />
<img width="355" height="791" alt="miner-detail-7" src="https://github.com/user-attachments/assets/54e22347-6b30-47c3-ad7c-80ee5af3db4a" />
<img width="357" height="792" alt="miner-detail-8" src="https://github.com/user-attachments/assets/e8b39f64-694a-4f1c-888f-d6c15c90de2f" />
<img width="354" height="793" alt="miner-detail-9" src="https://github.com/user-attachments/assets/45d2efe5-caba-4dbe-a13c-5961424eb546" />
<img width="352" height="792" alt="miner-detail-10" src="https://github.com/user-attachments/assets/93b4365a-02a4-4678-b28c-22fa852ae9c2" />


### Desktop

- [x] Full miner dashboard (hero, tier progress, score breakdown, activity, contributions)
- [x] Contributions: Pull requests tab with search/sort/pagination
- [x] Contributions: By repository tab

### Mobile

- [x] Hero with identity, hotkey row, profile chips (location / Open to Work / followers), stat pills
- [x] Tier progress and "Next: Unlock" banner
- [x] Developer Activity with TrustBadge under title
- [x] PR table with horizontal scroll and Merged column visible

## Checklist

- [x] New components are modularized/separated where sensible (`MinerDashboardHero`, `ScoreBreakdownCard`; existing `MinerTierPerformance`, `MinerActivity`, tables reused)
- [x] Uses predefined theme (e.g. no hardcoded colors) — `theme.ts` / `TIER_COLORS`, `STATUS_COLORS`, `alpha()`
- [x] Responsive/mobile checked — breakpoints, hotkey/identity layout, TrustBadge stacking, table scroll
- [x] Tested against the test API — miner stats, PRs, GitHub data, tier config
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
