### PR TITLE
fix: use local repoRes.data instead of stale repoData in issue count fallback

### DIFF
--- a/src/components/repositories/RepositoryCheckTab.tsx
+++ b/src/components/repositories/RepositoryCheckTab.tsx
@@ -91,9 +91,9 @@ const RepositoryCheckTab: React.FC<RepositoryCheckTabProps> = ({
           setHelpWantedCount(hwRes.data.total_count);
         } catch (e) {
           console.warn('Failed to fetch issue counts', e);
-          // Fallback to repoData count if search fails, though it includes PRs
-          if (repoData && repoData.open_issues_count !== undefined) {
-            setOpenIssuesCount(repoData.open_issues_count);
+          // Fallback to repo data count if search fails, though it includes PRs
+          if (repoRes.data && repoRes.data.open_issues_count !== undefined) {
+            setOpenIssuesCount(repoRes.data.open_issues_count);
           }
         }
       } catch (err: any) {


### PR DESCRIPTION
## Summary

In `RepositoryCheckTab.tsx`, the catch block for issue count fetching (line 95) references the `repoData` state variable. Inside the `useEffect` async callback, this is a stale closure value — `null` on first render since `setRepoData()` is async and the state hasn't updated yet. The fallback to `open_issues_count` never triggers.

## Changes

Replace `repoData` with the local `repoRes.data` variable which is already available in the same scope and holds the freshly fetched data.

The `eslint-disable-next-line react-hooks/exhaustive-deps` comment on line 110 is a further signal that dependency tracking was intentionally loosened, masking this stale reference.