### PR TITLE
fix: add /bounties route alias to IssuesPage

### DIFF
--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -50,6 +50,13 @@ const routesArray: AppRoute[] = [
     element: <IssuesPage />,
     showGlobalSearch: true,
   },
+  // /bounties is an alias for /issues (the bounties page)
+  {
+    name: 'bounties',
+    path: '/bounties/:tab?',
+    element: <IssuesPage />,
+    showGlobalSearch: true,
+  },
   { name: 'search', path: '/search', element: <SearchPage /> },
   {
     name: 'discoveries',


### PR DESCRIPTION
## Fix: /bounties URL returns 404

### Problem
The sidebar navigation labels the bounties section as **bounties**, but the actual route is /issues. Typing /bounties directly or sharing that URL results in a 404.

### Solution
Added a /bounties/:tab? route that renders the same IssuesPage component as /issues/:tab?. This makes /bounties a first-class, shareable URL while keeping the existing /issues route fully functional.

### Changes
- src/routes.tsx: Added a new route entry for /bounties/:tab? pointing to <IssuesPage />

### Testing
- /bounties now renders the bounties page (same content as /issues)
- /bounties works with optional tab suffix (e.g., /bounties/open, /bounties/closed)
- /issues continues to work as before

Closes #161