### PR TITLE
fix: reset page to 0 when author filter chip is removed

### DIFF
--- a/src/components/miners/MinerPRsTable.tsx
+++ b/src/components/miners/MinerPRsTable.tsx
@@ -246,7 +246,10 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
               <Chip
                 variant="filter"
                 label={`Author: ${selectedAuthor}`}
-                onDelete={() => setSelectedAuthor(null)}
+                onDelete={() => {
+                  setSelectedAuthor(null);
+                  setPage(0);
+                }}
               />
             )}
 


### PR DESCRIPTION
## Summary

Add `setPage(0)` call to the author filter chip's `onDelete` handler in `MinerPRsTable.tsx`. All other filter controls (status buttons) already reset the page when changed; the author chip was the only one that didn't, leaving users on an empty page after removing the filter.

@anderdc @LandynDev

## Related Issues

Fixes #158

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

No visual change — the fix corrects pagination state on filter removal.

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [ ] Screenshots included for any UI/visual changes