### PR TITLE
fix: assign rank badges after sorting on Top Miners page

### DIFF
--- a/src/components/leaderboard/TopMinersTable.tsx
+++ b/src/components/leaderboard/TopMinersTable.tsx
@@ -64,7 +64,10 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
       result = result.filter((m) => m.isEligible);
     }
 
-    return sortMinersList(result, sortOption);
+    return sortMinersList(result, sortOption).map((miner, index) => ({
+      ...miner,
+      rank: index + 1,
+    }));
   }, [miners, searchQuery, showEligibleOnly, sortOption]);
 
   useEffect(() => {


### PR DESCRIPTION
Move rank assignment from before sorting to after, so rank badges reflect the current sort order (Score, Earnings, PRs, Credibility) instead of staying frozen from the initial array index.

## Summary

Rank badges on miner cards were assigned based on the original array index before any sort was applied. When switching sort tabs (Earnings, PRs, Credibility), cards re-ordered correctly but rank badges (#1, #2, #3...) stayed frozen from the initial Score sort. Fixed by moving `rank: index + 1` assignment to after `sortMinersList()` for both eligible and ineligible groups.

## Related Issues

Fixes https://github.com/entrius/gittensor-ui/issues/168

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

### After fix — Score sort
<img width="1292" height="791" alt="pr-after-score" src="https://github.com/user-attachments/assets/46e7e054-c172-4787-b93b-f83698ec9a64" />

### After fix — Earnings sort
<img width="1292" height="791" alt="pr-after-earnings" src="https://github.com/user-attachments/assets/6b44bde7-6ab4-4f34-b73b-9ffc2fb0d4a2" />

### After fix — PRs sort
<img width="1292" height="791" alt="pr-after-prs" src="https://github.com/user-attachments/assets/2ab7633f-8f7b-44a3-b1e4-865ec76b5bb8" />

### After fix — Credibility sort
<img width="1292" height="791" alt="pr-after-credibility" src="https://github.com/user-attachments/assets/f509fbae-6455-4bec-aab3-101445c1eea0" />

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
