### PR TITLE
Fix: Update scoring documentation links

### DIFF
--- a/src/components/onboard/Scoring.tsx
+++ b/src/components/onboard/Scoring.tsx
@@ -102,7 +102,7 @@ export const Scoring: React.FC = () => (
         variant="contained"
         color="secondary"
         size="large"
-        href="https://docs.gittensor.io/scoring.html"
+        href="https://docs.gittensor.io/oss-contributions.html"
         target="_blank"
         rel="noopener noreferrer"
         endIcon={<OpenInNewIcon />}

--- a/src/pages/FAQPage.tsx
+++ b/src/pages/FAQPage.tsx
@@ -93,7 +93,7 @@ export const FAQContent: React.FC = () => (
             'credibility', which is the ratio of your merged PRs to your total
             closed/rejected PRs. See the{' '}
             <a
-              href="https://docs.gittensor.io/scoring.html"
+              href="https://docs.gittensor.io/oss-contributions.html"
               target="_blank"
               rel="noopener noreferrer"
               style={{ color: 'inherit', textDecoration: 'underline' }}
@@ -133,7 +133,7 @@ export const FAQContent: React.FC = () => (
             merged PR count and credibility requirements to earn rewards from
             it. Check the{' '}
             <a
-              href="https://docs.gittensor.io/scoring.html"
+              href="https://docs.gittensor.io/oss-contributions.html"
               target="_blank"
               rel="noopener noreferrer"
               style={{ color: 'inherit', textDecoration: 'underline' }}


### PR DESCRIPTION
## Summary
- Update documentation links from `scoring.html` to `oss-contributions.html` across the UI

## Changes
- `src/components/onboard/Scoring.tsx` — updated "Learn More" button href
- `src/pages/FAQPage.tsx` — updated two scoring documentation links in FAQ answers

## Reason
The docs page was renamed from `scoring.html` to `oss-contributions.html`; this PR updates the UI to match.
