### PR TITLE
fix: singular day when contribution heatmap shows only 1 day

### DIFF
--- a/src/components/dashboard/ContributionHeatmap.tsx
+++ b/src/components/dashboard/ContributionHeatmap.tsx
@@ -119,7 +119,7 @@ const ContributionHeatmap: React.FC<ContributionHeatmapProps> = ({
                 'Nov',
                 'Dec',
               ],
-              totalCount: `{{count}} contributions in the last ${totalDaysShown} days`,
+              totalCount: `{{count}} contributions in the last ${totalDaysShown} ${totalDaysShown === 1 ? 'day' : 'days'}`,
               weekdays: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
             }}
             blockSize={11}


### PR DESCRIPTION
## Fix: 'last 1 days' -> 'last 1 day' pluralization

### Problem
On the miner details Activity tab, the contribution heatmap footer always used the plural form "days" regardless of the actual count. For miners with only 1 day of history, this read awkwardly: "0 contributions in the last 1 days".

### Solution
Made the totalCount label conditionally pluralize based on totalDaysShown:
- totalDaysShown === 1 -> "last 1 day"
- totalDaysShown > 1 -> "last N days"

### Changes
- src/components/dashboard/ContributionHeatmap.tsx: 1-line fix

### Testing
- totalDaysShown === 1 renders "last 1 day" (singular)
- totalDaysShown > 1 renders "last N days" (existing behaviour unchanged)

Closes entrius/gittensor-ui#163