### PR TITLE
fix: block untracked repositories on details route and clarify tracked-only behavior

### DIFF
--- a/src/components/leaderboard/TopRepositoriesTable.tsx
+++ b/src/components/leaderboard/TopRepositoriesTable.tsx
@@ -126,6 +126,8 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
   );
   const [useLogScale, setUseLogScale] = useState(true);
   const isInitialMount = useRef(true);
+  const trimmedSearch = searchQuery.trim();
+  const isDirectRepoInput = /^[^/\s]+\/[^/\s]+$/.test(trimmedSearch);
 
   // Sync filter state to URL params (replace, don't push)
   const syncToUrl = useCallback(
@@ -774,10 +776,15 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
             </FormControl>
 
             <TextField
-              placeholder="Search..."
+              placeholder="Search or enter owner/repo..."
               size="small"
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && isDirectRepoInput) {
+                  onSelectRepository(trimmedSearch);
+                }
+              }}
               InputProps={{
                 startAdornment: (
                   <InputAdornment position="start">
@@ -1047,6 +1054,39 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
                   </TableRow>
                 );
               })}
+            {!filteredRepositories.length && trimmedSearch && isDirectRepoInput && (
+              <TableRow hover>
+                <TableCell colSpan={6} sx={{ ...bodyCellStyle, py: 2 }}>
+                  <Box
+                    sx={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'space-between',
+                      gap: 2,
+                    }}
+                  >
+                    <Typography sx={{ color: 'rgba(255,255,255,0.75)' }}>
+                      Repository not in tracked list. Open details for{' '}
+                      <Typography
+                        component="span"
+                        sx={{ fontFamily: '"JetBrains Mono", monospace' }}
+                      >
+                        {trimmedSearch}
+                      </Typography>
+                      ?
+                    </Typography>
+                    <Button
+                      size="small"
+                      variant="outlined"
+                      onClick={() => onSelectRepository(trimmedSearch)}
+                      sx={{ textTransform: 'none' }}
+                    >
+                      Open repository
+                    </Button>
+                  </Box>
+                </TableCell>
+              </TableRow>
+            )}
           </TableBody>
         </Table>
       </TableContainer>

--- a/src/components/leaderboard/TopRepositoriesTable.tsx
+++ b/src/components/leaderboard/TopRepositoriesTable.tsx
@@ -1054,39 +1054,41 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
                   </TableRow>
                 );
               })}
-            {!filteredRepositories.length && trimmedSearch && isDirectRepoInput && (
-              <TableRow hover>
-                <TableCell colSpan={6} sx={{ ...bodyCellStyle, py: 2 }}>
-                  <Box
-                    sx={{
-                      display: 'flex',
-                      alignItems: 'center',
-                      justifyContent: 'space-between',
-                      gap: 2,
-                    }}
-                  >
-                    <Typography sx={{ color: 'rgba(255,255,255,0.75)' }}>
-                      Repository not in tracked list. Open details for{' '}
-                      <Typography
-                        component="span"
-                        sx={{ fontFamily: '"JetBrains Mono", monospace' }}
-                      >
-                        {trimmedSearch}
-                      </Typography>
-                      ?
-                    </Typography>
-                    <Button
-                      size="small"
-                      variant="outlined"
-                      onClick={() => onSelectRepository(trimmedSearch)}
-                      sx={{ textTransform: 'none' }}
+            {!filteredRepositories.length &&
+              trimmedSearch &&
+              isDirectRepoInput && (
+                <TableRow hover>
+                  <TableCell colSpan={6} sx={{ ...bodyCellStyle, py: 2 }}>
+                    <Box
+                      sx={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'space-between',
+                        gap: 2,
+                      }}
                     >
-                      Open repository
-                    </Button>
-                  </Box>
-                </TableCell>
-              </TableRow>
-            )}
+                      <Typography sx={{ color: 'rgba(255,255,255,0.75)' }}>
+                        Repository not in tracked list. Open details for{' '}
+                        <Typography
+                          component="span"
+                          sx={{ fontFamily: '"JetBrains Mono", monospace' }}
+                        >
+                          {trimmedSearch}
+                        </Typography>
+                        ?
+                      </Typography>
+                      <Button
+                        size="small"
+                        variant="outlined"
+                        onClick={() => onSelectRepository(trimmedSearch)}
+                        sx={{ textTransform: 'none' }}
+                      >
+                        Open repository
+                      </Button>
+                    </Box>
+                  </TableCell>
+                </TableRow>
+              )}
           </TableBody>
         </Table>
       </TableContainer>

--- a/src/pages/RepositoryDetailsPage.tsx
+++ b/src/pages/RepositoryDetailsPage.tsx
@@ -1,12 +1,14 @@
 import React, { useState } from 'react';
 import { useSearchParams, useNavigate } from 'react-router-dom';
 import {
+  Alert,
   Box,
   Tab,
   Tabs,
   Typography,
   Button,
   Container,
+  CircularProgress,
   Grid,
   Chip,
   Avatar,
@@ -63,8 +65,10 @@ const RepositoryDetailsPage: React.FC = () => {
   const navigate = useNavigate();
   const repo = searchParams.get('name');
   const [tabValue, setTabValue] = useState(0);
-  const { data: repos } = useReposAndWeights();
+  const { data: repos, isLoading: isLoadingRepos } = useReposAndWeights();
   const { data: bountySummary } = useRepoBountySummary(repo || '');
+  const trackedRepo = repos?.find((r) => r.fullName === repo);
+  const isTrackedRepository = Boolean(trackedRepo);
 
   const owner = repo ? repo.split('/')[0] : '';
 
@@ -72,6 +76,50 @@ const RepositoryDetailsPage: React.FC = () => {
   if (!repo) {
     navigate('/miners');
     return null;
+  }
+
+  if (isLoadingRepos) {
+    return (
+      <Page title={`Repository - ${repo} `}>
+        <Container maxWidth="xl" sx={{ py: 8 }}>
+          <Box sx={{ display: 'flex', justifyContent: 'center' }}>
+            <CircularProgress size={36} />
+          </Box>
+        </Container>
+      </Page>
+    );
+  }
+
+  if (!isTrackedRepository) {
+    return (
+      <Page title={`Repository - ${repo} `}>
+        <SEO
+          title={`Repository - ${repo} `}
+          description={`View code, issues, PRs, and contributors for ${repo} on Gittensor.`}
+        />
+        <Container maxWidth="lg" sx={{ py: 4 }}>
+          <BackButton to="/repositories" label="Back to Repositories" />
+          <Alert
+            severity="warning"
+            sx={{
+              mt: 2,
+              backgroundColor: 'rgba(245, 124, 0, 0.08)',
+              border: '1px solid rgba(255, 183, 77, 0.3)',
+              color: '#ffcc80',
+              '& .MuiAlert-icon': { color: '#ffb74d' },
+            }}
+          >
+            <Typography sx={{ fontWeight: 600, mb: 0.5 }}>
+              This repository is not tracked by Gittensor.
+            </Typography>
+            <Typography sx={{ fontSize: '0.9rem' }}>
+              The repository details view is only available for tracked
+              repositories listed on the Repositories page.
+            </Typography>
+          </Alert>
+        </Container>
+      </Page>
+    );
   }
 
   const handleTabChange = (_event: React.SyntheticEvent, newValue: number) => {
@@ -130,8 +178,19 @@ const RepositoryDetailsPage: React.FC = () => {
                     {repo}
                   </Typography>
                   <Chip variant="info" label="Public" />
+                  <Chip
+                    label="Tracked"
+                    sx={{
+                      backgroundColor: 'rgba(46, 125, 50, 0.15)',
+                      color: '#66bb6a',
+                      border: '1px solid rgba(102, 187, 106, 0.35)',
+                      fontSize: '0.75rem',
+                      height: '24px',
+                      fontWeight: 600,
+                    }}
+                  />
                   {(() => {
-                    const currentRepo = repos?.find((r) => r.fullName === repo);
+                    const currentRepo = trackedRepo;
 
                     if (currentRepo?.inactiveAt) {
                       return (


### PR DESCRIPTION
## Summary

This PR clarifies repository status in the UI for direct `miners/repository?name=...` routes.

The original report is valid as a UX concern, but not a backend data bug: `biomejs/biome` is not in the tracked Gittensor repository list, so it should not appear in `/repositories` search/results. This change makes that explicit by blocking the full details experience for untracked repos and showing a clear warning state instead.

## Related Issues

Context: [#326](https://github.com/entrius/gittensor/issues/326)

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td><img width="1673" height="980" alt="before" src="https://github.com/user-attachments/assets/6e9555cc-bd23-4f48-97eb-2c0422ce1f70" /></td>
    <td><img width="1673" height="990" alt="after" src="https://github.com/user-attachments/assets/f2db7d1b-7cb1-48c5-922c-820e7a29ffa8" /></td>
  </tr>
</table>

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [ ] `npm run format` and `npm run lint:fix` have been run
- [ ] `npm run build` passes
- [x] Screenshots included for any UI/visual changes