### PR TITLE
fix: add /bounties route pointing to IssuesPage (#161)

### DIFF
--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -50,6 +50,12 @@ const routesArray: AppRoute[] = [
     element: <IssuesPage />,
     showGlobalSearch: true,
   },
+  {
+    name: 'bounties',
+    path: '/bounties',
+    element: <IssuesPage />,
+    showGlobalSearch: true,
+  },
   { name: 'search', path: '/search', element: <SearchPage /> },
   {
     name: 'discoveries',


### PR DESCRIPTION
## Summary
Fixes issue #161: `/bounties` URL returns 404 even though the sidebar button is labeled "bounties".

## Changes
- Added a `/bounties` route in `src/routes.tsx` that reuses the `IssuesPage` component
- Now both `/bounties` and `/issues` URLs work interchangeably

## Testing
- `/bounties` now renders the IssuesPage instead of 404
- Sidebar "bounties" link continues to work as before
