### PR TITLE
refactor: Replace any types with strict TypeScript types

### DIFF
--- a/src/api/PrsApi.ts
+++ b/src/api/PrsApi.ts
@@ -1,6 +1,10 @@
 // Pull Request API hooks - uses /prs endpoints
 import { useApiQuery } from './ApiUtils';
-import { type CommitLog, type PullRequestDetails } from './models/Dashboard';
+import {
+  type CommitLog,
+  type PullRequestComment,
+  type PullRequestDetails,
+} from './models/Dashboard';
 
 /**
  * Helper to create /prs endpoint queries
@@ -54,7 +58,12 @@ export const usePullRequestDetails = (
  * @param number - Pull request number
  */
 export const usePullRequestComments = (repo: string, number: number) =>
-  usePrsQuery<any[]>('usePullRequestComments', '/comments', undefined, {
-    repo,
-    number,
-  });
+  usePrsQuery<PullRequestComment[]>(
+    'usePullRequestComments',
+    '/comments',
+    undefined,
+    {
+      repo,
+      number,
+    },
+  );

--- a/src/api/models/Dashboard.ts
+++ b/src/api/models/Dashboard.ts
@@ -48,7 +48,7 @@ export type Stats = {
         percentChange24h: number;
         percentChange7d: number;
         lastUpdated: string;
-        metadata: any;
+        metadata: Record<string, unknown>;
       } | null;
       lastUpdated: string | null;
     };
@@ -60,7 +60,7 @@ export type Stats = {
         percentChange24h: number;
         percentChange7d: number;
         lastUpdated: string;
-        metadata: any;
+        metadata: Record<string, unknown>;
       } | null;
       lastUpdated: string | null;
     };

--- a/src/components/issues/IssueConversation.tsx
+++ b/src/components/issues/IssueConversation.tsx
@@ -6,7 +6,22 @@ import remarkGfm from 'remark-gfm';
 import rehypeRaw from 'rehype-raw';
 import { type IssueDetails } from '../../api/models/Issues';
 import { STATUS_COLORS } from '../../theme';
+
 import 'github-markdown-css/github-markdown-dark.css';
+
+/** An issue comment or the issue body rendered in the conversation timeline. */
+type ConversationItem = {
+  id: string;
+  user: {
+    login: string | null;
+    avatarUrl: string;
+    htmlUrl: string;
+  };
+  body: string;
+  createdAt: string;
+  authorAssociation: string;
+  isDescription?: boolean;
+};
 
 interface IssueConversationProps {
   issue: IssueDetails;
@@ -14,7 +29,7 @@ interface IssueConversationProps {
 
 const IssueConversation: React.FC<IssueConversationProps> = ({ issue }) => {
   const theme = useTheme();
-  const allItems = [
+  const allItems: ConversationItem[] = [
     {
       id: 'issue-description',
       user: {
@@ -63,7 +78,7 @@ const IssueConversation: React.FC<IssueConversationProps> = ({ issue }) => {
         position: 'relative',
       }}
     >
-      {allItems.map((item: any, index: number) => (
+      {allItems.map((item, index) => (
         <Box
           key={item.id}
           sx={{
@@ -92,7 +107,7 @@ const IssueConversation: React.FC<IssueConversationProps> = ({ issue }) => {
             >
               <Avatar
                 src={item.user.avatarUrl}
-                alt={item.user.login}
+                alt={item.user.login ?? undefined}
                 sx={{
                   width: 40,
                   height: 40,

--- a/src/components/leaderboard/SectionCard.tsx
+++ b/src/components/leaderboard/SectionCard.tsx
@@ -1,9 +1,17 @@
 import React from 'react';
-import { Card, Box, Typography, CardContent, Grid } from '@mui/material';
+import {
+  Card,
+  Box,
+  Typography,
+  CardContent,
+  Grid,
+  type SxProps,
+  type Theme,
+} from '@mui/material';
 
 export const SectionCard: React.FC<{
   children: React.ReactNode;
-  sx?: any;
+  sx?: SxProps<Theme>;
   title?: string;
   action?: React.ReactNode;
   centerContent?: React.ReactNode;

--- a/src/components/leaderboard/TopRepositoriesTable.tsx
+++ b/src/components/leaderboard/TopRepositoriesTable.tsx
@@ -30,6 +30,8 @@ import {
   Button,
   Switch,
   FormControlLabel,
+  type SxProps,
+  type Theme,
 } from '@mui/material';
 import SearchIcon from '@mui/icons-material/Search';
 import BarChartIcon from '@mui/icons-material/BarChart';
@@ -412,7 +414,7 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
     column: SortColumn;
     children: React.ReactNode;
     align?: 'left' | 'right';
-    sx?: any;
+    sx?: SxProps<Theme>;
   }) => (
     <TableCell
       align={align}

--- a/src/components/miners/MinerScoreCard.tsx
+++ b/src/components/miners/MinerScoreCard.tsx
@@ -26,6 +26,7 @@ import {
   useAllMiners,
   useMinerGithubData,
   useGeneralConfig,
+  type MinerEvaluation,
 } from '../../api';
 import {
   RANK_COLORS,
@@ -233,7 +234,7 @@ const MinerScoreCard: React.FC<MinerScoreCardProps> = ({ githubId }) => {
 
   const rankings = useMemo(() => {
     if (!allMinersStats || !minerStats) return null;
-    const rank = (_key: string, extract: (m: any) => number) =>
+    const rank = (_key: string, extract: (m: MinerEvaluation) => number) =>
       allMinersStats
         .slice()
         .sort((a, b) => extract(b) - extract(a))

--- a/src/components/prs/PRComments.tsx
+++ b/src/components/prs/PRComments.tsx
@@ -12,9 +12,21 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import rehypeRaw from 'rehype-raw';
 import { usePullRequestComments } from '../../api';
-import { type PullRequestDetails } from '../../api/models/Dashboard';
+import {
+  type PullRequestComment,
+  type PullRequestDetails,
+} from '../../api/models/Dashboard';
 import { STATUS_COLORS } from '../../theme';
 import 'github-markdown-css/github-markdown-dark.css'; // Import standard GitHub Dark styles
+
+/** A comment or the PR description rendered in the conversation timeline. */
+type ConversationItem = Omit<
+  PullRequestComment,
+  'id' | 'updatedAt' | 'htmlUrl'
+> & {
+  id: number | string;
+  isDescription?: boolean;
+};
 
 interface PRCommentsProps {
   repository: string;
@@ -51,7 +63,7 @@ const PRComments: React.FC<PRCommentsProps> = ({
     );
   }
 
-  const allItems = [
+  const allItems: ConversationItem[] = [
     {
       id: 'pr-description',
       user: {
@@ -102,7 +114,7 @@ const PRComments: React.FC<PRCommentsProps> = ({
         position: 'relative',
       }}
     >
-      {allItems.map((item: any, index: number) => (
+      {allItems.map((item, index) => (
         <Box
           key={item.id}
           sx={{

--- a/src/components/prs/PRHeader.tsx
+++ b/src/components/prs/PRHeader.tsx
@@ -3,11 +3,12 @@ import { Box, Typography, Avatar, Tooltip, alpha } from '@mui/material';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import { useNavigate } from 'react-router-dom';
 import { formatUsdEstimate } from '../../utils';
+import { type PullRequestDetails } from '../../api/models/Dashboard';
 import theme, { STATUS_COLORS } from '../../theme';
 interface PRHeaderProps {
   repository: string;
   pullRequestNumber: number;
-  prDetails: any; // Using any for now to avoid duplicating the full type definition, or import it if available
+  prDetails: PullRequestDetails;
 }
 
 const PRHeader: React.FC<PRHeaderProps> = ({

--- a/src/components/repositories/ContributingViewer.tsx
+++ b/src/components/repositories/ContributingViewer.tsx
@@ -177,7 +177,11 @@ const ContributingViewer: React.FC<ContributingViewerProps> = ({
         remarkPlugins={[remarkGfm]}
         rehypePlugins={[rehypeRaw]}
         components={{
-          a: ({ href, children, ...rest }: any) => (
+          a: ({
+            href,
+            children,
+            ...rest
+          }: React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
             <a
               href={resolveRelativeUrl(href, repositoryFullName, defaultBranch)}
               target="_blank"
@@ -187,7 +191,11 @@ const ContributingViewer: React.FC<ContributingViewerProps> = ({
               {children}
             </a>
           ),
-          img: ({ src, alt, ...rest }: any) => (
+          img: ({
+            src,
+            alt,
+            ...rest
+          }: React.ImgHTMLAttributes<HTMLImageElement>) => (
             <img
               src={resolveRelativeUrl(
                 src,

--- a/src/components/repositories/FileExplorer.tsx
+++ b/src/components/repositories/FileExplorer.tsx
@@ -155,7 +155,9 @@ const FileItem: React.FC<{
   );
 };
 
-export const buildFileTree = (flatFiles: any[]): FileNode[] => {
+export const buildFileTree = (
+  flatFiles: { path: string; type: 'blob' | 'tree' }[],
+): FileNode[] => {
   const root: FileNode[] = [];
   const map: Record<string, FileNode> = {};
 

--- a/src/components/repositories/ReadmeViewer.tsx
+++ b/src/components/repositories/ReadmeViewer.tsx
@@ -179,7 +179,11 @@ const ReadmeViewer: React.FC<ReadmeViewerProps> = ({ repositoryFullName }) => {
         remarkPlugins={[remarkGfm]}
         rehypePlugins={[rehypeRaw]}
         components={{
-          a: ({ href, children, ...rest }: any) => (
+          a: ({
+            href,
+            children,
+            ...rest
+          }: React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
             <a
               href={resolveRelativeUrl(href, repositoryFullName, defaultBranch)}
               target="_blank"
@@ -189,7 +193,11 @@ const ReadmeViewer: React.FC<ReadmeViewerProps> = ({ repositoryFullName }) => {
               {children}
             </a>
           ),
-          img: ({ src, alt, ...rest }: any) => (
+          img: ({
+            src,
+            alt,
+            ...rest
+          }: React.ImgHTMLAttributes<HTMLImageElement>) => (
             <img
               src={resolveRelativeUrl(
                 src,

--- a/src/components/repositories/RepositoryCheckTab.tsx
+++ b/src/components/repositories/RepositoryCheckTab.tsx
@@ -70,7 +70,9 @@ const RepositoryCheckTab: React.FC<RepositoryCheckTabProps> = ({
           `https://api.github.com/repos/${repositoryFullName}/git/trees/${branch}?recursive=1`,
         );
         if (treeRes.data.tree) {
-          setFileTree(treeRes.data.tree.map((node: any) => node.path));
+          setFileTree(
+            treeRes.data.tree.map((node: { path: string }) => node.path),
+          );
         }
 
         // Fetch issue counts
@@ -96,7 +98,7 @@ const RepositoryCheckTab: React.FC<RepositoryCheckTabProps> = ({
             setOpenIssuesCount(repoData.open_issues_count);
           }
         }
-      } catch (err: any) {
+      } catch (err: unknown) {
         console.error('Failed to fetch repo check data', err);
         setError('Failed to load repository health data.');
       } finally {

--- a/src/components/repositories/RepositoryCodeBrowser.tsx
+++ b/src/components/repositories/RepositoryCodeBrowser.tsx
@@ -67,9 +67,9 @@ const RepositoryCodeBrowser: React.FC<RepositoryCodeBrowserProps> = ({
           const nodes = buildFileTree(treeResponse.data.tree);
           setTree(nodes);
         }
-      } catch (err: any) {
+      } catch (err: unknown) {
         console.error('Failed to load repository data', err);
-        if (err.response?.status === 403) {
+        if (axios.isAxiosError(err) && err.response?.status === 403) {
           setError('GitHub API rate limit exceeded. Please try again later.');
         } else {
           setError('Failed to load repository structure.');


### PR DESCRIPTION
## Summary
- Replace `any[]` with `PullRequestComment[]` on the PR comments API hook
- Replace `prDetails: any` with `PullRequestDetails` in PRHeader
- Replace `props: any` with `React.ImgHTMLAttributes<HTMLImageElement>` in ReadmeViewer and ContributingViewer image renderers
- Type conversation item arrays in PRComments and IssueConversation instead of using `item: any` in `.map()`

## Related Issues
N/A — identified during codebase review

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots
N/A — no visual changes. All changes are compile-time type annotations only.

## Checklist
- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
