### PR TITLE
Redesign Miner Details Page as Personal Performance Dashboard

### DIFF
--- a/src/components/miners/EarningsOverview.tsx
+++ b/src/components/miners/EarningsOverview.tsx
@@ -1,0 +1,621 @@
+import React, { useMemo } from 'react';
+import {
+  Card,
+  Typography,
+  Box,
+  CircularProgress,
+  alpha,
+} from '@mui/material';
+import {
+  AccountBalanceWallet as WalletIcon,
+  TrendingUp as TrendIcon,
+} from '@mui/icons-material';
+import ReactECharts from 'echarts-for-react';
+import {
+  useMinerStats,
+  useMinerPRs,
+  useReposAndWeights,
+} from '../../api';
+import { TIER_COLORS, STATUS_COLORS } from '../../theme';
+
+interface EarningsOverviewProps {
+  githubId: string;
+}
+
+const EarningsOverview: React.FC<EarningsOverviewProps> = ({ githubId }) => {
+  const { data: minerStats, isLoading } = useMinerStats(githubId);
+  const { data: prs } = useMinerPRs(githubId);
+  const { data: repos } = useReposAndWeights();
+
+  // Build repo tier map
+  const repoTiers = useMemo(() => {
+    const map = new Map<string, string>();
+    if (Array.isArray(repos)) {
+      repos.forEach((repo) => {
+        if (repo?.fullName) {
+          map.set(repo.fullName, repo.tier || '');
+        }
+      });
+    }
+    return map;
+  }, [repos]);
+
+  // Earnings by tier
+  const tierEarnings = useMemo(() => {
+    if (!minerStats) return { bronze: 0, silver: 0, gold: 0 };
+    return {
+      bronze: Number(minerStats.bronzeScore || 0),
+      silver: Number(minerStats.silverScore || 0),
+      gold: Number(minerStats.goldScore || 0),
+    };
+  }, [minerStats]);
+
+  // Build historical score trend from PRs (grouped by month)
+  const scoreTrend = useMemo(() => {
+    if (!prs || prs.length === 0) return [];
+
+    const monthlyScores = new Map<string, number>();
+    const sortedPrs = [...prs]
+      .filter((pr) => pr.mergedAt)
+      .sort(
+        (a, b) =>
+          new Date(a.mergedAt!).getTime() - new Date(b.mergedAt!).getTime(),
+      );
+
+    sortedPrs.forEach((pr) => {
+      const date = new Date(pr.mergedAt!);
+      const key = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`;
+      const existing = monthlyScores.get(key) || 0;
+      monthlyScores.set(key, existing + parseFloat(pr.score || '0'));
+    });
+
+    return Array.from(monthlyScores.entries()).map(([month, score]) => ({
+      month,
+      score,
+    }));
+  }, [prs]);
+
+  // Top repos by score contribution
+  const topRepos = useMemo(() => {
+    if (!prs) return [];
+    const repoScores = new Map<string, number>();
+    prs.forEach((pr) => {
+      const existing = repoScores.get(pr.repository) || 0;
+      repoScores.set(pr.repository, existing + parseFloat(pr.score || '0'));
+    });
+    return Array.from(repoScores.entries())
+      .map(([repo, score]) => ({
+        repo,
+        score,
+        tier: repoTiers.get(repo) || '',
+      }))
+      .sort((a, b) => b.score - a.score)
+      .slice(0, 5);
+  }, [prs, repoTiers]);
+
+  // ECharts option for score trend
+  const chartOption = useMemo(() => {
+    if (scoreTrend.length === 0) return null;
+    return {
+      backgroundColor: 'transparent',
+      grid: {
+        left: '10%',
+        right: '5%',
+        top: '15%',
+        bottom: '15%',
+      },
+      tooltip: {
+        trigger: 'axis' as const,
+        backgroundColor: 'rgba(30, 30, 30, 0.95)',
+        borderColor: 'rgba(255, 255, 255, 0.1)',
+        textStyle: {
+          color: '#ffffff',
+          fontFamily: '"JetBrains Mono", monospace',
+          fontSize: 12,
+        },
+      },
+      xAxis: {
+        type: 'category' as const,
+        data: scoreTrend.map((d) => d.month),
+        axisLabel: {
+          color: 'rgba(255, 255, 255, 0.4)',
+          fontFamily: '"JetBrains Mono", monospace',
+          fontSize: 10,
+        },
+        axisLine: { lineStyle: { color: 'rgba(255, 255, 255, 0.1)' } },
+        axisTick: { show: false },
+      },
+      yAxis: {
+        type: 'value' as const,
+        axisLabel: {
+          color: 'rgba(255, 255, 255, 0.4)',
+          fontFamily: '"JetBrains Mono", monospace',
+          fontSize: 10,
+        },
+        splitLine: { lineStyle: { color: 'rgba(255, 255, 255, 0.05)' } },
+      },
+      series: [
+        {
+          name: 'Score',
+          type: 'line',
+          data: scoreTrend.map((d) => d.score.toFixed(2)),
+          smooth: true,
+          lineStyle: {
+            color: '#1d37fc',
+            width: 2,
+          },
+          areaStyle: {
+            color: {
+              type: 'linear',
+              x: 0,
+              y: 0,
+              x2: 0,
+              y2: 1,
+              colorStops: [
+                { offset: 0, color: 'rgba(29, 55, 252, 0.3)' },
+                { offset: 1, color: 'rgba(29, 55, 252, 0.02)' },
+              ],
+            },
+          },
+          itemStyle: {
+            color: '#1d37fc',
+          },
+        },
+      ],
+    };
+  }, [scoreTrend]);
+
+  if (isLoading) {
+    return (
+      <Card
+        sx={{
+          borderRadius: 3,
+          border: '1px solid rgba(255, 255, 255, 0.1)',
+          backgroundColor: 'transparent',
+          p: 4,
+          textAlign: 'center',
+        }}
+        elevation={0}
+      >
+        <CircularProgress size={30} sx={{ color: 'primary.main' }} />
+      </Card>
+    );
+  }
+
+  if (!minerStats) return null;
+
+  const dailyUsd = minerStats.usdPerDay ?? 0;
+  const dailyTao = minerStats.taoPerDay ?? 0;
+  const dailyAlpha = minerStats.alphaPerDay ?? 0;
+  const lifetimeUsd = minerStats.lifetimeUsd ?? 0;
+  const lifetimeTao = minerStats.lifetimeTao ?? 0;
+
+  const getTierColor = (tier: string): string => {
+    switch (tier.toLowerCase()) {
+      case 'gold':
+        return TIER_COLORS.gold;
+      case 'silver':
+        return TIER_COLORS.silver;
+      case 'bronze':
+        return TIER_COLORS.bronze;
+      default:
+        return 'rgba(255, 255, 255, 0.4)';
+    }
+  };
+
+  return (
+    <Card
+      sx={{
+        borderRadius: 3,
+        border: '1px solid rgba(255, 255, 255, 0.1)',
+        backgroundColor: 'transparent',
+        p: 3,
+      }}
+      elevation={0}
+    >
+      <Typography
+        variant="h6"
+        sx={{
+          color: '#ffffff',
+          fontFamily: '"JetBrains Mono", monospace',
+          mb: 3,
+          fontWeight: 600,
+          fontSize: '1.1rem',
+          display: 'flex',
+          alignItems: 'center',
+          gap: 1.5,
+          '&::before': {
+            content: '""',
+            width: '4px',
+            height: '20px',
+            backgroundColor: STATUS_COLORS.success,
+            borderRadius: '2px',
+          },
+        }}
+      >
+        Earnings Overview
+      </Typography>
+
+      {/* Earnings summary cards */}
+      <Box
+        sx={{
+          display: 'grid',
+          gridTemplateColumns: { xs: '1fr', sm: 'repeat(3, 1fr)' },
+          gap: 2,
+          mb: 3,
+        }}
+      >
+        {/* Daily */}
+        <Box
+          sx={{
+            p: 2.5,
+            borderRadius: 2,
+            backgroundColor: alpha(STATUS_COLORS.success, 0.05),
+            border: `1px solid ${alpha(STATUS_COLORS.success, 0.15)}`,
+          }}
+        >
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 1,
+              mb: 1.5,
+            }}
+          >
+            <WalletIcon
+              sx={{ fontSize: '1rem', color: STATUS_COLORS.success }}
+            />
+            <Typography
+              sx={{
+                color: 'rgba(255, 255, 255, 0.5)',
+                fontFamily: '"JetBrains Mono", monospace',
+                fontSize: '0.75rem',
+                textTransform: 'uppercase',
+                fontWeight: 600,
+              }}
+            >
+              Daily
+            </Typography>
+          </Box>
+          <Typography
+            sx={{
+              color: STATUS_COLORS.success,
+              fontFamily: '"JetBrains Mono", monospace',
+              fontSize: '1.5rem',
+              fontWeight: 700,
+              lineHeight: 1.2,
+            }}
+          >
+            ${Math.round(dailyUsd).toLocaleString()}
+          </Typography>
+          <Typography
+            sx={{
+              color: 'rgba(255, 255, 255, 0.4)',
+              fontFamily: '"JetBrains Mono", monospace',
+              fontSize: '0.75rem',
+              mt: 0.5,
+            }}
+          >
+            {dailyTao.toFixed(4)} TAO / {dailyAlpha.toFixed(4)} ALPHA
+          </Typography>
+        </Box>
+
+        {/* Monthly */}
+        <Box
+          sx={{
+            p: 2.5,
+            borderRadius: 2,
+            backgroundColor: 'rgba(255, 255, 255, 0.03)',
+            border: '1px solid rgba(255, 255, 255, 0.08)',
+          }}
+        >
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 1,
+              mb: 1.5,
+            }}
+          >
+            <TrendIcon sx={{ fontSize: '1rem', color: '#a3e635' }} />
+            <Typography
+              sx={{
+                color: 'rgba(255, 255, 255, 0.5)',
+                fontFamily: '"JetBrains Mono", monospace',
+                fontSize: '0.75rem',
+                textTransform: 'uppercase',
+                fontWeight: 600,
+              }}
+            >
+              Monthly (Est.)
+            </Typography>
+          </Box>
+          <Typography
+            sx={{
+              color: '#ffffff',
+              fontFamily: '"JetBrains Mono", monospace',
+              fontSize: '1.5rem',
+              fontWeight: 700,
+              lineHeight: 1.2,
+            }}
+          >
+            ${Math.round(dailyUsd * 30).toLocaleString()}
+          </Typography>
+          <Typography
+            sx={{
+              color: 'rgba(255, 255, 255, 0.4)',
+              fontFamily: '"JetBrains Mono", monospace',
+              fontSize: '0.75rem',
+              mt: 0.5,
+            }}
+          >
+            {(dailyTao * 30).toFixed(2)} TAO
+          </Typography>
+        </Box>
+
+        {/* Lifetime */}
+        <Box
+          sx={{
+            p: 2.5,
+            borderRadius: 2,
+            backgroundColor: 'rgba(255, 255, 255, 0.03)',
+            border: '1px solid rgba(255, 255, 255, 0.08)',
+          }}
+        >
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 1,
+              mb: 1.5,
+            }}
+          >
+            <WalletIcon
+              sx={{ fontSize: '1rem', color: 'rgba(255, 255, 255, 0.5)' }}
+            />
+            <Typography
+              sx={{
+                color: 'rgba(255, 255, 255, 0.5)',
+                fontFamily: '"JetBrains Mono", monospace',
+                fontSize: '0.75rem',
+                textTransform: 'uppercase',
+                fontWeight: 600,
+              }}
+            >
+              Lifetime
+            </Typography>
+          </Box>
+          <Typography
+            sx={{
+              color: '#ffffff',
+              fontFamily: '"JetBrains Mono", monospace',
+              fontSize: '1.5rem',
+              fontWeight: 700,
+              lineHeight: 1.2,
+            }}
+          >
+            ${Math.round(lifetimeUsd).toLocaleString()}
+          </Typography>
+          <Typography
+            sx={{
+              color: 'rgba(255, 255, 255, 0.4)',
+              fontFamily: '"JetBrains Mono", monospace',
+              fontSize: '0.75rem',
+              mt: 0.5,
+            }}
+          >
+            {lifetimeTao.toFixed(2)} TAO
+          </Typography>
+        </Box>
+      </Box>
+
+      {/* Score trend chart */}
+      {chartOption && (
+        <Box sx={{ mb: 3 }}>
+          <Typography
+            sx={{
+              color: 'rgba(255, 255, 255, 0.5)',
+              fontFamily: '"JetBrains Mono", monospace',
+              fontSize: '0.8rem',
+              textTransform: 'uppercase',
+              letterSpacing: '0.5px',
+              mb: 1.5,
+              fontWeight: 600,
+            }}
+          >
+            Score Contribution Trend
+          </Typography>
+          <ReactECharts
+            option={chartOption}
+            style={{ height: 200, width: '100%' }}
+            opts={{ renderer: 'canvas' }}
+          />
+        </Box>
+      )}
+
+      {/* Earnings by tier + top repos */}
+      <Box
+        sx={{
+          display: 'grid',
+          gridTemplateColumns: { xs: '1fr', md: '1fr 1fr' },
+          gap: 2,
+        }}
+      >
+        {/* By tier */}
+        <Box
+          sx={{
+            p: 2,
+            borderRadius: 2,
+            backgroundColor: 'rgba(255, 255, 255, 0.02)',
+            border: '1px solid rgba(255, 255, 255, 0.06)',
+          }}
+        >
+          <Typography
+            sx={{
+              color: 'rgba(255, 255, 255, 0.5)',
+              fontFamily: '"JetBrains Mono", monospace',
+              fontSize: '0.75rem',
+              textTransform: 'uppercase',
+              letterSpacing: '0.5px',
+              mb: 1.5,
+              fontWeight: 600,
+            }}
+          >
+            Score by Tier
+          </Typography>
+          {(['bronze', 'silver', 'gold'] as const).map((tier) => {
+            const score =
+              tierEarnings[tier];
+            const totalScore = Number(minerStats.totalScore || 1);
+            const pct = totalScore > 0 ? (score / totalScore) * 100 : 0;
+            return (
+              <Box key={tier} sx={{ mb: 1.5 }}>
+                <Box
+                  sx={{
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    mb: 0.25,
+                  }}
+                >
+                  <Typography
+                    sx={{
+                      color: getTierColor(tier),
+                      fontFamily: '"JetBrains Mono", monospace',
+                      fontSize: '0.8rem',
+                      fontWeight: 600,
+                      textTransform: 'capitalize',
+                    }}
+                  >
+                    {tier}
+                  </Typography>
+                  <Typography
+                    sx={{
+                      color: '#ffffff',
+                      fontFamily: '"JetBrains Mono", monospace',
+                      fontSize: '0.8rem',
+                      fontWeight: 600,
+                    }}
+                  >
+                    {score.toFixed(2)}
+                  </Typography>
+                </Box>
+                <Box
+                  sx={{
+                    height: 6,
+                    borderRadius: 3,
+                    backgroundColor: 'rgba(255, 255, 255, 0.06)',
+                    overflow: 'hidden',
+                  }}
+                >
+                  <Box
+                    sx={{
+                      width: `${pct}%`,
+                      height: '100%',
+                      borderRadius: 3,
+                      backgroundColor: getTierColor(tier),
+                      transition: 'width 0.5s ease',
+                    }}
+                  />
+                </Box>
+              </Box>
+            );
+          })}
+        </Box>
+
+        {/* Top repos */}
+        <Box
+          sx={{
+            p: 2,
+            borderRadius: 2,
+            backgroundColor: 'rgba(255, 255, 255, 0.02)',
+            border: '1px solid rgba(255, 255, 255, 0.06)',
+          }}
+        >
+          <Typography
+            sx={{
+              color: 'rgba(255, 255, 255, 0.5)',
+              fontFamily: '"JetBrains Mono", monospace',
+              fontSize: '0.75rem',
+              textTransform: 'uppercase',
+              letterSpacing: '0.5px',
+              mb: 1.5,
+              fontWeight: 600,
+            }}
+          >
+            Top Repos by Score
+          </Typography>
+          {topRepos.map((repo, i) => (
+            <Box
+              key={repo.repo}
+              sx={{
+                display: 'flex',
+                justifyContent: 'space-between',
+                alignItems: 'center',
+                py: 0.75,
+                borderBottom:
+                  i < topRepos.length - 1
+                    ? '1px solid rgba(255, 255, 255, 0.05)'
+                    : 'none',
+              }}
+            >
+              <Box
+                sx={{ display: 'flex', alignItems: 'center', gap: 1 }}
+              >
+                {repo.tier && (
+                  <Box
+                    sx={{
+                      width: 6,
+                      height: 6,
+                      borderRadius: '50%',
+                      backgroundColor: getTierColor(repo.tier),
+                      flexShrink: 0,
+                    }}
+                  />
+                )}
+                <Typography
+                  sx={{
+                    color: 'rgba(255, 255, 255, 0.7)',
+                    fontFamily: '"JetBrains Mono", monospace',
+                    fontSize: '0.75rem',
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                    maxWidth: 200,
+                  }}
+                >
+                  {repo.repo}
+                </Typography>
+              </Box>
+              <Typography
+                sx={{
+                  color: '#ffffff',
+                  fontFamily: '"JetBrains Mono", monospace',
+                  fontSize: '0.75rem',
+                  fontWeight: 600,
+                  flexShrink: 0,
+                }}
+              >
+                {repo.score.toFixed(2)}
+              </Typography>
+            </Box>
+          ))}
+          {topRepos.length === 0 && (
+            <Typography
+              sx={{
+                color: 'rgba(255, 255, 255, 0.3)',
+                fontFamily: '"JetBrains Mono", monospace',
+                fontSize: '0.8rem',
+                textAlign: 'center',
+                py: 2,
+              }}
+            >
+              No repository data
+            </Typography>
+          )}
+        </Box>
+      </Box>
+    </Card>
+  );
+};
+
+export default EarningsOverview;

--- a/src/components/miners/MinerDashboardHeader.tsx
+++ b/src/components/miners/MinerDashboardHeader.tsx
@@ -1,0 +1,496 @@
+import React, { useMemo } from 'react';
+import {
+  Card,
+  Typography,
+  Box,
+  CircularProgress,
+  Avatar,
+  Chip,
+  Stack,
+  Divider,
+  Tooltip,
+  alpha,
+} from '@mui/material';
+import {
+  GitHub as GitHubIcon,
+  Language as WebsiteIcon,
+  Twitter as TwitterIcon,
+  LocationOn as LocationIcon,
+  Business as CompanyIcon,
+  People as FollowersIcon,
+  Update as UpdateIcon,
+  EmojiEvents as RankIcon,
+  TrendingUp as ScoreIcon,
+  Verified as CredibilityIcon,
+  AccountBalanceWallet as EarningsIcon,
+} from '@mui/icons-material';
+import {
+  useMinerStats,
+  useMinerPRs,
+  useAllMiners,
+  useMinerGithubData,
+  type MinerEvaluation,
+} from '../../api';
+import { TIER_COLORS, STATUS_COLORS } from '../../theme';
+import TrustBadge from './TrustBadge';
+
+// Custom time formatting
+const formatTimeAgo = (date: Date): string => {
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffMins = Math.floor(diffMs / (1000 * 60));
+  const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+
+  if (diffMins < 1) return 'just now';
+  if (diffMins < 60) return `${diffMins}m ago`;
+  if (diffHours < 24) {
+    const mins = diffMins % 60;
+    return mins > 0 ? `${diffHours}h ${mins}m ago` : `${diffHours}h ago`;
+  }
+  if (diffDays === 1) return '1 day ago';
+  return `${diffDays} days ago`;
+};
+
+const getTierColor = (tier: string | undefined): string => {
+  switch (tier?.toLowerCase()) {
+    case 'gold':
+      return TIER_COLORS.gold;
+    case 'silver':
+      return TIER_COLORS.silver;
+    case 'bronze':
+      return TIER_COLORS.bronze;
+    default:
+      return 'rgba(255, 255, 255, 0.4)';
+  }
+};
+
+interface MinerDashboardHeaderProps {
+  githubId: string;
+}
+
+const MinerDashboardHeader: React.FC<MinerDashboardHeaderProps> = ({
+  githubId,
+}) => {
+  const { data: minerStats, isLoading, error } = useMinerStats(githubId);
+  const { data: prs } = useMinerPRs(githubId);
+  const { data: githubData } = useMinerGithubData(githubId);
+  const { data: allMinersStats } = useAllMiners();
+
+  const username = githubData?.login || prs?.[0]?.author || githubId;
+
+  // Calculate rank
+  const rank = useMemo(() => {
+    if (!allMinersStats || !minerStats) return null;
+    return (
+      allMinersStats
+        .slice()
+        .sort((a, b) => Number(b.totalScore) - Number(a.totalScore))
+        .findIndex((m) => m.githubId === githubId) + 1
+    );
+  }, [allMinersStats, minerStats, githubId]);
+
+  const totalMiners = allMinersStats?.length || 0;
+
+  if (isLoading) {
+    return (
+      <Card
+        sx={{
+          backgroundColor: 'transparent',
+          borderRadius: 3,
+          border: '1px solid rgba(255, 255, 255, 0.1)',
+          p: 4,
+          textAlign: 'center',
+        }}
+        elevation={0}
+      >
+        <CircularProgress size={40} sx={{ color: 'primary.main' }} />
+      </Card>
+    );
+  }
+
+  if (error || !minerStats) {
+    return (
+      <Card
+        sx={{
+          backgroundColor: 'rgba(255, 255, 255, 0.02)',
+          borderRadius: 3,
+          border: '1px solid rgba(255, 255, 255, 0.1)',
+          p: 4,
+        }}
+        elevation={0}
+      >
+        <Typography
+          sx={{
+            color: alpha(STATUS_COLORS.error, 0.9),
+            fontFamily: '"JetBrains Mono", monospace',
+            fontSize: '0.9rem',
+          }}
+        >
+          No data found for GitHub user: {githubId}
+        </Typography>
+      </Card>
+    );
+  }
+
+  const tierColor = getTierColor(minerStats.currentTier);
+  const credPercent = (Number(minerStats.credibility || 0) * 100).toFixed(1);
+
+  const keyStats = [
+    {
+      label: 'Total Score',
+      value: Number(minerStats.totalScore).toFixed(2),
+      icon: <ScoreIcon sx={{ fontSize: '1rem' }} />,
+      color: '#ffffff',
+    },
+    {
+      label: 'Credibility',
+      value: `${credPercent}%`,
+      icon: <CredibilityIcon sx={{ fontSize: '1rem' }} />,
+      color:
+        Number(minerStats.credibility || 0) >= 0.9
+          ? STATUS_COLORS.success
+          : Number(minerStats.credibility || 0) >= 0.7
+            ? '#a3e635'
+            : Number(minerStats.credibility || 0) >= 0.5
+              ? '#facc15'
+              : '#f87171',
+    },
+    {
+      label: 'Est. Daily',
+      value: `$${Math.round(minerStats.usdPerDay ?? 0).toLocaleString()}`,
+      icon: <EarningsIcon sx={{ fontSize: '1rem' }} />,
+      color:
+        (minerStats.usdPerDay ?? 0) > 0 ? STATUS_COLORS.success : '#ffffff',
+      subValue: `${(minerStats.taoPerDay ?? 0).toFixed(4)} TAO`,
+    },
+    {
+      label: 'Rank',
+      value: rank ? `#${rank}` : 'N/A',
+      icon: <RankIcon sx={{ fontSize: '1rem' }} />,
+      color:
+        rank === 1
+          ? TIER_COLORS.gold
+          : rank === 2
+            ? TIER_COLORS.silver
+            : rank === 3
+              ? TIER_COLORS.bronze
+              : '#ffffff',
+      subValue: totalMiners ? `of ${totalMiners}` : undefined,
+    },
+  ];
+
+  return (
+    <Card
+      sx={{
+        borderRadius: 3,
+        border: '1px solid',
+        borderColor: alpha(tierColor, 0.3),
+        backgroundColor: 'transparent',
+        p: 3,
+        position: 'relative',
+        overflow: 'visible',
+      }}
+      elevation={0}
+    >
+      {/* Updated timestamp */}
+      {minerStats.updatedAt && (
+        <Chip
+          icon={<UpdateIcon sx={{ fontSize: '0.9rem' }} />}
+          label={`Updated ${formatTimeAgo(new Date(minerStats.updatedAt))}`}
+          variant="outlined"
+          size="small"
+          sx={{
+            position: 'absolute',
+            top: 16,
+            right: 16,
+            fontFamily: '"JetBrains Mono", monospace',
+            fontSize: '0.7rem',
+            color: 'rgba(255, 255, 255, 0.5)',
+            borderColor: 'rgba(255, 255, 255, 0.15)',
+            backgroundColor: 'rgba(0, 0, 0, 0.3)',
+            '& .MuiChip-icon': { color: 'rgba(255, 255, 255, 0.4)' },
+          }}
+        />
+      )}
+
+      {/* Top section: Identity */}
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: { xs: 'column', md: 'row' },
+          gap: 3,
+          mb: 3,
+        }}
+      >
+        {/* Avatar + Name + Tier */}
+        <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 2.5 }}>
+          <Avatar
+            src={`https://avatars.githubusercontent.com/${username}`}
+            alt={username}
+            sx={{
+              width: 80,
+              height: 80,
+              border: `2px solid ${alpha(tierColor, 0.4)}`,
+              boxShadow: `0 0 20px ${alpha(tierColor, 0.15)}`,
+            }}
+          />
+          <Box>
+            {/* Name + Tier Badge */}
+            <Box
+              sx={{
+                display: 'inline-flex',
+                alignItems: 'stretch',
+                border: '1px solid',
+                borderColor: alpha(tierColor, 0.5),
+                borderRadius: '6px',
+                overflow: 'hidden',
+                backgroundColor: 'rgba(0,0,0,0.2)',
+                mb: 0.5,
+              }}
+            >
+              <Box
+                sx={{
+                  px: 2,
+                  py: 1,
+                  display: 'flex',
+                  alignItems: 'center',
+                  backgroundColor: 'rgba(255,255,255,0.02)',
+                }}
+              >
+                <Typography
+                  variant="h5"
+                  sx={{
+                    color: '#ffffff',
+                    fontFamily: '"JetBrains Mono", monospace',
+                    fontSize: '1.5rem',
+                    fontWeight: 700,
+                    lineHeight: 1.2,
+                  }}
+                >
+                  {githubData?.name || username}
+                </Typography>
+              </Box>
+              <Box
+                sx={{
+                  px: 1.5,
+                  display: 'flex',
+                  alignItems: 'center',
+                  borderLeft: '1px solid',
+                  borderColor: alpha(tierColor, 0.3),
+                  backgroundColor: alpha(tierColor, 0.1),
+                }}
+              >
+                <Typography
+                  sx={{
+                    fontFamily: '"JetBrains Mono", monospace',
+                    fontSize: '0.875rem',
+                    color: tierColor,
+                    textTransform: 'uppercase',
+                    letterSpacing: '1px',
+                    fontWeight: 700,
+                  }}
+                >
+                  {minerStats.currentTier || 'Unranked'}
+                </Typography>
+              </Box>
+            </Box>
+
+            {/* GitHub link */}
+            <Typography
+              component="a"
+              href={`https://github.com/${username}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              sx={{
+                color: 'primary.main',
+                fontFamily: '"JetBrains Mono", monospace',
+                fontSize: '1.1rem',
+                textDecoration: 'none',
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: 0.5,
+                '&:hover': { textDecoration: 'underline' },
+                mb: 0.5,
+              }}
+            >
+              <GitHubIcon fontSize="small" />@{username}
+            </Typography>
+
+            {/* Trust Badge */}
+            <Box sx={{ mt: 1 }}>
+              <TrustBadge
+                credibility={Number(minerStats.credibility || 0)}
+                totalPRs={Number(minerStats.totalPrs || 0)}
+              />
+            </Box>
+          </Box>
+        </Box>
+
+        <Divider
+          sx={{
+            display: { xs: 'block', md: 'none' },
+            borderColor: 'rgba(255, 255, 255, 0.1)',
+          }}
+        />
+
+        {/* Bio + social links */}
+        {githubData && (
+          <Box
+            sx={{
+              flex: 1,
+              display: 'flex',
+              flexDirection: 'column',
+              justifyContent: 'center',
+            }}
+          >
+            {githubData.bio && (
+              <Typography
+                sx={{
+                  color: 'rgba(255, 255, 255, 0.8)',
+                  fontStyle: 'italic',
+                  mb: 2,
+                  fontSize: '0.95rem',
+                  maxWidth: '600px',
+                }}
+              >
+                {githubData.bio}
+              </Typography>
+            )}
+            <Stack direction="row" gap={1.5} flexWrap="wrap">
+              {githubData.company && (
+                <Chip
+                  variant="info"
+                  icon={<CompanyIcon />}
+                  label={githubData.company}
+                />
+              )}
+              {githubData.location && (
+                <Chip
+                  variant="info"
+                  icon={<LocationIcon />}
+                  label={githubData.location}
+                />
+              )}
+              {githubData.blog && (
+                <Chip
+                  variant="status"
+                  component="a"
+                  href={
+                    githubData.blog.startsWith('http')
+                      ? githubData.blog
+                      : `https://${githubData.blog}`
+                  }
+                  target="_blank"
+                  icon={<WebsiteIcon />}
+                  label="Website"
+                  clickable
+                  sx={{
+                    color: STATUS_COLORS.info,
+                    borderColor: alpha(STATUS_COLORS.info, 0.3),
+                    '& .MuiChip-icon': { color: STATUS_COLORS.info },
+                  }}
+                />
+              )}
+              {githubData.twitterUsername && (
+                <Chip
+                  variant="status"
+                  component="a"
+                  href={`https://twitter.com/${githubData.twitterUsername}`}
+                  target="_blank"
+                  icon={<TwitterIcon />}
+                  label={`@${githubData.twitterUsername}`}
+                  clickable
+                  sx={{
+                    color: '#1DA1F2',
+                    borderColor: 'rgba(29, 161, 242, 0.3)',
+                    '& .MuiChip-icon': { color: '#1DA1F2' },
+                  }}
+                />
+              )}
+              <Chip
+                variant="info"
+                icon={<FollowersIcon />}
+                label={`${githubData.followers} followers`}
+              />
+            </Stack>
+          </Box>
+        )}
+      </Box>
+
+      {/* Key stats row */}
+      <Box
+        sx={{
+          display: 'grid',
+          gridTemplateColumns: {
+            xs: 'repeat(2, 1fr)',
+            sm: 'repeat(4, 1fr)',
+          },
+          gap: 2,
+        }}
+      >
+        {keyStats.map((stat) => (
+          <Box
+            key={stat.label}
+            sx={{
+              backgroundColor: 'rgba(255, 255, 255, 0.03)',
+              borderRadius: 2,
+              border: '1px solid rgba(255, 255, 255, 0.08)',
+              p: 2,
+              textAlign: 'center',
+            }}
+          >
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                gap: 0.5,
+                mb: 1,
+              }}
+            >
+              <Box sx={{ color: 'rgba(255, 255, 255, 0.5)' }}>{stat.icon}</Box>
+              <Typography
+                sx={{
+                  color: 'rgba(255, 255, 255, 0.5)',
+                  fontFamily: '"JetBrains Mono", monospace',
+                  fontSize: '0.75rem',
+                  textTransform: 'uppercase',
+                  letterSpacing: '0.5px',
+                  fontWeight: 600,
+                }}
+              >
+                {stat.label}
+              </Typography>
+            </Box>
+            <Typography
+              sx={{
+                color: stat.color,
+                fontFamily: '"JetBrains Mono", monospace',
+                fontSize: '1.5rem',
+                fontWeight: 700,
+                lineHeight: 1.2,
+              }}
+            >
+              {stat.value}
+            </Typography>
+            {stat.subValue && (
+              <Typography
+                sx={{
+                  color: 'rgba(255, 255, 255, 0.4)',
+                  fontFamily: '"JetBrains Mono", monospace',
+                  fontSize: '0.75rem',
+                  mt: 0.5,
+                }}
+              >
+                {stat.subValue}
+              </Typography>
+            )}
+          </Box>
+        ))}
+      </Box>
+    </Card>
+  );
+};
+
+export default MinerDashboardHeader;

--- a/src/components/miners/MinerInsights.tsx
+++ b/src/components/miners/MinerInsights.tsx
@@ -1,0 +1,307 @@
+import React, { useMemo } from 'react';
+import {
+  Card,
+  Typography,
+  Box,
+  CircularProgress,
+  alpha,
+} from '@mui/material';
+import {
+  Lightbulb as InsightIcon,
+  TrendingUp as GrowthIcon,
+  Warning as WarningIcon,
+  EmojiEvents as TrophyIcon,
+  Star as StarIcon,
+} from '@mui/icons-material';
+import {
+  useMinerStats,
+  useMinerPRs,
+  useReposAndWeights,
+  useTierConfigurations,
+} from '../../api';
+import { TIER_COLORS, STATUS_COLORS } from '../../theme';
+
+interface MinerInsightsProps {
+  githubId: string;
+}
+
+interface Insight {
+  type: 'success' | 'warning' | 'tip' | 'achievement';
+  icon: React.ReactNode;
+  message: string;
+  color: string;
+}
+
+const TIER_LEVELS: Record<string, number> = {
+  bronze: 1,
+  silver: 2,
+  gold: 3,
+};
+
+const MinerInsights: React.FC<MinerInsightsProps> = ({ githubId }) => {
+  const { data: minerStats, isLoading } = useMinerStats(githubId);
+  const { data: prs } = useMinerPRs(githubId);
+  const { data: repos } = useReposAndWeights();
+  const { data: tierConfigData } = useTierConfigurations();
+
+  // Build repo weight map
+  const repoWeights = useMemo(() => {
+    const map = new Map<string, number>();
+    if (Array.isArray(repos)) {
+      repos.forEach((repo) => {
+        if (repo?.fullName) {
+          map.set(repo.fullName, parseFloat(repo.weight || '0'));
+        }
+      });
+    }
+    return map;
+  }, [repos]);
+
+  const insights = useMemo((): Insight[] => {
+    if (!minerStats) return [];
+
+    const result: Insight[] = [];
+    const currentTierLevel =
+      TIER_LEVELS[(minerStats.currentTier || '').toLowerCase()] || 0;
+    const tierConfigs = tierConfigData?.tiers;
+    const credibility = Number(minerStats.credibility || 0);
+    const openPrs = Number(minerStats.totalOpenPrs || 0);
+    const mergedPrs = Number(minerStats.totalMergedPrs || 0);
+    const closedPrs = Number(minerStats.totalClosedPrs || 0);
+
+    // Tier unlock proximity insights
+    if (currentTierLevel < 3) {
+      const nextTierNames = ['Bronze', 'Silver', 'Gold'];
+      const nextTierName = nextTierNames[currentTierLevel]; // 0->Bronze, 1->Silver, 2->Gold
+      const nextConfig = tierConfigs?.find(
+        (t) => t.name.toLowerCase() === nextTierName.toLowerCase(),
+      );
+
+      if (nextConfig) {
+        const tierKey = nextTierName.toLowerCase() as
+          | 'bronze'
+          | 'silver'
+          | 'gold';
+        const qualifiedRepos = Number(
+          minerStats[
+            `${tierKey}QualifiedUniqueRepos` as keyof typeof minerStats
+          ] || 0,
+        );
+        const tierCredibility = Number(
+          minerStats[
+            `${tierKey}Credibility` as keyof typeof minerStats
+          ] || 0,
+        );
+        const tierTokenScore = Number(
+          minerStats[
+            `${tierKey}TokenScore` as keyof typeof minerStats
+          ] || 0,
+        );
+
+        const reposNeeded =
+          nextConfig.requiredQualifiedUniqueRepos - qualifiedRepos;
+        if (reposNeeded > 0 && reposNeeded <= 3) {
+          result.push({
+            type: 'tip',
+            icon: <GrowthIcon sx={{ fontSize: '1.1rem' }} />,
+            message: `Your ${nextTierName} tier is ${reposNeeded} qualified repo${reposNeeded > 1 ? 's' : ''} away from unlocking!`,
+            color: '#a3e635',
+          });
+        }
+
+        if (
+          nextConfig.requiredMinTokenScore &&
+          tierTokenScore < nextConfig.requiredMinTokenScore
+        ) {
+          const tokenNeeded =
+            nextConfig.requiredMinTokenScore - tierTokenScore;
+          result.push({
+            type: 'tip',
+            icon: <StarIcon sx={{ fontSize: '1.1rem' }} />,
+            message: `Need ${tokenNeeded.toFixed(0)} more token score in ${nextTierName} repos to unlock that tier.`,
+            color: TIER_COLORS[tierKey as keyof typeof TIER_COLORS],
+          });
+        }
+      }
+    }
+
+    // Credibility insights
+    if (credibility < 0.9 && credibility >= 0.7) {
+      const prsNeeded = Math.ceil(
+        (0.9 * (mergedPrs + closedPrs) - mergedPrs) / (1 - 0.9),
+      );
+      if (prsNeeded > 0 && prsNeeded <= 10) {
+        result.push({
+          type: 'tip',
+          icon: <GrowthIcon sx={{ fontSize: '1.1rem' }} />,
+          message: `Your credibility is ${(credibility * 100).toFixed(0)}% - merging ${prsNeeded} more PR${prsNeeded > 1 ? 's' : ''} (without closures) will reach 90%.`,
+          color: '#a3e635',
+        });
+      }
+    }
+
+    if (credibility >= 1.0 && mergedPrs >= 5) {
+      result.push({
+        type: 'achievement',
+        icon: <TrophyIcon sx={{ fontSize: '1.1rem' }} />,
+        message: `Perfect 100% credibility with ${mergedPrs} merged PRs - exceptional track record!`,
+        color: STATUS_COLORS.success,
+      });
+    }
+
+    // Open PR risk warning
+    if (openPrs >= 5) {
+      result.push({
+        type: 'warning',
+        icon: <WarningIcon sx={{ fontSize: '1.1rem' }} />,
+        message: `You have ${openPrs} open PRs. Open PRs have collateral deducted from your score. Consider closing or getting them merged.`,
+        color: STATUS_COLORS.warning,
+      });
+    }
+
+    const collateral = Number(minerStats.totalCollateralScore || 0);
+    if (collateral > 0) {
+      result.push({
+        type: 'warning',
+        icon: <WarningIcon sx={{ fontSize: '1.1rem' }} />,
+        message: `${collateral.toFixed(2)} score is held as collateral for open PRs. Getting them merged will recover this score.`,
+        color: '#fb923c',
+      });
+    }
+
+    // Top repos insight
+    if (prs && prs.length > 0) {
+      const repoScores = new Map<string, number>();
+      prs.forEach((pr) => {
+        const existing = repoScores.get(pr.repository) || 0;
+        repoScores.set(pr.repository, existing + parseFloat(pr.score || '0'));
+      });
+
+      const topRepos = Array.from(repoScores.entries())
+        .sort((a, b) => b[1] - a[1])
+        .slice(0, 3);
+
+      if (topRepos.length > 0) {
+        const topRepoStr = topRepos
+          .map(([repo, score]) => {
+            const weight = repoWeights.get(repo);
+            return `${repo.split('/').pop()} (${score.toFixed(2)}${weight ? `, weight: ${weight.toFixed(2)}` : ''})`;
+          })
+          .join(', ');
+
+        result.push({
+          type: 'success',
+          icon: <InsightIcon sx={{ fontSize: '1.1rem' }} />,
+          message: `Your highest-scoring repos: ${topRepoStr}`,
+          color: STATUS_COLORS.info,
+        });
+      }
+    }
+
+    // Current tier achievement
+    if (currentTierLevel === 3) {
+      result.push({
+        type: 'achievement',
+        icon: <TrophyIcon sx={{ fontSize: '1.1rem' }} />,
+        message:
+          'All tiers unlocked! You are contributing at the highest level across Bronze, Silver, and Gold repositories.',
+        color: TIER_COLORS.gold,
+      });
+    }
+
+    return result;
+  }, [minerStats, prs, repoWeights, tierConfigData]);
+
+  if (isLoading) {
+    return (
+      <Card
+        sx={{
+          borderRadius: 3,
+          border: '1px solid rgba(255, 255, 255, 0.1)',
+          backgroundColor: 'transparent',
+          p: 4,
+          textAlign: 'center',
+        }}
+        elevation={0}
+      >
+        <CircularProgress size={30} sx={{ color: 'primary.main' }} />
+      </Card>
+    );
+  }
+
+  if (!minerStats || insights.length === 0) return null;
+
+  return (
+    <Card
+      sx={{
+        borderRadius: 3,
+        border: '1px solid rgba(255, 255, 255, 0.1)',
+        backgroundColor: 'transparent',
+        p: 3,
+      }}
+      elevation={0}
+    >
+      <Typography
+        variant="h6"
+        sx={{
+          color: '#ffffff',
+          fontFamily: '"JetBrains Mono", monospace',
+          mb: 2.5,
+          fontWeight: 600,
+          fontSize: '1.1rem',
+          display: 'flex',
+          alignItems: 'center',
+          gap: 1.5,
+          '&::before': {
+            content: '""',
+            width: '4px',
+            height: '20px',
+            backgroundColor: STATUS_COLORS.info,
+            borderRadius: '2px',
+          },
+        }}
+      >
+        Insights & Recommendations
+      </Typography>
+
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+        {insights.map((insight, index) => (
+          <Box
+            key={index}
+            sx={{
+              display: 'flex',
+              alignItems: 'flex-start',
+              gap: 1.5,
+              p: 2,
+              borderRadius: 2,
+              backgroundColor: alpha(insight.color, 0.05),
+              border: `1px solid ${alpha(insight.color, 0.15)}`,
+            }}
+          >
+            <Box
+              sx={{
+                color: insight.color,
+                mt: 0.25,
+                flexShrink: 0,
+              }}
+            >
+              {insight.icon}
+            </Box>
+            <Typography
+              sx={{
+                color: 'rgba(255, 255, 255, 0.8)',
+                fontFamily: '"JetBrains Mono", monospace',
+                fontSize: '0.85rem',
+                lineHeight: 1.6,
+              }}
+            >
+              {insight.message}
+            </Typography>
+          </Box>
+        ))}
+      </Box>
+    </Card>
+  );
+};
+
+export default MinerInsights;

--- a/src/components/miners/MinerPRsTable.tsx
+++ b/src/components/miners/MinerPRsTable.tsx
@@ -13,10 +13,22 @@ import {
   Avatar,
   Chip,
   Button,
+  TextField,
+  InputAdornment,
+  TableSortLabel,
+  Pagination,
 } from '@mui/material';
+import {
+  Search as SearchIcon,
+} from '@mui/icons-material';
 import { useMinerPRs } from '../../api';
 import { useNavigate } from 'react-router-dom';
-import theme from '../../theme';
+import theme, { TIER_COLORS } from '../../theme';
+
+type PRSortField = 'score' | 'date' | 'additions' | 'number';
+type PRSortOrder = 'asc' | 'desc';
+
+const ROWS_PER_PAGE = 15;
 
 interface MinerPRsTableProps {
   githubId: string;
@@ -30,8 +42,23 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
   const [statusFilter, setStatusFilter] = useState<
     'all' | 'open' | 'merged' | 'closed'
   >('all');
+  const [searchQuery, setSearchQuery] = useState('');
+  const [tierFilter, setTierFilter] = useState<string | null>(null);
+  const [sortField, setSortField] = useState<PRSortField>('date');
+  const [sortOrder, setSortOrder] = useState<PRSortOrder>('desc');
+  const [page, setPage] = useState(1);
 
-  // Filter PRs by selected repository, author, and status
+  const handleSort = (field: PRSortField) => {
+    if (sortField === field) {
+      setSortOrder(sortOrder === 'asc' ? 'desc' : 'asc');
+    } else {
+      setSortField(field);
+      setSortOrder('desc');
+    }
+    setPage(1);
+  };
+
+  // Filter PRs by selected repository, author, status, search, and tier
   const filteredPRs = useMemo(() => {
     if (!prs) return [];
     let filtered = prs;
@@ -54,8 +81,57 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
         (pr) => pr.prState === 'CLOSED' && !pr.mergedAt,
       );
     }
+    // Search filter
+    if (searchQuery.trim()) {
+      const q = searchQuery.toLowerCase();
+      filtered = filtered.filter(
+        (pr) =>
+          pr.pullRequestTitle?.toLowerCase().includes(q) ||
+          pr.repository?.toLowerCase().includes(q),
+      );
+    }
+    // Tier filter
+    if (tierFilter) {
+      filtered = filtered.filter(
+        (pr) => pr.tier?.toLowerCase() === tierFilter.toLowerCase(),
+      );
+    }
     return filtered;
-  }, [prs, selectedRepo, selectedAuthor, statusFilter]);
+  }, [prs, selectedRepo, selectedAuthor, statusFilter, searchQuery, tierFilter]);
+
+  // Sort filtered PRs
+  const sortedPRs = useMemo(() => {
+    const sorted = [...filteredPRs];
+    sorted.sort((a, b) => {
+      let cmp = 0;
+      switch (sortField) {
+        case 'score':
+          cmp = parseFloat(a.score || '0') - parseFloat(b.score || '0');
+          break;
+        case 'date': {
+          const dateA = a.mergedAt || a.prCreatedAt || '';
+          const dateB = b.mergedAt || b.prCreatedAt || '';
+          cmp = new Date(dateA).getTime() - new Date(dateB).getTime();
+          break;
+        }
+        case 'additions':
+          cmp = (a.additions || 0) - (b.additions || 0);
+          break;
+        case 'number':
+          cmp = a.pullRequestNumber - b.pullRequestNumber;
+          break;
+      }
+      return sortOrder === 'asc' ? cmp : -cmp;
+    });
+    return sorted;
+  }, [filteredPRs, sortField, sortOrder]);
+
+  // Paginate
+  const totalPages = Math.max(1, Math.ceil(sortedPRs.length / ROWS_PER_PAGE));
+  const paginatedPRs = sortedPRs.slice(
+    (page - 1) * ROWS_PER_PAGE,
+    page * ROWS_PER_PAGE,
+  );
 
   const statusCounts = useMemo(() => {
     if (!prs) return { all: 0, open: 0, merged: 0, closed: 0 };
@@ -114,6 +190,7 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
             justifyContent: 'space-between',
             flexWrap: 'wrap',
             gap: 2,
+            mb: 2,
           }}
         >
           <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 1.5 }}>
@@ -136,7 +213,7 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
               }}
             >
               ({filteredPRs.length}
-              {selectedRepo || selectedAuthor || statusFilter !== 'all'
+              {selectedRepo || selectedAuthor || statusFilter !== 'all' || searchQuery || tierFilter
                 ? ` of ${prs?.length || 0}`
                 : ''}
               )
@@ -164,6 +241,18 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
                 onDelete={() => setSelectedAuthor(null)}
               />
             )}
+            {tierFilter && (
+              <Chip
+                variant="filter"
+                label={`Tier: ${tierFilter}`}
+                onDelete={() => { setTierFilter(null); setPage(1); }}
+                sx={{
+                  color: tierFilter === 'Gold' ? TIER_COLORS.gold
+                    : tierFilter === 'Silver' ? TIER_COLORS.silver
+                    : TIER_COLORS.bronze,
+                }}
+              />
+            )}
 
             {/* Status Filter Buttons */}
             <Box sx={{ display: 'flex', gap: 0.5 }}>
@@ -172,30 +261,106 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
                 count={statusCounts.all}
                 color={theme.palette.status.neutral}
                 selected={statusFilter === 'all'}
-                onClick={() => setStatusFilter('all')}
+                onClick={() => { setStatusFilter('all'); setPage(1); }}
               />
               <FilterButton
                 label="Open"
                 count={statusCounts.open}
                 color={theme.palette.status.open}
                 selected={statusFilter === 'open'}
-                onClick={() => setStatusFilter('open')}
+                onClick={() => { setStatusFilter('open'); setPage(1); }}
               />
               <FilterButton
                 label="Merged"
                 count={statusCounts.merged}
                 color={theme.palette.status.merged}
                 selected={statusFilter === 'merged'}
-                onClick={() => setStatusFilter('merged')}
+                onClick={() => { setStatusFilter('merged'); setPage(1); }}
               />
               <FilterButton
                 label="Closed"
                 count={statusCounts.closed}
                 color={theme.palette.status.closed}
                 selected={statusFilter === 'closed'}
-                onClick={() => setStatusFilter('closed')}
+                onClick={() => { setStatusFilter('closed'); setPage(1); }}
               />
             </Box>
+          </Box>
+        </Box>
+
+        {/* Search + Tier filter row */}
+        <Box
+          sx={{
+            display: 'flex',
+            gap: 1.5,
+            flexWrap: 'wrap',
+            alignItems: 'center',
+          }}
+        >
+          <TextField
+            size="small"
+            placeholder="Search by title or repo..."
+            value={searchQuery}
+            onChange={(e) => { setSearchQuery(e.target.value); setPage(1); }}
+            InputProps={{
+              startAdornment: (
+                <InputAdornment position="start">
+                  <SearchIcon sx={{ fontSize: '1rem', color: 'rgba(255,255,255,0.3)' }} />
+                </InputAdornment>
+              ),
+            }}
+            sx={{
+              flex: 1,
+              minWidth: 200,
+              '& .MuiOutlinedInput-root': {
+                fontFamily: '"JetBrains Mono", monospace',
+                fontSize: '0.8rem',
+                color: '#ffffff',
+                backgroundColor: 'rgba(255,255,255,0.03)',
+                borderRadius: '8px',
+                '& fieldset': {
+                  borderColor: 'rgba(255,255,255,0.1)',
+                },
+                '&:hover fieldset': {
+                  borderColor: 'rgba(255,255,255,0.2)',
+                },
+                '&.Mui-focused fieldset': {
+                  borderColor: 'primary.main',
+                },
+              },
+            }}
+          />
+          <Box sx={{ display: 'flex', gap: 0.5 }}>
+            {['Bronze', 'Silver', 'Gold'].map((tier) => (
+              <Button
+                key={tier}
+                size="small"
+                onClick={() => {
+                  setTierFilter(tierFilter === tier ? null : tier);
+                  setPage(1);
+                }}
+                sx={{
+                  color: tierFilter === tier
+                    ? (tier === 'Gold' ? TIER_COLORS.gold : tier === 'Silver' ? TIER_COLORS.silver : TIER_COLORS.bronze)
+                    : 'rgba(255,255,255,0.4)',
+                  backgroundColor: tierFilter === tier ? 'rgba(255,255,255,0.08)' : 'transparent',
+                  borderRadius: '6px',
+                  px: 1.5,
+                  minWidth: 'auto',
+                  textTransform: 'none',
+                  fontFamily: '"JetBrains Mono", monospace',
+                  fontSize: '0.75rem',
+                  border: tierFilter === tier
+                    ? `1px solid ${tier === 'Gold' ? TIER_COLORS.gold : tier === 'Silver' ? TIER_COLORS.silver : TIER_COLORS.bronze}`
+                    : '1px solid transparent',
+                  '&:hover': {
+                    backgroundColor: 'rgba(255,255,255,0.1)',
+                  },
+                }}
+              >
+                {tier}
+              </Button>
+            ))}
           </Box>
         </Box>
       </Box>
@@ -253,7 +418,16 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
           >
             <TableHead>
               <TableRow>
-                <TableCell sx={headerCellStyle}>PR #</TableCell>
+                <TableCell sx={headerCellStyle}>
+                  <TableSortLabel
+                    active={sortField === 'number'}
+                    direction={sortField === 'number' ? sortOrder : 'desc'}
+                    onClick={() => handleSort('number')}
+                    sx={sortLabelSx}
+                  >
+                    PR #
+                  </TableSortLabel>
+                </TableCell>
                 <TableCell sx={headerCellStyle}>Title</TableCell>
                 <TableCell
                   sx={{
@@ -270,10 +444,24 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
                     display: { xs: 'none', md: 'table-cell' },
                   }}
                 >
-                  +/-
+                  <TableSortLabel
+                    active={sortField === 'additions'}
+                    direction={sortField === 'additions' ? sortOrder : 'desc'}
+                    onClick={() => handleSort('additions')}
+                    sx={sortLabelSx}
+                  >
+                    +/-
+                  </TableSortLabel>
                 </TableCell>
                 <TableCell align="right" sx={headerCellStyle}>
-                  Score
+                  <TableSortLabel
+                    active={sortField === 'score'}
+                    direction={sortField === 'score' ? sortOrder : 'desc'}
+                    onClick={() => handleSort('score')}
+                    sx={sortLabelSx}
+                  >
+                    Score
+                  </TableSortLabel>
                 </TableCell>
                 <TableCell
                   align="right"
@@ -282,12 +470,19 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
                     display: { xs: 'none', sm: 'table-cell' },
                   }}
                 >
-                  Merged
+                  <TableSortLabel
+                    active={sortField === 'date'}
+                    direction={sortField === 'date' ? sortOrder : 'desc'}
+                    onClick={() => handleSort('date')}
+                    sx={sortLabelSx}
+                  >
+                    Merged
+                  </TableSortLabel>
                 </TableCell>
               </TableRow>
             </TableHead>
             <TableBody>
-              {filteredPRs.map((pr, index) => (
+              {paginatedPRs.map((pr, index) => (
                 <TableRow
                   key={`${pr.repository}-${pr.pullRequestNumber}-${index}`}
                   onClick={() => {
@@ -489,8 +684,53 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
           </Table>
         </TableContainer>
       )}
+
+      {/* Pagination */}
+      {sortedPRs.length > ROWS_PER_PAGE && (
+        <Box
+          sx={{
+            display: 'flex',
+            justifyContent: 'center',
+            p: 2,
+            borderTop: '1px solid rgba(255, 255, 255, 0.1)',
+          }}
+        >
+          <Pagination
+            count={totalPages}
+            page={page}
+            onChange={(_e, newPage) => setPage(newPage)}
+            size="small"
+            sx={{
+              '& .MuiPaginationItem-root': {
+                color: 'rgba(255, 255, 255, 0.5)',
+                fontFamily: '"JetBrains Mono", monospace',
+                fontSize: '0.75rem',
+                '&.Mui-selected': {
+                  backgroundColor: 'rgba(29, 55, 252, 0.2)',
+                  color: '#ffffff',
+                  border: '1px solid rgba(29, 55, 252, 0.4)',
+                },
+                '&:hover': {
+                  backgroundColor: 'rgba(255, 255, 255, 0.08)',
+                },
+              },
+            }}
+          />
+        </Box>
+      )}
     </Card>
   );
+};
+
+const sortLabelSx = {
+  color: 'inherit',
+  '&:hover': { color: 'rgba(255, 255, 255, 0.9)' },
+  '&.Mui-active': {
+    color: 'rgba(255, 255, 255, 0.9)',
+    '& .MuiTableSortLabel-icon': {
+      color: 'rgba(255, 255, 255, 0.9) !important',
+    },
+  },
 };
 
 const headerCellStyle = {

--- a/src/components/miners/MinerRepositoriesTable.tsx
+++ b/src/components/miners/MinerRepositoriesTable.tsx
@@ -12,8 +12,14 @@ import {
   CircularProgress,
   Avatar,
   TableSortLabel,
+  TextField,
+  InputAdornment,
+  Chip,
   alpha,
 } from '@mui/material';
+import {
+  Search as SearchIcon,
+} from '@mui/icons-material';
 import { useMinerPRs, useReposAndWeights } from '../../api';
 import { useNavigate } from 'react-router-dom';
 import { TIER_COLORS } from '../../theme';
@@ -54,6 +60,8 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
   const { data: repos, isLoading: isLoadingRepos } = useReposAndWeights();
   const [sortField, setSortField] = useState<SortField>('score');
   const [sortOrder, setSortOrder] = useState<SortOrder>('desc');
+  const [repoSearch, setRepoSearch] = useState('');
+  const [tierFilterRepo, setTierFilterRepo] = useState<string | null>(null);
 
   // Build repository weights and tiers maps
   const repoWeights = useMemo(() => {
@@ -102,9 +110,19 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
     return Array.from(statsMap.values());
   }, [prs, repoWeights, repoTiers]);
 
-  // Sort repository stats
+  // Filter and sort repository stats
   const sortedRepoStats = useMemo(() => {
-    const sorted = [...repoStats];
+    let filtered = [...repoStats];
+    if (repoSearch.trim()) {
+      const q = repoSearch.toLowerCase();
+      filtered = filtered.filter((r) => r.repository.toLowerCase().includes(q));
+    }
+    if (tierFilterRepo) {
+      filtered = filtered.filter(
+        (r) => r.tier.toLowerCase() === tierFilterRepo.toLowerCase(),
+      );
+    }
+    const sorted = filtered;
     sorted.sort((a, b) => {
       let compareValue = 0;
 
@@ -130,7 +148,7 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
       return sortOrder === 'asc' ? compareValue : -compareValue;
     });
     return sorted;
-  }, [repoStats, sortField, sortOrder]);
+  }, [repoStats, sortField, sortOrder, repoSearch, tierFilterRepo]);
 
   const handleSort = (field: SortField) => {
     if (sortField === field) {
@@ -204,17 +222,79 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
           borderBottom: '1px solid rgba(255, 255, 255, 0.1)',
         }}
       >
-        <Typography
-          variant="h6"
+        <Box
           sx={{
-            color: '#ffffff',
-            fontFamily: '"JetBrains Mono", monospace',
-            fontSize: '1.1rem',
-            fontWeight: 500,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            flexWrap: 'wrap',
+            gap: 2,
+            mb: 2,
           }}
         >
-          Top Repositories
-        </Typography>
+          <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 1.5 }}>
+            <Typography
+              variant="h6"
+              sx={{
+                color: '#ffffff',
+                fontFamily: '"JetBrains Mono", monospace',
+                fontSize: '1.1rem',
+                fontWeight: 500,
+              }}
+            >
+              Top Repositories
+            </Typography>
+            <Typography
+              sx={{
+                color: 'rgba(255, 255, 255, 0.5)',
+                fontFamily: '"JetBrains Mono", monospace',
+                fontSize: '0.75rem',
+              }}
+            >
+              ({sortedRepoStats.length}
+              {repoSearch || tierFilterRepo ? ` of ${repoStats.length}` : ''})
+            </Typography>
+          </Box>
+          {tierFilterRepo && (
+            <Chip
+              variant="filter"
+              label={`Tier: ${tierFilterRepo}`}
+              onDelete={() => setTierFilterRepo(null)}
+              sx={{
+                color: tierFilterRepo === 'Gold' ? TIER_COLORS.gold
+                  : tierFilterRepo === 'Silver' ? TIER_COLORS.silver
+                  : TIER_COLORS.bronze,
+              }}
+            />
+          )}
+        </Box>
+        <TextField
+          size="small"
+          placeholder="Search repositories..."
+          value={repoSearch}
+          onChange={(e) => setRepoSearch(e.target.value)}
+          InputProps={{
+            startAdornment: (
+              <InputAdornment position="start">
+                <SearchIcon sx={{ fontSize: '1rem', color: 'rgba(255,255,255,0.3)' }} />
+              </InputAdornment>
+            ),
+          }}
+          sx={{
+            width: '100%',
+            maxWidth: 400,
+            '& .MuiOutlinedInput-root': {
+              fontFamily: '"JetBrains Mono", monospace',
+              fontSize: '0.8rem',
+              color: '#ffffff',
+              backgroundColor: 'rgba(255,255,255,0.03)',
+              borderRadius: '8px',
+              '& fieldset': { borderColor: 'rgba(255,255,255,0.1)' },
+              '&:hover fieldset': { borderColor: 'rgba(255,255,255,0.2)' },
+              '&.Mui-focused fieldset': { borderColor: 'primary.main' },
+            },
+          }}
+        />
       </Box>
 
       <TableContainer sx={{ maxHeight: '400px', overflow: 'auto' }}>
@@ -426,14 +506,24 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
                     />
                     {repo.tier && (
                       <Box
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setTierFilterRepo(
+                            tierFilterRepo === repo.tier ? null : repo.tier,
+                          );
+                        }}
                         sx={{
-                          width: 6,
-                          height: 6,
+                          width: 8,
+                          height: 8,
                           borderRadius: '50%',
                           backgroundColor: getTierColor(repo.tier),
                           flexShrink: 0,
+                          cursor: 'pointer',
+                          '&:hover': {
+                            boxShadow: `0 0 6px ${getTierColor(repo.tier)}`,
+                          },
                         }}
-                        title={`${repo.tier} tier`}
+                        title={`Filter by ${repo.tier} tier`}
                       />
                     )}
                     <Typography

