### PR TITLE
Fix/leaderboard sidebar duplicate key

### DIFF
--- a/src/components/leaderboard/LeaderboardSidebar.tsx
+++ b/src/components/leaderboard/LeaderboardSidebar.tsx
@@ -99,7 +99,7 @@ export const LeaderboardSidebar: React.FC<LeaderboardSidebarProps> = ({
           {(leaderboardType === 'earners' ? topEarners : mostActive).map(
             (miner, i) => (
               <LeaderboardRow
-                key={miner.hotkey}
+                key={miner.githubId || miner.hotkey}
                 miner={miner}
                 rank={i + 1}
                 type={leaderboardType}

--- a/src/components/leaderboard/LeaderboardSidebar.tsx
+++ b/src/components/leaderboard/LeaderboardSidebar.tsx
@@ -99,7 +99,7 @@ export const LeaderboardSidebar: React.FC<LeaderboardSidebarProps> = ({
           {(leaderboardType === 'earners' ? topEarners : mostActive).map(
             (miner, i) => (
               <LeaderboardRow
-                key={miner.githubId || miner.hotkey}
+                key={miner.githubId}
                 miner={miner}
                 rank={i + 1}
                 type={leaderboardType}

--- a/src/components/leaderboard/MinerSection.tsx
+++ b/src/components/leaderboard/MinerSection.tsx
@@ -51,7 +51,7 @@ export const MinerSection: React.FC<MinerSectionProps> = ({
       <Box sx={{ p: 1.5, pt: 1, flex: 1 }}>
         <Grid container spacing={2}>
           {visibleMiners.map((miner) => (
-            <Grid item xs={12} sm={12} md={6} lg={4} xl={4} key={miner.hotkey}>
+            <Grid item xs={12} sm={12} md={6} lg={4} xl={4} key={miner.githubId || miner.hotkey}>
               <MinerCard
                 miner={miner}
                 onClick={() =>

--- a/src/components/leaderboard/MinerSection.tsx
+++ b/src/components/leaderboard/MinerSection.tsx
@@ -51,7 +51,7 @@ export const MinerSection: React.FC<MinerSectionProps> = ({
       <Box sx={{ p: 1.5, pt: 1, flex: 1 }}>
         <Grid container spacing={2}>
           {visibleMiners.map((miner) => (
-            <Grid item xs={12} sm={12} md={6} lg={4} xl={4} key={miner.githubId || miner.hotkey}>
+            <Grid item xs={12} sm={12} md={6} lg={4} xl={4} key={miner.githubId}>
               <MinerCard
                 miner={miner}
                 onClick={() =>

--- a/src/components/leaderboard/MinerSection.tsx
+++ b/src/components/leaderboard/MinerSection.tsx
@@ -51,7 +51,15 @@ export const MinerSection: React.FC<MinerSectionProps> = ({
       <Box sx={{ p: 1.5, pt: 1, flex: 1 }}>
         <Grid container spacing={2}>
           {visibleMiners.map((miner) => (
-            <Grid item xs={12} sm={12} md={6} lg={4} xl={4} key={miner.githubId}>
+            <Grid
+              item
+              xs={12}
+              sm={12}
+              md={6}
+              lg={4}
+              xl={4}
+              key={miner.githubId}
+            >
               <MinerCard
                 miner={miner}
                 onClick={() =>


### PR DESCRIPTION
## Summary

- Fix React key collision in LeaderboardSidebar causing duplicate/ghost entries when switching between Top Earners and Most Active tabs
- Changed list key from `miner.hotkey` (can be shared/N/A) to `miner.githubId` (unique per row)


## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots


https://github.com/user-attachments/assets/48345df1-c376-4d3e-8f09-2d3836cde831

![spider-yamet](https://github.com/user-attachments/assets/c0bfdac7-0eed-4080-b2da-140bf60211b7)
![madelyngamble2](https://github.com/user-attachments/assets/0d95a1cf-9277-43c7-beef-1affff3483df)
