### PR TITLE
feat: Surface Review Quality Multiplier in PR Details Page

### DIFF
--- a/src/components/prs/PRDetailsCard.tsx
+++ b/src/components/prs/PRDetailsCard.tsx
@@ -160,12 +160,16 @@ const PRDetailsCard: React.FC<PRDetailsCardProps> = ({
           credibilityScalar: prDetails.credibilityScalar,
         },
         {
-          label: 'Repo Unique',
-          value: `${parseFloat(prDetails.repositoryUniquenessMultiplier ?? '0').toFixed(2)}x`,
+          label: 'Review Quality',
+          value: `${parseFloat(prDetails.reviewQualityMultiplier ?? '1').toFixed(2)}x`,
         },
         {
           label: 'Time Decay',
           value: `${parseFloat(prDetails.timeDecayMultiplier ?? '0').toFixed(2)}x`,
+        },
+        {
+          label: 'Repo Unique',
+          value: `${parseFloat(prDetails.repositoryUniquenessMultiplier ?? '0').toFixed(2)}x`,
         },
       ];
 

--- a/src/components/prs/PRDetailsCard.tsx
+++ b/src/components/prs/PRDetailsCard.tsx
@@ -161,7 +161,7 @@ const PRDetailsCard: React.FC<PRDetailsCardProps> = ({
         },
         {
           label: 'Review Quality',
-          value: `${parseFloat(prDetails.reviewQualityMultiplier ?? '1').toFixed(2)}x`,
+          value: `${parseFloat(prDetails.reviewQualityMultiplier ?? '0').toFixed(2)}x`,
         },
         {
           label: 'Time Decay',


### PR DESCRIPTION
## Summary
- Adds the `reviewQualityMultiplier` as "Review Quality" to the score multipliers section on the PR details page
- Reorders multipliers: Review Quality placed before Time Decay, Repo Unique moved to end

## Screenshot
<img width="1180" height="141" alt="image" src="https://github.com/user-attachments/assets/9154566a-b1fd-4d24-bc98-25a8fc9a7ecb" />


Closes #113
