### PR TITLE
Fix relative links in README tab to point to GitHub

### DIFF
--- a/src/components/repositories/ContributingViewer.tsx
+++ b/src/components/repositories/ContributingViewer.tsx
@@ -5,7 +5,7 @@ import remarkGfm from 'remark-gfm';
 import rehypeRaw from 'rehype-raw';
 import axios from 'axios';
 import { STATUS_COLORS } from '../../theme';
-import { createLinkRenderer, createImageRenderer } from './MarkdownRenderers';
+import { resolveRelativeUrl } from './MarkdownRenderers';
 
 interface ContributingViewerProps {
   repositoryFullName: string; // e.g., "opentensor/bittensor"
@@ -81,9 +81,6 @@ const ContributingViewer: React.FC<ContributingViewerProps> = ({
       </Alert>
     );
   }
-
-  const LinkRenderer = createLinkRenderer(repositoryFullName, defaultBranch);
-  const ImageRenderer = createImageRenderer(repositoryFullName, defaultBranch);
 
   return (
     <Paper
@@ -179,7 +176,21 @@ const ContributingViewer: React.FC<ContributingViewerProps> = ({
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
         rehypePlugins={[rehypeRaw]}
-        components={{ a: LinkRenderer, img: ImageRenderer }}
+        components={{
+          a: ({ href, children, ...rest }: any) => (
+            <a href={resolveRelativeUrl(href, repositoryFullName, defaultBranch)} target="_blank" rel="noopener noreferrer" {...rest}>
+              {children}
+            </a>
+          ),
+          img: ({ src, alt, ...rest }: any) => (
+            <img
+              src={resolveRelativeUrl(src, repositoryFullName, defaultBranch, 'cdn')}
+              alt={alt}
+              style={{ maxWidth: '100%', height: 'auto', borderRadius: '6px', margin: '16px 0' }}
+              {...rest}
+            />
+          ),
+        }}
       >
         {content || ''}
       </ReactMarkdown>

--- a/src/components/repositories/ContributingViewer.tsx
+++ b/src/components/repositories/ContributingViewer.tsx
@@ -5,6 +5,7 @@ import remarkGfm from 'remark-gfm';
 import rehypeRaw from 'rehype-raw';
 import axios from 'axios';
 import { STATUS_COLORS } from '../../theme';
+import { createLinkRenderer, createImageRenderer } from './MarkdownRenderers';
 
 interface ContributingViewerProps {
   repositoryFullName: string; // e.g., "opentensor/bittensor"
@@ -81,65 +82,8 @@ const ContributingViewer: React.FC<ContributingViewerProps> = ({
     );
   }
 
-  // Custom renderer for links to handle relative paths
-  const LinkRenderer = (props: any) => {
-    const { href, children, ...rest } = props;
-    let finalHref = href;
-
-    if (
-      href &&
-      !href.startsWith('http') &&
-      !href.startsWith('//') &&
-      !href.startsWith('#') &&
-      !href.startsWith('mailto:')
-    ) {
-      const cleanPath = href.startsWith('./')
-        ? href.slice(2)
-        : href.startsWith('/')
-          ? href.slice(1)
-          : href;
-      const hasExtension = /\.[a-zA-Z0-9]+$/.test(cleanPath.replace(/\/$/, ''));
-      const isDirectory = cleanPath.endsWith('/') || !hasExtension;
-      const type = isDirectory ? 'tree' : 'blob';
-      const normalizedPath = cleanPath.replace(/\/$/, '');
-      finalHref = `https://github.com/${repositoryFullName}/${type}/${defaultBranch}/${normalizedPath}`;
-    }
-
-    return (
-      <a href={finalHref} target="_blank" rel="noopener noreferrer" {...rest}>
-        {children}
-      </a>
-    );
-  };
-
-  // Custom renderer for images to handle relative paths
-  const ImageRenderer = (props: any) => {
-    const { src, alt, ...rest } = props;
-    let finalSrc = src;
-
-    if (src && !src.startsWith('http') && !src.startsWith('//')) {
-      const cleanPath = src.startsWith('./')
-        ? src.slice(2)
-        : src.startsWith('/')
-          ? src.slice(1)
-          : src;
-      finalSrc = `https://cdn.jsdelivr.net/gh/${repositoryFullName}@${defaultBranch}/${cleanPath}`;
-    }
-
-    return (
-      <img
-        src={finalSrc}
-        alt={alt}
-        style={{
-          maxWidth: '100%',
-          height: 'auto',
-          borderRadius: '6px',
-          margin: '16px 0',
-        }}
-        {...rest}
-      />
-    );
-  };
+  const LinkRenderer = createLinkRenderer(repositoryFullName, defaultBranch);
+  const ImageRenderer = createImageRenderer(repositoryFullName, defaultBranch);
 
   return (
     <Paper

--- a/src/components/repositories/ContributingViewer.tsx
+++ b/src/components/repositories/ContributingViewer.tsx
@@ -81,6 +81,37 @@ const ContributingViewer: React.FC<ContributingViewerProps> = ({
     );
   }
 
+  // Custom renderer for links to handle relative paths
+  const LinkRenderer = (props: any) => {
+    const { href, children, ...rest } = props;
+    let finalHref = href;
+
+    if (
+      href &&
+      !href.startsWith('http') &&
+      !href.startsWith('//') &&
+      !href.startsWith('#') &&
+      !href.startsWith('mailto:')
+    ) {
+      const cleanPath = href.startsWith('./')
+        ? href.slice(2)
+        : href.startsWith('/')
+          ? href.slice(1)
+          : href;
+      const hasExtension = /\.[a-zA-Z0-9]+$/.test(cleanPath.replace(/\/$/, ''));
+      const isDirectory = cleanPath.endsWith('/') || !hasExtension;
+      const type = isDirectory ? 'tree' : 'blob';
+      const normalizedPath = cleanPath.replace(/\/$/, '');
+      finalHref = `https://github.com/${repositoryFullName}/${type}/${defaultBranch}/${normalizedPath}`;
+    }
+
+    return (
+      <a href={finalHref} target="_blank" rel="noopener noreferrer" {...rest}>
+        {children}
+      </a>
+    );
+  };
+
   // Custom renderer for images to handle relative paths
   const ImageRenderer = (props: any) => {
     const { src, alt, ...rest } = props;
@@ -204,7 +235,7 @@ const ContributingViewer: React.FC<ContributingViewerProps> = ({
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
         rehypePlugins={[rehypeRaw]}
-        components={{ img: ImageRenderer }}
+        components={{ a: LinkRenderer, img: ImageRenderer }}
       >
         {content || ''}
       </ReactMarkdown>

--- a/src/components/repositories/ContributingViewer.tsx
+++ b/src/components/repositories/ContributingViewer.tsx
@@ -178,15 +178,30 @@ const ContributingViewer: React.FC<ContributingViewerProps> = ({
         rehypePlugins={[rehypeRaw]}
         components={{
           a: ({ href, children, ...rest }: any) => (
-            <a href={resolveRelativeUrl(href, repositoryFullName, defaultBranch)} target="_blank" rel="noopener noreferrer" {...rest}>
+            <a
+              href={resolveRelativeUrl(href, repositoryFullName, defaultBranch)}
+              target="_blank"
+              rel="noopener noreferrer"
+              {...rest}
+            >
               {children}
             </a>
           ),
           img: ({ src, alt, ...rest }: any) => (
             <img
-              src={resolveRelativeUrl(src, repositoryFullName, defaultBranch, 'cdn')}
+              src={resolveRelativeUrl(
+                src,
+                repositoryFullName,
+                defaultBranch,
+                'cdn',
+              )}
               alt={alt}
-              style={{ maxWidth: '100%', height: 'auto', borderRadius: '6px', margin: '16px 0' }}
+              style={{
+                maxWidth: '100%',
+                height: 'auto',
+                borderRadius: '6px',
+                margin: '16px 0',
+              }}
               {...rest}
             />
           ),

--- a/src/components/repositories/MarkdownRenderers.tsx
+++ b/src/components/repositories/MarkdownRenderers.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+
+export const createLinkRenderer = (repositoryFullName: string, defaultBranch: string) => {
+  const LinkRenderer = (props: any) => {
+    const { href, children, ...rest } = props;
+    let finalHref = href;
+
+    if (
+      href &&
+      !href.startsWith('http') &&
+      !href.startsWith('//') &&
+      !href.startsWith('#') &&
+      !href.startsWith('mailto:')
+    ) {
+      const cleanPath = href.startsWith('./')
+        ? href.slice(2)
+        : href.startsWith('/')
+          ? href.slice(1)
+          : href;
+      const hasExtension = /\.[a-zA-Z0-9]+$/.test(cleanPath.replace(/\/$/, ''));
+      const isDirectory = cleanPath.endsWith('/') || !hasExtension;
+      const type = isDirectory ? 'tree' : 'blob';
+      const normalizedPath = cleanPath.replace(/\/$/, '');
+      finalHref = `https://github.com/${repositoryFullName}/${type}/${defaultBranch}/${normalizedPath}`;
+    }
+
+    return (
+      <a href={finalHref} target="_blank" rel="noopener noreferrer" {...rest}>
+        {children}
+      </a>
+    );
+  };
+  return LinkRenderer;
+};
+
+export const createImageRenderer = (repositoryFullName: string, defaultBranch: string) => {
+  const ImageRenderer = (props: any) => {
+    const { src, alt, ...rest } = props;
+    let finalSrc = src;
+
+    if (src && !src.startsWith('http') && !src.startsWith('//')) {
+      const cleanPath = src.startsWith('./')
+        ? src.slice(2)
+        : src.startsWith('/')
+          ? src.slice(1)
+          : src;
+      finalSrc = `https://cdn.jsdelivr.net/gh/${repositoryFullName}@${defaultBranch}/${cleanPath}`;
+    }
+
+    return (
+      <img
+        src={finalSrc}
+        alt={alt}
+        style={{
+          maxWidth: '100%',
+          height: 'auto',
+          borderRadius: '6px',
+          margin: '16px 0',
+        }}
+        {...rest}
+      />
+    );
+  };
+  return ImageRenderer;
+};

--- a/src/components/repositories/MarkdownRenderers.tsx
+++ b/src/components/repositories/MarkdownRenderers.tsx
@@ -8,7 +8,13 @@ export const resolveRelativeUrl = (
   defaultBranch: string,
   type: 'blob' | 'cdn' = 'blob',
 ): string | undefined => {
-  if (!url || url.startsWith('http') || url.startsWith('//') || url.startsWith('#') || url.startsWith('mailto:')) {
+  if (
+    !url ||
+    url.startsWith('http') ||
+    url.startsWith('//') ||
+    url.startsWith('#') ||
+    url.startsWith('mailto:')
+  ) {
     return url;
   }
 

--- a/src/components/repositories/MarkdownRenderers.tsx
+++ b/src/components/repositories/MarkdownRenderers.tsx
@@ -1,71 +1,24 @@
-import React from 'react';
-
-export const createLinkRenderer = (
+/**
+ * Resolve a relative URL to an absolute GitHub URL.
+ * Returns the original URL if it's already absolute.
+ */
+export const resolveRelativeUrl = (
+  url: string | undefined,
   repositoryFullName: string,
   defaultBranch: string,
-) => {
-  const LinkRenderer = (props: any) => {
-    const { href, children, ...rest } = props;
-    let finalHref = href;
+  type: 'blob' | 'cdn' = 'blob',
+): string | undefined => {
+  if (!url || url.startsWith('http') || url.startsWith('//') || url.startsWith('#') || url.startsWith('mailto:')) {
+    return url;
+  }
 
-    if (
-      href &&
-      !href.startsWith('http') &&
-      !href.startsWith('//') &&
-      !href.startsWith('#') &&
-      !href.startsWith('mailto:')
-    ) {
-      const cleanPath = href.startsWith('./')
-        ? href.slice(2)
-        : href.startsWith('/')
-          ? href.slice(1)
-          : href;
-      const hasExtension = /\.[a-zA-Z0-9]+$/.test(cleanPath.replace(/\/$/, ''));
-      const isDirectory = cleanPath.endsWith('/') || !hasExtension;
-      const type = isDirectory ? 'tree' : 'blob';
-      const normalizedPath = cleanPath.replace(/\/$/, '');
-      finalHref = `https://github.com/${repositoryFullName}/${type}/${defaultBranch}/${normalizedPath}`;
-    }
+  const cleanPath = url.replace(/^\.\//, '').replace(/^\//, '');
 
-    return (
-      <a href={finalHref} target="_blank" rel="noopener noreferrer" {...rest}>
-        {children}
-      </a>
-    );
-  };
-  return LinkRenderer;
-};
+  if (type === 'cdn') {
+    return `https://cdn.jsdelivr.net/gh/${repositoryFullName}@${defaultBranch}/${cleanPath}`;
+  }
 
-export const createImageRenderer = (
-  repositoryFullName: string,
-  defaultBranch: string,
-) => {
-  const ImageRenderer = (props: any) => {
-    const { src, alt, ...rest } = props;
-    let finalSrc = src;
-
-    if (src && !src.startsWith('http') && !src.startsWith('//')) {
-      const cleanPath = src.startsWith('./')
-        ? src.slice(2)
-        : src.startsWith('/')
-          ? src.slice(1)
-          : src;
-      finalSrc = `https://cdn.jsdelivr.net/gh/${repositoryFullName}@${defaultBranch}/${cleanPath}`;
-    }
-
-    return (
-      <img
-        src={finalSrc}
-        alt={alt}
-        style={{
-          maxWidth: '100%',
-          height: 'auto',
-          borderRadius: '6px',
-          margin: '16px 0',
-        }}
-        {...rest}
-      />
-    );
-  };
-  return ImageRenderer;
+  const hasExtension = /\.[a-zA-Z0-9]+$/.test(cleanPath.replace(/\/$/, ''));
+  const ghType = cleanPath.endsWith('/') || !hasExtension ? 'tree' : 'blob';
+  return `https://github.com/${repositoryFullName}/${ghType}/${defaultBranch}/${cleanPath.replace(/\/$/, '')}`;
 };

--- a/src/components/repositories/MarkdownRenderers.tsx
+++ b/src/components/repositories/MarkdownRenderers.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 
-export const createLinkRenderer = (repositoryFullName: string, defaultBranch: string) => {
+export const createLinkRenderer = (
+  repositoryFullName: string,
+  defaultBranch: string,
+) => {
   const LinkRenderer = (props: any) => {
     const { href, children, ...rest } = props;
     let finalHref = href;
@@ -33,7 +36,10 @@ export const createLinkRenderer = (repositoryFullName: string, defaultBranch: st
   return LinkRenderer;
 };
 
-export const createImageRenderer = (repositoryFullName: string, defaultBranch: string) => {
+export const createImageRenderer = (
+  repositoryFullName: string,
+  defaultBranch: string,
+) => {
   const ImageRenderer = (props: any) => {
     const { src, alt, ...rest } = props;
     let finalSrc = src;

--- a/src/components/repositories/ReadmeViewer.tsx
+++ b/src/components/repositories/ReadmeViewer.tsx
@@ -68,6 +68,38 @@ const ReadmeViewer: React.FC<ReadmeViewerProps> = ({ repositoryFullName }) => {
     );
   }
 
+  // Custom renderer for links to handle relative paths
+  const LinkRenderer = (props: any) => {
+    const { href, children, ...rest } = props;
+    let finalHref = href;
+
+    if (
+      href &&
+      !href.startsWith('http') &&
+      !href.startsWith('//') &&
+      !href.startsWith('#') &&
+      !href.startsWith('mailto:')
+    ) {
+      const cleanPath = href.startsWith('./')
+        ? href.slice(2)
+        : href.startsWith('/')
+          ? href.slice(1)
+          : href;
+      // Use /tree/ for directories (no extension or ends with /), /blob/ for files
+      const hasExtension = /\.[a-zA-Z0-9]+$/.test(cleanPath.replace(/\/$/, ''));
+      const isDirectory = cleanPath.endsWith('/') || !hasExtension;
+      const type = isDirectory ? 'tree' : 'blob';
+      const normalizedPath = cleanPath.replace(/\/$/, '');
+      finalHref = `https://github.com/${repositoryFullName}/${type}/${defaultBranch}/${normalizedPath}`;
+    }
+
+    return (
+      <a href={finalHref} target="_blank" rel="noopener noreferrer" {...rest}>
+        {children}
+      </a>
+    );
+  };
+
   // Custom renderer for images to handle relative paths
   const ImageRenderer = (props: any) => {
     const { src, alt, ...rest } = props;
@@ -209,6 +241,7 @@ const ReadmeViewer: React.FC<ReadmeViewerProps> = ({ repositoryFullName }) => {
         remarkPlugins={[remarkGfm]}
         rehypePlugins={[rehypeRaw]}
         components={{
+          a: LinkRenderer,
           img: ImageRenderer,
         }}
       >

--- a/src/components/repositories/ReadmeViewer.tsx
+++ b/src/components/repositories/ReadmeViewer.tsx
@@ -5,7 +5,7 @@ import remarkGfm from 'remark-gfm';
 import rehypeRaw from 'rehype-raw';
 import axios from 'axios';
 import { STATUS_COLORS } from '../../theme';
-import { createLinkRenderer, createImageRenderer } from './MarkdownRenderers';
+import { resolveRelativeUrl } from './MarkdownRenderers';
 
 interface ReadmeViewerProps {
   repositoryFullName: string; // e.g., "opentensor/bittensor"
@@ -69,9 +69,6 @@ const ReadmeViewer: React.FC<ReadmeViewerProps> = ({ repositoryFullName }) => {
     );
   }
 
-  const LinkRenderer = createLinkRenderer(repositoryFullName, defaultBranch);
-  const ImageRenderer = createImageRenderer(repositoryFullName, defaultBranch);
-
   return (
     <Paper
       elevation={0}
@@ -90,7 +87,7 @@ const ReadmeViewer: React.FC<ReadmeViewerProps> = ({ repositoryFullName }) => {
           borderBottom: '1px solid #30363d',
           pb: 0.3,
           mb: 3,
-          mt: 1, // Reduced from 4
+          mt: 1,
           fontWeight: 600,
           color: '#ffffff',
         },
@@ -99,7 +96,7 @@ const ReadmeViewer: React.FC<ReadmeViewerProps> = ({ repositoryFullName }) => {
           borderBottom: '1px solid #30363d',
           pb: 0.3,
           mb: 3,
-          mt: 2, // Reduced from 4
+          mt: 2,
           fontWeight: 600,
           color: '#ffffff',
         },
@@ -182,8 +179,19 @@ const ReadmeViewer: React.FC<ReadmeViewerProps> = ({ repositoryFullName }) => {
         remarkPlugins={[remarkGfm]}
         rehypePlugins={[rehypeRaw]}
         components={{
-          a: LinkRenderer,
-          img: ImageRenderer,
+          a: ({ href, children, ...rest }: any) => (
+            <a href={resolveRelativeUrl(href, repositoryFullName, defaultBranch)} target="_blank" rel="noopener noreferrer" {...rest}>
+              {children}
+            </a>
+          ),
+          img: ({ src, alt, ...rest }: any) => (
+            <img
+              src={resolveRelativeUrl(src, repositoryFullName, defaultBranch, 'cdn')}
+              alt={alt}
+              style={{ maxWidth: '100%', height: 'auto', borderRadius: '6px', margin: '16px 0' }}
+              {...rest}
+            />
+          ),
         }}
       >
         {content || ''}

--- a/src/components/repositories/ReadmeViewer.tsx
+++ b/src/components/repositories/ReadmeViewer.tsx
@@ -5,6 +5,7 @@ import remarkGfm from 'remark-gfm';
 import rehypeRaw from 'rehype-raw';
 import axios from 'axios';
 import { STATUS_COLORS } from '../../theme';
+import { createLinkRenderer, createImageRenderer } from './MarkdownRenderers';
 
 interface ReadmeViewerProps {
   repositoryFullName: string; // e.g., "opentensor/bittensor"
@@ -68,68 +69,8 @@ const ReadmeViewer: React.FC<ReadmeViewerProps> = ({ repositoryFullName }) => {
     );
   }
 
-  // Custom renderer for links to handle relative paths
-  const LinkRenderer = (props: any) => {
-    const { href, children, ...rest } = props;
-    let finalHref = href;
-
-    if (
-      href &&
-      !href.startsWith('http') &&
-      !href.startsWith('//') &&
-      !href.startsWith('#') &&
-      !href.startsWith('mailto:')
-    ) {
-      const cleanPath = href.startsWith('./')
-        ? href.slice(2)
-        : href.startsWith('/')
-          ? href.slice(1)
-          : href;
-      // Use /tree/ for directories (no extension or ends with /), /blob/ for files
-      const hasExtension = /\.[a-zA-Z0-9]+$/.test(cleanPath.replace(/\/$/, ''));
-      const isDirectory = cleanPath.endsWith('/') || !hasExtension;
-      const type = isDirectory ? 'tree' : 'blob';
-      const normalizedPath = cleanPath.replace(/\/$/, '');
-      finalHref = `https://github.com/${repositoryFullName}/${type}/${defaultBranch}/${normalizedPath}`;
-    }
-
-    return (
-      <a href={finalHref} target="_blank" rel="noopener noreferrer" {...rest}>
-        {children}
-      </a>
-    );
-  };
-
-  // Custom renderer for images to handle relative paths
-  const ImageRenderer = (props: any) => {
-    const { src, alt, ...rest } = props;
-    let finalSrc = src;
-
-    if (src && !src.startsWith('http') && !src.startsWith('//')) {
-      // Convert relative path to absolute GitHub user content path
-      // e.g. ./assets/img.png -> https://raw.githubusercontent.com/user/repo/branch/assets/img.png
-      const cleanPath = src.startsWith('./')
-        ? src.slice(2)
-        : src.startsWith('/')
-          ? src.slice(1)
-          : src;
-      finalSrc = `https://cdn.jsdelivr.net/gh/${repositoryFullName}@${defaultBranch}/${cleanPath}`;
-    }
-
-    return (
-      <img
-        src={finalSrc}
-        alt={alt}
-        style={{
-          maxWidth: '100%',
-          height: 'auto',
-          borderRadius: '6px',
-          margin: '16px 0',
-        }}
-        {...rest}
-      />
-    );
-  };
+  const LinkRenderer = createLinkRenderer(repositoryFullName, defaultBranch);
+  const ImageRenderer = createImageRenderer(repositoryFullName, defaultBranch);
 
   return (
     <Paper

--- a/src/components/repositories/ReadmeViewer.tsx
+++ b/src/components/repositories/ReadmeViewer.tsx
@@ -180,15 +180,30 @@ const ReadmeViewer: React.FC<ReadmeViewerProps> = ({ repositoryFullName }) => {
         rehypePlugins={[rehypeRaw]}
         components={{
           a: ({ href, children, ...rest }: any) => (
-            <a href={resolveRelativeUrl(href, repositoryFullName, defaultBranch)} target="_blank" rel="noopener noreferrer" {...rest}>
+            <a
+              href={resolveRelativeUrl(href, repositoryFullName, defaultBranch)}
+              target="_blank"
+              rel="noopener noreferrer"
+              {...rest}
+            >
               {children}
             </a>
           ),
           img: ({ src, alt, ...rest }: any) => (
             <img
-              src={resolveRelativeUrl(src, repositoryFullName, defaultBranch, 'cdn')}
+              src={resolveRelativeUrl(
+                src,
+                repositoryFullName,
+                defaultBranch,
+                'cdn',
+              )}
               alt={alt}
-              style={{ maxWidth: '100%', height: 'auto', borderRadius: '6px', margin: '16px 0' }}
+              style={{
+                maxWidth: '100%',
+                height: 'auto',
+                borderRadius: '6px',
+                margin: '16px 0',
+              }}
               {...rest}
             />
           ),

--- a/src/components/repositories/index.ts
+++ b/src/components/repositories/index.ts
@@ -11,3 +11,4 @@ export { default as ReadmeViewer } from './ReadmeViewer';
 export { default as RepositoryCodeBrowser } from './RepositoryCodeBrowser';
 export { default as RepositoryMaintainers } from './RepositoryMaintainers';
 export { default as RepositoryCheckTab } from './RepositoryCheckTab';
+export { createLinkRenderer, createImageRenderer } from './MarkdownRenderers';

--- a/src/components/repositories/index.ts
+++ b/src/components/repositories/index.ts
@@ -11,4 +11,4 @@ export { default as ReadmeViewer } from './ReadmeViewer';
 export { default as RepositoryCodeBrowser } from './RepositoryCodeBrowser';
 export { default as RepositoryMaintainers } from './RepositoryMaintainers';
 export { default as RepositoryCheckTab } from './RepositoryCheckTab';
-export { createLinkRenderer, createImageRenderer } from './MarkdownRenderers';
+export { resolveRelativeUrl } from './MarkdownRenderers';


### PR DESCRIPTION
## Summary

Rewrite relative links in rendered README markdown to resolve to the source GitHub repository instead of localhost. Relative hrefs (e.g. `CONTRIBUTING.md`, `doc/developer-notes.md`, `doc`) are prefixed with the correct GitHub blob URL.

## Related Issues

Fixes #115

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Checklist

- [ ] New components are modularized/separated where sensible
- [ ] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes

## Screenshots
[Screencast from 2026-03-20 20-06-08.webm](https://github.com/user-attachments/assets/50f8c5bf-99ef-4d97-a413-b3498188d9c6)
