### PR TITLE
search: debounce input (300ms) and show loading spinner in GlobalSearchBar

### DIFF
--- a/src/components/layout/GlobalSearchBar.tsx
+++ b/src/components/layout/GlobalSearchBar.tsx
@@ -180,6 +180,13 @@ const GlobalSearchBar: React.FC = () => {
   const [query, setQuery] = useState('');
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 
+  // Debounced query: avoid firing search requests on every keystroke.
+  const [debouncedQuery, setDebouncedQuery] = useState(query);
+  useEffect(() => {
+    const t = setTimeout(() => setDebouncedQuery(query), 300);
+    return () => clearTimeout(t);
+  }, [query]);
+
   // Activate dataset loading after search interaction or on the /search page.
   const [isSearchActivated, setIsSearchActivated] = useState(isSearchPage);
 
@@ -192,7 +199,7 @@ const GlobalSearchBar: React.FC = () => {
     prResults,
     issueResults,
   } = useSearchResults(
-    query,
+    debouncedQuery,
     {
       miners: QUICK_RESULT_LIMIT,
       repositories: QUICK_RESULT_LIMIT,
@@ -295,15 +302,19 @@ const GlobalSearchBar: React.FC = () => {
           ),
           endAdornment: query ? (
             <InputAdornment position="end">
-              <IconButton
-                size="small"
-                onClick={clearQuery}
-                edge="end"
-                aria-label="clear search"
-                sx={(theme) => ({ color: theme.palette.text.secondary })}
-              >
-                <CloseIcon fontSize="small" />
-              </IconButton>
+              {isLoading ? (
+                <CircularProgress size={18} />
+              ) : (
+                <IconButton
+                  size="small"
+                  onClick={clearQuery}
+                  edge="end"
+                  aria-label="clear search"
+                  sx={(theme) => ({ color: theme.palette.text.secondary })}
+                >
+                  <CloseIcon fontSize="small" />
+                </IconButton>
+              )}
             </InputAdornment>
           ) : undefined,
         }}


### PR DESCRIPTION
Summary

Debounce the global search input by 300ms to reduce unnecessary backend requests while typing and show a small loading spinner inside the input while quick-results are loading. This is a narrow UX/perf change limited to the GlobalSearchBar component.

Files changed
- src/components/layout/GlobalSearchBar.tsx (single small change)

Why
- Prevents spamming quick-results API for every keystroke
- Improves perceived responsiveness by signalling loading state

How I tested
1. Ran the app locally and verified the top/global search input.
2. Typed quickly and confirmed fewer backend requests were emitted.
3. Confirmed a spinner appears while results load and the clear button shows when idle.

Notes / Contributing Guidelines
- I based this branch cleanly on upstream/main and force-pushed only the single commit containing the change so the PR now contains only the intended diff and no unrelated commits.
- Please let me know if you want a different debounce duration or prefer a shared debounce util. I can also add a unit or integration test if you want.

Checklist follow-up (per repo CONTRIBUTING)
- I confirmed the change is small and non-breaking; if CI requires linting/format adjustments I will address them in a follow-up commit.
- If you'd like me to run tests or add a changelog entry, I will add them before merging.
