### PR TITLE
fix: rewrite relative links to absolute GitHub URLs in markdown viewers

### DIFF
--- a/src/components/repositories/ContributingViewer.tsx
+++ b/src/components/repositories/ContributingViewer.tsx
@@ -110,6 +110,27 @@ const ContributingViewer: React.FC<ContributingViewerProps> = ({
     );
   };
 
+  // Custom renderer for links to handle relative paths
+  const LinkRenderer = (props: any) => {
+    const { href, children, ...rest } = props;
+    let finalHref = href;
+
+    if (href && !href.startsWith('http') && !href.startsWith('//') && !href.startsWith('#') && !href.startsWith('mailto:')) {
+      const cleanPath = href.startsWith('./')
+        ? href.slice(2)
+        : href.startsWith('/')
+          ? href.slice(1)
+          : href;
+      finalHref = `https://github.com/${repositoryFullName}/blob/${defaultBranch}/${cleanPath}`;
+    }
+
+    return (
+      <a href={finalHref} target="_blank" rel="noopener noreferrer" {...rest}>
+        {children}
+      </a>
+    );
+  };
+
   return (
     <Paper
       elevation={0}
@@ -204,7 +225,7 @@ const ContributingViewer: React.FC<ContributingViewerProps> = ({
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
         rehypePlugins={[rehypeRaw]}
-        components={{ img: ImageRenderer }}
+        components={{ img: ImageRenderer, a: LinkRenderer }}
       >
         {content || ''}
       </ReactMarkdown>

--- a/src/components/repositories/ReadmeViewer.tsx
+++ b/src/components/repositories/ReadmeViewer.tsx
@@ -99,6 +99,27 @@ const ReadmeViewer: React.FC<ReadmeViewerProps> = ({ repositoryFullName }) => {
     );
   };
 
+  // Custom renderer for links to handle relative paths
+  const LinkRenderer = (props: any) => {
+    const { href, children, ...rest } = props;
+    let finalHref = href;
+
+    if (href && !href.startsWith('http') && !href.startsWith('//') && !href.startsWith('#') && !href.startsWith('mailto:')) {
+      const cleanPath = href.startsWith('./')
+        ? href.slice(2)
+        : href.startsWith('/')
+          ? href.slice(1)
+          : href;
+      finalHref = `https://github.com/${repositoryFullName}/blob/${defaultBranch}/${cleanPath}`;
+    }
+
+    return (
+      <a href={finalHref} target="_blank" rel="noopener noreferrer" {...rest}>
+        {children}
+      </a>
+    );
+  };
+
   return (
     <Paper
       elevation={0}
@@ -210,6 +231,7 @@ const ReadmeViewer: React.FC<ReadmeViewerProps> = ({ repositoryFullName }) => {
         rehypePlugins={[rehypeRaw]}
         components={{
           img: ImageRenderer,
+          a: LinkRenderer,
         }}
       >
         {content || ''}


### PR DESCRIPTION
## Summary

Fixes #115

`ReadmeViewer` and `ContributingViewer` already rewrite relative image paths to absolute CDN URLs via `ImageRenderer`, but relative links (e.g., `[Contributing](CONTRIBUTING.md)`) are not handled. These links resolve against the current `gittensor.io` page URL instead of the GitHub repository, leading to 404s.

## Changes

Add a `LinkRenderer` component to both `ReadmeViewer.tsx` and `ContributingViewer.tsx` that rewrites relative `href` values to `https://github.com/{repo}/blob/{branch}/{path}`, following the same pattern used by `ImageRenderer` for images. Anchors (`#`), `mailto:`, and absolute URLs are left unchanged.