### PR TITLE
fix: correct docs link on issue discovery page

### DIFF
--- a/src/components/miners/MinerInsightsCard.tsx
+++ b/src/components/miners/MinerInsightsCard.tsx
@@ -19,6 +19,8 @@ import {
 
 interface MinerInsightsCardProps {
   githubId: string;
+  /** URL for the 'Learn more about scoring' docs link. Defaults to the OSS contributions doc. */
+  scoringDocsUrl?: string;
 }
 
 type InsightType = 'warning' | 'tip' | 'achievement';
@@ -154,7 +156,7 @@ const getInsightStyle = (type: InsightType) => {
   }
 };
 
-const MinerInsightsCard: React.FC<MinerInsightsCardProps> = ({ githubId }) => {
+const MinerInsightsCard: React.FC<MinerInsightsCardProps> = ({ githubId, scoringDocsUrl }) => {
   const { data: minerStats } = useMinerStats(githubId);
   const { data: generalConfig } = useGeneralConfig();
 
@@ -286,7 +288,7 @@ const MinerInsightsCard: React.FC<MinerInsightsCardProps> = ({ githubId }) => {
         Learn more about scoring in the{' '}
         <Typography
           component="a"
-          href="https://docs.gittensor.io/oss-contributions.html"
+          href={scoringDocsUrl ?? 'https://docs.gittensor.io/oss-contributions.html'}
           target="_blank"
           rel="noopener noreferrer"
           sx={{

--- a/src/pages/DiscoveryMinerDetailsPage.tsx
+++ b/src/pages/DiscoveryMinerDetailsPage.tsx
@@ -110,7 +110,7 @@ const DiscoveryMinerDetailsPage: React.FC = () => {
           <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
             {activeTab === 'overview' && (
               <>
-                <MinerInsightsCard githubId={githubId} />
+                <MinerInsightsCard githubId={githubId} scoringDocsUrl="https://docs.gittensor.io/issue-discovery.html" />
                 <MinerScoreBreakdown githubId={githubId} />
               </>
             )}


### PR DESCRIPTION
## Fix: Wrong docs link on issue discovery page

### Problem
On the issue discovery page (/discoveries/details), the Insights card footer links to https://docs.gittensor.io/oss-contributions.html instead of https://docs.gittensor.io/issue-discovery.html. This is inconsistent — the OSS contributions miners already use the oss-contributions doc, so the issue discovery page should link to its own doc.

### Solution
Added an optional scoringDocsUrl prop to MinerInsightsCard:
- MinerDetailsPage (/miners/details): uses default (oss-contributions.html) — unchanged
- DiscoveryMinerDetailsPage (/discoveries/details): passes issue-discovery.html

### Changes
- src/components/miners/MinerInsightsCard.tsx: added optional scoringDocsUrl prop with default to oss-contributions.html
- src/pages/DiscoveryMinerDetailsPage.tsx: passes the correct issue-discovery.html URL

Closes entrius/gittensor-ui#152