### PR TITLE
feat: Enhance miner repositories table with token score, filters, and pagination

### DIFF
--- a/src/components/miners/EmptyStateMessage.tsx
+++ b/src/components/miners/EmptyStateMessage.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Box, Typography, alpha } from '@mui/material';
+
+interface EmptyStateMessageProps {
+  message: string;
+}
+
+const EmptyStateMessage: React.FC<EmptyStateMessageProps> = ({ message }) => {
+  return (
+    <Box sx={{ textAlign: 'center', py: 8 }}>
+      <Typography
+        sx={{
+          color: (t) => alpha(t.palette.text.primary, 0.5),
+          fontFamily: '"JetBrains Mono", monospace',
+          fontSize: '0.9rem',
+        }}
+      >
+        {message}
+      </Typography>
+    </Box>
+  );
+};
+
+export default EmptyStateMessage;

--- a/src/components/miners/MinerRepositoriesTable.styles.ts
+++ b/src/components/miners/MinerRepositoriesTable.styles.ts
@@ -1,0 +1,65 @@
+import { type Theme, alpha } from '@mui/material';
+import { type SxProps } from '@mui/system';
+
+export const getHeaderCellStyle = (theme: Theme) => ({
+  backgroundColor: theme.palette.surface.elevated,
+  backdropFilter: 'blur(8px)',
+  color: alpha(theme.palette.text.primary, 0.7),
+  fontFamily: '"JetBrains Mono", monospace',
+  fontWeight: 500,
+  fontSize: '0.75rem',
+  borderBottom: `1px solid ${theme.palette.border.light}`,
+  textTransform: 'uppercase' as const,
+  letterSpacing: '0.5px',
+});
+
+export const getBodyCellStyle = (theme: Theme) => ({
+  color: theme.palette.text.primary,
+  fontFamily: '"JetBrains Mono", monospace',
+  borderBottom: `1px solid ${theme.palette.border.light}`,
+  fontSize: '0.85rem',
+});
+
+export const sortLabelSx: SxProps<Theme> = {
+  color: 'inherit',
+  '&:hover': {
+    color: (t: Theme) => alpha(t.palette.text.primary, 0.9),
+  },
+  '&.Mui-active': {
+    color: (t: Theme) => alpha(t.palette.text.primary, 0.9),
+    '& .MuiTableSortLabel-icon': {
+      color: (t: Theme) => `${alpha(t.palette.text.primary, 0.9)} !important`,
+    },
+  },
+};
+
+export const searchFieldSx: SxProps<Theme> = {
+  mt: 2,
+  maxWidth: 400,
+  minWidth: 350,
+  '& .MuiOutlinedInput-root': {
+    fontFamily: '"JetBrains Mono", monospace',
+    fontSize: '0.8rem',
+    color: 'text.primary',
+    backgroundColor: 'surface.subtle',
+    borderRadius: 2,
+    '& fieldset': { borderColor: 'border.light' },
+    '&:hover fieldset': { borderColor: 'border.medium' },
+    '&.Mui-focused fieldset': { borderColor: 'primary.main' },
+  },
+};
+
+export const tableContainerSx: SxProps<Theme> = {
+  overflowY: 'auto',
+  overflowX: 'auto',
+  '&::-webkit-scrollbar': {
+    width: { xs: '6px', sm: '8px' },
+    height: { xs: '6px', sm: '8px' },
+  },
+  '&::-webkit-scrollbar-track': { backgroundColor: 'transparent' },
+  '&::-webkit-scrollbar-thumb': {
+    backgroundColor: 'border.light',
+    borderRadius: '4px',
+    '&:hover': { backgroundColor: 'border.medium' },
+  },
+};

--- a/src/components/miners/MinerRepositoriesTable.tsx
+++ b/src/components/miners/MinerRepositoriesTable.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import {
   Card,
   Typography,
@@ -22,7 +22,11 @@ import {
   NavigateBefore as PrevIcon,
   NavigateNext as NextIcon,
 } from '@mui/icons-material';
-import { useMinerPRs, useReposAndWeights, useTierConfigurations } from '../../api';
+import {
+  useMinerPRs,
+  useReposAndWeights,
+  useTierConfigurations,
+} from '../../api';
 import { useNavigate } from 'react-router-dom';
 import { TIER_COLORS } from '../../theme';
 import ExplorerFilterButton from './ExplorerFilterButton';
@@ -128,12 +132,15 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
     return map;
   }, [tierConfig]);
 
-  const isRepoQualified = (repo: RepoStats) => {
-    const tier = repo.tier.toLowerCase();
-    const threshold = tierThresholds.get(tier);
-    if (threshold == null) return false;
-    return repo.tokenScore >= threshold;
-  };
+  const isRepoQualified = useCallback(
+    (repo: RepoStats) => {
+      const tier = repo.tier.toLowerCase();
+      const threshold = tierThresholds.get(tier);
+      if (threshold == null) return false;
+      return repo.tokenScore >= threshold;
+    },
+    [tierThresholds],
+  );
 
   // Aggregate PRs by repository
   const repoStats = useMemo(() => {
@@ -176,7 +183,13 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
       filtered = filtered.filter((r) => r.repository.toLowerCase().includes(q));
     }
     return filtered;
-  }, [repoStats, tierFilter, qualificationFilter, searchQuery]);
+  }, [
+    repoStats,
+    tierFilter,
+    qualificationFilter,
+    searchQuery,
+    isRepoQualified,
+  ]);
 
   const sortedRepoStats = useMemo(
     () => sortMinerRepoStats(filteredRepoStats, sortField, sortOrder),
@@ -209,7 +222,7 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
       else unqualified++;
     }
     return { all: repoStats.length, qualified, unqualified };
-  }, [repoStats, tierThresholds]);
+  }, [repoStats, isRepoQualified]);
 
   const handleSort = (field: RepoSortField) => {
     if (sortField === field) {
@@ -290,9 +303,13 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
                 fontSize: '0.75rem',
               }}
             >
-              ({tierFilter !== 'all' || qualificationFilter !== 'all' || searchQuery.trim()
+              (
+              {tierFilter !== 'all' ||
+              qualificationFilter !== 'all' ||
+              searchQuery.trim()
                 ? `${sortedRepoStats.length} of ${repoStats.length}`
-                : sortedRepoStats.length})
+                : sortedRepoStats.length}
+              )
             </Typography>
           </Box>
           <Box
@@ -312,21 +329,30 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
                 count={qualificationCounts.all}
                 color={theme.palette.status.neutral}
                 selected={qualificationFilter === 'all'}
-                onClick={() => { setQualificationFilter('all'); setPage(0); }}
+                onClick={() => {
+                  setQualificationFilter('all');
+                  setPage(0);
+                }}
               />
               <ExplorerFilterButton
                 label="Qualified"
                 count={qualificationCounts.qualified}
                 color={theme.palette.status.merged}
                 selected={qualificationFilter === 'qualified'}
-                onClick={() => { setQualificationFilter('qualified'); setPage(0); }}
+                onClick={() => {
+                  setQualificationFilter('qualified');
+                  setPage(0);
+                }}
               />
               <ExplorerFilterButton
                 label="Unqualified"
                 count={qualificationCounts.unqualified}
                 color={theme.palette.status.closed}
                 selected={qualificationFilter === 'unqualified'}
-                onClick={() => { setQualificationFilter('unqualified'); setPage(0); }}
+                onClick={() => {
+                  setQualificationFilter('unqualified');
+                  setPage(0);
+                }}
               />
             </Box>
 
@@ -337,28 +363,40 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
                 count={tierCounts.all}
                 color={theme.palette.status.neutral}
                 selected={tierFilter === 'all'}
-                onClick={() => { setTierFilter('all'); setPage(0); }}
+                onClick={() => {
+                  setTierFilter('all');
+                  setPage(0);
+                }}
               />
               <ExplorerFilterButton
                 label="Gold"
                 count={tierCounts.gold}
                 color={TIER_COLORS.gold}
                 selected={tierFilter === 'gold'}
-                onClick={() => { setTierFilter('gold'); setPage(0); }}
+                onClick={() => {
+                  setTierFilter('gold');
+                  setPage(0);
+                }}
               />
               <ExplorerFilterButton
                 label="Silver"
                 count={tierCounts.silver}
                 color={TIER_COLORS.silver}
                 selected={tierFilter === 'silver'}
-                onClick={() => { setTierFilter('silver'); setPage(0); }}
+                onClick={() => {
+                  setTierFilter('silver');
+                  setPage(0);
+                }}
               />
               <ExplorerFilterButton
                 label="Bronze"
                 count={tierCounts.bronze}
                 color={TIER_COLORS.bronze}
                 selected={tierFilter === 'bronze'}
-                onClick={() => { setTierFilter('bronze'); setPage(0); }}
+                onClick={() => {
+                  setTierFilter('bronze');
+                  setPage(0);
+                }}
               />
             </Box>
           </Box>
@@ -369,7 +407,10 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
           size="small"
           placeholder="Search repositories..."
           value={searchQuery}
