### PR TITLE
fix: render descriptions with proper GitHub-style formatting

### DIFF
--- a/src/components/issues/IssueConversation.tsx
+++ b/src/components/issues/IssueConversation.tsx
@@ -1,9 +1,12 @@
 import React from 'react';
 import { Box, Typography, Avatar, Paper, Link, Chip } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import rehypeRaw from 'rehype-raw';
 import { type IssueDetails } from '../../api/models/Issues';
 import { STATUS_COLORS } from '../../theme';
-import 'github-markdown-css/github-markdown-dark.css'; // Import standard GitHub Dark styles
+import 'github-markdown-css/github-markdown-dark.css';
 
 interface IssueConversationProps {
   issue: IssueDetails;
@@ -19,7 +22,7 @@ const IssueConversation: React.FC<IssueConversationProps> = ({ issue }) => {
         avatarUrl: `https://avatars.githubusercontent.com/${issue.authorLogin}`,
         htmlUrl: `https://github.com/${issue.authorLogin}`,
       },
-      body: issue.body || '*No description provided.*',
+      body: issue.body || '<em>No description provided.</em>',
       createdAt: issue.createdAt,
       authorAssociation: 'OWNER', // Assuming creator is owner for display purposes, or fetch actual association if available
       isDescription: true,
@@ -55,7 +58,7 @@ const IssueConversation: React.FC<IssueConversationProps> = ({ issue }) => {
         flexDirection: 'column',
         gap: 3,
         pt: 2,
-        maxWidth: '960px', // Widen slightly for better code block readability
+        maxWidth: '960px',
         mx: 'auto',
         position: 'relative',
       }}
@@ -239,15 +242,29 @@ const IssueConversation: React.FC<IssueConversationProps> = ({ issue }) => {
                 },
                 '& h1': { fontSize: '2em' },
                 '& h2': { fontSize: '1.5em' },
+                '& h3': { fontSize: '1.25em' },
+                '& p': { mb: 2, mt: 0 },
                 '& a': { color: colors.accent.fg, textDecoration: 'none' },
                 '& a:hover': { textDecoration: 'underline' },
+                '& ul, & ol': {
+                  pl: '2em',
+                  mb: 2,
+                  listStyleType: 'disc',
+                },
+                '& ol': { listStyleType: 'decimal' },
+                '& li': { mb: 0.5 },
+                '& li + li': { mt: '0.25em' },
                 '& blockquote': {
                   padding: '0 1em',
                   color: colors.fg.muted,
                   borderLeft: `0.25em solid ${colors.border.default}`,
                   my: 2,
+                  mx: 0,
                 },
