### PR TITLE
refactor: Extract duplicated monthly rewards calculation into shared hook

### DIFF
--- a/src/hooks/useMonthlyRewards.ts
+++ b/src/hooks/useMonthlyRewards.ts
@@ -1,0 +1,26 @@
+import { useMemo } from 'react';
+import { useStats } from '../api';
+
+const DAILY_ALPHA_EMISSIONS = 2952;
+
+export const useMonthlyRewards = (): number | undefined => {
+  const { data: stats } = useStats();
+
+  return useMemo(() => {
+    if (
+      !stats?.prices?.tao?.data?.price ||
+      !stats?.prices?.alpha?.data?.price
+    ) {
+      return undefined;
+    }
+    const taoPrice = stats.prices.tao.data.price;
+    const alphaPrice = stats.prices.alpha.data.price;
+    const now = new Date();
+    const daysInMonth = new Date(
+      now.getFullYear(),
+      now.getMonth() + 1,
+      0,
+    ).getDate();
+    return taoPrice * alphaPrice * DAILY_ALPHA_EMISSIONS * daysInMonth;
+  }, [stats?.prices]);
+};

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -6,29 +6,10 @@ import MonetizationOnIcon from '@mui/icons-material/MonetizationOn';
 import VerifiedUserIcon from '@mui/icons-material/VerifiedUser';
 import { Page } from '../components/layout';
 import { SEO } from '../components';
-import { useStats } from '../api';
+import { useMonthlyRewards } from '../hooks/useMonthlyRewards';
 
 export const AboutContent: React.FC = () => {
-  const { data: stats } = useStats();
-
-  const monthlyRewards = React.useMemo(() => {
-    if (
-      !stats?.prices?.tao?.data?.price ||
-      !stats?.prices?.alpha?.data?.price
-    ) {
-      return undefined;
-    }
-    const taoPrice = stats.prices.tao.data.price;
-    const alphaPrice = stats.prices.alpha.data.price;
-    const dailyAlphaEmissions = 2952;
-    const now = new Date();
-    const daysInMonth = new Date(
-      now.getFullYear(),
-      now.getMonth() + 1,
-      0,
-    ).getDate();
-    return taoPrice * alphaPrice * dailyAlphaEmissions * daysInMonth;
-  }, [stats?.prices]);
+  const monthlyRewards = useMonthlyRewards();
 
   return (
     <Box

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -2,30 +2,10 @@ import React from 'react';
 import { Box, Stack, Typography } from '@mui/material';
 import { Page } from '../components/layout';
 import { SEO } from '../components';
-import { useStats } from '../api';
+import { useMonthlyRewards } from '../hooks/useMonthlyRewards';
 
 const HomePage: React.FC = () => {
-  const { data: stats } = useStats();
-
-  // Calculate monthly rewards: TAO price × Alpha price × 2952 × days in current month
-  const monthlyRewards = React.useMemo(() => {
-    if (
-      !stats?.prices?.tao?.data?.price ||
-      !stats?.prices?.alpha?.data?.price
-    ) {
-      return undefined;
-    }
-    const taoPrice = stats.prices.tao.data.price;
-    const alphaPrice = stats.prices.alpha.data.price;
-    const dailyAlphaEmissions = 2952;
-    const now = new Date();
-    const daysInMonth = new Date(
-      now.getFullYear(),
-      now.getMonth() + 1,
-      0,
-    ).getDate();
-    return taoPrice * alphaPrice * dailyAlphaEmissions * daysInMonth;
-  }, [stats?.prices]);
+  const monthlyRewards = useMonthlyRewards();
 
   return (
     <Page title="Home">


### PR DESCRIPTION
## Summary
- Copy/paste code is a real concern generally, refactored using React custom hook.
- Extract duplicated `monthlyRewards` calculation from `HomePage.tsx` and `AboutPage.tsx` into a shared `useMonthlyRewards` hook

## Related Issues
N/A — identified during codebase review

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots
N/A — no visual changes.

## Checklist
- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
