### PR TITLE
fix: add /bounties route to resolve 404 issue (#161)

### DIFF
--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -50,6 +50,12 @@ const routesArray: AppRoute[] = [
     element: <IssuesPage />,
     showGlobalSearch: true,
   },
+  {
+    name: 'bounties',
+    path: '/bounties',
+    element: <IssuesPage />,
+    showGlobalSearch: true,
+  },
   { name: 'search', path: '/search', element: <SearchPage /> },
   {
     name: 'discoveries',


### PR DESCRIPTION
## Fix: Add /bounties route (#161)

**Issue:** The sidebar nav item labeled "bounties" routes to `/issues`, but the URL `/bounties` returns a 404. This is confusing when sharing links or typing the URL directly.

**Root cause:** No route existed for `/bounties` in `src/routes.tsx`.

**Fix:** Added a new route entry for `/bounties` that reuses the existing `IssuesPage` component (same as `/issues`), so both URLs work interchangeably.

```tsx
{
  name: 'bounties',
  path: '/bounties',
  element: <IssuesPage />,
  showGlobalSearch: true,
},
```

**Before:** `/bounties` → 404 Not Found  
**After:** `/bounties` → renders the bounties/issues page (same as `/issues`)

Closes #161