-          onChange={(e) => { setSearchQuery(e.target.value); setPage(0); }}
+          onChange={(e) => {
+            setSearchQuery(e.target.value);
+            setPage(0);
+          }}
           InputProps={{
             startAdornment: (
               <InputAdornment position="start">
@@ -425,379 +466,386 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
           </Typography>
         </Box>
       ) : (
-      <>
-      <TableContainer
-        sx={{
-          overflowY: 'auto',
-          overflowX: 'auto',
-          '&::-webkit-scrollbar': {
-            width: { xs: '6px', sm: '8px' },
-            height: { xs: '6px', sm: '8px' },
-          },
-          '&::-webkit-scrollbar-track': { backgroundColor: 'transparent' },
-          '&::-webkit-scrollbar-thumb': {
-            backgroundColor: 'border.light',
-            borderRadius: '4px',
-            '&:hover': { backgroundColor: 'border.medium' },
-          },
-        }}
-      >
-        <Table
-          stickyHeader
-          sx={{ tableLayout: 'fixed', minWidth: '700px' }}
-        >
-          <TableHead>
-            <TableRow>
-              <TableCell sx={headerCellStyle}>
-                <TableSortLabel
-                  active={sortField === 'rank'}
-                  direction={sortField === 'rank' ? sortOrder : 'desc'}
-                  onClick={() => handleSort('rank')}
-                  sx={{
-                    color: 'inherit',
-                    '&:hover': {
-                      color: (t) => alpha(t.palette.text.primary, 0.9),
-                    },
-                    '&.Mui-active': {
-                      color: (t) => alpha(t.palette.text.primary, 0.9),
-                      '& .MuiTableSortLabel-icon': {
-                        color: (t) =>
-                          `${alpha(t.palette.text.primary, 0.9)} !important`,
-                      },
-                    },
-                  }}
-                >
-                  Rank
-                </TableSortLabel>
-              </TableCell>
-              <TableCell sx={headerCellStyle}>
-                <TableSortLabel
-                  active={sortField === 'repository'}
-                  direction={sortField === 'repository' ? sortOrder : 'asc'}
-                  onClick={() => handleSort('repository')}
-                  sx={{
-                    color: 'inherit',
-                    '&:hover': {
-                      color: (t) => alpha(t.palette.text.primary, 0.9),
-                    },
-                    '&.Mui-active': {
-                      color: (t) => alpha(t.palette.text.primary, 0.9),
-                      '& .MuiTableSortLabel-icon': {
-                        color: (t) =>
-                          `${alpha(t.palette.text.primary, 0.9)} !important`,
-                      },
-                    },
-                  }}
-                >
-                  Repository
-                </TableSortLabel>
-              </TableCell>
-              <TableCell align="right" sx={headerCellStyle}>
-                <TableSortLabel
-                  active={sortField === 'prs'}
-                  direction={sortField === 'prs' ? sortOrder : 'desc'}
-                  onClick={() => handleSort('prs')}
-                  sx={{
-                    color: 'inherit',
-                    '&:hover': {
-                      color: (t) => alpha(t.palette.text.primary, 0.9),
-                    },
-                    '&.Mui-active': {
-                      color: (t) => alpha(t.palette.text.primary, 0.9),
-                      '& .MuiTableSortLabel-icon': {
-                        color: (t) =>
-                          `${alpha(t.palette.text.primary, 0.9)} !important`,
-                      },
-                    },
-                  }}
-                >
-                  PRs
-                </TableSortLabel>
-              </TableCell>
-              <TableCell align="right" sx={headerCellStyle}>
-                <TableSortLabel
-                  active={sortField === 'score'}
-                  direction={sortField === 'score' ? sortOrder : 'desc'}
-                  onClick={() => handleSort('score')}
-                  sx={{
-                    color: 'inherit',
-                    '&:hover': {
-                      color: (t) => alpha(t.palette.text.primary, 0.9),
-                    },
-                    '&.Mui-active': {
-                      color: (t) => alpha(t.palette.text.primary, 0.9),
-                      '& .MuiTableSortLabel-icon': {
-                        color: (t) =>
-                          `${alpha(t.palette.text.primary, 0.9)} !important`,
-                      },
-                    },
-                  }}
-                >
-                  Score
-                </TableSortLabel>
-              </TableCell>
-              <TableCell align="right" sx={headerCellStyle}>
-                <TableSortLabel
-                  active={sortField === 'tokenScore'}
-                  direction={sortField === 'tokenScore' ? sortOrder : 'desc'}
-                  onClick={() => handleSort('tokenScore')}
-                  sx={{
-                    color: 'inherit',
-                    '&:hover': {
-                      color: (t) => alpha(t.palette.text.primary, 0.9),
-                    },
-                    '&.Mui-active': {
-                      color: (t) => alpha(t.palette.text.primary, 0.9),
-                      '& .MuiTableSortLabel-icon': {
-                        color: (t) =>
-                          `${alpha(t.palette.text.primary, 0.9)} !important`,
-                      },
-                    },
-                  }}
-                >
-                  Token Score
-                </TableSortLabel>
-              </TableCell>
-              <TableCell align="right" sx={headerCellStyle}>
-                Avg/PR
-              </TableCell>
-              <TableCell align="right" sx={headerCellStyle}>
-                <TableSortLabel
-                  active={sortField === 'weight'}
-                  direction={sortField === 'weight' ? sortOrder : 'desc'}
-                  onClick={() => handleSort('weight')}
-                  sx={{
-                    color: 'inherit',
-                    '&:hover': {
-                      color: (t) => alpha(t.palette.text.primary, 0.9),
-                    },
-                    '&.Mui-active': {
-                      color: (t) => alpha(t.palette.text.primary, 0.9),
-                      '& .MuiTableSortLabel-icon': {
-                        color: (t) =>
-                          `${alpha(t.palette.text.primary, 0.9)} !important`,
-                      },
-                    },
-                  }}
-                >
-                  Weight
-                </TableSortLabel>
-              </TableCell>
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {pagedRepoStats.map((repo, index) => {
-              const rank = page * PAGE_SIZE + index;
-              return (
-              <TableRow
-                key={repo.repository}
-                sx={{
-                  '&:hover': {
-                    backgroundColor: 'surface.light',
-                  },
-                  transition: 'background-color 0.2s',
-                }}
-              >
-                <TableCell sx={bodyCellStyle}>
-                  <Box
-                    sx={{
-                      backgroundColor: 'background.default',
-                      borderRadius: '2px',
-                      width: '28px',
-                      height: '28px',
-                      display: 'inline-flex',
-                      alignItems: 'center',
-                      justifyContent: 'center',
-                      flexShrink: 0,
-                      border: '1px solid',
-                      borderColor: (t) =>
-                        rank === 0
-                          ? alpha(TIER_COLORS.gold, 0.4)
-                          : rank === 1
-                            ? alpha(TIER_COLORS.silver, 0.4)
-                            : rank === 2
-                              ? alpha(TIER_COLORS.bronze, 0.4)
-                              : alpha(t.palette.text.primary, 0.15),
-                      boxShadow:
-                        rank === 0
-                          ? `0 0 12px ${alpha(TIER_COLORS.gold, 0.4)}, 0 0 4px ${alpha(TIER_COLORS.gold, 0.2)}`
-                          : rank === 1
-                            ? `0 0 12px ${alpha(TIER_COLORS.silver, 0.4)}, 0 0 4px ${alpha(TIER_COLORS.silver, 0.2)}`
-                            : rank === 2
-                              ? `0 0 12px ${alpha(TIER_COLORS.bronze, 0.4)}, 0 0 4px ${alpha(TIER_COLORS.bronze, 0.2)}`
-                              : 'none',
-                    }}
-                  >
-                    <Typography
-                      component="span"
+        <>
+          <TableContainer
+            sx={{
+              overflowY: 'auto',
+              overflowX: 'auto',
+              '&::-webkit-scrollbar': {
+                width: { xs: '6px', sm: '8px' },
+                height: { xs: '6px', sm: '8px' },
+              },
+              '&::-webkit-scrollbar-track': { backgroundColor: 'transparent' },
+              '&::-webkit-scrollbar-thumb': {
+                backgroundColor: 'border.light',
+                borderRadius: '4px',
+                '&:hover': { backgroundColor: 'border.medium' },
+              },
+            }}
+          >
+            <Table
+              stickyHeader
+              sx={{ tableLayout: 'fixed', minWidth: '700px' }}
+            >
+              <TableHead>
+                <TableRow>
+                  <TableCell sx={headerCellStyle}>
+                    <TableSortLabel
+                      active={sortField === 'rank'}
+                      direction={sortField === 'rank' ? sortOrder : 'desc'}
+                      onClick={() => handleSort('rank')}
                       sx={{
-                        color: (t) =>
-                          rank === 0
-                            ? TIER_COLORS.gold
-                            : rank === 1
-                              ? TIER_COLORS.silver
-                              : rank === 2
-                                ? TIER_COLORS.bronze
-                                : alpha(t.palette.text.primary, 0.6),
-                        fontFamily: '"JetBrains Mono", monospace',
-                        fontSize: '0.7rem',
-                        fontWeight: 600,
-                        lineHeight: 1,
-                        display: 'flex',
-                        alignItems: 'center',
-                        justifyContent: 'center',
-                      }}
-                    >
-                      {page * PAGE_SIZE + index + 1}
-                    </Typography>
-                  </Box>
-                </TableCell>
-                <TableCell sx={bodyCellStyle}>
-                  <Box
-                    onClick={() =>
-                      navigate(
-                        `/miners/repository?name=${encodeURIComponent(repo.repository)}`,
-                        {
-                          state: {
-                            backLabel: `Back to ${prs?.[0]?.author || githubId}`,
+                        color: 'inherit',
+                        '&:hover': {
+                          color: (t) => alpha(t.palette.text.primary, 0.9),
+                        },
+                        '&.Mui-active': {
+                          color: (t) => alpha(t.palette.text.primary, 0.9),
+                          '& .MuiTableSortLabel-icon': {
+                            color: (t) =>
+                              `${alpha(t.palette.text.primary, 0.9)} !important`,
                           },
                         },
-                      )
-                    }
-                    sx={{
-                      display: 'flex',
-                      alignItems: 'center',
-                      gap: 1.5,
-                      cursor: 'pointer',
-                      '&:hover': {
-                        color: 'primary.main',
-                        '& .MuiTypography-root': {
-                          textDecoration: 'underline',
-                        },
-                      },
-                      transition: 'color 0.2s',
-                    }}
-                  >
-                    <Avatar
-                      src={`https://avatars.githubusercontent.com/${repo.repository.split('/')[0]}`}
-                      alt={repo.repository.split('/')[0]}
-                      sx={{
-                        width: 24,
-                        height: 24,
-                        border: '1px solid',
-                        borderColor: 'border.medium',
-                        backgroundColor:
-                          repo.repository.split('/')[0] === 'opentensor'
-                            ? 'text.primary'
-                            : repo.repository.split('/')[0] === 'bitcoin'
-                              ? 'status.warning'
-                              : 'transparent',
-                      }}
-                    />
-                    {repo.tier && (
-                      <Box
-                        sx={{
-                          width: 6,
-                          height: 6,
-                          borderRadius: '50%',
-                          backgroundColor: tierColorFor(repo.tier, TIER_COLORS),
-                          flexShrink: 0,
-                        }}
-                        title={`${repo.tier} tier`}
-                      />
-                    )}
-                    <Typography
-                      component="span"
-                      sx={{
-                        fontFamily: '"JetBrains Mono", monospace',
-                        fontSize: '0.85rem',
-                        transition: 'color 0.2s',
                       }}
                     >
-                      {repo.repository}
-                    </Typography>
-                  </Box>
-                </TableCell>
-                <TableCell align="right" sx={bodyCellStyle}>
-                  {repo.prs}
-                </TableCell>
-                <TableCell align="right" sx={bodyCellStyle}>
-                  {repo.score.toFixed(4)}
-                </TableCell>
-                <TableCell align="right" sx={bodyCellStyle}>
-                  {repo.tokenScore.toFixed(2)}
-                </TableCell>
-                <TableCell
-                  align="right"
-                  sx={{
-                    ...bodyCellStyle,
-                    color: (t) => alpha(t.palette.text.primary, 0.5),
-                  }}
-                >
-                  {repo.prs > 0 ? (repo.score / repo.prs).toFixed(4) : '—'}
-                </TableCell>
-                <TableCell align="right" sx={bodyCellStyle}>
-                  {repo.weight.toFixed(4)}
-                </TableCell>
-              </TableRow>
-              );
-            })}
-          </TableBody>
-        </Table>
-      </TableContainer>
+                      Rank
+                    </TableSortLabel>
+                  </TableCell>
+                  <TableCell sx={headerCellStyle}>
+                    <TableSortLabel
+                      active={sortField === 'repository'}
+                      direction={sortField === 'repository' ? sortOrder : 'asc'}
+                      onClick={() => handleSort('repository')}
+                      sx={{
+                        color: 'inherit',
+                        '&:hover': {
+                          color: (t) => alpha(t.palette.text.primary, 0.9),
+                        },
+                        '&.Mui-active': {
+                          color: (t) => alpha(t.palette.text.primary, 0.9),
+                          '& .MuiTableSortLabel-icon': {
+                            color: (t) =>
+                              `${alpha(t.palette.text.primary, 0.9)} !important`,
+                          },
+                        },
+                      }}
+                    >
+                      Repository
+                    </TableSortLabel>
+                  </TableCell>
+                  <TableCell align="right" sx={headerCellStyle}>
+                    <TableSortLabel
+                      active={sortField === 'prs'}
+                      direction={sortField === 'prs' ? sortOrder : 'desc'}
+                      onClick={() => handleSort('prs')}
+                      sx={{
+                        color: 'inherit',
+                        '&:hover': {
+                          color: (t) => alpha(t.palette.text.primary, 0.9),
+                        },
+                        '&.Mui-active': {
+                          color: (t) => alpha(t.palette.text.primary, 0.9),
+                          '& .MuiTableSortLabel-icon': {
+                            color: (t) =>
+                              `${alpha(t.palette.text.primary, 0.9)} !important`,
+                          },
+                        },
+                      }}
+                    >
+                      PRs
+                    </TableSortLabel>
+                  </TableCell>
+                  <TableCell align="right" sx={headerCellStyle}>
+                    <TableSortLabel
+                      active={sortField === 'score'}
+                      direction={sortField === 'score' ? sortOrder : 'desc'}
+                      onClick={() => handleSort('score')}
+                      sx={{
+                        color: 'inherit',
+                        '&:hover': {
+                          color: (t) => alpha(t.palette.text.primary, 0.9),
+                        },
+                        '&.Mui-active': {
+                          color: (t) => alpha(t.palette.text.primary, 0.9),
+                          '& .MuiTableSortLabel-icon': {
+                            color: (t) =>
+                              `${alpha(t.palette.text.primary, 0.9)} !important`,
+                          },
+                        },
+                      }}
+                    >
+                      Score
+                    </TableSortLabel>
+                  </TableCell>
+                  <TableCell align="right" sx={headerCellStyle}>
+                    <TableSortLabel
+                      active={sortField === 'tokenScore'}
+                      direction={
+                        sortField === 'tokenScore' ? sortOrder : 'desc'
+                      }
+                      onClick={() => handleSort('tokenScore')}
+                      sx={{
+                        color: 'inherit',
+                        '&:hover': {
+                          color: (t) => alpha(t.palette.text.primary, 0.9),
+                        },
+                        '&.Mui-active': {
+                          color: (t) => alpha(t.palette.text.primary, 0.9),
+                          '& .MuiTableSortLabel-icon': {
+                            color: (t) =>
+                              `${alpha(t.palette.text.primary, 0.9)} !important`,
+                          },
+                        },
+                      }}
+                    >
+                      Token Score
+                    </TableSortLabel>
+                  </TableCell>
+                  <TableCell align="right" sx={headerCellStyle}>
+                    Avg/PR
+                  </TableCell>
+                  <TableCell align="right" sx={headerCellStyle}>
+                    <TableSortLabel
+                      active={sortField === 'weight'}
+                      direction={sortField === 'weight' ? sortOrder : 'desc'}
+                      onClick={() => handleSort('weight')}
+                      sx={{
+                        color: 'inherit',
+                        '&:hover': {
+                          color: (t) => alpha(t.palette.text.primary, 0.9),
+                        },
+                        '&.Mui-active': {
+                          color: (t) => alpha(t.palette.text.primary, 0.9),
+                          '& .MuiTableSortLabel-icon': {
+                            color: (t) =>
+                              `${alpha(t.palette.text.primary, 0.9)} !important`,
+                          },
+                        },
+                      }}
+                    >
+                      Weight
+                    </TableSortLabel>
+                  </TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {pagedRepoStats.map((repo, index) => {
+                  const rank = page * PAGE_SIZE + index;
+                  return (
+                    <TableRow
+                      key={repo.repository}
+                      sx={{
+                        '&:hover': {
+                          backgroundColor: 'surface.light',
+                        },
+                        transition: 'background-color 0.2s',
+                      }}
+                    >
+                      <TableCell sx={bodyCellStyle}>
+                        <Box
+                          sx={{
+                            backgroundColor: 'background.default',
+                            borderRadius: '2px',
+                            width: '28px',
+                            height: '28px',
+                            display: 'inline-flex',
+                            alignItems: 'center',
+                            justifyContent: 'center',
+                            flexShrink: 0,
+                            border: '1px solid',
+                            borderColor: (t) =>
+                              rank === 0
+                                ? alpha(TIER_COLORS.gold, 0.4)
+                                : rank === 1
+                                  ? alpha(TIER_COLORS.silver, 0.4)
+                                  : rank === 2
+                                    ? alpha(TIER_COLORS.bronze, 0.4)
+                                    : alpha(t.palette.text.primary, 0.15),
+                            boxShadow:
+                              rank === 0
+                                ? `0 0 12px ${alpha(TIER_COLORS.gold, 0.4)}, 0 0 4px ${alpha(TIER_COLORS.gold, 0.2)}`
+                                : rank === 1
+                                  ? `0 0 12px ${alpha(TIER_COLORS.silver, 0.4)}, 0 0 4px ${alpha(TIER_COLORS.silver, 0.2)}`
+                                  : rank === 2
+                                    ? `0 0 12px ${alpha(TIER_COLORS.bronze, 0.4)}, 0 0 4px ${alpha(TIER_COLORS.bronze, 0.2)}`
+                                    : 'none',
+                          }}
+                        >
+                          <Typography
+                            component="span"
+                            sx={{
+                              color: (t) =>
+                                rank === 0
+                                  ? TIER_COLORS.gold
+                                  : rank === 1
+                                    ? TIER_COLORS.silver
+                                    : rank === 2
+                                      ? TIER_COLORS.bronze
+                                      : alpha(t.palette.text.primary, 0.6),
+                              fontFamily: '"JetBrains Mono", monospace',
+                              fontSize: '0.7rem',
+                              fontWeight: 600,
+                              lineHeight: 1,
+                              display: 'flex',
+                              alignItems: 'center',
+                              justifyContent: 'center',
+                            }}
+                          >
+                            {page * PAGE_SIZE + index + 1}
+                          </Typography>
+                        </Box>
+                      </TableCell>
+                      <TableCell sx={bodyCellStyle}>
+                        <Box
+                          onClick={() =>
+                            navigate(
+                              `/miners/repository?name=${encodeURIComponent(repo.repository)}`,
+                              {
+                                state: {
+                                  backLabel: `Back to ${prs?.[0]?.author || githubId}`,
+                                },
+                              },
+                            )
+                          }
+                          sx={{
+                            display: 'flex',
+                            alignItems: 'center',
+                            gap: 1.5,
+                            cursor: 'pointer',
+                            '&:hover': {
+                              color: 'primary.main',
+                              '& .MuiTypography-root': {
+                                textDecoration: 'underline',
+                              },
+                            },
+                            transition: 'color 0.2s',
+                          }}
+                        >
+                          <Avatar
+                            src={`https://avatars.githubusercontent.com/${repo.repository.split('/')[0]}`}
+                            alt={repo.repository.split('/')[0]}
+                            sx={{
+                              width: 24,
+                              height: 24,
+                              border: '1px solid',
+                              borderColor: 'border.medium',
+                              backgroundColor:
+                                repo.repository.split('/')[0] === 'opentensor'
+                                  ? 'text.primary'
+                                  : repo.repository.split('/')[0] === 'bitcoin'
+                                    ? 'status.warning'
+                                    : 'transparent',
+                            }}
+                          />
+                          {repo.tier && (
+                            <Box
+                              sx={{
+                                width: 6,
+                                height: 6,
+                                borderRadius: '50%',
+                                backgroundColor: tierColorFor(
+                                  repo.tier,
+                                  TIER_COLORS,
+                                ),
+                                flexShrink: 0,
+                              }}
+                              title={`${repo.tier} tier`}
+                            />
+                          )}
+                          <Typography
+                            component="span"
+                            sx={{
+                              fontFamily: '"JetBrains Mono", monospace',
+                              fontSize: '0.85rem',
+                              transition: 'color 0.2s',
+                            }}
+                          >
+                            {repo.repository}
+                          </Typography>
+                        </Box>
+                      </TableCell>
+                      <TableCell align="right" sx={bodyCellStyle}>
+                        {repo.prs}
+                      </TableCell>
+                      <TableCell align="right" sx={bodyCellStyle}>
+                        {repo.score.toFixed(4)}
+                      </TableCell>
+                      <TableCell align="right" sx={bodyCellStyle}>
+                        {repo.tokenScore.toFixed(2)}
+                      </TableCell>
+                      <TableCell
+                        align="right"
+                        sx={{
+                          ...bodyCellStyle,
+                          color: (t) => alpha(t.palette.text.primary, 0.5),
+                        }}
+                      >
+                        {repo.prs > 0
+                          ? (repo.score / repo.prs).toFixed(4)
+                          : '—'}
+                      </TableCell>
+                      <TableCell align="right" sx={bodyCellStyle}>
+                        {repo.weight.toFixed(4)}
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </Table>
+          </TableContainer>
 
-      {/* Pagination */}
-      {totalPages > 1 && (
-        <Box
-          sx={{
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            gap: 2,
-            py: 1.5,
-            borderTop: '1px solid',
-            borderColor: 'border.subtle',
-          }}
-        >
-          <Box
-            onClick={() => setPage((p) => Math.max(0, p - 1))}
-            sx={{
-              cursor: page > 0 ? 'pointer' : 'default',
-              opacity: page > 0 ? 1 : 0.3,
-              display: 'flex',
-              alignItems: 'center',
-              color: (t) => alpha(t.palette.text.primary, 0.6),
-              '&:hover': page > 0 ? { color: 'text.primary' } : {},
-            }}
-          >
-            <PrevIcon sx={{ fontSize: '1.2rem' }} />
-          </Box>
-          <Typography
-            sx={{
-              fontFamily: '"JetBrains Mono", monospace',
-              fontSize: '0.75rem',
-              color: (t) => alpha(t.palette.text.primary, 0.5),
-            }}
-          >
-            {page + 1} / {totalPages}
-          </Typography>
-          <Box
-            onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
-            sx={{
-              cursor: page < totalPages - 1 ? 'pointer' : 'default',
-              opacity: page < totalPages - 1 ? 1 : 0.3,
-              display: 'flex',
-              alignItems: 'center',
-              color: (t) => alpha(t.palette.text.primary, 0.6),
-              '&:hover':
-                page < totalPages - 1 ? { color: 'text.primary' } : {},
-            }}
-          >
-            <NextIcon sx={{ fontSize: '1.2rem' }} />
-          </Box>
-        </Box>
-      )}
-      </>
+          {/* Pagination */}
+          {totalPages > 1 && (
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                gap: 2,
+                py: 1.5,
+                borderTop: '1px solid',
+                borderColor: 'border.subtle',
+              }}
+            >
+              <Box
+                onClick={() => setPage((p) => Math.max(0, p - 1))}
+                sx={{
+                  cursor: page > 0 ? 'pointer' : 'default',
+                  opacity: page > 0 ? 1 : 0.3,
+                  display: 'flex',
+                  alignItems: 'center',
+                  color: (t) => alpha(t.palette.text.primary, 0.6),
+                  '&:hover': page > 0 ? { color: 'text.primary' } : {},
+                }}
+              >
+                <PrevIcon sx={{ fontSize: '1.2rem' }} />
+              </Box>
+              <Typography
+                sx={{
+                  fontFamily: '"JetBrains Mono", monospace',
+                  fontSize: '0.75rem',
+                  color: (t) => alpha(t.palette.text.primary, 0.5),
+                }}
+              >
+                {page + 1} / {totalPages}
+              </Typography>
+              <Box
+                onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
+                sx={{
+                  cursor: page < totalPages - 1 ? 'pointer' : 'default',
+                  opacity: page < totalPages - 1 ? 1 : 0.3,
+                  display: 'flex',
+                  alignItems: 'center',
+                  color: (t) => alpha(t.palette.text.primary, 0.6),
+                  '&:hover':
+                    page < totalPages - 1 ? { color: 'text.primary' } : {},
+                }}
+              >
+                <NextIcon sx={{ fontSize: '1.2rem' }} />
+              </Box>
+            </Box>
+          )}
+        </>
       )}
     </Card>
   );

--- a/src/components/miners/MinerRepositoriesTable.tsx
+++ b/src/components/miners/MinerRepositoriesTable.tsx
@@ -17,8 +17,12 @@ import {
   alpha,
   useTheme,
 } from '@mui/material';
-import { Search as SearchIcon } from '@mui/icons-material';
-import { useMinerPRs, useReposAndWeights } from '../../api';
+import {
+  Search as SearchIcon,
+  NavigateBefore as PrevIcon,
+  NavigateNext as NextIcon,
+} from '@mui/icons-material';
+import { useMinerPRs, useReposAndWeights, useTierConfigurations } from '../../api';
 import { useNavigate } from 'react-router-dom';
 import { TIER_COLORS } from '../../theme';
 import ExplorerFilterButton from './ExplorerFilterButton';
@@ -41,9 +45,12 @@ interface RepoStats {
   repository: string;
   prs: number;
   score: number;
+  tokenScore: number;
   weight: number;
   tier: string;
 }
+
+const PAGE_SIZE = 20;
 
 const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
   githubId,
@@ -53,13 +60,18 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
   const navigate = useNavigate();
   const { data: prs, isLoading: isLoadingPRs } = useMinerPRs(githubId);
   const { data: repos, isLoading: isLoadingRepos } = useReposAndWeights();
+  const { data: tierConfig } = useTierConfigurations();
   const [sortField, setSortField] = useState<RepoSortField>('score');
   const [sortOrder, setSortOrder] = useState<SortOrder>('desc');
   const [internalTierFilter, setTierFilter] = useState<MinerTierFilter>('all');
   const tierFilter: MinerTierFilter =
     (externalTierFilter?.toLowerCase() as MinerTierFilter) ||
     internalTierFilter;
+  const [qualificationFilter, setQualificationFilter] = useState<
+    'all' | 'qualified' | 'unqualified'
+  >('all');
   const [searchQuery, setSearchQuery] = useState('');
+  const [page, setPage] = useState(0);
 
   const headerCellStyle = {
     backgroundColor: theme.palette.surface.elevated,
@@ -105,6 +117,24 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
     return map;
   }, [repos]);
 
+  // Build tier threshold map: tier name -> requiredMinTokenScorePerRepo
+  const tierThresholds = useMemo(() => {
+    const map = new Map<string, number>();
+    if (tierConfig?.tiers) {
+      tierConfig.tiers.forEach((t) => {
+        map.set(t.name.toLowerCase(), t.requiredMinTokenScorePerRepo);
+      });
+    }
+    return map;
+  }, [tierConfig]);
+
+  const isRepoQualified = (repo: RepoStats) => {
+    const tier = repo.tier.toLowerCase();
+    const threshold = tierThresholds.get(tier);
+    if (threshold == null) return false;
+    return repo.tokenScore >= threshold;
+  };
+
   // Aggregate PRs by repository
   const repoStats = useMemo(() => {
     if (!prs || prs.length === 0) return [];
@@ -116,11 +146,15 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
         repository: pr.repository,
         prs: 0,
         score: 0,
+        tokenScore: 0,
         weight: repoWeights.get(pr.repository) || 0,
         tier: repoTiers.get(pr.repository) || '',
       };
       existing.prs += 1;
       existing.score += parseFloat(pr.score || '0');
+      if (pr.prState === 'MERGED') {
+        existing.tokenScore += parseFloat(String(pr.tokenScore ?? '0'));
+      }
       statsMap.set(pr.repository, existing);
     });
 
@@ -130,17 +164,31 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
   // Filter and sort repository stats
   const filteredRepoStats = useMemo(() => {
     let filtered = filterMinerRepoStats(repoStats, tierFilter);
+    if (qualificationFilter !== 'all') {
+      filtered = filtered.filter((r) =>
+        qualificationFilter === 'qualified'
+          ? isRepoQualified(r)
+          : !isRepoQualified(r),
+      );
+    }
     if (searchQuery.trim()) {
       const q = searchQuery.toLowerCase();
       filtered = filtered.filter((r) => r.repository.toLowerCase().includes(q));
     }
     return filtered;
-  }, [repoStats, tierFilter, searchQuery]);
+  }, [repoStats, tierFilter, qualificationFilter, searchQuery]);
 
   const sortedRepoStats = useMemo(
     () => sortMinerRepoStats(filteredRepoStats, sortField, sortOrder),
     [filteredRepoStats, sortField, sortOrder],
   );
+
+  const pagedRepoStats = useMemo(() => {
+    const start = page * PAGE_SIZE;
+    return sortedRepoStats.slice(start, start + PAGE_SIZE);
+  }, [sortedRepoStats, page]);
+
+  const totalPages = Math.ceil(sortedRepoStats.length / PAGE_SIZE);
 
   const tierCounts = useMemo(() => {
     const counts = { all: repoStats.length, gold: 0, silver: 0, bronze: 0 };
@@ -152,6 +200,16 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
     }
     return counts;
   }, [repoStats]);
+
+  const qualificationCounts = useMemo(() => {
+    let qualified = 0;
+    let unqualified = 0;
+    for (const repo of repoStats) {
+      if (isRepoQualified(repo)) qualified++;
+      else unqualified++;
+    }
+    return { all: repoStats.length, qualified, unqualified };
+  }, [repoStats, tierThresholds]);
 
   const handleSort = (field: RepoSortField) => {
     if (sortField === field) {
@@ -178,84 +236,6 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
         elevation={0}
       >
         <CircularProgress size={40} sx={{ color: 'primary.main' }} />
-      </Card>
-    );
-  }
-
-  if (!prs || prs.length === 0) {
-    return (
-      <Card
-        sx={{
-          borderRadius: 3,
-          border: '1px solid',
-          borderColor: 'border.light',
-          backgroundColor: 'transparent',
-          p: 4,
-        }}
-        elevation={0}
-      >
-        <Typography
-          sx={{
-            color: (t) => alpha(t.palette.text.primary, 0.5),
-            fontFamily: '"JetBrains Mono", monospace',
-            fontSize: '0.9rem',
-            textAlign: 'center',
-          }}
-        >
-          No repository contributions found
-        </Typography>
-      </Card>
-    );
-  }
-
-  if (!tierFilter && repoStats.length === 0) {
-    return (
-      <Card
-        sx={{
-          borderRadius: 3,
-          border: '1px solid',
-          borderColor: 'border.light',
-          backgroundColor: 'transparent',
-          p: 4,
-        }}
-        elevation={0}
-      >
-        <Typography
-          sx={{
-            color: (t) => alpha(t.palette.text.primary, 0.5),
-            fontFamily: '"JetBrains Mono", monospace',
-            fontSize: '0.9rem',
-            textAlign: 'center',
-          }}
-        >
-          No repository contributions found
-        </Typography>
-      </Card>
-    );
-  }
-
-  if (tierFilter && filteredRepoStats.length === 0) {
-    return (
-      <Card
-        sx={{
-          borderRadius: 3,
-          border: '1px solid',
-          borderColor: 'border.light',
-          backgroundColor: 'transparent',
-          p: 4,
-        }}
-        elevation={0}
-      >
-        <Typography
-          sx={{
-            color: (t) => alpha(t.palette.text.primary, 0.5),
-            fontFamily: '"JetBrains Mono", monospace',
-            fontSize: '0.9rem',
-            textAlign: 'center',
-          }}
-        >
-          No repositories in this tier
-        </Typography>
       </Card>
     );
   }
@@ -297,11 +277,11 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
               sx={{
                 color: 'text.primary',
                 fontFamily: '"JetBrains Mono", monospace',
-                fontSize: '1.1rem',
+                fontSize: { xs: '0.95rem', sm: '1.1rem' },
                 fontWeight: 500,
               }}
             >
-              Top Repositories
+              Repositories
             </Typography>
             <Typography
               sx={{
@@ -310,39 +290,77 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
                 fontSize: '0.75rem',
               }}
             >
-              ({sortedRepoStats.length}
-              {tierFilter !== 'all' ? ` of ${repoStats.length}` : ''})
+              ({tierFilter !== 'all' || qualificationFilter !== 'all' || searchQuery.trim()
+                ? `${sortedRepoStats.length} of ${repoStats.length}`
+                : sortedRepoStats.length})
             </Typography>
           </Box>
-          <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap' }}>
-            <ExplorerFilterButton
-              label="All"
-              count={tierCounts.all}
-              color={theme.palette.status.neutral}
-              selected={tierFilter === 'all'}
-              onClick={() => setTierFilter('all')}
-            />
-            <ExplorerFilterButton
-              label="Gold"
-              count={tierCounts.gold}
-              color={TIER_COLORS.gold}
-              selected={tierFilter === 'gold'}
-              onClick={() => setTierFilter('gold')}
-            />
-            <ExplorerFilterButton
-              label="Silver"
-              count={tierCounts.silver}
-              color={TIER_COLORS.silver}
-              selected={tierFilter === 'silver'}
-              onClick={() => setTierFilter('silver')}
-            />
-            <ExplorerFilterButton
-              label="Bronze"
-              count={tierCounts.bronze}
-              color={TIER_COLORS.bronze}
-              selected={tierFilter === 'bronze'}
-              onClick={() => setTierFilter('bronze')}
-            />
+          <Box
+            sx={{
+              display: 'flex',
+              flexDirection: { xs: 'column', sm: 'row' },
+              gap: { xs: 1.5, sm: 1 },
+              flexWrap: 'wrap',
+              alignItems: { xs: 'flex-start', sm: 'center' },
+              width: { xs: '100%', sm: 'auto' },
+            }}
+          >
+            {/* Qualification Filter Buttons */}
+            <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap' }}>
+              <ExplorerFilterButton
+                label="All"
+                count={qualificationCounts.all}
+                color={theme.palette.status.neutral}
+                selected={qualificationFilter === 'all'}
+                onClick={() => { setQualificationFilter('all'); setPage(0); }}
+              />
+              <ExplorerFilterButton
+                label="Qualified"
+                count={qualificationCounts.qualified}
+                color={theme.palette.status.merged}
+                selected={qualificationFilter === 'qualified'}
+                onClick={() => { setQualificationFilter('qualified'); setPage(0); }}
+              />
+              <ExplorerFilterButton
+                label="Unqualified"
+                count={qualificationCounts.unqualified}
+                color={theme.palette.status.closed}
+                selected={qualificationFilter === 'unqualified'}
+                onClick={() => { setQualificationFilter('unqualified'); setPage(0); }}
+              />
+            </Box>
+
+            {/* Tier Filter Buttons */}
+            <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap' }}>
+              <ExplorerFilterButton
+                label="All Tiers"
+                count={tierCounts.all}
+                color={theme.palette.status.neutral}
+                selected={tierFilter === 'all'}
+                onClick={() => { setTierFilter('all'); setPage(0); }}
+              />
+              <ExplorerFilterButton
+                label="Gold"
+                count={tierCounts.gold}
+                color={TIER_COLORS.gold}
+                selected={tierFilter === 'gold'}
+                onClick={() => { setTierFilter('gold'); setPage(0); }}
+              />
+              <ExplorerFilterButton
+                label="Silver"
+                count={tierCounts.silver}
+                color={TIER_COLORS.silver}
+                selected={tierFilter === 'silver'}
+                onClick={() => { setTierFilter('silver'); setPage(0); }}
+              />
+              <ExplorerFilterButton
+                label="Bronze"
+                count={tierCounts.bronze}
+                color={TIER_COLORS.bronze}
+                selected={tierFilter === 'bronze'}
+                onClick={() => { setTierFilter('bronze'); setPage(0); }}
+              />
+            </Box>
           </Box>
         </Box>
 
