### PR TITLE
fix:  Repository Name Overlaps Adjacent Columns in Discovery Miner Details

### DIFF
--- a/src/components/miners/MinerRepositoriesTable.tsx
+++ b/src/components/miners/MinerRepositoriesTable.tsx
@@ -226,7 +226,7 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
                     activeField={sortField}
                     activeOrder={sortOrder}
                     onSort={handleSort}
-                    cellStyle={headerCellStyle}
+                    cellStyle={{ ...headerCellStyle, width: '6%' }}
                   />
                   <SortableHeaderCell
                     field="repository"
@@ -235,7 +235,7 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
                     activeField={sortField}
                     activeOrder={sortOrder}
                     onSort={handleSort}
-                    cellStyle={headerCellStyle}
+                    cellStyle={{ ...headerCellStyle, width: '30%' }}
                   />
                   <SortableHeaderCell
                     field="prs"
@@ -245,7 +245,7 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
                     activeField={sortField}
                     activeOrder={sortOrder}
                     onSort={handleSort}
-                    cellStyle={headerCellStyle}
+                    cellStyle={{ ...headerCellStyle, width: '8%' }}
                   />
                   <SortableHeaderCell
                     field="score"
@@ -255,7 +255,7 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
                     activeField={sortField}
                     activeOrder={sortOrder}
                     onSort={handleSort}
-                    cellStyle={headerCellStyle}
+                    cellStyle={{ ...headerCellStyle, width: '14%' }}
                   />
                   <SortableHeaderCell
                     field="tokenScore"
@@ -265,9 +265,12 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
                     activeField={sortField}
                     activeOrder={sortOrder}
                     onSort={handleSort}
-                    cellStyle={headerCellStyle}
+                    cellStyle={{ ...headerCellStyle, width: '14%' }}
                   />
-                  <TableCell align="right" sx={headerCellStyle}>
+                  <TableCell
+                    align="right"
+                    sx={{ ...headerCellStyle, width: '14%' }}
+                  >
                     Avg/PR
                   </TableCell>
                   <SortableHeaderCell
@@ -278,7 +281,7 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
                     activeField={sortField}
                     activeOrder={sortOrder}
                     onSort={handleSort}
-                    cellStyle={headerCellStyle}
+                    cellStyle={{ ...headerCellStyle, width: '14%' }}
                   />
                 </TableRow>
               </TableHead>
@@ -366,6 +369,7 @@ const RepoTableRow: React.FC<RepoTableRowProps> = ({
             alignItems: 'center',
             gap: 1.5,
             cursor: 'pointer',
+            overflow: 'hidden',
             '&:hover': {
               color: 'primary.main',
               '& .MuiTypography-root': {
@@ -388,10 +392,14 @@ const RepoTableRow: React.FC<RepoTableRowProps> = ({
           />
           <Typography
             component="span"
+            title={repo.repository}
             sx={{
               fontFamily: '"JetBrains Mono", monospace',
               fontSize: '0.85rem',
               transition: 'color 0.2s',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
             }}
           >
             {repo.repository}


### PR DESCRIPTION
## Summary

Fix long repository names overflowing into adjacent numeric columns on the Discovery Miner Details → Repositories tab. Adds explicit column width percentages to the fixed-layout table and truncates repository names with ellipsis. Full name is visible on hover via a title attribute.

## Related Issues

Fixes #134

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

<!-- Include before/after screenshots for every UI/visual change. Remove this section if not applicable. -->
<img width="1717" height="757" alt="image" src="https://github.com/user-attachments/assets/4977b13a-51af-41d6-856a-921a0ee2c72f" />

<img width="1802" height="763" alt="image" src="https://github.com/user-attachments/assets/8a3ef2bf-ef92-4943-8c7a-80fb3e4337da" />


## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes