### PR TITLE
refactor: Extract duplicated truncateText to shared utils

### DIFF
--- a/src/components/dashboard/LeaderboardCharts.tsx
+++ b/src/components/dashboard/LeaderboardCharts.tsx
@@ -12,13 +12,9 @@ import {
 import BarChartIcon from '@mui/icons-material/BarChart';
 import ReactECharts from 'echarts-for-react';
 import { useAllPrs, useReposAndWeights } from '../../api';
+import { truncateText } from '../../utils';
 
 const CHART_DOT_COLOR = 'rgba(88, 166, 255, 0.9)';
-
-const truncateText = (text: string, maxLength: number): string => {
-  if (!text) return '';
-  return text.length > maxLength ? `${text.substring(0, maxLength)}...` : text;
-};
 
 const LeaderboardCharts: React.FC = () => {
   const [activeTab, setActiveTab] = useState(0);

--- a/src/components/leaderboard/TopPRsTable.tsx
+++ b/src/components/leaderboard/TopPRsTable.tsx
@@ -33,7 +33,7 @@ import BarChartIcon from '@mui/icons-material/BarChart';
 import TableChartIcon from '@mui/icons-material/TableChart';
 import ReactECharts from 'echarts-for-react';
 import { type CommitLog } from '../../api/models/Dashboard';
-import { formatUsdEstimate } from '../../utils';
+import { formatUsdEstimate, truncateText } from '../../utils';
 import theme, { RANK_COLORS, STATUS_COLORS } from '../../theme';
 
 interface TopPRsTableProps {
@@ -43,12 +43,6 @@ interface TopPRsTableProps {
   onSelectMiner: (githubId: string) => void;
   onSelectRepository: (repositoryFullName: string) => void;
 }
-
-// Utility function to truncate text
-const truncateText = (text: string, maxLength: number): string => {
-  if (!text) return '';
-  return text.length > maxLength ? `${text.substring(0, maxLength)}...` : text;
-};
 
 const TopPRsTable: React.FC<TopPRsTableProps> = ({
   prs,

--- a/src/components/leaderboard/TopRepositoriesTable.tsx
+++ b/src/components/leaderboard/TopRepositoriesTable.tsx
@@ -37,6 +37,7 @@ import TableChartIcon from '@mui/icons-material/TableChart';
 import ReactECharts from 'echarts-for-react';
 import { useSearchParams } from 'react-router-dom';
 import { RANK_COLORS } from '../../theme';
+import { truncateText } from '../../utils';
 
 interface RepoStats {
   repository: string;
@@ -62,12 +63,6 @@ interface TopRepositoriesTableProps {
   isLoading?: boolean;
   onSelectRepository: (repositoryFullName: string) => void;
 }
-
-// Utility function to truncate text
-const truncateText = (text: string, maxLength: number): string => {
-  if (!text) return '';
-  return text.length > maxLength ? `${text.substring(0, maxLength)}...` : text;
-};
 
 const VALID_SORT_COLUMNS: SortColumn[] = [
   'rank',

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -28,6 +28,11 @@ export const formatTokenAmount = (
  * @param options.showZero - Whether to show "$0" for zero/negative values (default: false, returns null)
  * @returns Formatted string like "$5", "<$1", or null if value is invalid/zero
  */
+export const truncateText = (text: string, maxLength: number): string => {
+  if (!text) return '';
+  return text.length > maxLength ? `${text.substring(0, maxLength)}...` : text;
+};
+
 export const formatUsdEstimate = (
   value: number | null | undefined,
   options?: { includeApproxPrefix?: boolean; showZero?: boolean },


### PR DESCRIPTION
## Summary
- Copy/paste code is a big concern, centralized the util func, removes 3 duplicated code.
- Move `truncateText` utility function from three separate files into `src/utils/format.ts`
- Import the shared function in all three files

## Related Issues
N/A — identified during codebase review

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots
N/A — no visual changes.

## Checklist
- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