-                // Updated Code Block Styling
+                '& input[type="checkbox"]': {
+                  mr: 0.5,
+                  verticalAlign: 'middle',
+                },
                 '& code': {
                   padding: '0.2em 0.4em',
                   margin: 0,
@@ -259,8 +276,36 @@ const IssueConversation: React.FC<IssueConversationProps> = ({ issue }) => {
                 '& pre': {
                   mt: 2,
                   mb: 2,
+                  p: 2,
                   borderRadius: '6px',
-                  overflow: 'hidden', // Let SyntaxHighlighter handle scroll
+                  overflow: 'auto',
+                  backgroundColor: theme.palette.surface.elevated,
+                  border: `1px solid ${colors.border.default}`,
+                  '& code': {
+                    backgroundColor: 'transparent',
+                    p: 0,
+                    fontSize: '100%',
+                  },
+                },
+                '& table': {
+                  borderCollapse: 'collapse',
+                  width: '100%',
+                  mb: 2,
+                  overflowX: 'auto',
+                },
+                '& th, & td': {
+                  border: `1px solid ${colors.border.default}`,
+                  padding: '6px 13px',
+                },
+                '& th': { fontWeight: 600 },
+                '& tr:nth-of-type(2n)': {
+                  backgroundColor: theme.palette.surface.elevated,
+                },
+                '& hr': {
+                  height: '0.25em',
+                  my: 3,
+                  backgroundColor: colors.border.default,
+                  border: 0,
                 },
                 '& img': {
                   maxWidth: '100%',
@@ -274,21 +319,16 @@ const IssueConversation: React.FC<IssueConversationProps> = ({ issue }) => {
                   fontSize: '14px',
                   lineHeight: 1.6,
                 },
-                '& .markdown-body pre': {
-                  backgroundColor: theme.palette.surface.elevated, // Distinct code block background
-                  border: `1px solid ${colors.border.default}`,
-                  borderRadius: '6px',
-                },
-                '& .markdown-body code': {
-                  fontFamily: '"JetBrains Mono", monospace',
-                },
               }}
             >
-              <div
-                className="markdown-body"
-                dangerouslySetInnerHTML={{ __html: item.body }}
-                style={{ fontSize: '14px' }}
-              />
+              <div className="markdown-body" style={{ fontSize: '14px' }}>
+                <ReactMarkdown
+                  remarkPlugins={[remarkGfm]}
+                  rehypePlugins={[rehypeRaw]}
+                >
+                  {item.body}
+                </ReactMarkdown>
+              </div>
             </Box>
           </Paper>
         </Box>

--- a/src/components/prs/PRComments.tsx
+++ b/src/components/prs/PRComments.tsx
@@ -8,6 +8,9 @@ import {
   CircularProgress,
   Chip,
 } from '@mui/material';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import rehypeRaw from 'rehype-raw';
 import { usePullRequestComments } from '../../api';
 import { type PullRequestDetails } from '../../api/models/Dashboard';
 import { STATUS_COLORS } from '../../theme';
@@ -56,7 +59,7 @@ const PRComments: React.FC<PRCommentsProps> = ({
         avatarUrl: `https://avatars.githubusercontent.com/${prDetails.authorLogin}`,
         htmlUrl: `https://github.com/${prDetails.authorLogin}`,
       },
-      body: prDetails.description || '*No description provided.*',
+      body: prDetails.description || '<em>No description provided.</em>',
       createdAt: prDetails.createdAt,
       authorAssociation: 'OWNER',
       isDescription: true,
@@ -94,7 +97,7 @@ const PRComments: React.FC<PRCommentsProps> = ({
         flexDirection: 'column',
         gap: 3,
         pt: 2,
-        maxWidth: '960px', // Widen slightly for better code block readability
+        maxWidth: '960px',
         mx: 'auto',
         position: 'relative',
       }}
@@ -278,15 +281,29 @@ const PRComments: React.FC<PRCommentsProps> = ({
                 },
                 '& h1': { fontSize: '2em' },
                 '& h2': { fontSize: '1.5em' },
+                '& h3': { fontSize: '1.25em' },
+                '& p': { mb: 2, mt: 0 },
                 '& a': { color: colors.accent.fg, textDecoration: 'none' },
                 '& a:hover': { textDecoration: 'underline' },
+                '& ul, & ol': {
+                  pl: '2em',
+                  mb: 2,
+                  listStyleType: 'disc',
+                },
+                '& ol': { listStyleType: 'decimal' },
+                '& li': { mb: 0.5 },
+                '& li + li': { mt: '0.25em' },
                 '& blockquote': {
                   padding: '0 1em',
                   color: colors.fg.muted,
                   borderLeft: `0.25em solid ${colors.border.default}`,
                   my: 2,
+                  mx: 0,
                 },
-                // Updated Code Block Styling
+                '& input[type="checkbox"]': {
+                  mr: 0.5,
+                  verticalAlign: 'middle',
+                },
                 '& code': {
                   padding: '0.2em 0.4em',
                   margin: 0,
@@ -298,8 +315,36 @@ const PRComments: React.FC<PRCommentsProps> = ({
                 '& pre': {
                   mt: 2,
                   mb: 2,
+                  p: 2,
                   borderRadius: '6px',
-                  overflow: 'hidden', // Let SyntaxHighlighter handle scroll
+                  overflow: 'auto',
+                  backgroundColor: '#161b22',
+                  border: `1px solid ${colors.border.default}`,
+                  '& code': {
+                    backgroundColor: 'transparent',
+                    p: 0,
+                    fontSize: '100%',
+                  },
+                },
+                '& table': {
+                  borderCollapse: 'collapse',
+                  width: '100%',
+                  mb: 2,
+                  overflowX: 'auto',
+                },
+                '& th, & td': {
+                  border: `1px solid ${colors.border.default}`,
+                  padding: '6px 13px',
+                },
+                '& th': { fontWeight: 600 },
+                '& tr:nth-of-type(2n)': {
+                  backgroundColor: '#161b22',
+                },
+                '& hr': {
+                  height: '0.25em',
+                  my: 3,
+                  backgroundColor: colors.border.default,
+                  border: 0,
                 },
                 '& img': {
                   maxWidth: '100%',
@@ -313,21 +358,16 @@ const PRComments: React.FC<PRCommentsProps> = ({
                   fontSize: '14px',
                   lineHeight: 1.6,
                 },
-                '& .markdown-body pre': {
-                  backgroundColor: '#161b22', // Distinct code block background
-                  border: `1px solid ${colors.border.default}`,
-                  borderRadius: '6px',
-                },
-                '& .markdown-body code': {
-                  fontFamily: '"JetBrains Mono", monospace',
-                },
               }}
             >
-              <div
-                className="markdown-body"
-                dangerouslySetInnerHTML={{ __html: item.body }}
-                style={{ fontSize: '14px' }}
-              />
+              <div className="markdown-body" style={{ fontSize: '14px' }}>
+                <ReactMarkdown
+                  remarkPlugins={[remarkGfm]}
+                  rehypePlugins={[rehypeRaw]}
+                >
+                  {item.body}
+                </ReactMarkdown>
+              </div>
             </Box>
           </Paper>
         </Box>


### PR DESCRIPTION
## Summary
- Replace `dangerouslySetInnerHTML` with `ReactMarkdown` + `rehypeRaw` for safe rendering of GitHub-provided HTML in issue bodies and PR conversations
- Add missing CSS for lists, paragraphs, tables, code blocks, and other elements that MUI CssBaseline resets — restoring proper GitHub-style formatting
- Fix fallback text that rendered markdown asterisks as literal characters

## Test plan
- [ ] Open an issue detail page — verify headings, lists, tables, code blocks render properly
- [ ] Open a PR detail page — verify description and comments render with GitHub-style formatting
- [ ] Verify issues/PRs with no description show italic "No description provided."
- [ ] Confirm `npm run build` and `npm run lint` pass cleanly

Closes #128

Before:
<img width="1305" height="646" alt="image" src="https://github.com/user-attachments/assets/f25da5f5-0a32-48af-b6c9-7f5506eb6385" />

After:
<img width="1329" height="707" alt="image" src="https://github.com/user-attachments/assets/99f8b4df-3d6c-40a5-b6da-f118d133941b" />

Before: 
<img width="1290" height="842" alt="image" src="https://github.com/user-attachments/assets/4a89d059-ce38-4791-8482-d558ca60b527" />

After:
<img width="1377" height="945" alt="image" src="https://github.com/user-attachments/assets/4b29af12-ff74-4d48-9b91-b7ad53c12e35" />