### PR TITLE
fix: prevent PR status chart text overflow at lg breakpoint

### DIFF
--- a/src/components/dashboard/GlobalActivity.tsx
+++ b/src/components/dashboard/GlobalActivity.tsx
@@ -217,6 +217,7 @@ const GlobalActivity: React.FC = () => {
                   flexDirection: 'row',
                   gap: { xs: 1, sm: 3, lg: 1.5, xl: 3 },
                   flex: 1,
+                  minWidth: 0,
                 }}
               >
                 <PRStatusChart

--- a/src/components/dashboard/PRStatusChart.tsx
+++ b/src/components/dashboard/PRStatusChart.tsx
@@ -104,6 +104,7 @@ const PRStatusChart: React.FC<PRStatusChartProps> = ({
         display: 'flex',
         flexDirection: 'column',
         alignItems: 'center',
+        minWidth: 0,
       }}
     >
       <Typography
@@ -173,9 +174,13 @@ const StatItem: React.FC<{ label: string; value: number }> = ({
   label,
   value,
 }) => (
-  <Stack gap={1} direction="column" alignItems="center">
-    <Typography variant="statLabel">{label}</Typography>
-    <Typography variant="statValue">{value}</Typography>
+  <Stack gap={1} direction="column" alignItems="center" sx={{ minWidth: 0 }}>
+    <Typography variant="statLabel" noWrap>
+      {label}
+    </Typography>
+    <Typography variant="statValue" noWrap>
+      {value}
+    </Typography>
   </Stack>
 );
 


### PR DESCRIPTION
Add minWidth: 0 to flex containers and noWrap to stat text in the dashboard ACTIVE/UNRANKED section to prevent MERGED, OPEN, CLOSED labels and values from overflowing the card boundary.

## Summary

Fix text overflow in the PR Status Chart (ACTIVE/UNRANKED section) on the Dashboard at the `lg` breakpoint (~1280px). The MERGED, OPEN, CLOSED labels and values on the UNRANKED side were spilling past the card's right edge due to flex items defaulting to `min-width: auto`.

## Related Issues

Fixes https://github.com/entrius/gittensor-ui/issues/138

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

| Before | After |
|--------|-------|
| <img width="453" height="412" alt="Screenshot 2026-04-10 131447" src="https://github.com/user-attachments/assets/00ef8fe3-5cd8-40ed-9eb9-2a8fdf9549d2" /> | <img width="388" height="356" alt="Screenshot 2026-04-10 133241" src="https://github.com/user-attachments/assets/1f962521-e24e-4a0f-9991-46f81827ec1e" /> |

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes