### PR TITLE
Fix/onboard step7 active styling

### DIFF
--- a/src/components/onboard/GettingStarted.tsx
+++ b/src/components/onboard/GettingStarted.tsx
@@ -453,31 +453,36 @@ export const GettingStarted: React.FC = () => {
                   height: 48,
                   borderRadius: '50%',
                   bgcolor:
-                    activeStep === index
-                      ? 'rgba(29, 55, 252, 0.15)'
-                      : '#0b0b0b',
+                    activeStep === index && item.active
+                      ? 'rgba(255, 215, 0, 0.15)'
+                      : activeStep === index
+                        ? 'rgba(29, 55, 252, 0.15)'
+                        : '#0b0b0b',
                   border: '2px solid',
-                  borderColor: item.active
-                    ? 'secondary.main'
-                    : activeStep === index
-                      ? 'primary.main'
-                      : 'rgba(255,255,255,0.1)',
-                  color: item.active
-                    ? 'secondary.main'
-                    : activeStep === index
-                      ? 'primary.main'
-                      : 'rgba(255, 255, 255, 0.5)',
+                  borderColor:
+                    activeStep === index && item.active
+                      ? 'secondary.main'
+                      : activeStep === index
+                        ? 'primary.main'
+                        : 'rgba(255,255,255,0.1)',
+                  color:
+                    activeStep === index && item.active
+                      ? 'secondary.main'
+                      : activeStep === index
+                        ? 'primary.main'
+                        : 'rgba(255, 255, 255, 0.5)',
                   display: 'flex',
                   alignItems: 'center',
                   justifyContent: 'center',
                   fontFamily: MONO,
                   fontWeight: 'bold',
                   fontSize: '1.1rem',
-                  boxShadow: item.active
-                    ? '0 0 20px rgba(255, 215, 0, 0.15)'
-                    : activeStep === index
-                      ? '0 0 15px rgba(29, 55, 252, 0.2)'
-                      : 'none',
+                  boxShadow:
+                    activeStep === index && item.active
+                      ? '0 0 20px rgba(255, 215, 0, 0.15)'
+                      : activeStep === index
+                        ? '0 0 15px rgba(29, 55, 252, 0.2)'
+                        : 'none',
                   transition: 'all 0.2s ease',
                   flexShrink: 0,
                 }}
@@ -490,11 +495,12 @@ export const GettingStarted: React.FC = () => {
                     fontFamily: MONO,
                     fontWeight: 600,
                     fontSize: '0.85rem',
-                    color: item.active
-                      ? 'secondary.main'
-                      : activeStep === index
-                        ? '#fff'
-                        : 'rgba(255,255,255,0.7)',
+                    color:
+                      activeStep === index && item.active
+                        ? 'secondary.main'
+                        : activeStep === index
+                          ? '#fff'
+                          : 'rgba(255,255,255,0.7)',
                     mb: 0.25,
                   }}
                 >


### PR DESCRIPTION
## Summary

Fix Step 7 (Contribute) circle indicator on the onboard stepper to only show gold styling when selected. Previously, `item.active` was checked independently — making Step 7 always gold regardless of selection state, with an inconsistent blue background when clicked. Now all style properties (`bgcolor`, `borderColor`, `color`, `boxShadow`, title `color`) use `activeStep === index && item.active`, so Step 7 appears gray/default when not selected and fully gold when selected.

## Related Issues

Fixes https://github.com/entrius/gittensor-ui/issues/139

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Video

https://github.com/user-attachments/assets/e902f935-a4f0-470a-9967-3cc60bc2f4e0

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes