### PR TITLE
Display additional acceptable branches on repository page

### DIFF
--- a/src/api/ReposApi.ts
+++ b/src/api/ReposApi.ts
@@ -1,7 +1,7 @@
 // Repository API hooks - uses /repos endpoints
 import { useApiQuery } from './ApiUtils';
 import { type RepositoryMaintainer, type RepositoryIssue } from './models';
-import { type CommitLog } from './models/Dashboard';
+import { type CommitLog, type Repository } from './models/Dashboard';
 
 /**
  * Helper to create /repos endpoint queries
@@ -17,6 +17,16 @@ const useReposQuery = <TResponse = void, TSelect = TResponse>(
     `/repos${url}`,
     refetchInterval,
     queryParams,
+  );
+
+/**
+ * Get config for a specific repository (weight, tier, additional branches, etc.)
+ * @param repo - Full repository name (e.g., "opentensor/btcli")
+ */
+export const useRepositoryConfig = (repo: string) =>
+  useReposQuery<Repository>(
+    'useRepositoryConfig',
+    `/${encodeURIComponent(repo)}`,
   );
 
 /**

--- a/src/components/repositories/RepositoryStats.tsx
+++ b/src/components/repositories/RepositoryStats.tsx
@@ -1,10 +1,11 @@
 import React, { useMemo } from 'react';
-import { Box, Typography, Skeleton, Divider } from '@mui/material';
+import { Box, Typography, Skeleton, Divider, Chip } from '@mui/material';
 import {
   useReposAndWeights,
   useAllPrs,
   useRepositoryIssues,
   useRepoBountySummary,
+  useRepositoryConfig,
 } from '../../api';
 import { TIER_COLORS, STATUS_COLORS } from '../../theme';
 
@@ -20,6 +21,7 @@ const RepositoryStats: React.FC<RepositoryStatsProps> = ({
   const { data: issues, isLoading: isLoadingIssues } =
     useRepositoryIssues(repositoryFullName);
   const { data: bountySummary } = useRepoBountySummary(repositoryFullName);
+  const { data: repoConfig } = useRepositoryConfig(repositoryFullName);
 
   const repository = useMemo(
     () =>
@@ -339,6 +341,45 @@ const RepositoryStats: React.FC<RepositoryStatsProps> = ({
             )}
           </>
         )}
+
+        {/* Additional Acceptable Branches */}
+        {repoConfig?.additionalAcceptableBranches &&
+          repoConfig.additionalAcceptableBranches.length > 0 && (
+            <>
+              <Divider
+                sx={{ borderColor: 'rgba(255,255,255,0.1)', my: 0.5 }}
+              />
+              <Typography
+                variant="body2"
+                sx={{ fontSize: '13px', color: STATUS_COLORS.open }}
+              >
+                Scorable Branches
+              </Typography>
+              <Box
+                sx={{
+                  display: 'flex',
+                  flexWrap: 'wrap',
+                  gap: 0.75,
+                }}
+              >
+                {repoConfig.additionalAcceptableBranches.map((branch) => (
+                  <Chip
+                    key={branch}
+                    label={branch}
+                    size="small"
+                    sx={{
+                      fontFamily: '"JetBrains Mono", monospace',
+                      fontSize: '12px',
+                      height: '24px',
+                      bgcolor: 'rgba(255,255,255,0.06)',
+                      color: '#fff',
+                      border: '1px solid rgba(255,255,255,0.1)',
+                    }}
+                  />
+                ))}
+              </Box>
+            </>
+          )}
       </Box>
     </Box>
   );

--- a/src/components/repositories/RepositoryStats.tsx
+++ b/src/components/repositories/RepositoryStats.tsx
@@ -346,9 +346,7 @@ const RepositoryStats: React.FC<RepositoryStatsProps> = ({
         {repoConfig?.additionalAcceptableBranches &&
           repoConfig.additionalAcceptableBranches.length > 0 && (
             <>
-              <Divider
-                sx={{ borderColor: 'rgba(255,255,255,0.1)', my: 0.5 }}
-              />
+              <Divider sx={{ borderColor: 'rgba(255,255,255,0.1)', my: 0.5 }} />
               <Typography
                 variant="body2"
                 sx={{ fontSize: '13px', color: STATUS_COLORS.open }}


### PR DESCRIPTION
## Summary
- Add `useRepositoryConfig` hook for `GET /repos/{owner}%2F{repo}` endpoint to fetch per-repo config
- Display additional acceptable (scorable) branches as chips in the Repository Stats sidebar on the repository detail page
- Section only renders when a repo has additional branches configured

Closes #122

## Screenshots

**Repo with additional branches (BitMind-AI/bitmind-subnet):**
The "Scorable Branches" section appears at the bottom of the Repository Stats sidebar showing the `testnet` branch chip.

<img width="2309" height="979" alt="image" src="https://github.com/user-attachments/assets/5b321ae9-336a-435b-97b4-4c5d2c0c072c" />

<img width="2322" height="1095" alt="image" src="https://github.com/user-attachments/assets/13d207ff-b8a5-4039-ba22-76eff0330ebf" />

<img width="2313" height="1001" alt="image" src="https://github.com/user-attachments/assets/aeb7ec7c-ecdd-4659-b6f6-856cd342e9f0" />

**Preview:** https://gittensor-ui.vercel.app/miners/repository?name=BitMind-AI%2Fbitmind-subnet

## Test plan
- [ ] Visit a repo with additional branches (e.g. BitMind-AI/bitmind-subnet) — "Scorable Branches" section shows with branch chips
- [ ] Visit a repo without additional branches (e.g. axios/axios) — section does not appear
- [ ] Verify build and lint pass cleanly