### PR TITLE
refactor: Extract duplicated getRankIcon into shared RankIcon component

### DIFF
--- a/src/components/leaderboard/RankIcon.tsx
+++ b/src/components/leaderboard/RankIcon.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { Box, Typography, alpha } from '@mui/material';
+import { RANK_COLORS } from '../../theme';
+
+const getRankColor = (rank: number) => {
+  if (rank === 1) return RANK_COLORS.first;
+  if (rank === 2) return RANK_COLORS.second;
+  if (rank === 3) return RANK_COLORS.third;
+  return null;
+};
+
+export const RankIcon: React.FC<{ rank: number }> = ({ rank }) => {
+  const color = getRankColor(rank);
+
+  return (
+    <Box
+      sx={{
+        backgroundColor: '#000000',
+        borderRadius: '2px',
+        width: '22px',
+        height: '22px',
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        flexShrink: 0,
+        border: '1px solid',
+        borderColor: color ? alpha(color, 0.4) : 'rgba(255, 255, 255, 0.15)',
+        boxShadow: color
+          ? `0 0 12px ${alpha(color, 0.4)}, 0 0 4px ${alpha(color, 0.2)}`
+          : 'none',
+      }}
+    >
+      <Typography
+        component="span"
+        sx={{
+          color: color ?? 'rgba(255, 255, 255, 0.6)',
+          fontFamily: '"JetBrains Mono", monospace',
+          fontSize: '0.65rem',
+          fontWeight: 600,
+          lineHeight: 1,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        {rank}
+      </Typography>
+    </Box>
+  );
+};

--- a/src/components/leaderboard/TopPRsTable.tsx
+++ b/src/components/leaderboard/TopPRsTable.tsx
@@ -34,7 +34,8 @@ import TableChartIcon from '@mui/icons-material/TableChart';
 import ReactECharts from 'echarts-for-react';
 import { type CommitLog } from '../../api/models/Dashboard';
 import { formatUsdEstimate, truncateText } from '../../utils';
-import theme, { RANK_COLORS, STATUS_COLORS } from '../../theme';
+import { RankIcon } from './RankIcon';
+import theme, { STATUS_COLORS } from '../../theme';
 
 interface TopPRsTableProps {
   prs: CommitLog[];
@@ -728,7 +729,7 @@ const TopPRsTable: React.FC<TopPRsTableProps> = ({
                   }}
                 >
                   <TableCell sx={{ ...bodyCellStyle, width: '80px' }}>
-                    {getRankIcon(pr.rank || 0)}
+                    <RankIcon rank={pr.rank || 0} />
                   </TableCell>
                   <TableCell sx={{ ...bodyCellStyle, width: '40%' }}>
                     <Tooltip title={pr.pullRequestTitle || ''} placement="top">
@@ -1000,60 +1001,5 @@ const bodyCellStyle = {
   height: '52px',
   boxSizing: 'border-box' as const,
 };
-
-const getRankIcon = (rank: number) => (
-  <Box
-    sx={{
-      backgroundColor: '#000000',
-      borderRadius: '2px',
-      width: '22px',
-      height: '22px',
-      display: 'inline-flex',
-      alignItems: 'center',
-      justifyContent: 'center',
-      flexShrink: 0,
-      border: '1px solid',
-      borderColor:
-        rank === 1
-          ? alpha(RANK_COLORS.first, 0.4)
-          : rank === 2
-            ? alpha(RANK_COLORS.second, 0.4)
-            : rank === 3
-              ? alpha(RANK_COLORS.third, 0.4)
-              : 'rgba(255, 255, 255, 0.15)',
-      boxShadow:
-        rank === 1
-          ? `0 0 12px ${alpha(RANK_COLORS.first, 0.4)}, 0 0 4px ${alpha(RANK_COLORS.first, 0.2)}`
-          : rank === 2
-            ? `0 0 12px ${alpha(RANK_COLORS.second, 0.4)}, 0 0 4px ${alpha(RANK_COLORS.second, 0.2)}`
-            : rank === 3
-              ? `0 0 12px ${alpha(RANK_COLORS.third, 0.4)}, 0 0 4px ${alpha(RANK_COLORS.third, 0.2)}`
-              : 'none',
-    }}
-  >
-    <Typography
-      component="span"
-      sx={{
-        color:
-          rank === 1
-            ? RANK_COLORS.first
-            : rank === 2
-              ? RANK_COLORS.second
-              : rank === 3
-                ? RANK_COLORS.third
-                : 'rgba(255, 255, 255, 0.6)',
-        fontFamily: '"JetBrains Mono", monospace',
-        fontSize: '0.65rem',
-        fontWeight: 600,
-        lineHeight: 1,
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-      }}
-    >
-      {rank}
-    </Typography>
-  </Box>
-);
 
 export default TopPRsTable;

--- a/src/components/leaderboard/TopRepositoriesTable.tsx
+++ b/src/components/leaderboard/TopRepositoriesTable.tsx
@@ -6,7 +6,6 @@ import React, {
   useRef,
 } from 'react';
 import {
-  alpha,
   Box,
   Card,
   Table,
@@ -38,8 +37,8 @@ import BarChartIcon from '@mui/icons-material/BarChart';
 import TableChartIcon from '@mui/icons-material/TableChart';
 import ReactECharts from 'echarts-for-react';
 import { useSearchParams } from 'react-router-dom';
-import { RANK_COLORS } from '../../theme';
 import { truncateText } from '../../utils';
+import { RankIcon } from './RankIcon';
 
 interface RepoStats {
   repository: string;
@@ -732,7 +731,7 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
                     }}
                   >
                     <TableCell sx={{ ...bodyCellStyle, width: '60px', pr: 0 }}>
-                      {getRankIcon(repo.rank || 0)}
+                      <RankIcon rank={repo.rank || 0} />
                     </TableCell>
                     <TableCell sx={{ ...bodyCellStyle, width: '35%', pl: 1.5 }}>
                       <Box
@@ -941,60 +940,5 @@ const bodyCellStyle = {
   height: '52px',
   boxSizing: 'border-box' as const,
 };
-
-const getRankIcon = (rank: number) => (
-  <Box
-    sx={{
-      backgroundColor: '#000000',
-      borderRadius: '2px',
-      width: '22px',
-      height: '22px',
-      display: 'inline-flex',
-      alignItems: 'center',
-      justifyContent: 'center',
-      flexShrink: 0,
-      border: '1px solid',
-      borderColor:
-        rank === 1
-          ? alpha(RANK_COLORS.first, 0.4)
-          : rank === 2
-            ? alpha(RANK_COLORS.second, 0.4)
-            : rank === 3
-              ? alpha(RANK_COLORS.third, 0.4)
-              : 'rgba(255, 255, 255, 0.15)',
-      boxShadow:
-        rank === 1
-          ? `0 0 12px ${alpha(RANK_COLORS.first, 0.4)}, 0 0 4px ${alpha(RANK_COLORS.first, 0.2)}`
-          : rank === 2
-            ? `0 0 12px ${alpha(RANK_COLORS.second, 0.4)}, 0 0 4px ${alpha(RANK_COLORS.second, 0.2)}`
-            : rank === 3
-              ? `0 0 12px ${alpha(RANK_COLORS.third, 0.4)}, 0 0 4px ${alpha(RANK_COLORS.third, 0.2)}`
-              : 'none',
-    }}
-  >
-    <Typography
-      component="span"
-      sx={{
-        color:
-          rank === 1
-            ? RANK_COLORS.first
-            : rank === 2
-              ? RANK_COLORS.second
-              : rank === 3
-                ? RANK_COLORS.third
-                : 'rgba(255, 255, 255, 0.6)',
-        fontFamily: '"JetBrains Mono", monospace',
-        fontSize: '0.65rem',
-        fontWeight: 600,
-        lineHeight: 1,
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-      }}
-    >
-      {rank}
-    </Typography>
-  </Box>
-);
 
 export default TopRepositoriesTable;

--- a/src/components/leaderboard/index.ts
+++ b/src/components/leaderboard/index.ts
@@ -4,6 +4,7 @@ export { default as TopPRsTable } from './TopPRsTable';
 export { default as TopRepositoriesTable } from './TopRepositoriesTable';
 export { LeaderboardSidebar } from './LeaderboardSidebar';
 export { MinerCard } from './MinerCard';
+export { RankIcon } from './RankIcon';
 export { SectionCard } from './SectionCard';
 
 // Types and utilities


### PR DESCRIPTION
## Summary
- Extract duplicated `getRankIcon` function (~55 lines each) from `TopPRsTable.tsx` and `TopRepositoriesTable.tsx` into a shared `RankIcon` component
- Fixes Copy/Paste code concern: centralized component implementation is correct.
- Reduced number of redudant imports by this refactor: `import { RANK_COLORS } from '../../theme';`
- Clean up unused `RANK_COLORS` and `alpha` imports from both consumer files
- Export `RankIcon` from the leaderboard barrel file

## Related Issues
N/A — identified during codebase review

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots
N/A — no visual changes. Same rank badge rendering, same colors and styles.

## Checklist
- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