--- a/src/components/miners/ScoreBreakdownPanel.tsx
+++ b/src/components/miners/ScoreBreakdownPanel.tsx
@@ -1,0 +1,695 @@
+import React, { useState } from 'react';
+import {
+  Card,
+  Typography,
+  Box,
+  CircularProgress,
+  Tooltip,
+  Collapse,
+  IconButton,
+  alpha,
+  LinearProgress,
+} from '@mui/material';
+import {
+  InfoOutlined as InfoIcon,
+  ExpandMore as ExpandIcon,
+  ArrowForward as ArrowIcon,
+} from '@mui/icons-material';
+import {
+  useMinerStats,
+  useMinerPRs,
+  useGeneralConfig,
+  type MinerEvaluation,
+} from '../../api';
+import { TIER_COLORS, STATUS_COLORS } from '../../theme';
+
+const TIER_LEVELS: Record<string, number> = {
+  bronze: 1,
+  silver: 2,
+  gold: 3,
+};
+
+const calculateDynamicThreshold = (
+  minerStats: MinerEvaluation,
+  prScoring: { excessivePrPenaltyThreshold?: number; openPrThresholdTokenScore?: number; maxOpenPrThreshold?: number } | undefined,
+): number => {
+  const baseThreshold = prScoring?.excessivePrPenaltyThreshold ?? 10;
+  const tokenScorePer = prScoring?.openPrThresholdTokenScore ?? 500;
+  const maxThreshold = prScoring?.maxOpenPrThreshold ?? 30;
+
+  const currentTierLevel = TIER_LEVELS[(minerStats.currentTier || '').toLowerCase()] || 0;
+
+  let unlockedTokenScore = 0;
+  if (currentTierLevel >= 1) unlockedTokenScore += Number(minerStats.bronzeTokenScore || 0);
+  if (currentTierLevel >= 2) unlockedTokenScore += Number(minerStats.silverTokenScore || 0);
+  if (currentTierLevel >= 3) unlockedTokenScore += Number(minerStats.goldTokenScore || 0);
+
+  const bonus = Math.floor(unlockedTokenScore / tokenScorePer);
+  return Math.min(baseThreshold + bonus, maxThreshold);
+};
+
+interface ScoreBreakdownPanelProps {
+  githubId: string;
+}
+
+interface TierBreakdown {
+  name: string;
+  color: string;
+  score: number;
+  tokenScore: number;
+  structuralCount: number;
+  structuralScore: number;
+  leafCount: number;
+  leafScore: number;
+  collateral: number;
+  credibility: number;
+  mergedPrs: number;
+  totalPrs: number;
+  isUnlocked: boolean;
+}
+
+const ScoreBreakdownPanel: React.FC<ScoreBreakdownPanelProps> = ({
+  githubId,
+}) => {
+  const { data: minerStats, isLoading } = useMinerStats(githubId);
+  const { data: prs } = useMinerPRs(githubId);
+  const { data: generalConfig } = useGeneralConfig();
+  const [expandedTier, setExpandedTier] = useState<string | null>(null);
+
+  if (isLoading) {
+    return (
+      <Card
+        sx={{
+          borderRadius: 3,
+          border: '1px solid rgba(255, 255, 255, 0.1)',
+          backgroundColor: 'transparent',
+          p: 4,
+          textAlign: 'center',
+        }}
+        elevation={0}
+      >
+        <CircularProgress size={30} sx={{ color: 'primary.main' }} />
+      </Card>
+    );
+  }
+
+  if (!minerStats) return null;
+
+  const currentTierLevel = TIER_LEVELS[(minerStats.currentTier || '').toLowerCase()] || 0;
+  const openPrThreshold = calculateDynamicThreshold(minerStats, generalConfig?.repositoryPrScoring);
+
+  const baseScore = Number(minerStats.baseTotalScore || 0);
+  const credibilityMultiplier = Number(minerStats.credibility || 0);
+  const collateralDeduction = Number(minerStats.totalCollateralScore || 0);
+  const finalScore = Number(minerStats.totalScore || 0);
+
+  // Tier breakdowns
+  const tiers: TierBreakdown[] = [
+    {
+      name: 'Bronze',
+      color: TIER_COLORS.bronze,
+      score: Number(minerStats.bronzeScore || 0),
+      tokenScore: Number(minerStats.bronzeTokenScore || 0),
+      structuralCount: Number(minerStats.bronzeStructuralCount || 0),
+      structuralScore: Number(minerStats.bronzeStructuralScore || 0),
+      leafCount: Number(minerStats.bronzeLeafCount || 0),
+      leafScore: Number(minerStats.bronzeLeafScore || 0),
+      collateral: Number(minerStats.bronzeCollateralScore || 0),
+      credibility: Number(minerStats.bronzeCredibility || 0),
+      mergedPrs: Number(minerStats.bronzeMergedPrs || 0),
+      totalPrs: Number(minerStats.bronzeTotalPrs || 0),
+      isUnlocked: currentTierLevel >= 1,
+    },
+    {
+      name: 'Silver',
+      color: TIER_COLORS.silver,
+      score: Number(minerStats.silverScore || 0),
+      tokenScore: Number(minerStats.silverTokenScore || 0),
+      structuralCount: Number(minerStats.silverStructuralCount || 0),
+      structuralScore: Number(minerStats.silverStructuralScore || 0),
+      leafCount: Number(minerStats.silverLeafCount || 0),
+      leafScore: Number(minerStats.silverLeafScore || 0),
+      collateral: Number(minerStats.silverCollateralScore || 0),
+      credibility: Number(minerStats.silverCredibility || 0),
+      mergedPrs: Number(minerStats.silverMergedPrs || 0),
+      totalPrs: Number(minerStats.silverTotalPrs || 0),
+      isUnlocked: currentTierLevel >= 2,
+    },
+    {
+      name: 'Gold',
+      color: TIER_COLORS.gold,
+      score: Number(minerStats.goldScore || 0),
+      tokenScore: Number(minerStats.goldTokenScore || 0),
+      structuralCount: Number(minerStats.goldStructuralCount || 0),
+      structuralScore: Number(minerStats.goldStructuralScore || 0),
+      leafCount: Number(minerStats.goldLeafCount || 0),
+      leafScore: Number(minerStats.goldLeafScore || 0),
+      collateral: Number(minerStats.goldCollateralScore || 0),
+      credibility: Number(minerStats.goldCredibility || 0),
+      mergedPrs: Number(minerStats.goldMergedPrs || 0),
+      totalPrs: Number(minerStats.goldTotalPrs || 0),
+      isUnlocked: currentTierLevel >= 3,
+    },
+  ];
+
+  const tooltipSx = {
+    tooltip: {
+      sx: {
+        backgroundColor: 'rgba(30, 30, 30, 0.95)',
+        color: '#ffffff',
+        fontSize: '0.75rem',
+        fontFamily: '"JetBrains Mono", monospace',
+        padding: '8px 12px',
+        borderRadius: '6px',
+        border: '1px solid rgba(255, 255, 255, 0.1)',
+        maxWidth: 280,
+      },
+    },
+    arrow: { sx: { color: 'rgba(30, 30, 30, 0.95)' } },
+  };
+
+  return (
+    <Card
+      sx={{
+        borderRadius: 3,
+        border: '1px solid rgba(255, 255, 255, 0.1)',
+        backgroundColor: 'transparent',
+        p: 3,
+      }}
+      elevation={0}
+    >
+      {/* Section title */}
+      <Typography
+        variant="h6"
+        sx={{
+          color: '#ffffff',
+          fontFamily: '"JetBrains Mono", monospace',
+          mb: 3,
+          fontWeight: 600,
+          fontSize: '1.1rem',
+          display: 'flex',
+          alignItems: 'center',
+          gap: 1.5,
+          '&::before': {
+            content: '""',
+            width: '4px',
+            height: '20px',
+            backgroundColor: 'primary.main',
+            borderRadius: '2px',
+          },
+        }}
+      >
+        Score Breakdown
+      </Typography>
+
+      {/* Score pipeline visualization */}
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: { xs: 'column', md: 'row' },
+          alignItems: { xs: 'stretch', md: 'center' },
+          gap: { xs: 1, md: 0 },
+          mb: 3,
+          p: 2,
+          borderRadius: 2,
+          backgroundColor: 'rgba(255, 255, 255, 0.02)',
+          border: '1px solid rgba(255, 255, 255, 0.06)',
+        }}
+      >
+        {/* Base Score */}
+        <Tooltip
+          title="Sum of all merged PR token scores across unlocked tiers"
+          arrow
+          slotProps={tooltipSx}
+        >
+          <Box sx={{ flex: 1, textAlign: 'center', cursor: 'pointer' }}>
+            <Typography
+              sx={{
+                color: 'rgba(255, 255, 255, 0.5)',
+                fontFamily: '"JetBrains Mono", monospace',
+                fontSize: '0.7rem',
+                textTransform: 'uppercase',
+                letterSpacing: '0.5px',
+                mb: 0.5,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                gap: 0.5,
+              }}
+            >
+              Base Score <InfoIcon sx={{ fontSize: '0.75rem' }} />
+            </Typography>
+            <Typography
+              sx={{
+                color: '#ffffff',
+                fontFamily: '"JetBrains Mono", monospace',
+                fontSize: '1.25rem',
+                fontWeight: 700,
+              }}
+            >
+              {baseScore.toFixed(2)}
+            </Typography>
+          </Box>
+        </Tooltip>
+
+        <ArrowIcon
+          sx={{
+            color: 'rgba(255, 255, 255, 0.2)',
+            display: { xs: 'none', md: 'block' },
+          }}
+        />
+
+        {/* Credibility Multiplier */}
+        <Tooltip
+          title="Applied per-tier based on merged/total PR ratio. Higher credibility = higher score multiplier."
+          arrow
+          slotProps={tooltipSx}
+        >
+          <Box sx={{ flex: 1, textAlign: 'center', cursor: 'pointer' }}>
+            <Typography
+              sx={{
+                color: 'rgba(255, 255, 255, 0.5)',
+                fontFamily: '"JetBrains Mono", monospace',
+                fontSize: '0.7rem',
+                textTransform: 'uppercase',
+                letterSpacing: '0.5px',
+                mb: 0.5,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                gap: 0.5,
+              }}
+            >
+              Credibility <InfoIcon sx={{ fontSize: '0.75rem' }} />
+            </Typography>
+            <Typography
+              sx={{
+                color:
+                  credibilityMultiplier >= 0.9
+                    ? STATUS_COLORS.success
+                    : credibilityMultiplier >= 0.7
+                      ? '#a3e635'
+                      : '#facc15',
+                fontFamily: '"JetBrains Mono", monospace',
+                fontSize: '1.25rem',
+                fontWeight: 700,
+              }}
+            >
+              {(credibilityMultiplier * 100).toFixed(1)}%
+            </Typography>
+          </Box>
+        </Tooltip>
+
+        <ArrowIcon
+          sx={{
+            color: 'rgba(255, 255, 255, 0.2)',
+            display: { xs: 'none', md: 'block' },
+          }}
+        />
+
+        {/* Collateral Deduction */}
+        <Tooltip
+          title={`Open PRs have collateral deducted. ${Number(minerStats.totalOpenPrs || 0)} open PRs, threshold: ${openPrThreshold}.`}
+          arrow
+          slotProps={tooltipSx}
+        >
+          <Box sx={{ flex: 1, textAlign: 'center', cursor: 'pointer' }}>
+            <Typography
+              sx={{
+                color: 'rgba(255, 255, 255, 0.5)',
+                fontFamily: '"JetBrains Mono", monospace',
+                fontSize: '0.7rem',
+                textTransform: 'uppercase',
+                letterSpacing: '0.5px',
+                mb: 0.5,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                gap: 0.5,
+              }}
+            >
+              Collateral <InfoIcon sx={{ fontSize: '0.75rem' }} />
+            </Typography>
+            <Typography
+              sx={{
+                color:
+                  collateralDeduction > 0
+                    ? 'rgba(248, 113, 113, 0.9)'
+                    : 'rgba(255, 255, 255, 0.4)',
+                fontFamily: '"JetBrains Mono", monospace',
+                fontSize: '1.25rem',
+                fontWeight: 700,
+              }}
+            >
+              {collateralDeduction > 0
+                ? `-${collateralDeduction.toFixed(2)}`
+                : '0.00'}
+            </Typography>
+          </Box>
+        </Tooltip>
+
+        <ArrowIcon
+          sx={{
+            color: 'rgba(255, 255, 255, 0.2)',
+            display: { xs: 'none', md: 'block' },
+          }}
+        />
+
+        {/* Final Score */}
+        <Box
+          sx={{
+            flex: 1,
+            textAlign: 'center',
+            p: 1.5,
+            borderRadius: 1.5,
+            backgroundColor: alpha('#1d37fc', 0.1),
+            border: `1px solid ${alpha('#1d37fc', 0.3)}`,
+          }}
+        >
+          <Typography
+            sx={{
+              color: 'rgba(255, 255, 255, 0.5)',
+              fontFamily: '"JetBrains Mono", monospace',
+              fontSize: '0.7rem',
+              textTransform: 'uppercase',
+              letterSpacing: '0.5px',
+              mb: 0.5,
+            }}
+          >
+            Final Score
+          </Typography>
+          <Typography
+            sx={{
+              color: '#ffffff',
+              fontFamily: '"JetBrains Mono", monospace',
+              fontSize: '1.25rem',
+              fontWeight: 700,
+            }}
+          >
+            {finalScore.toFixed(2)}
+          </Typography>
+        </Box>
+      </Box>
+
+      {/* Per-tier breakdowns */}
+      <Typography
+        sx={{
+          color: 'rgba(255, 255, 255, 0.5)',
+          fontFamily: '"JetBrains Mono", monospace',
+          fontSize: '0.8rem',
+          textTransform: 'uppercase',
+          letterSpacing: '0.5px',
+          mb: 2,
+          fontWeight: 600,
+        }}
+      >
+        Per-Tier Details
+      </Typography>
+
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+        {tiers.map((tier) => {
+          const isExpanded = expandedTier === tier.name;
+          return (
+            <Box
+              key={tier.name}
+              sx={{
+                borderRadius: 2,
+                border: '1px solid',
+                borderColor: tier.isUnlocked
+                  ? alpha(tier.color, 0.2)
+                  : 'rgba(255, 255, 255, 0.06)',
+                backgroundColor: tier.isUnlocked
+                  ? alpha(tier.color, 0.03)
+                  : 'rgba(255, 255, 255, 0.01)',
+                opacity: tier.isUnlocked ? 1 : 0.5,
+                overflow: 'hidden',
+              }}
+            >
+              {/* Tier header - clickable */}
+              <Box
+                onClick={() =>
+                  setExpandedTier(isExpanded ? null : tier.name)
+                }
+                sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'space-between',
+                  p: 2,
+                  cursor: 'pointer',
+                  '&:hover': {
+                    backgroundColor: 'rgba(255, 255, 255, 0.02)',
+                  },
+                  transition: 'background-color 0.2s',
+                }}
+              >
+                <Box
+                  sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}
+                >
+                  <Box
+                    sx={{
+                      width: 10,
+                      height: 10,
+                      borderRadius: '50%',
+                      backgroundColor: tier.color,
+                    }}
+                  />
+                  <Typography
+                    sx={{
+                      color: tier.color,
+                      fontFamily: '"JetBrains Mono", monospace',
+                      fontSize: '0.9rem',
+                      fontWeight: 600,
+                    }}
+                  >
+                    {tier.name}
+                    {!tier.isUnlocked && ' (Locked)'}
+                  </Typography>
+                </Box>
+                <Box
+                  sx={{ display: 'flex', alignItems: 'center', gap: 2 }}
+                >
+                  <Typography
+                    sx={{
+                      color: '#ffffff',
+                      fontFamily: '"JetBrains Mono", monospace',
+                      fontSize: '0.9rem',
+                      fontWeight: 600,
+                    }}
+                  >
+                    {tier.score.toFixed(2)}
+                  </Typography>
+                  <IconButton
+                    size="small"
+                    sx={{
+                      color: 'rgba(255, 255, 255, 0.4)',
+                      transform: isExpanded
+                        ? 'rotate(180deg)'
+                        : 'rotate(0deg)',
+                      transition: 'transform 0.2s',
+                    }}
+                  >
+                    <ExpandIcon fontSize="small" />
+                  </IconButton>
+                </Box>
+              </Box>
+
+              {/* Expanded details */}
+              <Collapse in={isExpanded}>
+                <Box
+                  sx={{
+                    p: 2,
+                    pt: 0,
+                    display: 'grid',
+                    gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr' },
+                    gap: 2,
+                  }}
+                >
+                  {/* Structural vs Leaf */}
+                  <Box>
+                    <Typography
+                      sx={{
+                        color: 'rgba(255, 255, 255, 0.4)',
+                        fontFamily: '"JetBrains Mono", monospace',
+                        fontSize: '0.7rem',
+                        textTransform: 'uppercase',
+                        mb: 1,
+                      }}
+                    >
+                      Node Scoring
+                    </Typography>
+                    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+                      <Box>
+                        <Box
+                          sx={{
+                            display: 'flex',
+                            justifyContent: 'space-between',
+                            mb: 0.5,
+                          }}
+                        >
+                          <Typography
+                            sx={{
+                              color: 'rgba(255, 255, 255, 0.6)',
+                              fontFamily: '"JetBrains Mono", monospace',
+                              fontSize: '0.75rem',
+                            }}
+                          >
+                            Structural ({tier.structuralCount} nodes)
+                          </Typography>
+                          <Typography
+                            sx={{
+                              color: '#ffffff',
+                              fontFamily: '"JetBrains Mono", monospace',
+                              fontSize: '0.75rem',
+                              fontWeight: 600,
+                            }}
+                          >
+                            {tier.structuralScore.toFixed(2)}
+                          </Typography>
+                        </Box>
+                        <LinearProgress
+                          variant="determinate"
+                          value={
+                            tier.tokenScore > 0
+                              ? (tier.structuralScore / tier.tokenScore) * 100
+                              : 0
+                          }
+                          sx={{
+                            height: 4,
+                            borderRadius: 2,
+                            backgroundColor: 'rgba(255, 255, 255, 0.06)',
+                            '& .MuiLinearProgress-bar': {
+                              backgroundColor: alpha(tier.color, 0.6),
+                              borderRadius: 2,
+                            },
+                          }}
+                        />
+                      </Box>
+                      <Box>
+                        <Box
+                          sx={{
+                            display: 'flex',
+                            justifyContent: 'space-between',
+                            mb: 0.5,
+                          }}
+                        >
+                          <Typography
+                            sx={{
+                              color: 'rgba(255, 255, 255, 0.6)',
+                              fontFamily: '"JetBrains Mono", monospace',
+                              fontSize: '0.75rem',
+                            }}
+                          >
+                            Leaf ({tier.leafCount} nodes)
+                          </Typography>
+                          <Typography
+                            sx={{
+                              color: '#ffffff',
+                              fontFamily: '"JetBrains Mono", monospace',
+                              fontSize: '0.75rem',
+                              fontWeight: 600,
+                            }}
+                          >
+                            {tier.leafScore.toFixed(2)}
+                          </Typography>
+                        </Box>
+                        <LinearProgress
+                          variant="determinate"
+                          value={
+                            tier.tokenScore > 0
+                              ? (tier.leafScore / tier.tokenScore) * 100
+                              : 0
+                          }
+                          sx={{
+                            height: 4,
+                            borderRadius: 2,
+                            backgroundColor: 'rgba(255, 255, 255, 0.06)',
+                            '& .MuiLinearProgress-bar': {
+                              backgroundColor: alpha(tier.color, 0.4),
+                              borderRadius: 2,
+                            },
+                          }}
+                        />
+                      </Box>
+                    </Box>
+                  </Box>
+
+                  {/* PR Stats */}
+                  <Box>
+                    <Typography
+                      sx={{
+                        color: 'rgba(255, 255, 255, 0.4)',
+                        fontFamily: '"JetBrains Mono", monospace',
+                        fontSize: '0.7rem',
+                        textTransform: 'uppercase',
+                        mb: 1,
+                      }}
+                    >
+                      PR Statistics
+                    </Typography>
+                    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+                      {[
+                        {
+                          label: 'Token Score',
+                          val: tier.tokenScore.toFixed(2),
+                        },
+                        {
+                          label: 'Credibility',
+                          val: `${(tier.credibility * 100).toFixed(1)}%`,
+                        },
+                        {
+                          label: 'Merged PRs',
+                          val: `${tier.mergedPrs} / ${tier.totalPrs}`,
+                        },
+                        {
+                          label: 'Collateral',
+                          val:
+                            tier.collateral > 0
+                              ? `-${tier.collateral.toFixed(2)}`
+                              : '0.00',
+                          color:
+                            tier.collateral > 0
+                              ? 'rgba(248, 113, 113, 0.8)'
+                              : undefined,
+                        },
+                      ].map((item) => (
+                        <Box
+                          key={item.label}
+                          sx={{
+                            display: 'flex',
+                            justifyContent: 'space-between',
+                          }}
+                        >
+                          <Typography
+                            sx={{
+                              color: 'rgba(255, 255, 255, 0.6)',
+                              fontFamily: '"JetBrains Mono", monospace',
+                              fontSize: '0.75rem',
+                            }}
+                          >
+                            {item.label}
+                          </Typography>
+                          <Typography
+                            sx={{
+                              color: item.color || '#ffffff',
+                              fontFamily: '"JetBrains Mono", monospace',
+                              fontSize: '0.75rem',
+                              fontWeight: 600,
+                            }}
+                          >
+                            {item.val}
+                          </Typography>
+                        </Box>
+                      ))}
+                    </Box>
+                  </Box>
+                </Box>
+              </Collapse>
+            </Box>
+          );
+        })}
+      </Box>
+    </Card>
+  );
+};
+
+export default ScoreBreakdownPanel;

--- a/src/components/miners/TierProgressTracker.tsx
+++ b/src/components/miners/TierProgressTracker.tsx
@@ -1,0 +1,437 @@
+import React from 'react';
+import {
+  Card,
+  Typography,
+  Box,
+  CircularProgress,
+  LinearProgress,
+  Chip,
+  alpha,
+} from '@mui/material';
+import {
+  Lock as LockIcon,
+  LockOpen as UnlockedIcon,
+  Star as StarIcon,
+  CheckCircle as CheckIcon,
+} from '@mui/icons-material';
+import {
+  useMinerStats,
+  useTierConfigurations,
+  type TierConfig,
+} from '../../api';
+import { TIER_COLORS } from '../../theme';
+
+const TIER_LEVELS: Record<string, number> = {
+  bronze: 1,
+  silver: 2,
+  gold: 3,
+};
+
+interface TierProgressTrackerProps {
+  githubId: string;
+}
+
+interface TierRequirement {
+  label: string;
+  current: number;
+  required: number;
+  format: (v: number) => string;
+}
+
+const TierProgressTracker: React.FC<TierProgressTrackerProps> = ({
+  githubId,
+}) => {
+  const { data: minerStats, isLoading } = useMinerStats(githubId);
+  const { data: tierConfigData } = useTierConfigurations();
+
+  if (isLoading) {
+    return (
+      <Card
+        sx={{
+          borderRadius: 3,
+          border: '1px solid rgba(255, 255, 255, 0.1)',
+          backgroundColor: 'transparent',
+          p: 4,
+          textAlign: 'center',
+        }}
+        elevation={0}
+      >
+        <CircularProgress size={30} sx={{ color: 'primary.main' }} />
+      </Card>
+    );
+  }
+
+  if (!minerStats) return null;
+
+  const tierConfigs = tierConfigData?.tiers;
+  const currentTierLevel =
+    TIER_LEVELS[(minerStats.currentTier || '').toLowerCase()] || 0;
+
+  const getConfig = (name: string): TierConfig | undefined =>
+    tierConfigs?.find((t) => t.name.toLowerCase() === name.toLowerCase());
+
+  const tiers = [
+    {
+      name: 'Bronze',
+      level: 1,
+      color: TIER_COLORS.bronze,
+      stats: {
+        tokenScore: Number(minerStats.bronzeTokenScore || 0),
+        qualifiedRepos: Number(minerStats.bronzeQualifiedUniqueRepos || 0),
+        credibility: Number(minerStats.bronzeCredibility || 0),
+        score: Number(minerStats.bronzeScore || 0),
+        mergedPrs: Number(minerStats.bronzeMergedPrs || 0),
+      },
+    },
+    {
+      name: 'Silver',
+      level: 2,
+      color: TIER_COLORS.silver,
+      stats: {
+        tokenScore: Number(minerStats.silverTokenScore || 0),
+        qualifiedRepos: Number(minerStats.silverQualifiedUniqueRepos || 0),
+        credibility: Number(minerStats.silverCredibility || 0),
+        score: Number(minerStats.silverScore || 0),
+        mergedPrs: Number(minerStats.silverMergedPrs || 0),
+      },
+    },
+    {
+      name: 'Gold',
+      level: 3,
+      color: TIER_COLORS.gold,
+      stats: {
+        tokenScore: Number(minerStats.goldTokenScore || 0),
+        qualifiedRepos: Number(minerStats.goldQualifiedUniqueRepos || 0),
+        credibility: Number(minerStats.goldCredibility || 0),
+        score: Number(minerStats.goldScore || 0),
+        mergedPrs: Number(minerStats.goldMergedPrs || 0),
+      },
+    },
+  ];
+
+  return (
+    <Card
+      sx={{
+        borderRadius: 3,
+        border: '1px solid rgba(255, 255, 255, 0.1)',
+        backgroundColor: 'transparent',
+        p: 3,
+      }}
+      elevation={0}
+    >
+      <Typography
+        variant="h6"
+        sx={{
+          color: '#ffffff',
+          fontFamily: '"JetBrains Mono", monospace',
+          mb: 3,
+          fontWeight: 600,
+          fontSize: '1.1rem',
+          display: 'flex',
+          alignItems: 'center',
+          gap: 1.5,
+          '&::before': {
+            content: '""',
+            width: '4px',
+            height: '20px',
+            backgroundColor: 'primary.main',
+            borderRadius: '2px',
+          },
+        }}
+      >
+        Tier Progress
+      </Typography>
+
+      {/* Tier ladder visualization */}
+      <Box sx={{ position: 'relative' }}>
+        {tiers.map((tier, index) => {
+          const isUnlocked = tier.level <= currentTierLevel;
+          const isCurrentTier =
+            tier.name.toLowerCase() ===
+            (minerStats.currentTier || '').toLowerCase();
+          const isNextTier = tier.level === currentTierLevel + 1;
+          const config = getConfig(tier.name);
+
+          // Build requirements for this tier
+          const requirements: TierRequirement[] = [];
+          if (config) {
+            requirements.push({
+              label: 'Qualified Repos',
+              current: tier.stats.qualifiedRepos,
+              required: config.requiredQualifiedUniqueRepos,
+              format: (v) => String(v),
+            });
+            requirements.push({
+              label: 'Credibility',
+              current: tier.stats.credibility,
+              required: config.requiredCredibility,
+              format: (v) => `${(v * 100).toFixed(0)}%`,
+            });
+            if (config.requiredMinTokenScore) {
+              requirements.push({
+                label: 'Token Score',
+                current: tier.stats.tokenScore,
+                required: config.requiredMinTokenScore,
+                format: (v) => v.toFixed(0),
+              });
+            }
+          }
+
+          const allRequirementsMet = requirements.every(
+            (r) => r.current >= r.required,
+          );
+
+          return (
+            <Box key={tier.name}>
+              {/* Connecting line between tiers */}
+              {index > 0 && (
+                <Box
+                  sx={{
+                    width: 2,
+                    height: 24,
+                    ml: '19px',
+                    backgroundColor:
+                      tier.level <= currentTierLevel
+                        ? alpha(tier.color, 0.4)
+                        : 'rgba(255, 255, 255, 0.08)',
+                  }}
+                />
+              )}
+
+              <Box
+                sx={{
+                  display: 'flex',
+                  gap: 2,
+                  p: 2,
+                  borderRadius: 2,
+                  border: '1px solid',
+                  borderColor: isCurrentTier
+                    ? alpha(tier.color, 0.4)
+                    : isUnlocked
+                      ? alpha(tier.color, 0.15)
+                      : 'rgba(255, 255, 255, 0.06)',
+                  backgroundColor: isCurrentTier
+                    ? alpha(tier.color, 0.05)
+                    : 'transparent',
+                  opacity: !isUnlocked && !isNextTier ? 0.5 : 1,
+                  position: 'relative',
+                }}
+              >
+                {/* Tier indicator circle */}
+                <Box
+                  sx={{
+                    width: 40,
+                    height: 40,
+                    borderRadius: '50%',
+                    border: '2px solid',
+                    borderColor: isUnlocked
+                      ? tier.color
+                      : 'rgba(255, 255, 255, 0.15)',
+                    backgroundColor: isUnlocked
+                      ? alpha(tier.color, 0.15)
+                      : 'rgba(255, 255, 255, 0.02)',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    flexShrink: 0,
+                    boxShadow: isCurrentTier
+                      ? `0 0 16px ${alpha(tier.color, 0.3)}`
+                      : 'none',
+                  }}
+                >
+                  {isUnlocked ? (
+                    isCurrentTier ? (
+                      <StarIcon
+                        sx={{ fontSize: '1.2rem', color: tier.color }}
+                      />
+                    ) : (
+                      <CheckIcon
+                        sx={{ fontSize: '1.2rem', color: tier.color }}
+                      />
+                    )
+                  ) : (
+                    <LockIcon
+                      sx={{
+                        fontSize: '1rem',
+                        color: 'rgba(255, 255, 255, 0.3)',
+                      }}
+                    />
+                  )}
+                </Box>
+
+                {/* Tier content */}
+                <Box sx={{ flex: 1, minWidth: 0 }}>
+                  <Box
+                    sx={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'space-between',
+                      mb: 1,
+                    }}
+                  >
+                    <Box
+                      sx={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: 1,
+                      }}
+                    >
+                      <Typography
+                        sx={{
+                          color: tier.color,
+                          fontFamily: '"JetBrains Mono", monospace',
+                          fontSize: '1rem',
+                          fontWeight: 700,
+                        }}
+                      >
+                        {tier.name}
+                      </Typography>
+                      {isCurrentTier && (
+                        <Chip
+                          label="CURRENT"
+                          size="small"
+                          sx={{
+                            height: 20,
+                            fontFamily: '"JetBrains Mono", monospace',
+                            fontSize: '0.6rem',
+                            fontWeight: 700,
+                            color: tier.color,
+                            backgroundColor: alpha(tier.color, 0.15),
+                            border: `1px solid ${alpha(tier.color, 0.3)}`,
+                          }}
+                        />
+                      )}
+                      {isUnlocked && !isCurrentTier && (
+                        <Chip
+                          label="UNLOCKED"
+                          size="small"
+                          icon={
+                            <UnlockedIcon
+                              sx={{
+                                fontSize: '0.7rem',
+                                color: `${tier.color} !important`,
+                              }}
+                            />
+                          }
+                          sx={{
+                            height: 20,
+                            fontFamily: '"JetBrains Mono", monospace',
+                            fontSize: '0.6rem',
+                            color: tier.color,
+                            backgroundColor: alpha(tier.color, 0.1),
+                            border: `1px solid ${alpha(tier.color, 0.2)}`,
+                          }}
+                        />
+                      )}
+                    </Box>
+                    <Typography
+                      sx={{
+                        color: '#ffffff',
+                        fontFamily: '"JetBrains Mono", monospace',
+                        fontSize: '0.9rem',
+                        fontWeight: 600,
+                      }}
+                    >
+                      {tier.stats.score.toFixed(2)} pts
+                    </Typography>
+                  </Box>
+
+                  {/* Requirements progress bars */}
+                  {(isNextTier || isCurrentTier) &&
+                    requirements.length > 0 && (
+                      <Box
+                        sx={{
+                          display: 'flex',
+                          flexDirection: 'column',
+                          gap: 1,
+                        }}
+                      >
+                        {requirements.map((req) => {
+                          const progress = Math.min(
+                            (req.current / req.required) * 100,
+                            100,
+                          );
+                          const isMet = req.current >= req.required;
+
+                          return (
+                            <Box key={req.label}>
+                              <Box
+                                sx={{
+                                  display: 'flex',
+                                  justifyContent: 'space-between',
+                                  mb: 0.25,
+                                }}
+                              >
+                                <Typography
+                                  sx={{
+                                    color: 'rgba(255, 255, 255, 0.5)',
+                                    fontFamily:
+                                      '"JetBrains Mono", monospace',
+                                    fontSize: '0.7rem',
+                                  }}
+                                >
+                                  {req.label}
+                                </Typography>
+                                <Typography
+                                  sx={{
+                                    color: isMet
+                                      ? alpha(tier.color, 0.9)
+                                      : 'rgba(255, 255, 255, 0.6)',
+                                    fontFamily:
+                                      '"JetBrains Mono", monospace',
+                                    fontSize: '0.7rem',
+                                    fontWeight: 600,
+                                  }}
+                                >
+                                  {req.format(req.current)} /{' '}
+                                  {req.format(req.required)}
+                                  {isMet && ' \u2713'}
+                                </Typography>
+                              </Box>
+                              <LinearProgress
+                                variant="determinate"
+                                value={progress}
+                                sx={{
+                                  height: 4,
+                                  borderRadius: 2,
+                                  backgroundColor:
+                                    'rgba(255, 255, 255, 0.06)',
+                                  '& .MuiLinearProgress-bar': {
+                                    backgroundColor: isMet
+                                      ? tier.color
+                                      : alpha(tier.color, 0.5),
+                                    borderRadius: 2,
+                                  },
+                                }}
+                              />
+                            </Box>
+                          );
+                        })}
+                      </Box>
+                    )}
+
+                  {/* Celebration state for fully unlocked */}
+                  {isUnlocked && allRequirementsMet && !isCurrentTier && (
+                    <Typography
+                      sx={{
+                        color: alpha(tier.color, 0.7),
+                        fontFamily: '"JetBrains Mono", monospace',
+                        fontSize: '0.75rem',
+                        fontStyle: 'italic',
+                      }}
+                    >
+                      All requirements met - {tier.stats.mergedPrs} merged
+                      PRs
+                    </Typography>
+                  )}
+                </Box>
+              </Box>
+            </Box>
+          );
+        })}
+      </Box>
+    </Card>
+  );
+};
+
+export default TierProgressTracker;

--- a/src/components/miners/index.ts
+++ b/src/components/miners/index.ts
@@ -1,8 +1,13 @@
 export { default as CredibilityChart } from './CredibilityChart';
 export { default as MinerActivity } from './MinerActivity';
+export { default as MinerDashboardHeader } from './MinerDashboardHeader';
+export { default as MinerInsights } from './MinerInsights';
 export { default as MinerPRsTable } from './MinerPRsTable';
 export { default as MinerRepositoriesTable } from './MinerRepositoriesTable';
 export { default as MinerScoreCard } from './MinerScoreCard';
 export { default as MinerTierPerformance } from './MinerTierPerformance';
+export { default as ScoreBreakdownPanel } from './ScoreBreakdownPanel';
+export { default as TierProgressTracker } from './TierProgressTracker';
+export { default as EarningsOverview } from './EarningsOverview';
 export { default as PerformanceRadar } from './PerformanceRadar';
 export { default as TrustBadge, getRiskAssessment } from './TrustBadge';

--- a/src/pages/MinerDetailsPage.tsx
+++ b/src/pages/MinerDetailsPage.tsx
@@ -1,13 +1,16 @@
 import React from 'react';
 import { useSearchParams, useNavigate } from 'react-router-dom';
-import { Box } from '@mui/material';
+import { Box, Grid } from '@mui/material';
 import { Page } from '../components/layout';
 import {
-  MinerScoreCard,
+  MinerDashboardHeader,
+  MinerInsights,
+  ScoreBreakdownPanel,
+  TierProgressTracker,
+  EarningsOverview,
   MinerActivity,
   MinerRepositoriesTable,
   MinerPRsTable,
-  MinerTierPerformance,
   BackButton,
   SEO,
 } from '../components';
@@ -52,19 +55,32 @@ const MinerDetailsPage: React.FC = () => {
         >
           <BackButton to="/top-miners" />
 
-          {/* Miner Score Card */}
-          <MinerScoreCard githubId={githubId} />
+          {/* Dashboard Header - replaces MinerScoreCard as the hero section */}
+          <MinerDashboardHeader githubId={githubId} />
+
+          {/* Smart Insights - actionable recommendations */}
+          <MinerInsights githubId={githubId} />
+
+          {/* Score Breakdown + Tier Progress side by side on desktop */}
+          <Grid container spacing={3}>
+            <Grid item xs={12} md={7}>
+              <ScoreBreakdownPanel githubId={githubId} />
+            </Grid>
+            <Grid item xs={12} md={5}>
+              <TierProgressTracker githubId={githubId} />
+            </Grid>
+          </Grid>
+
+          {/* Earnings Overview */}
+          <EarningsOverview githubId={githubId} />
 
           {/* Activity Visualization */}
           <MinerActivity githubId={githubId} />
 
-          {/* Tier Performance */}
-          <MinerTierPerformance githubId={githubId} />
-
-          {/* Top Repositories */}
+          {/* Top Repositories - enhanced with search/filter */}
           <MinerRepositoriesTable githubId={githubId} />
 
-          {/* Miner PRs Table */}
+          {/* Miner PRs Table - enhanced with search, sort, tier filter, pagination */}
           <MinerPRsTable githubId={githubId} />
         </Box>
       </Box>


### PR DESCRIPTION
## Summary

Redesigns the miner details page (#95) from a monolithic card-based layout into a purpose-built personal performance dashboard with 5 new components and 2 enhanced existing components.

### New Components (2,600+ lines of new code)

- **MinerDashboardHeader** - Focused identity section with avatar, name, tier badge, trust badge, and a key stats row (Total Score, Credibility %, Est. Daily Earnings in TAO+USD, Rank)
- **ScoreBreakdownPanel** - Visual pipeline: Base Score -> Credibility Multiplier -> Collateral Deduction -> Final Score. Expandable per-tier details showing structural vs leaf node scoring split with progress bars
- **TierProgressTracker** - Vertical tier ladder visualization with current position indicator, progress bars showing exact values vs requirements (qualified repos, credibility, token score), celebration states for unlocked tiers
- **EarningsOverview** - Daily/monthly/lifetime earnings cards in TAO + USD, score contribution trend line chart (echarts-for-react), breakdown by tier with proportional bars, top repos by score
- **MinerInsights** - Smart actionable recommendations: tier unlock proximity alerts, credibility improvement targets, open PR risk warnings, top scoring repos highlight, achievement badges

### Enhanced Components

- **MinerPRsTable** - Added: text search (by title or repo), tier filter buttons (Bronze/Silver/Gold), sortable columns (PR#, Score, Date, +/-), pagination (15 rows per page)
- **MinerRepositoriesTable** - Added: search filter, clickable tier dots for tier filtering, result count display

### Page Layout (MinerDetailsPage.tsx)

```
BackButton
MinerDashboardHeader          <- hero section
MinerInsights                 <- actionable tips
ScoreBreakdownPanel | TierProgressTracker  <- side by side (7/5 grid)
EarningsOverview              <- earnings focus
MinerActivity                 <- existing heatmap
MinerRepositoriesTable        <- enhanced with search
MinerPRsTable                 <- enhanced with search/sort/pagination
```

### Design Decisions

- All components follow existing patterns: MUI 5 with sx prop styling, dark theme (transparent backgrounds, rgba borders), JetBrains Mono for data, Inter for text
- Tier colors maintained: gold (#FFD700), silver (#C0C0C0), bronze (#CD7F32)
- All existing data remains accessible - no metrics were removed
- Components fetch their own data via existing TanStack React Query hooks (useMinerStats, useMinerPRs, useMinerGithubData, useAllMiners, useTierConfigurations, useReposAndWeights, useGeneralConfig)
- Score breakdown pipeline uses tooltips to explain each multiplier
- MinerInsights component generates recommendations dynamically based on actual miner data

### Build

- `npm run build` passes with zero TypeScript errors
- No new dependencies added (uses existing echarts-for-react, MUI, React Query)

## Test Plan

- [ ] Verify MinerDashboardHeader displays correct avatar, name, tier badge, trust badge, and key stats
- [ ] Verify ScoreBreakdownPanel pipeline shows correct Base Score -> Credibility -> Collateral -> Final Score values
- [ ] Verify expanding per-tier details shows structural/leaf node breakdown
- [ ] Verify TierProgressTracker shows correct progress bars with actual/required values
- [ ] Verify EarningsOverview displays daily/monthly/lifetime earnings correctly
- [ ] Verify score trend chart renders with merged PR data
- [ ] Verify MinerInsights generates appropriate recommendations
- [ ] Verify MinerPRsTable search filters by title and repo name
- [ ] Verify MinerPRsTable tier filter works for Bronze/Silver/Gold
- [ ] Verify MinerPRsTable sorting works on all sortable columns
- [ ] Verify MinerPRsTable pagination navigates correctly
- [ ] Verify MinerRepositoriesTable search filters correctly
- [ ] Verify MinerRepositoriesTable tier dot click filters by tier
- [ ] Verify responsive layout works on mobile (xs) and desktop (md+)
- [ ] Verify all tooltips display explanation text on hover

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)