@@ -351,7 +369,7 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
           size="small"
           placeholder="Search repositories..."
           value={searchQuery}
-          onChange={(e) => setSearchQuery(e.target.value)}
+          onChange={(e) => { setSearchQuery(e.target.value); setPage(0); }}
           InputProps={{
             startAdornment: (
               <InputAdornment position="start">
@@ -366,7 +384,8 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
           }}
           sx={{
             mt: 2,
-            maxWidth: 300,
+            maxWidth: 400,
+            minWidth: 350,
             '& .MuiOutlinedInput-root': {
               fontFamily: '"JetBrains Mono", monospace',
               fontSize: '0.8rem',
@@ -381,8 +400,52 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
         />
       </Box>
 
-      <TableContainer sx={{ maxHeight: '400px', overflow: 'auto' }}>
-        <Table stickyHeader>
+      {!prs || prs.length === 0 ? (
+        <Box sx={{ textAlign: 'center', py: 8 }}>
+          <Typography
+            sx={{
+              color: (t) => alpha(t.palette.text.primary, 0.5),
+              fontFamily: '"JetBrains Mono", monospace',
+              fontSize: '0.9rem',
+            }}
+          >
+            No repository contributions found
+          </Typography>
+        </Box>
+      ) : sortedRepoStats.length === 0 ? (
+        <Box sx={{ textAlign: 'center', py: 8 }}>
+          <Typography
+            sx={{
+              color: (t) => alpha(t.palette.text.primary, 0.5),
+              fontFamily: '"JetBrains Mono", monospace',
+              fontSize: '0.9rem',
+            }}
+          >
+            No repositories found for the selected filters
+          </Typography>
+        </Box>
+      ) : (
+      <>
+      <TableContainer
+        sx={{
+          overflowY: 'auto',
+          overflowX: 'auto',
+          '&::-webkit-scrollbar': {
+            width: { xs: '6px', sm: '8px' },
+            height: { xs: '6px', sm: '8px' },
+          },
+          '&::-webkit-scrollbar-track': { backgroundColor: 'transparent' },
+          '&::-webkit-scrollbar-thumb': {
+            backgroundColor: 'border.light',
+            borderRadius: '4px',
+            '&:hover': { backgroundColor: 'border.medium' },
+          },
+        }}
+      >
+        <Table
+          stickyHeader
+          sx={{ tableLayout: 'fixed', minWidth: '700px' }}
+        >
           <TableHead>
             <TableRow>
               <TableCell sx={headerCellStyle}>
@@ -474,6 +537,28 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
                 </TableSortLabel>
               </TableCell>
               <TableCell align="right" sx={headerCellStyle}>
+                <TableSortLabel
+                  active={sortField === 'tokenScore'}
+                  direction={sortField === 'tokenScore' ? sortOrder : 'desc'}
+                  onClick={() => handleSort('tokenScore')}
+                  sx={{
+                    color: 'inherit',
+                    '&:hover': {
+                      color: (t) => alpha(t.palette.text.primary, 0.9),
+                    },
+                    '&.Mui-active': {
+                      color: (t) => alpha(t.palette.text.primary, 0.9),
+                      '& .MuiTableSortLabel-icon': {
+                        color: (t) =>
+                          `${alpha(t.palette.text.primary, 0.9)} !important`,
+                      },
+                    },
+                  }}
+                >
+                  Token Score
+                </TableSortLabel>
+              </TableCell>
+              <TableCell align="right" sx={headerCellStyle}>
                 Avg/PR
               </TableCell>
               <TableCell align="right" sx={headerCellStyle}>
@@ -501,7 +586,9 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
             </TableRow>
           </TableHead>
           <TableBody>
-            {sortedRepoStats.map((repo, index) => (
+            {pagedRepoStats.map((repo, index) => {
+              const rank = page * PAGE_SIZE + index;
+              return (
               <TableRow
                 key={repo.repository}
                 sx={{
@@ -524,19 +611,19 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
                       flexShrink: 0,
                       border: '1px solid',
                       borderColor: (t) =>
-                        index === 0
+                        rank === 0
                           ? alpha(TIER_COLORS.gold, 0.4)
-                          : index === 1
+                          : rank === 1
                             ? alpha(TIER_COLORS.silver, 0.4)
-                            : index === 2
+                            : rank === 2
                               ? alpha(TIER_COLORS.bronze, 0.4)
                               : alpha(t.palette.text.primary, 0.15),
                       boxShadow:
-                        index === 0
+                        rank === 0
                           ? `0 0 12px ${alpha(TIER_COLORS.gold, 0.4)}, 0 0 4px ${alpha(TIER_COLORS.gold, 0.2)}`
-                          : index === 1
+                          : rank === 1
                             ? `0 0 12px ${alpha(TIER_COLORS.silver, 0.4)}, 0 0 4px ${alpha(TIER_COLORS.silver, 0.2)}`
-                            : index === 2
+                            : rank === 2
                               ? `0 0 12px ${alpha(TIER_COLORS.bronze, 0.4)}, 0 0 4px ${alpha(TIER_COLORS.bronze, 0.2)}`
                               : 'none',
                     }}
@@ -545,11 +632,11 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
                       component="span"
                       sx={{
                         color: (t) =>
-                          index === 0
+                          rank === 0
                             ? TIER_COLORS.gold
-                            : index === 1
+                            : rank === 1
                               ? TIER_COLORS.silver
-                              : index === 2
+                              : rank === 2
                                 ? TIER_COLORS.bronze
                                 : alpha(t.palette.text.primary, 0.6),
                         fontFamily: '"JetBrains Mono", monospace',
@@ -561,7 +648,7 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
                         justifyContent: 'center',
                       }}
                     >
-                      {index + 1}
+                      {page * PAGE_SIZE + index + 1}
                     </Typography>
                   </Box>
                 </TableCell>
@@ -637,6 +724,9 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
                 <TableCell align="right" sx={bodyCellStyle}>
                   {repo.score.toFixed(4)}
                 </TableCell>
+                <TableCell align="right" sx={bodyCellStyle}>
+                  {repo.tokenScore.toFixed(2)}
+                </TableCell>
                 <TableCell
                   align="right"
                   sx={{
@@ -650,10 +740,65 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
                   {repo.weight.toFixed(4)}
                 </TableCell>
               </TableRow>
-            ))}
+              );
+            })}
           </TableBody>
         </Table>
       </TableContainer>
+
+      {/* Pagination */}
+      {totalPages > 1 && (
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: 2,
+            py: 1.5,
+            borderTop: '1px solid',
+            borderColor: 'border.subtle',
+          }}
+        >
+          <Box
+            onClick={() => setPage((p) => Math.max(0, p - 1))}
+            sx={{
+              cursor: page > 0 ? 'pointer' : 'default',
+              opacity: page > 0 ? 1 : 0.3,
+              display: 'flex',
+              alignItems: 'center',
+              color: (t) => alpha(t.palette.text.primary, 0.6),
+              '&:hover': page > 0 ? { color: 'text.primary' } : {},
+            }}
+          >
+            <PrevIcon sx={{ fontSize: '1.2rem' }} />
+          </Box>
+          <Typography
+            sx={{
+              fontFamily: '"JetBrains Mono", monospace',
+              fontSize: '0.75rem',
+              color: (t) => alpha(t.palette.text.primary, 0.5),
+            }}
+          >
+            {page + 1} / {totalPages}
+          </Typography>
+          <Box
+            onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
+            sx={{
+              cursor: page < totalPages - 1 ? 'pointer' : 'default',
+              opacity: page < totalPages - 1 ? 1 : 0.3,
+              display: 'flex',
+              alignItems: 'center',
+              color: (t) => alpha(t.palette.text.primary, 0.6),
+              '&:hover':
+                page < totalPages - 1 ? { color: 'text.primary' } : {},
+            }}
+          >
+            <NextIcon sx={{ fontSize: '1.2rem' }} />
+          </Box>
+        </Box>
+      )}
+      </>
+      )}
     </Card>
   );
 };

--- a/src/components/miners/MinerRepositoriesTable.tsx
+++ b/src/components/miners/MinerRepositoriesTable.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import {
   Card,
   Typography,
@@ -11,17 +11,12 @@ import {
   TableRow,
   CircularProgress,
   Avatar,
-  TableSortLabel,
   TextField,
   InputAdornment,
   alpha,
   useTheme,
 } from '@mui/material';
-import {
-  Search as SearchIcon,
-  NavigateBefore as PrevIcon,
-  NavigateNext as NextIcon,
-} from '@mui/icons-material';
+import { Search as SearchIcon } from '@mui/icons-material';
 import {
   useMinerPRs,
   useReposAndWeights,
@@ -30,12 +25,34 @@ import {
 import { useNavigate } from 'react-router-dom';
 import { TIER_COLORS } from '../../theme';
 import ExplorerFilterButton from './ExplorerFilterButton';
+import SortableHeaderCell from './SortableHeaderCell';
+import RankBadge from './RankBadge';
+import EmptyStateMessage from './EmptyStateMessage';
+import TablePagination from './TablePagination';
+import {
+  getHeaderCellStyle,
+  getBodyCellStyle,
+  searchFieldSx,
+  tableContainerSx,
+} from './MinerRepositoriesTable.styles';
 import {
   type MinerTierFilter,
+  type QualificationFilter,
   type RepoSortField,
   type SortOrder,
+  type RepoStats,
+  buildRepoWeightsMap,
+  buildRepoTiersMap,
+  buildTierThresholdsMap,
+  aggregatePRsByRepository,
   filterMinerRepoStats,
+  filterByQualification,
+  filterBySearch,
   sortMinerRepoStats,
+  computeTierCounts,
+  computeQualificationCounts,
+  hasActiveFilters,
+  getDisplayCount,
   tierColorFor,
 } from '../../utils/ExplorerUtils';
 
@@ -43,15 +60,6 @@ interface MinerRepositoriesTableProps {
   githubId: string;
   /** When set externally (e.g. from TierDetailsPage), overrides internal tier filter. */
   tierFilter?: string;
-}
-
-interface RepoStats {
-  repository: string;
-  prs: number;
-  score: number;
-  tokenScore: number;
-  weight: number;
-  tier: string;
 }
 
 const PAGE_SIZE = 20;
@@ -71,125 +79,39 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
   const tierFilter: MinerTierFilter =
     (externalTierFilter?.toLowerCase() as MinerTierFilter) ||
     internalTierFilter;
-  const [qualificationFilter, setQualificationFilter] = useState<
-    'all' | 'qualified' | 'unqualified'
-  >('all');
+  const [qualificationFilter, setQualificationFilter] =
+    useState<QualificationFilter>('all');
   const [searchQuery, setSearchQuery] = useState('');
   const [page, setPage] = useState(0);
 
-  const headerCellStyle = {
-    backgroundColor: theme.palette.surface.elevated,
-    backdropFilter: 'blur(8px)',
-    color: alpha(theme.palette.text.primary, 0.7),
-    fontFamily: '"JetBrains Mono", monospace',
-    fontWeight: 500,
-    fontSize: '0.75rem',
-    borderBottom: `1px solid ${theme.palette.border.light}`,
-    textTransform: 'uppercase' as const,
-    letterSpacing: '0.5px',
-  };
+  const headerCellStyle = useMemo(() => getHeaderCellStyle(theme), [theme]);
+  const bodyCellStyle = useMemo(() => getBodyCellStyle(theme), [theme]);
 
-  const bodyCellStyle = {
-    color: theme.palette.text.primary,
-    fontFamily: '"JetBrains Mono", monospace',
-    borderBottom: `1px solid ${theme.palette.border.light}`,
-    fontSize: '0.85rem',
-  };
-
-  // Build repository weights and tiers maps
-  const repoWeights = useMemo(() => {
-    const map = new Map<string, number>();
-    if (Array.isArray(repos)) {
-      repos.forEach((repo) => {
-        if (repo && repo.fullName) {
-          map.set(repo.fullName, parseFloat(repo.weight || '0'));
-        }
-      });
-    }
-    return map;
-  }, [repos]);
-
-  const repoTiers = useMemo(() => {
-    const map = new Map<string, string>();
-    if (Array.isArray(repos)) {
-      repos.forEach((repo) => {
-        if (repo && repo.fullName) {
-          map.set(repo.fullName, repo.tier || '');
-        }
-      });
-    }
-    return map;
-  }, [repos]);
-
-  // Build tier threshold map: tier name -> requiredMinTokenScorePerRepo
-  const tierThresholds = useMemo(() => {
-    const map = new Map<string, number>();
-    if (tierConfig?.tiers) {
-      tierConfig.tiers.forEach((t) => {
-        map.set(t.name.toLowerCase(), t.requiredMinTokenScorePerRepo);
-      });
-    }
-    return map;
-  }, [tierConfig]);
-
-  const isRepoQualified = useCallback(
-    (repo: RepoStats) => {
-      const tier = repo.tier.toLowerCase();
-      const threshold = tierThresholds.get(tier);
-      if (threshold == null) return false;
-      return repo.tokenScore >= threshold;
-    },
-    [tierThresholds],
+  // Build lookup maps from API data
+  const repoWeights = useMemo(() => buildRepoWeightsMap(repos), [repos]);
+  const repoTiers = useMemo(() => buildRepoTiersMap(repos), [repos]);
+  const tierThresholds = useMemo(
+    () => buildTierThresholdsMap(tierConfig),
+    [tierConfig],
   );
 
   // Aggregate PRs by repository
-  const repoStats = useMemo(() => {
-    if (!prs || prs.length === 0) return [];
-
-    const statsMap = new Map<string, RepoStats>();
-
-    prs.forEach((pr) => {
-      const existing = statsMap.get(pr.repository) || {
-        repository: pr.repository,
-        prs: 0,
-        score: 0,
-        tokenScore: 0,
-        weight: repoWeights.get(pr.repository) || 0,
-        tier: repoTiers.get(pr.repository) || '',
-      };
-      existing.prs += 1;
-      existing.score += parseFloat(pr.score || '0');
-      if (pr.prState === 'MERGED') {
-        existing.tokenScore += parseFloat(String(pr.tokenScore ?? '0'));
-      }
-      statsMap.set(pr.repository, existing);
-    });
-
-    return Array.from(statsMap.values());
-  }, [prs, repoWeights, repoTiers]);
+  const repoStats = useMemo(
+    () => aggregatePRsByRepository(prs || [], repoWeights, repoTiers),
+    [prs, repoWeights, repoTiers],
+  );
 
   // Filter and sort repository stats
   const filteredRepoStats = useMemo(() => {
     let filtered = filterMinerRepoStats(repoStats, tierFilter);
-    if (qualificationFilter !== 'all') {
-      filtered = filtered.filter((r) =>
-        qualificationFilter === 'qualified'
-          ? isRepoQualified(r)
-          : !isRepoQualified(r),
-      );
-    }
-    if (searchQuery.trim()) {
-      const q = searchQuery.toLowerCase();
-      filtered = filtered.filter((r) => r.repository.toLowerCase().includes(q));
-    }
+    filtered = filterByQualification(
+      filtered,
+      qualificationFilter,
+      tierThresholds,
+    );
+    filtered = filterBySearch(filtered, searchQuery);
     return filtered;
-  }, [
-    repoStats,
-    tierFilter,
-    qualificationFilter,
-    searchQuery,
-    isRepoQualified,
-  ]);
+  }, [repoStats, tierFilter, qualificationFilter, tierThresholds, searchQuery]);
 
   const sortedRepoStats = useMemo(
     () => sortMinerRepoStats(filteredRepoStats, sortField, sortOrder),
@@ -203,26 +125,12 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
 
   const totalPages = Math.ceil(sortedRepoStats.length / PAGE_SIZE);
 
-  const tierCounts = useMemo(() => {
-    const counts = { all: repoStats.length, gold: 0, silver: 0, bronze: 0 };
-    for (const repo of repoStats) {
-      const tier = repo.tier.toLowerCase();
-      if (tier === 'gold') counts.gold++;
-      else if (tier === 'silver') counts.silver++;
-      else if (tier === 'bronze') counts.bronze++;
-    }
-    return counts;
-  }, [repoStats]);
+  const tierCounts = useMemo(() => computeTierCounts(repoStats), [repoStats]);
 
-  const qualificationCounts = useMemo(() => {
-    let qualified = 0;
-    let unqualified = 0;
-    for (const repo of repoStats) {
-      if (isRepoQualified(repo)) qualified++;
-      else unqualified++;
-    }
-    return { all: repoStats.length, qualified, unqualified };
-  }, [repoStats, isRepoQualified]);
+  const qualificationCounts = useMemo(
+    () => computeQualificationCounts(repoStats, tierThresholds),
+    [repoStats, tierThresholds],
+  );
 
   const handleSort = (field: RepoSortField) => {
     if (sortField === field) {
@@ -232,6 +140,19 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
       setSortOrder('desc');
     }
   };
+
+  const resetPage = () => setPage(0);
+
+  const isFiltered = hasActiveFilters(
+    tierFilter,
+    qualificationFilter,
+    searchQuery,
+  );
+  const displayCount = getDisplayCount(
+    sortedRepoStats.length,
+    repoStats.length,
+    isFiltered,
+  );
 
   const isLoading = isLoadingPRs || isLoadingRepos;
 
@@ -303,13 +224,7 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
                 fontSize: '0.75rem',
               }}
             >
-              (
-              {tierFilter !== 'all' ||
-              qualificationFilter !== 'all' ||
-              searchQuery.trim()
-                ? `${sortedRepoStats.length} of ${repoStats.length}`
-                : sortedRepoStats.length}
-              )
+              ({displayCount})
             </Typography>
           </Box>
           <Box
@@ -331,7 +246,7 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
                 selected={qualificationFilter === 'all'}
                 onClick={() => {
                   setQualificationFilter('all');
-                  setPage(0);
+                  resetPage();
                 }}
               />
               <ExplorerFilterButton
@@ -341,7 +256,7 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
                 selected={qualificationFilter === 'qualified'}
                 onClick={() => {
                   setQualificationFilter('qualified');
-                  setPage(0);
+                  resetPage();
                 }}
               />
               <ExplorerFilterButton
@@ -351,7 +266,7 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
                 selected={qualificationFilter === 'unqualified'}
                 onClick={() => {
                   setQualificationFilter('unqualified');
-                  setPage(0);
+                  resetPage();
                 }}
               />
             </Box>
@@ -365,7 +280,7 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
                 selected={tierFilter === 'all'}
                 onClick={() => {
                   setTierFilter('all');
-                  setPage(0);
+                  resetPage();
                 }}
               />
               <ExplorerFilterButton
@@ -375,7 +290,7 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
                 selected={tierFilter === 'gold'}
                 onClick={() => {
                   setTierFilter('gold');
-                  setPage(0);
+                  resetPage();
                 }}
               />
               <ExplorerFilterButton
@@ -385,7 +300,7 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
                 selected={tierFilter === 'silver'}
                 onClick={() => {
                   setTierFilter('silver');
-                  setPage(0);
+                  resetPage();
                 }}
               />
               <ExplorerFilterButton
@@ -395,7 +310,7 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
                 selected={tierFilter === 'bronze'}
                 onClick={() => {
                   setTierFilter('bronze');
-                  setPage(0);
+                  resetPage();
                 }}
               />
             </Box>
@@ -409,7 +324,7 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
           value={searchQuery}
           onChange={(e) => {
             setSearchQuery(e.target.value);
-            setPage(0);
+            resetPage();
           }}
           InputProps={{
             startAdornment: (
@@ -423,432 +338,252 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
               </InputAdornment>
             ),
           }}
-          sx={{
-            mt: 2,
-            maxWidth: 400,
-            minWidth: 350,
-            '& .MuiOutlinedInput-root': {
-              fontFamily: '"JetBrains Mono", monospace',
-              fontSize: '0.8rem',
-              color: 'text.primary',
-              backgroundColor: 'surface.subtle',
-              borderRadius: 2,
-              '& fieldset': { borderColor: 'border.light' },
-              '&:hover fieldset': { borderColor: 'border.medium' },
-              '&.Mui-focused fieldset': { borderColor: 'primary.main' },
-            },
-          }}
+          sx={searchFieldSx}
         />
       </Box>
 
       {!prs || prs.length === 0 ? (
-        <Box sx={{ textAlign: 'center', py: 8 }}>
-          <Typography
-            sx={{
-              color: (t) => alpha(t.palette.text.primary, 0.5),
-              fontFamily: '"JetBrains Mono", monospace',
-              fontSize: '0.9rem',
-            }}
-          >
-            No repository contributions found
-          </Typography>
-        </Box>
+        <EmptyStateMessage message="No repository contributions found" />
       ) : sortedRepoStats.length === 0 ? (
-        <Box sx={{ textAlign: 'center', py: 8 }}>
-          <Typography
-            sx={{
-              color: (t) => alpha(t.palette.text.primary, 0.5),
-              fontFamily: '"JetBrains Mono", monospace',
-              fontSize: '0.9rem',
-            }}
-          >
-            No repositories found for the selected filters
-          </Typography>
-        </Box>
+        <EmptyStateMessage message="No repositories found for the selected filters" />
       ) : (
         <>
-          <TableContainer
-            sx={{
-              overflowY: 'auto',
-              overflowX: 'auto',
-              '&::-webkit-scrollbar': {
-                width: { xs: '6px', sm: '8px' },
-                height: { xs: '6px', sm: '8px' },
-              },
-              '&::-webkit-scrollbar-track': { backgroundColor: 'transparent' },
-              '&::-webkit-scrollbar-thumb': {
-                backgroundColor: 'border.light',
-                borderRadius: '4px',
-                '&:hover': { backgroundColor: 'border.medium' },
-              },
-            }}
-          >
+          <TableContainer sx={tableContainerSx}>
             <Table
               stickyHeader
               sx={{ tableLayout: 'fixed', minWidth: '700px' }}
             >
               <TableHead>
                 <TableRow>
-                  <TableCell sx={headerCellStyle}>
-                    <TableSortLabel
-                      active={sortField === 'rank'}
-                      direction={sortField === 'rank' ? sortOrder : 'desc'}
-                      onClick={() => handleSort('rank')}
-                      sx={{
-                        color: 'inherit',
-                        '&:hover': {
-                          color: (t) => alpha(t.palette.text.primary, 0.9),
-                        },
-                        '&.Mui-active': {
-                          color: (t) => alpha(t.palette.text.primary, 0.9),
-                          '& .MuiTableSortLabel-icon': {
-                            color: (t) =>
-                              `${alpha(t.palette.text.primary, 0.9)} !important`,
-                          },
-                        },
-                      }}
-                    >
-                      Rank
-                    </TableSortLabel>
-                  </TableCell>
-                  <TableCell sx={headerCellStyle}>
-                    <TableSortLabel
-                      active={sortField === 'repository'}
-                      direction={sortField === 'repository' ? sortOrder : 'asc'}
-                      onClick={() => handleSort('repository')}
-                      sx={{
-                        color: 'inherit',
-                        '&:hover': {
-                          color: (t) => alpha(t.palette.text.primary, 0.9),
-                        },
-                        '&.Mui-active': {
-                          color: (t) => alpha(t.palette.text.primary, 0.9),
-                          '& .MuiTableSortLabel-icon': {
-                            color: (t) =>
-                              `${alpha(t.palette.text.primary, 0.9)} !important`,
-                          },
-                        },
-                      }}
-                    >
-                      Repository
-                    </TableSortLabel>
-                  </TableCell>
-                  <TableCell align="right" sx={headerCellStyle}>
-                    <TableSortLabel
-                      active={sortField === 'prs'}
-                      direction={sortField === 'prs' ? sortOrder : 'desc'}
-                      onClick={() => handleSort('prs')}
-                      sx={{
-                        color: 'inherit',
-                        '&:hover': {
-                          color: (t) => alpha(t.palette.text.primary, 0.9),
-                        },
-                        '&.Mui-active': {
-                          color: (t) => alpha(t.palette.text.primary, 0.9),
-                          '& .MuiTableSortLabel-icon': {
-                            color: (t) =>
-                              `${alpha(t.palette.text.primary, 0.9)} !important`,
-                          },
-                        },
-                      }}
-                    >
-                      PRs
-                    </TableSortLabel>
-                  </TableCell>
-                  <TableCell align="right" sx={headerCellStyle}>
-                    <TableSortLabel
-                      active={sortField === 'score'}
-                      direction={sortField === 'score' ? sortOrder : 'desc'}
-                      onClick={() => handleSort('score')}
-                      sx={{
-                        color: 'inherit',
-                        '&:hover': {
-                          color: (t) => alpha(t.palette.text.primary, 0.9),
-                        },
-                        '&.Mui-active': {
-                          color: (t) => alpha(t.palette.text.primary, 0.9),
-                          '& .MuiTableSortLabel-icon': {
-                            color: (t) =>
-                              `${alpha(t.palette.text.primary, 0.9)} !important`,
-                          },
-                        },
-                      }}
-                    >
-                      Score
-                    </TableSortLabel>
-                  </TableCell>
-                  <TableCell align="right" sx={headerCellStyle}>
-                    <TableSortLabel
-                      active={sortField === 'tokenScore'}
-                      direction={
-                        sortField === 'tokenScore' ? sortOrder : 'desc'
-                      }
-                      onClick={() => handleSort('tokenScore')}
-                      sx={{
-                        color: 'inherit',
-                        '&:hover': {
-                          color: (t) => alpha(t.palette.text.primary, 0.9),
-                        },
-                        '&.Mui-active': {
-                          color: (t) => alpha(t.palette.text.primary, 0.9),
-                          '& .MuiTableSortLabel-icon': {
-                            color: (t) =>
-                              `${alpha(t.palette.text.primary, 0.9)} !important`,
-                          },
-                        },
-                      }}
-                    >
-                      Token Score
-                    </TableSortLabel>
-                  </TableCell>
+                  <SortableHeaderCell
+                    field="rank"
+                    label="Rank"
+                    defaultDirection="desc"
+                    activeField={sortField}
+                    activeOrder={sortOrder}
+                    onSort={handleSort}
+                    cellStyle={headerCellStyle}
+                  />
+                  <SortableHeaderCell
+                    field="repository"
+                    label="Repository"
+                    defaultDirection="asc"
+                    activeField={sortField}
+                    activeOrder={sortOrder}
+                    onSort={handleSort}
+                    cellStyle={headerCellStyle}
+                  />
+                  <SortableHeaderCell
+                    field="prs"
+                    label="PRs"
+                    align="right"
+                    defaultDirection="desc"
+                    activeField={sortField}
+                    activeOrder={sortOrder}
+                    onSort={handleSort}
+                    cellStyle={headerCellStyle}
+                  />
+                  <SortableHeaderCell
+                    field="score"
+                    label="Score"
+                    align="right"
+                    defaultDirection="desc"
+                    activeField={sortField}
+                    activeOrder={sortOrder}
+                    onSort={handleSort}
+                    cellStyle={headerCellStyle}
+                  />
+                  <SortableHeaderCell
+                    field="tokenScore"
+                    label="Token Score"
+                    align="right"
+                    defaultDirection="desc"
+                    activeField={sortField}
+                    activeOrder={sortOrder}
+                    onSort={handleSort}
+                    cellStyle={headerCellStyle}
+                  />
                   <TableCell align="right" sx={headerCellStyle}>
                     Avg/PR
                   </TableCell>
-                  <TableCell align="right" sx={headerCellStyle}>
-                    <TableSortLabel
-                      active={sortField === 'weight'}
-                      direction={sortField === 'weight' ? sortOrder : 'desc'}
-                      onClick={() => handleSort('weight')}
-                      sx={{
-                        color: 'inherit',
-                        '&:hover': {
-                          color: (t) => alpha(t.palette.text.primary, 0.9),
-                        },
-                        '&.Mui-active': {
-                          color: (t) => alpha(t.palette.text.primary, 0.9),
-                          '& .MuiTableSortLabel-icon': {
-                            color: (t) =>
-                              `${alpha(t.palette.text.primary, 0.9)} !important`,
-                          },
-                        },
-                      }}
-                    >
-                      Weight
-                    </TableSortLabel>
-                  </TableCell>
+                  <SortableHeaderCell
+                    field="weight"
+                    label="Weight"
+                    align="right"
+                    defaultDirection="desc"
+                    activeField={sortField}
+                    activeOrder={sortOrder}
+                    onSort={handleSort}
+                    cellStyle={headerCellStyle}
+                  />
                 </TableRow>
               </TableHead>
               <TableBody>
                 {pagedRepoStats.map((repo, index) => {
                   const rank = page * PAGE_SIZE + index;
                   return (
-                    <TableRow
+                    <RepoTableRow
                       key={repo.repository}
-                      sx={{
-                        '&:hover': {
-                          backgroundColor: 'surface.light',
-                        },
-                        transition: 'background-color 0.2s',
-                      }}
-                    >
-                      <TableCell sx={bodyCellStyle}>
-                        <Box
-                          sx={{
-                            backgroundColor: 'background.default',
-                            borderRadius: '2px',
-                            width: '28px',
-                            height: '28px',
-                            display: 'inline-flex',
-                            alignItems: 'center',
-                            justifyContent: 'center',
-                            flexShrink: 0,
-                            border: '1px solid',
-                            borderColor: (t) =>
-                              rank === 0
-                                ? alpha(TIER_COLORS.gold, 0.4)
-                                : rank === 1
-                                  ? alpha(TIER_COLORS.silver, 0.4)
-                                  : rank === 2
-                                    ? alpha(TIER_COLORS.bronze, 0.4)
-                                    : alpha(t.palette.text.primary, 0.15),
-                            boxShadow:
-                              rank === 0
-                                ? `0 0 12px ${alpha(TIER_COLORS.gold, 0.4)}, 0 0 4px ${alpha(TIER_COLORS.gold, 0.2)}`
-                                : rank === 1
-                                  ? `0 0 12px ${alpha(TIER_COLORS.silver, 0.4)}, 0 0 4px ${alpha(TIER_COLORS.silver, 0.2)}`
-                                  : rank === 2
-                                    ? `0 0 12px ${alpha(TIER_COLORS.bronze, 0.4)}, 0 0 4px ${alpha(TIER_COLORS.bronze, 0.2)}`
-                                    : 'none',
-                          }}
-                        >
-                          <Typography
-                            component="span"
-                            sx={{
-                              color: (t) =>
-                                rank === 0
-                                  ? TIER_COLORS.gold
-                                  : rank === 1
-                                    ? TIER_COLORS.silver
-                                    : rank === 2
-                                      ? TIER_COLORS.bronze
-                                      : alpha(t.palette.text.primary, 0.6),
-                              fontFamily: '"JetBrains Mono", monospace',
-                              fontSize: '0.7rem',
-                              fontWeight: 600,
-                              lineHeight: 1,
-                              display: 'flex',
-                              alignItems: 'center',
-                              justifyContent: 'center',
-                            }}
-                          >
-                            {page * PAGE_SIZE + index + 1}
-                          </Typography>
-                        </Box>
-                      </TableCell>
-                      <TableCell sx={bodyCellStyle}>
-                        <Box
-                          onClick={() =>
-                            navigate(
-                              `/miners/repository?name=${encodeURIComponent(repo.repository)}`,
-                              {
-                                state: {
-                                  backLabel: `Back to ${prs?.[0]?.author || githubId}`,
-                                },
-                              },
-                            )
-                          }
-                          sx={{
-                            display: 'flex',
-                            alignItems: 'center',
-                            gap: 1.5,
-                            cursor: 'pointer',
-                            '&:hover': {
-                              color: 'primary.main',
-                              '& .MuiTypography-root': {
-                                textDecoration: 'underline',
-                              },
-                            },
-                            transition: 'color 0.2s',
-                          }}
-                        >
-                          <Avatar
-                            src={`https://avatars.githubusercontent.com/${repo.repository.split('/')[0]}`}
-                            alt={repo.repository.split('/')[0]}
-                            sx={{
-                              width: 24,
-                              height: 24,
-                              border: '1px solid',
-                              borderColor: 'border.medium',
-                              backgroundColor:
-                                repo.repository.split('/')[0] === 'opentensor'
-                                  ? 'text.primary'
-                                  : repo.repository.split('/')[0] === 'bitcoin'
-                                    ? 'status.warning'
-                                    : 'transparent',
-                            }}
-                          />
-                          {repo.tier && (
-                            <Box
-                              sx={{
-                                width: 6,
-                                height: 6,
-                                borderRadius: '50%',
-                                backgroundColor: tierColorFor(
-                                  repo.tier,
-                                  TIER_COLORS,
-                                ),
-                                flexShrink: 0,
-                              }}
-                              title={`${repo.tier} tier`}
-                            />
-                          )}
-                          <Typography
-                            component="span"
-                            sx={{
-                              fontFamily: '"JetBrains Mono", monospace',
-                              fontSize: '0.85rem',
-                              transition: 'color 0.2s',
-                            }}
-                          >
-                            {repo.repository}
-                          </Typography>
-                        </Box>
-                      </TableCell>
-                      <TableCell align="right" sx={bodyCellStyle}>
-                        {repo.prs}
-                      </TableCell>
-                      <TableCell align="right" sx={bodyCellStyle}>
-                        {repo.score.toFixed(4)}
-                      </TableCell>
-                      <TableCell align="right" sx={bodyCellStyle}>
-                        {repo.tokenScore.toFixed(2)}
-                      </TableCell>
-                      <TableCell
-                        align="right"
-                        sx={{
-                          ...bodyCellStyle,
-                          color: (t) => alpha(t.palette.text.primary, 0.5),
-                        }}
-                      >
-                        {repo.prs > 0
-                          ? (repo.score / repo.prs).toFixed(4)
-                          : '—'}
-                      </TableCell>
-                      <TableCell align="right" sx={bodyCellStyle}>
-                        {repo.weight.toFixed(4)}
-                      </TableCell>
-                    </TableRow>
+                      repo={repo}
+                      rank={rank}
+                      bodyCellStyle={bodyCellStyle}
+                      prs={prs}
+                      githubId={githubId}
+                      navigate={navigate}
+                    />
                   );
                 })}
               </TableBody>
             </Table>
           </TableContainer>
 
-          {/* Pagination */}
-          {totalPages > 1 && (
-            <Box
-              sx={{
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                gap: 2,
-                py: 1.5,
-                borderTop: '1px solid',
-                borderColor: 'border.subtle',
-              }}
-            >
-              <Box
-                onClick={() => setPage((p) => Math.max(0, p - 1))}
-                sx={{
-                  cursor: page > 0 ? 'pointer' : 'default',
-                  opacity: page > 0 ? 1 : 0.3,
-                  display: 'flex',
-                  alignItems: 'center',
-                  color: (t) => alpha(t.palette.text.primary, 0.6),
-                  '&:hover': page > 0 ? { color: 'text.primary' } : {},
-                }}
-              >
-                <PrevIcon sx={{ fontSize: '1.2rem' }} />
-              </Box>
-              <Typography
-                sx={{
-                  fontFamily: '"JetBrains Mono", monospace',
-                  fontSize: '0.75rem',
-                  color: (t) => alpha(t.palette.text.primary, 0.5),
-                }}
-              >
-                {page + 1} / {totalPages}
-              </Typography>
-              <Box
-                onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
-                sx={{
-                  cursor: page < totalPages - 1 ? 'pointer' : 'default',
-                  opacity: page < totalPages - 1 ? 1 : 0.3,
-                  display: 'flex',
-                  alignItems: 'center',
-                  color: (t) => alpha(t.palette.text.primary, 0.6),
-                  '&:hover':
-                    page < totalPages - 1 ? { color: 'text.primary' } : {},
-                }}
-              >
-                <NextIcon sx={{ fontSize: '1.2rem' }} />
-              </Box>
-            </Box>
-          )}
+          <TablePagination
+            page={page}
+            totalPages={totalPages}
+            onPageChange={setPage}
+          />
         </>
       )}
     </Card>
   );
+};
+
+// ---------------------------------------------------------------------------
+// Row sub-component
+// ---------------------------------------------------------------------------
+
+interface RepoTableRowProps {
+  repo: RepoStats;
+  rank: number;
+  bodyCellStyle: Record<string, unknown>;
+  prs: { author?: string }[] | undefined;
+  githubId: string;
+  navigate: ReturnType<typeof useNavigate>;
+}
+
+const RepoTableRow: React.FC<RepoTableRowProps> = ({
+  repo,
+  rank,
+  bodyCellStyle,
+  prs,
+  githubId,
+  navigate,
+}) => {
+  const owner = repo.repository.split('/')[0];
+  const avatarBgColor = getAvatarBgColor(owner);
+  const avgPerPr = repo.prs > 0 ? (repo.score / repo.prs).toFixed(4) : '\u2014';
+
+  return (
+    <TableRow
+      sx={{
+        '&:hover': {
+          backgroundColor: 'surface.light',
+        },
+        transition: 'background-color 0.2s',
+      }}
+    >
+      <TableCell sx={bodyCellStyle}>
+        <RankBadge rank={rank} displayNumber={rank + 1} />
+      </TableCell>
+      <TableCell sx={bodyCellStyle}>
+        <Box
+          onClick={() =>
+            navigate(
+              `/miners/repository?name=${encodeURIComponent(repo.repository)}`,
+              {
+                state: {
+                  backLabel: `Back to ${prs?.[0]?.author || githubId}`,
+                },
+              },
+            )
+          }
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 1.5,
+            cursor: 'pointer',
+            '&:hover': {
+              color: 'primary.main',
+              '& .MuiTypography-root': {
+                textDecoration: 'underline',
+              },
+            },
+            transition: 'color 0.2s',
+          }}
+        >
+          <Avatar
+            src={`https://avatars.githubusercontent.com/${owner}`}
+            alt={owner}
+            sx={{
+              width: 24,
+              height: 24,
+              border: '1px solid',
+              borderColor: 'border.medium',
+              backgroundColor: avatarBgColor,
+            }}
+          />
+          {repo.tier && (
+            <Box
+              sx={{
+                width: 6,
+                height: 6,
+                borderRadius: '50%',
+                backgroundColor: tierColorFor(repo.tier, TIER_COLORS),
+                flexShrink: 0,
+              }}
+              title={`${repo.tier} tier`}
+            />
+          )}
+          <Typography
+            component="span"
+            sx={{
+              fontFamily: '"JetBrains Mono", monospace',
+              fontSize: '0.85rem',
+              transition: 'color 0.2s',
+            }}
+          >
+            {repo.repository}
+          </Typography>
+        </Box>
+      </TableCell>
+      <TableCell align="right" sx={bodyCellStyle}>
+        {repo.prs}
+      </TableCell>
+      <TableCell align="right" sx={bodyCellStyle}>
+        {repo.score.toFixed(4)}
+      </TableCell>
+      <TableCell align="right" sx={bodyCellStyle}>
+        {repo.tokenScore.toFixed(2)}
+      </TableCell>
+      <TableCell
+        align="right"
+        sx={{
+          ...bodyCellStyle,
+          color: (t) => alpha(t.palette.text.primary, 0.5),
+        }}
+      >
+        {avgPerPr}
+      </TableCell>
+      <TableCell align="right" sx={bodyCellStyle}>
+        {repo.weight.toFixed(4)}
+      </TableCell>
+    </TableRow>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Avatar background color helper
+// ---------------------------------------------------------------------------
+
+const getAvatarBgColor = (owner: string): string => {
+  switch (owner) {
+    case 'opentensor':
+      return 'text.primary';
+    case 'bitcoin':
+      return 'status.warning';
+    default:
+      return 'transparent';
+  }
 };
 
 export default MinerRepositoriesTable;

--- a/src/components/miners/RankBadge.tsx
+++ b/src/components/miners/RankBadge.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { Box, Typography, alpha, useTheme } from '@mui/material';
+import { TIER_COLORS } from '../../theme';
+
+interface RankBadgeProps {
+  rank: number;
+  displayNumber: number;
+}
+
+const getRankTierColor = (rank: number): string | null => {
+  switch (rank) {
+    case 0:
+      return TIER_COLORS.gold;
+    case 1:
+      return TIER_COLORS.silver;
+    case 2:
+      return TIER_COLORS.bronze;
+    default:
+      return null;
+  }
+};
+
+const getRankBorderColor = (rank: number, fallbackColor: string): string => {
+  const tierColor = getRankTierColor(rank);
+  if (tierColor) {
+    return alpha(tierColor, 0.4);
+  }
+  return fallbackColor;
+};
+
+const getRankBoxShadow = (rank: number): string => {
+  const tierColor = getRankTierColor(rank);
+  if (tierColor) {
+    return `0 0 12px ${alpha(tierColor, 0.4)}, 0 0 4px ${alpha(tierColor, 0.2)}`;
+  }
+  return 'none';
+};
+
+const getRankTextColor = (rank: number, fallbackColor: string): string => {
+  const tierColor = getRankTierColor(rank);
+  if (tierColor) {
+    return tierColor;
+  }
+  return fallbackColor;
+};
+
+const RankBadge: React.FC<RankBadgeProps> = ({ rank, displayNumber }) => {
+  const theme = useTheme();
+  const defaultBorderColor = alpha(theme.palette.text.primary, 0.15);
+  const defaultTextColor = alpha(theme.palette.text.primary, 0.6);
+
+  return (
+    <Box
+      sx={{
+        backgroundColor: 'background.default',
+        borderRadius: '2px',
+        width: '28px',
+        height: '28px',
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        flexShrink: 0,
+        border: '1px solid',
+        borderColor: getRankBorderColor(rank, defaultBorderColor),
+        boxShadow: getRankBoxShadow(rank),
+      }}
+    >
+      <Typography
+        component="span"
+        sx={{
+          color: getRankTextColor(rank, defaultTextColor),
+          fontFamily: '"JetBrains Mono", monospace',
+          fontSize: '0.7rem',
+          fontWeight: 600,
+          lineHeight: 1,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        {displayNumber}
+      </Typography>
+    </Box>
+  );
+};
+
+export default RankBadge;

--- a/src/components/miners/SortableHeaderCell.tsx
+++ b/src/components/miners/SortableHeaderCell.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { TableCell, TableSortLabel } from '@mui/material';
+import { type RepoSortField, type SortOrder } from '../../utils/ExplorerUtils';
+import { sortLabelSx } from './MinerRepositoriesTable.styles';
+
+interface SortableHeaderCellProps {
+  field: RepoSortField;
+  label: string;
+  align?: 'left' | 'right';
+  defaultDirection: SortOrder;
+  activeField: RepoSortField;
+  activeOrder: SortOrder;
+  onSort: (field: RepoSortField) => void;
+  cellStyle: Record<string, unknown>;
+}
+
+const SortableHeaderCell: React.FC<SortableHeaderCellProps> = ({
+  field,
+  label,
+  align,
+  defaultDirection,
+  activeField,
+  activeOrder,
+  onSort,
+  cellStyle,
+}) => {
+  const isActive = activeField === field;
+  const direction = isActive ? activeOrder : defaultDirection;
+
+  return (
+    <TableCell align={align} sx={cellStyle}>
+      <TableSortLabel
+        active={isActive}
+        direction={direction}
+        onClick={() => onSort(field)}
+        sx={sortLabelSx}
+      >
+        {label}
+      </TableSortLabel>
+    </TableCell>
+  );
+};
+
+export default SortableHeaderCell;

--- a/src/components/miners/TablePagination.tsx
+++ b/src/components/miners/TablePagination.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import { Box, Typography, alpha } from '@mui/material';
+import {
+  NavigateBefore as PrevIcon,
+  NavigateNext as NextIcon,
+} from '@mui/icons-material';
+
+interface TablePaginationProps {
+  page: number;
+  totalPages: number;
+  onPageChange: (newPage: number) => void;
+}
+
+const TablePagination: React.FC<TablePaginationProps> = ({
+  page,
+  totalPages,
+  onPageChange,
+}) => {
+  if (totalPages <= 1) {
+    return null;
+  }
+
+  const canGoPrev = page > 0;
+  const canGoNext = page < totalPages - 1;
+
+  const handlePrev = () => {
+    if (canGoPrev) {
+      onPageChange(page - 1);
+    }
+  };
+
+  const handleNext = () => {
+    if (canGoNext) {
+      onPageChange(page + 1);
+    }
+  };
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 2,
+        py: 1.5,
+        borderTop: '1px solid',
+        borderColor: 'border.subtle',
+      }}
+    >
+      <Box
+        onClick={handlePrev}
+        sx={{
+          cursor: canGoPrev ? 'pointer' : 'default',
+          opacity: canGoPrev ? 1 : 0.3,
+          display: 'flex',
+          alignItems: 'center',
+          color: (t) => alpha(t.palette.text.primary, 0.6),
+          '&:hover': canGoPrev ? { color: 'text.primary' } : {},
+        }}
+      >
+        <PrevIcon sx={{ fontSize: '1.2rem' }} />
+      </Box>
+      <Typography
+        sx={{
+          fontFamily: '"JetBrains Mono", monospace',
+          fontSize: '0.75rem',
+          color: (t) => alpha(t.palette.text.primary, 0.5),
+        }}
+      >
+        {page + 1} / {totalPages}
+      </Typography>
+      <Box
+        onClick={handleNext}
+        sx={{
+          cursor: canGoNext ? 'pointer' : 'default',
+          opacity: canGoNext ? 1 : 0.3,
+          display: 'flex',
+          alignItems: 'center',
+          color: (t) => alpha(t.palette.text.primary, 0.6),
+          '&:hover': canGoNext ? { color: 'text.primary' } : {},
+        }}
+      >
+        <NextIcon sx={{ fontSize: '1.2rem' }} />
+      </Box>
+    </Box>
+  );
+};
+
+export default TablePagination;

--- a/src/components/miners/index.ts
+++ b/src/components/miners/index.ts
@@ -1,4 +1,5 @@
 export { default as CredibilityChart } from './CredibilityChart';
+export { default as EmptyStateMessage } from './EmptyStateMessage';
 export { default as ExplorerFilterButton } from './ExplorerFilterButton';
 export { default as MinerActivity } from './MinerActivity';
 export { default as MinerFocusCard } from './MinerFocusCard';
@@ -9,4 +10,7 @@ export { default as MinerScoreBreakdown } from './MinerScoreBreakdown';
 export { default as MinerScoreCard } from './MinerScoreCard';
 export { default as MinerTierPerformance } from './MinerTierPerformance';
 export { default as PerformanceRadar } from './PerformanceRadar';
+export { default as RankBadge } from './RankBadge';
+export { default as SortableHeaderCell } from './SortableHeaderCell';
+export { default as TablePagination } from './TablePagination';
 export { default as TrustBadge, getRiskAssessment } from './TrustBadge';

--- a/src/tests/ExplorerUtils.test.ts
+++ b/src/tests/ExplorerUtils.test.ts
@@ -129,10 +129,38 @@ describe('getTierFilterValue', () => {
 
 describe('filterMinerRepoStats', () => {
   const mockStats: RepoStats[] = [
-    { repository: 'repo1', prs: 5, score: 100, tokenScore: 80, weight: 0.5, tier: 'gold' },
-    { repository: 'repo2', prs: 3, score: 50, tokenScore: 40, weight: 0.3, tier: 'silver' },
-    { repository: 'repo3', prs: 2, score: 25, tokenScore: 20, weight: 0.2, tier: 'bronze' },
-    { repository: 'repo4', prs: 4, score: 75, tokenScore: 60, weight: 0.4, tier: 'Gold' },
+    {
+      repository: 'repo1',
+      prs: 5,
+      score: 100,
+      tokenScore: 80,
+      weight: 0.5,
+      tier: 'gold',
+    },
+    {
+      repository: 'repo2',
+      prs: 3,
+      score: 50,
+      tokenScore: 40,
+      weight: 0.3,
+      tier: 'silver',
+    },
+    {
+      repository: 'repo3',
+      prs: 2,
+      score: 25,
+      tokenScore: 20,
+      weight: 0.2,
+      tier: 'bronze',
+    },
+    {
+      repository: 'repo4',
+      prs: 4,
+      score: 75,
+      tokenScore: 60,
+      weight: 0.4,
+      tier: 'Gold',
+    },
   ];
 
   it('returns all stats when filter is all', () => {
@@ -160,9 +188,30 @@ describe('filterMinerRepoStats', () => {
 
 describe('sortMinerRepoStats', () => {
   const mockStats: RepoStats[] = [
-    { repository: 'beta', prs: 5, score: 100, tokenScore: 80, weight: 0.5, tier: 'gold' },
-    { repository: 'alpha', prs: 3, score: 50, tokenScore: 40, weight: 0.3, tier: 'silver' },
-    { repository: 'gamma', prs: 2, score: 75, tokenScore: 60, weight: 0.2, tier: 'bronze' },
+    {
+      repository: 'beta',
+      prs: 5,
+      score: 100,
+      tokenScore: 80,
+      weight: 0.5,
+      tier: 'gold',
+    },
+    {
+      repository: 'alpha',
+      prs: 3,
+      score: 50,
+      tokenScore: 40,
+      weight: 0.3,
+      tier: 'silver',
+    },
+    {
+      repository: 'gamma',
+      prs: 2,
+      score: 75,
+      tokenScore: 60,
+      weight: 0.2,
+      tier: 'bronze',
+    },
   ];
 
   it('sorts by repository name ascending', () => {

--- a/src/tests/ExplorerUtils.test.ts
+++ b/src/tests/ExplorerUtils.test.ts
@@ -129,10 +129,10 @@ describe('getTierFilterValue', () => {
 
 describe('filterMinerRepoStats', () => {
   const mockStats: RepoStats[] = [
-    { repository: 'repo1', prs: 5, score: 100, weight: 0.5, tier: 'gold' },
-    { repository: 'repo2', prs: 3, score: 50, weight: 0.3, tier: 'silver' },
-    { repository: 'repo3', prs: 2, score: 25, weight: 0.2, tier: 'bronze' },
-    { repository: 'repo4', prs: 4, score: 75, weight: 0.4, tier: 'Gold' },
+    { repository: 'repo1', prs: 5, score: 100, tokenScore: 80, weight: 0.5, tier: 'gold' },
+    { repository: 'repo2', prs: 3, score: 50, tokenScore: 40, weight: 0.3, tier: 'silver' },
+    { repository: 'repo3', prs: 2, score: 25, tokenScore: 20, weight: 0.2, tier: 'bronze' },
+    { repository: 'repo4', prs: 4, score: 75, tokenScore: 60, weight: 0.4, tier: 'Gold' },
   ];
 
   it('returns all stats when filter is all', () => {
@@ -160,9 +160,9 @@ describe('filterMinerRepoStats', () => {
 
 describe('sortMinerRepoStats', () => {
   const mockStats: RepoStats[] = [
-    { repository: 'beta', prs: 5, score: 100, weight: 0.5, tier: 'gold' },
-    { repository: 'alpha', prs: 3, score: 50, weight: 0.3, tier: 'silver' },
-    { repository: 'gamma', prs: 2, score: 75, weight: 0.2, tier: 'bronze' },
+    { repository: 'beta', prs: 5, score: 100, tokenScore: 80, weight: 0.5, tier: 'gold' },
+    { repository: 'alpha', prs: 3, score: 50, tokenScore: 40, weight: 0.3, tier: 'silver' },
+    { repository: 'gamma', prs: 2, score: 75, tokenScore: 60, weight: 0.2, tier: 'bronze' },
   ];
 
   it('sorts by repository name ascending', () => {

--- a/src/tests/ExplorerUtils.test.ts
+++ b/src/tests/ExplorerUtils.test.ts
@@ -12,6 +12,17 @@ import {
   sortMinerRepoStats,
   countPrTiers,
   filterPrsByTier,
+  buildRepoWeightsMap,
+  buildRepoTiersMap,
+  buildTierThresholdsMap,
+  isRepoQualified,
+  aggregatePRsByRepository,
+  computeTierCounts,
+  computeQualificationCounts,
+  hasActiveFilters,
+  getDisplayCount,
+  filterByQualification,
+  filterBySearch,
   type RepoStats,
 } from '../utils/ExplorerUtils';
 
@@ -428,5 +439,379 @@ describe('normalizeCommitLogs', () => {
   it('filters out non-commit-log items from array', () => {
     const arr = [{ repository: 'r', pullRequestNumber: 1 }, { foo: 'bar' }];
     expect(normalizeCommitLogs(arr)).toHaveLength(1);
+  });
+});
+
+describe('buildRepoWeightsMap', () => {
+  it('returns empty map for undefined', () => {
+    expect(buildRepoWeightsMap(undefined).size).toBe(0);
+  });
+
+  it('returns empty map for empty array', () => {
+    expect(buildRepoWeightsMap([]).size).toBe(0);
+  });
+
+  it('builds map from valid repos', () => {
+    const repos = [
+      {
+        fullName: 'org/repo1',
+        owner: 'org',
+        name: 'repo1',
+        weight: '0.5',
+        tier: 'gold',
+      },
+      {
+        fullName: 'org/repo2',
+        owner: 'org',
+        name: 'repo2',
+        weight: '0.3',
+        tier: 'silver',
+      },
+    ];
+    const map = buildRepoWeightsMap(repos);
+    expect(map.get('org/repo1')).toBe(0.5);
+    expect(map.get('org/repo2')).toBe(0.3);
+  });
+
+  it('skips entries with missing fullName', () => {
+    const repos = [
+      { fullName: '', owner: '', name: '', weight: '0.5', tier: 'gold' },
+    ];
+    const map = buildRepoWeightsMap(repos);
+    expect(map.size).toBe(0);
+  });
+});
+
+describe('buildRepoTiersMap', () => {
+  it('returns empty map for undefined', () => {
+    expect(buildRepoTiersMap(undefined).size).toBe(0);
+  });
+
+  it('builds map from valid repos', () => {
+    const repos = [
+      {
+        fullName: 'org/repo1',
+        owner: 'org',
+        name: 'repo1',
+        weight: '0.5',
+        tier: 'gold',
+      },
+    ];
+    const map = buildRepoTiersMap(repos);
+    expect(map.get('org/repo1')).toBe('gold');
+  });
+});
+
+describe('buildTierThresholdsMap', () => {
+  it('returns empty map for undefined', () => {
+    expect(buildTierThresholdsMap(undefined).size).toBe(0);
+  });
+
+  it('builds map from tier config', () => {
+    const config = {
+      tiers: [
+        { name: 'Gold', requiredMinTokenScorePerRepo: 100 } as any,
+        { name: 'Silver', requiredMinTokenScorePerRepo: 50 } as any,
+      ],
+      tierOrder: ['Gold', 'Silver'],
+    };
+    const map = buildTierThresholdsMap(config);
+    expect(map.get('gold')).toBe(100);
+    expect(map.get('silver')).toBe(50);
+  });
+});
+
+describe('isRepoQualified', () => {
+  const thresholds = new Map([
+    ['gold', 100],
+    ['silver', 50],
+    ['bronze', 25],
+  ]);
+
+  it('returns true when tokenScore meets threshold', () => {
+    const repo: RepoStats = {
+      repository: 'r',
+      prs: 1,
+      score: 10,
+      tokenScore: 100,
+      weight: 0.5,
+      tier: 'gold',
+    };
+    expect(isRepoQualified(repo, thresholds)).toBe(true);
+  });
+
+  it('returns true when tokenScore exceeds threshold', () => {
+    const repo: RepoStats = {
+      repository: 'r',
+      prs: 1,
+      score: 10,
+      tokenScore: 200,
+      weight: 0.5,
+      tier: 'gold',
+    };
+    expect(isRepoQualified(repo, thresholds)).toBe(true);
+  });
+
+  it('returns false when tokenScore is below threshold', () => {
+    const repo: RepoStats = {
+      repository: 'r',
+      prs: 1,
+      score: 10,
+      tokenScore: 99,
+      weight: 0.5,
+      tier: 'gold',
+    };
+    expect(isRepoQualified(repo, thresholds)).toBe(false);
+  });
+
+  it('returns false when tier is not in thresholds', () => {
+    const repo: RepoStats = {
+      repository: 'r',
+      prs: 1,
+      score: 10,
+      tokenScore: 999,
+      weight: 0.5,
+      tier: 'platinum',
+    };
+    expect(isRepoQualified(repo, thresholds)).toBe(false);
+  });
+});
+
+describe('aggregatePRsByRepository', () => {
+  const weights = new Map([['org/repo1', 0.5]]);
+  const tiers = new Map([['org/repo1', 'gold']]);
+
+  it('returns empty array for empty prs', () => {
+    expect(aggregatePRsByRepository([], weights, tiers)).toEqual([]);
+  });
+
+  it('aggregates PRs into repo stats', () => {
+    const prs = [
+      {
+        repository: 'org/repo1',
+        score: '10',
+        prState: 'MERGED',
+        tokenScore: 50,
+      },
+      { repository: 'org/repo1', score: '5', prState: 'OPEN', tokenScore: 30 },
+    ] as any[];
+    const result = aggregatePRsByRepository(prs, weights, tiers);
+    expect(result).toHaveLength(1);
+    expect(result[0].prs).toBe(2);
+    expect(result[0].score).toBe(15);
+    expect(result[0].tokenScore).toBe(50); // only MERGED PR counted
+    expect(result[0].weight).toBe(0.5);
+    expect(result[0].tier).toBe('gold');
+  });
+
+  it('creates separate entries for different repos', () => {
+    const prs = [
+      {
+        repository: 'org/repo1',
+        score: '10',
+        prState: 'MERGED',
+        tokenScore: 50,
+      },
+      {
+        repository: 'org/repo2',
+        score: '5',
+        prState: 'MERGED',
+        tokenScore: 30,
+      },
+    ] as any[];
+    const result = aggregatePRsByRepository(prs, weights, tiers);
+    expect(result).toHaveLength(2);
+  });
+});
+
+describe('computeTierCounts', () => {
+  it('counts tiers correctly', () => {
+    const stats: RepoStats[] = [
+      {
+        repository: 'r1',
+        prs: 1,
+        score: 10,
+        tokenScore: 50,
+        weight: 0.5,
+        tier: 'gold',
+      },
+      {
+        repository: 'r2',
+        prs: 1,
+        score: 10,
+        tokenScore: 50,
+        weight: 0.5,
+        tier: 'Gold',
+      },
+      {
+        repository: 'r3',
+        prs: 1,
+        score: 10,
+        tokenScore: 50,
+        weight: 0.5,
+        tier: 'silver',
+      },
+      {
+        repository: 'r4',
+        prs: 1,
+        score: 10,
+        tokenScore: 50,
+        weight: 0.5,
+        tier: 'bronze',
+      },
+    ];
+    const counts = computeTierCounts(stats);
+    expect(counts.all).toBe(4);
+    expect(counts.gold).toBe(2);
+    expect(counts.silver).toBe(1);
+    expect(counts.bronze).toBe(1);
+  });
+
+  it('returns zeros for empty array', () => {
+    const counts = computeTierCounts([]);
+    expect(counts).toEqual({ all: 0, gold: 0, silver: 0, bronze: 0 });
+  });
+});
+
+describe('computeQualificationCounts', () => {
+  const thresholds = new Map([
+    ['gold', 100],
+    ['silver', 50],
+  ]);
+
+  it('counts qualified and unqualified repos', () => {
+    const stats: RepoStats[] = [
+      {
+        repository: 'r1',
+        prs: 1,
+        score: 10,
+        tokenScore: 150,
+        weight: 0.5,
+        tier: 'gold',
+      },
+      {
+        repository: 'r2',
+        prs: 1,
+        score: 10,
+        tokenScore: 30,
+        weight: 0.5,
+        tier: 'silver',
+      },
+      {
+        repository: 'r3',
+        prs: 1,
+        score: 10,
+        tokenScore: 80,
+        weight: 0.5,
+        tier: 'gold',
+      },
+    ];
+    const counts = computeQualificationCounts(stats, thresholds);
+    expect(counts.all).toBe(3);
+    expect(counts.qualified).toBe(1);
+    expect(counts.unqualified).toBe(2);
+  });
+});
+
+describe('hasActiveFilters', () => {
+  it('returns false when all filters are default', () => {
+    expect(hasActiveFilters('all', 'all', '')).toBe(false);
+    expect(hasActiveFilters('all', 'all', '  ')).toBe(false);
+  });
+
+  it('returns true when tier filter is active', () => {
+    expect(hasActiveFilters('gold', 'all', '')).toBe(true);
+  });
+
+  it('returns true when qualification filter is active', () => {
+    expect(hasActiveFilters('all', 'qualified', '')).toBe(true);
+  });
+
+  it('returns true when search query is active', () => {
+    expect(hasActiveFilters('all', 'all', 'repo')).toBe(true);
+  });
+});
+
+describe('getDisplayCount', () => {
+  it('returns filtered format when filtered', () => {
+    expect(getDisplayCount(5, 10, true)).toBe('5 of 10');
+  });
+
+  it('returns simple count when not filtered', () => {
+    expect(getDisplayCount(10, 10, false)).toBe('10');
+  });
+});
+
+describe('filterByQualification', () => {
+  const thresholds = new Map([['gold', 100]]);
+  const stats: RepoStats[] = [
+    {
+      repository: 'r1',
+      prs: 1,
+      score: 10,
+      tokenScore: 150,
+      weight: 0.5,
+      tier: 'gold',
+    },
+    {
+      repository: 'r2',
+      prs: 1,
+      score: 10,
+      tokenScore: 50,
+      weight: 0.5,
+      tier: 'gold',
+    },
+  ];
+
+  it('returns all when filter is all', () => {
+    expect(filterByQualification(stats, 'all', thresholds)).toEqual(stats);
+  });
+
+  it('returns only qualified repos', () => {
+    const result = filterByQualification(stats, 'qualified', thresholds);
+    expect(result).toHaveLength(1);
+    expect(result[0].repository).toBe('r1');
+  });
+
+  it('returns only unqualified repos', () => {
+    const result = filterByQualification(stats, 'unqualified', thresholds);
+    expect(result).toHaveLength(1);
+    expect(result[0].repository).toBe('r2');
+  });
+});
+
+describe('filterBySearch', () => {
+  const stats: RepoStats[] = [
+    {
+      repository: 'org/alpha',
+      prs: 1,
+      score: 10,
+      tokenScore: 50,
+      weight: 0.5,
+      tier: 'gold',
+    },
+    {
+      repository: 'org/beta',
+      prs: 1,
+      score: 10,
+      tokenScore: 50,
+      weight: 0.5,
+      tier: 'silver',
+    },
+  ];
+
+  it('returns all when search is empty', () => {
+    expect(filterBySearch(stats, '')).toEqual(stats);
+    expect(filterBySearch(stats, '  ')).toEqual(stats);
+  });
+
+  it('filters by repository name (case insensitive)', () => {
+    const result = filterBySearch(stats, 'Alpha');
+    expect(result).toHaveLength(1);
+    expect(result[0].repository).toBe('org/alpha');
+  });
+
+  it('returns empty when no match', () => {
+    expect(filterBySearch(stats, 'gamma')).toEqual([]);
   });
 });

--- a/src/utils/ExplorerUtils.ts
+++ b/src/utils/ExplorerUtils.ts
@@ -184,7 +184,13 @@ export const filterMinerRepoStats = (
   );
 };
 
-export type RepoSortField = 'rank' | 'repository' | 'prs' | 'score' | 'tokenScore' | 'weight';
+export type RepoSortField =
+  | 'rank'
+  | 'repository'
+  | 'prs'
+  | 'score'
+  | 'tokenScore'
+  | 'weight';
 export type SortOrder = 'asc' | 'desc';
 
 export const sortMinerRepoStats = (

--- a/src/utils/ExplorerUtils.ts
+++ b/src/utils/ExplorerUtils.ts
@@ -1,7 +1,9 @@
 import {
   type CommitLog,
   type MinerEvaluation,
+  type Repository,
   type RepositoryPrScoring,
+  type TierConfigResponse,
 } from '../api';
 
 export const TIER_LEVELS: Record<string, number> = {
@@ -263,4 +265,207 @@ export const filterPrsByTier = <
     const tier = pr.tier || repoTiers.get(pr.repository) || '';
     return tier.toLowerCase() === tierFilter.toLowerCase();
   });
+};
+
+// ---------------------------------------------------------------------------
+// Qualification filter
+// ---------------------------------------------------------------------------
+
+export type QualificationFilter = 'all' | 'qualified' | 'unqualified';
+
+// ---------------------------------------------------------------------------
+// Map builders – extract lookup maps from API data
+// ---------------------------------------------------------------------------
+
+export const buildRepoWeightsMap = (
+  repos: Repository[] | undefined,
+): Map<string, number> => {
+  const map = new Map<string, number>();
+  if (!Array.isArray(repos)) return map;
+  for (const repo of repos) {
+    if (repo && repo.fullName) {
+      map.set(repo.fullName, parseFloat(repo.weight || '0'));
+    }
+  }
+  return map;
+};
+
+export const buildRepoTiersMap = (
+  repos: Repository[] | undefined,
+): Map<string, string> => {
+  const map = new Map<string, string>();
+  if (!Array.isArray(repos)) return map;
+  for (const repo of repos) {
+    if (repo && repo.fullName) {
+      map.set(repo.fullName, repo.tier || '');
+    }
+  }
+  return map;
+};
+
+export const buildTierThresholdsMap = (
+  tierConfig: TierConfigResponse | undefined,
+): Map<string, number> => {
+  const map = new Map<string, number>();
+  if (!tierConfig?.tiers) return map;
+  for (const t of tierConfig.tiers) {
+    map.set(t.name.toLowerCase(), t.requiredMinTokenScorePerRepo);
+  }
+  return map;
+};
+
+// ---------------------------------------------------------------------------
+// Qualification helpers
+// ---------------------------------------------------------------------------
+
+export const isRepoQualified = (
+  repo: RepoStats,
+  tierThresholds: Map<string, number>,
+): boolean => {
+  const tier = repo.tier.toLowerCase();
+  const threshold = tierThresholds.get(tier);
+  if (threshold == null) return false;
+  return repo.tokenScore >= threshold;
+};
+
+export interface QualificationCounts {
+  all: number;
+  qualified: number;
+  unqualified: number;
+}
+
+export const computeQualificationCounts = (
+  repoStats: RepoStats[],
+  tierThresholds: Map<string, number>,
+): QualificationCounts => {
+  let qualified = 0;
+  let unqualified = 0;
+  for (const repo of repoStats) {
+    if (isRepoQualified(repo, tierThresholds)) {
+      qualified++;
+    } else {
+      unqualified++;
+    }
+  }
+  return { all: repoStats.length, qualified, unqualified };
+};
+
+// ---------------------------------------------------------------------------
+// PR aggregation – builds per-repository stats from commit logs
+// ---------------------------------------------------------------------------
+
+export const aggregatePRsByRepository = (
+  prs: CommitLog[],
+  repoWeights: Map<string, number>,
+  repoTiers: Map<string, string>,
+): RepoStats[] => {
+  if (!prs || prs.length === 0) return [];
+
+  const statsMap = new Map<string, RepoStats>();
+
+  for (const pr of prs) {
+    const existing = statsMap.get(pr.repository) || {
+      repository: pr.repository,
+      prs: 0,
+      score: 0,
+      tokenScore: 0,
+      weight: repoWeights.get(pr.repository) || 0,
+      tier: repoTiers.get(pr.repository) || '',
+    };
+    existing.prs += 1;
+    existing.score += parseFloat(pr.score || '0');
+    if (pr.prState === 'MERGED') {
+      existing.tokenScore += parseFloat(String(pr.tokenScore ?? '0'));
+    }
+    statsMap.set(pr.repository, existing);
+  }
+
+  return Array.from(statsMap.values());
+};
+
+// ---------------------------------------------------------------------------
+// Tier counts
+// ---------------------------------------------------------------------------
+
+export interface TierCounts {
+  all: number;
+  gold: number;
+  silver: number;
+  bronze: number;
+}
+
+export const computeTierCounts = (repoStats: RepoStats[]): TierCounts => {
+  const counts: TierCounts = {
+    all: repoStats.length,
+    gold: 0,
+    silver: 0,
+    bronze: 0,
+  };
+  for (const repo of repoStats) {
+    const tier = repo.tier.toLowerCase();
+    if (tier === 'gold') {
+      counts.gold++;
+    } else if (tier === 'silver') {
+      counts.silver++;
+    } else if (tier === 'bronze') {
+      counts.bronze++;
+    }
+  }
+  return counts;
+};
+
+// ---------------------------------------------------------------------------
+// Filter / display helpers
+// ---------------------------------------------------------------------------
+
+export const hasActiveFilters = (
+  tierFilter: MinerTierFilter,
+  qualificationFilter: QualificationFilter,
+  searchQuery: string,
+): boolean => {
+  return (
+    tierFilter !== 'all' ||
+    qualificationFilter !== 'all' ||
+    !!searchQuery.trim()
+  );
+};
+
+export const getDisplayCount = (
+  filteredCount: number,
+  totalCount: number,
+  isFiltered: boolean,
+): string => {
+  if (isFiltered) {
+    return `${filteredCount} of ${totalCount}`;
+  }
+  return String(filteredCount);
+};
+
+// ---------------------------------------------------------------------------
+// Qualification-based filtering
+// ---------------------------------------------------------------------------
+
+export const filterByQualification = (
+  stats: RepoStats[],
+  qualificationFilter: QualificationFilter,
+  tierThresholds: Map<string, number>,
+): RepoStats[] => {
+  switch (qualificationFilter) {
+    case 'qualified':
+      return stats.filter((r) => isRepoQualified(r, tierThresholds));
+    case 'unqualified':
+      return stats.filter((r) => !isRepoQualified(r, tierThresholds));
+    case 'all':
+    default:
+      return stats;
+  }
+};
+
+export const filterBySearch = (
+  stats: RepoStats[],
+  searchQuery: string,
+): RepoStats[] => {
+  const q = searchQuery.trim().toLowerCase();
+  if (!q) return stats;
+  return stats.filter((r) => r.repository.toLowerCase().includes(q));
 };

--- a/src/utils/ExplorerUtils.ts
+++ b/src/utils/ExplorerUtils.ts
@@ -159,6 +159,7 @@ export interface RepoStats {
   repository: string;
   prs: number;
   score: number;
+  tokenScore: number;
   weight: number;
   tier: string;
 }
@@ -173,7 +174,7 @@ export const filterMinerRepoStats = (
   );
 };
 
-export type RepoSortField = 'rank' | 'repository' | 'prs' | 'score' | 'weight';
+export type RepoSortField = 'rank' | 'repository' | 'prs' | 'score' | 'tokenScore' | 'weight';
 export type SortOrder = 'asc' | 'desc';
 
 export const sortMinerRepoStats = (
@@ -193,6 +194,9 @@ export const sortMinerRepoStats = (
         break;
       case 'score':
         compareValue = a.score - b.score;
+        break;
+      case 'tokenScore':
+        compareValue = a.tokenScore - b.tokenScore;
         break;
       case 'weight':
         compareValue = a.weight - b.weight;


### PR DESCRIPTION
## Changes

### 1. Token Score column and qualification filters

Added sortable "Token Score" column showing total token score per repository (merged PRs only). Added qualification filter buttons (All / Qualified / Unqualified) based on tier-specific `requiredMinTokenScorePerRepo` thresholds (Bronze: 5, Silver: 89, Gold: 144). Qualification counts are independent of tier filter, matching PR page behavior.

**Before**
<img width="1248" height="272" alt="image" src="https://github.com/user-attachments/assets/4bcbcf4a-0752-415d-ac9c-570cb07a7752" />

**After**
<img width="1249" height="275" alt="image" src="https://github.com/user-attachments/assets/ec9a54bd-3256-4cdb-824b-e38fa1f44d38" />

### 2. Table UX improvements

- Added pagination (20 per page) with prev/next navigation
- Styled scrollbar matching PR page
- Header and filter bar always visible regardless of data/filter state
- Distinct empty messages: "No repository contributions found" vs "No repositories found for the selected filters"
- Responsive layout matching PR page

**Before**
<img width="1274" height="177" alt="image" src="https://github.com/user-attachments/assets/bc4b83f2-ebe7-4e79-ab6f-f043475aaec1" />

**After**
<img width="1248" height="374" alt="image" src="https://github.com/user-attachments/assets/32217eca-85c7-43ee-a656-c765c94c2d07" />

**Before**
<img width="1257" height="387" alt="image" src="https://github.com/user-attachments/assets/67232223-41c9-476a-a8fd-55d204a75972" />

**After**
<img width="1260" height="275" alt="image" src="https://github.com/user-attachments/assets/af221c3f-015d-45f1-a130-01b737c3b25e" />
<img width="1256" height="131" alt="image" src="https://github.com/user-attachments/assets/f417406d-f744-40ca-8827-3545edd80780" />


## Test plan
- [x] Verify Token Score column displays correct totals (merged PRs only)
- [x] Verify qualification filters use correct tier thresholds
- [x] Verify pagination works with filters and search
- [x] Verify empty states show correct messages with filters visible
- [x] Confirm all 46 existing tests pass
