### PR TITLE
Add issue leaderboard metrics to Discoveries without removing PR views

### DIFF
--- a/src/components/leaderboard/LeaderboardSidebar.tsx
+++ b/src/components/leaderboard/LeaderboardSidebar.tsx
@@ -15,15 +15,15 @@ interface LeaderboardSidebarProps {
   variant?: 'oss' | 'discoveries';
 }
 
+type LeaderboardListType = 'earners' | 'prs' | 'issues';
+
 export const LeaderboardSidebar: React.FC<LeaderboardSidebarProps> = ({
   miners,
   onSelectMiner,
   variant = 'oss',
 }) => {
-  // State for toggling lists
-  const [leaderboardType, setLeaderboardType] = useState<'earners' | 'active'>(
-    'earners',
-  );
+  const [leaderboardType, setLeaderboardType] =
+    useState<LeaderboardListType>('earners');
 
   // Stats (Use original unfiltered list for stats)
   const topEarners = useMemo(
@@ -34,10 +34,18 @@ export const LeaderboardSidebar: React.FC<LeaderboardSidebarProps> = ({
     [miners],
   );
 
-  const mostActive = useMemo(
+  const topPRs = useMemo(
     () =>
       [...miners]
         .sort((a, b) => (b.totalPRs || 0) - (a.totalPRs || 0))
+        .slice(0, 5),
+    [miners],
+  );
+
+  const topIssues = useMemo(
+    () =>
+      [...miners]
+        .sort((a, b) => (b.totalIssues || 0) - (a.totalIssues || 0))
         .slice(0, 5),
     [miners],
   );
@@ -48,6 +56,7 @@ export const LeaderboardSidebar: React.FC<LeaderboardSidebarProps> = ({
       totalMiners: miners.length,
       eligible: miners.filter((m) => m.isEligible).length,
       totalPRs: miners.reduce((acc, m) => acc + (m.totalPRs || 0), 0),
+      totalIssues: miners.reduce((acc, m) => acc + (m.totalIssues || 0), 0),
       dailyPool: miners.reduce((acc, m) => acc + (m.usdPerDay || 0), 0),
     }),
     [miners],
@@ -73,9 +82,12 @@ export const LeaderboardSidebar: React.FC<LeaderboardSidebarProps> = ({
             value={networkStats.eligible}
           />
           <StatRow
-            label={variant === 'discoveries' ? 'Total Issues' : 'Total PRs'}
+            label="Total PRs"
             value={networkStats.totalPRs}
           />
+          {variant === 'discoveries' && (
+            <StatRow label="Total Issues" value={networkStats.totalIssues} />
+          )}
           <StatRow
             label="Daily Pool"
             value={`$${networkStats.dailyPool.toLocaleString()}`}
@@ -86,7 +98,7 @@ export const LeaderboardSidebar: React.FC<LeaderboardSidebarProps> = ({
 
       {/* CARD 2: Leaderboard Lists (Tabs) */}
       <SectionCard
-        title={leaderboardType === 'earners' ? 'Top Earners' : 'Most Active'}
+        title={leaderboardType === 'earners' ? 'Top Earners' : leaderboardType === 'issues' ? 'Top Issues' : 'Top PRs'}
         action={
           <LeaderboardTabs
             activeTab={leaderboardType}
@@ -97,8 +109,8 @@ export const LeaderboardSidebar: React.FC<LeaderboardSidebarProps> = ({
         sx={{ flexShrink: 0 }}
       >
         <Box sx={{ px: 2, pb: 2 }}>
-          <LeaderboardHeader type={leaderboardType} variant={variant} />
-          {(leaderboardType === 'earners' ? topEarners : mostActive).map(
+          <LeaderboardHeader type={leaderboardType} />
+          {(leaderboardType === 'earners' ? topEarners : leaderboardType === 'issues' ? topIssues : topPRs).map(
             (miner, i) => (
               <LeaderboardRow
                 key={miner.id}
@@ -154,8 +166,8 @@ const StatRow: React.FC<StatRowProps> = ({ label, value, valueColor }) => (
 );
 
 interface LeaderboardTabsProps {
-  activeTab: 'earners' | 'active';
-  onTabChange: (tab: 'earners' | 'active') => void;
+  activeTab: LeaderboardListType;
+  onTabChange: (tab: LeaderboardListType) => void;
   variant?: 'oss' | 'discoveries';
 }
 
@@ -175,10 +187,10 @@ const LeaderboardTabs: React.FC<LeaderboardTabsProps> = ({
   >
     {[
       { label: '$', value: 'earners' as const },
-      {
-        label: variant === 'discoveries' ? 'Issues' : 'PRs',
-        value: 'active' as const,
-      },
+      { label: 'PRs', value: 'prs' as const },
+      ...(variant === 'discoveries'
+        ? [{ label: 'Issues', value: 'issues' as const }]
+        : []),
     ].map((option) => (
       <Box
         key={option.value}
@@ -220,13 +232,11 @@ const LeaderboardTabs: React.FC<LeaderboardTabsProps> = ({
 );
 
 interface LeaderboardHeaderProps {
-  type: 'earners' | 'active';
-  variant?: 'oss' | 'discoveries';
+  type: LeaderboardListType;
 }
 
 const LeaderboardHeader: React.FC<LeaderboardHeaderProps> = ({
   type,
-  variant = 'oss',
 }) => (
   <Box
     sx={(theme) => ({
@@ -268,7 +278,7 @@ const LeaderboardHeader: React.FC<LeaderboardHeaderProps> = ({
     >
       {type === 'earners'
         ? '$/Day'
-        : variant === 'discoveries'
+        : type === 'issues'
           ? 'Issues'
           : 'PRs'}
     </Typography>
@@ -278,7 +288,7 @@ const LeaderboardHeader: React.FC<LeaderboardHeaderProps> = ({
 interface LeaderboardRowProps {
   miner: MinerStats;
   rank: number;
-  type: 'earners' | 'active';
+  type: LeaderboardListType;
   onClick: () => void;
 }
 
@@ -350,7 +360,9 @@ const LeaderboardRow: React.FC<LeaderboardRowProps> = ({
     >
       {type === 'earners'
         ? `$${Math.round(miner.usdPerDay || 0).toLocaleString()}`
-        : miner.totalPRs}
+        : type === 'issues'
+          ? miner.totalIssues
+          : miner.totalPRs}
     </Typography>
   </Box>
 );

--- a/src/components/leaderboard/LeaderboardSidebar.tsx
+++ b/src/components/leaderboard/LeaderboardSidebar.tsx
@@ -15,15 +15,15 @@ interface LeaderboardSidebarProps {
   variant?: 'oss' | 'discoveries';
 }
 
-type LeaderboardListType = 'earners' | 'prs' | 'issues';
-
 export const LeaderboardSidebar: React.FC<LeaderboardSidebarProps> = ({
   miners,
   onSelectMiner,
   variant = 'oss',
 }) => {
-  const [leaderboardType, setLeaderboardType] =
-    useState<LeaderboardListType>('earners');
+  // State for toggling lists
+  const [leaderboardType, setLeaderboardType] = useState<'earners' | 'active'>(
+    'earners',
+  );
 
   // Stats (Use original unfiltered list for stats)
   const topEarners = useMemo(
@@ -34,20 +34,16 @@ export const LeaderboardSidebar: React.FC<LeaderboardSidebarProps> = ({
     [miners],
   );
 
-  const topPRs = useMemo(
+  const mostActive = useMemo(
     () =>
       [...miners]
-        .sort((a, b) => (b.totalPRs || 0) - (a.totalPRs || 0))
+        .sort((a, b) =>
+          variant === 'discoveries'
+            ? (b.totalIssues || 0) - (a.totalIssues || 0)
+            : (b.totalPRs || 0) - (a.totalPRs || 0),
+        )
         .slice(0, 5),
-    [miners],
-  );
-
-  const topIssues = useMemo(
-    () =>
-      [...miners]
-        .sort((a, b) => (b.totalIssues || 0) - (a.totalIssues || 0))
-        .slice(0, 5),
-    [miners],
+    [miners, variant],
   );
 
   // Network Stats Data
@@ -82,12 +78,13 @@ export const LeaderboardSidebar: React.FC<LeaderboardSidebarProps> = ({
             value={networkStats.eligible}
           />
           <StatRow
-            label="Total PRs"
-            value={networkStats.totalPRs}
+            label={variant === 'discoveries' ? 'Total Issues' : 'Total PRs'}
+            value={
+              variant === 'discoveries'
+                ? networkStats.totalIssues
+                : networkStats.totalPRs
+            }
           />
-          {variant === 'discoveries' && (
-            <StatRow label="Total Issues" value={networkStats.totalIssues} />
-          )}
           <StatRow
             label="Daily Pool"
             value={`$${networkStats.dailyPool.toLocaleString()}`}
@@ -98,7 +95,7 @@ export const LeaderboardSidebar: React.FC<LeaderboardSidebarProps> = ({
 
       {/* CARD 2: Leaderboard Lists (Tabs) */}
       <SectionCard
-        title={leaderboardType === 'earners' ? 'Top Earners' : leaderboardType === 'issues' ? 'Top Issues' : 'Top PRs'}
+        title={leaderboardType === 'earners' ? 'Top Earners' : 'Most Active'}
         action={
           <LeaderboardTabs
             activeTab={leaderboardType}
@@ -109,14 +106,15 @@ export const LeaderboardSidebar: React.FC<LeaderboardSidebarProps> = ({
         sx={{ flexShrink: 0 }}
       >
         <Box sx={{ px: 2, pb: 2 }}>
-          <LeaderboardHeader type={leaderboardType} />
-          {(leaderboardType === 'earners' ? topEarners : leaderboardType === 'issues' ? topIssues : topPRs).map(
+          <LeaderboardHeader type={leaderboardType} variant={variant} />
+          {(leaderboardType === 'earners' ? topEarners : mostActive).map(
             (miner, i) => (
               <LeaderboardRow
                 key={miner.id}
                 miner={miner}
                 rank={i + 1}
                 type={leaderboardType}
+                variant={variant}
                 onClick={() =>
                   onSelectMiner(miner.githubId || miner.author || '')
                 }
@@ -166,8 +164,8 @@ const StatRow: React.FC<StatRowProps> = ({ label, value, valueColor }) => (
 );
 
 interface LeaderboardTabsProps {
-  activeTab: LeaderboardListType;
-  onTabChange: (tab: LeaderboardListType) => void;
+  activeTab: 'earners' | 'active';
+  onTabChange: (tab: 'earners' | 'active') => void;
   variant?: 'oss' | 'discoveries';
 }
 
@@ -187,10 +185,10 @@ const LeaderboardTabs: React.FC<LeaderboardTabsProps> = ({
   >
     {[
       { label: '$', value: 'earners' as const },
-      { label: 'PRs', value: 'prs' as const },
-      ...(variant === 'discoveries'
-        ? [{ label: 'Issues', value: 'issues' as const }]
-        : []),
+      {
+        label: variant === 'discoveries' ? 'Issues' : 'PRs',
+        value: 'active' as const,
+      },
     ].map((option) => (
       <Box
         key={option.value}
@@ -232,11 +230,13 @@ const LeaderboardTabs: React.FC<LeaderboardTabsProps> = ({
 );
 
 interface LeaderboardHeaderProps {
-  type: LeaderboardListType;
+  type: 'earners' | 'active';
+  variant?: 'oss' | 'discoveries';
 }
 
 const LeaderboardHeader: React.FC<LeaderboardHeaderProps> = ({
   type,
+  variant = 'oss',
 }) => (
   <Box
     sx={(theme) => ({
@@ -278,7 +278,7 @@ const LeaderboardHeader: React.FC<LeaderboardHeaderProps> = ({
     >
       {type === 'earners'
         ? '$/Day'
-        : type === 'issues'
+        : variant === 'discoveries'
           ? 'Issues'
           : 'PRs'}
     </Typography>
@@ -288,7 +288,8 @@ const LeaderboardHeader: React.FC<LeaderboardHeaderProps> = ({
 interface LeaderboardRowProps {
   miner: MinerStats;
   rank: number;
-  type: LeaderboardListType;
+  type: 'earners' | 'active';
+  variant?: 'oss' | 'discoveries';
   onClick: () => void;
 }
 
@@ -296,6 +297,7 @@ const LeaderboardRow: React.FC<LeaderboardRowProps> = ({
   miner,
   rank,
   type,
+  variant = 'oss',
   onClick,
 }) => (
   <Box
@@ -360,7 +362,7 @@ const LeaderboardRow: React.FC<LeaderboardRowProps> = ({
     >
       {type === 'earners'
         ? `$${Math.round(miner.usdPerDay || 0).toLocaleString()}`
-        : type === 'issues'
+        : variant === 'discoveries'
           ? miner.totalIssues
           : miner.totalPRs}
     </Typography>

--- a/src/components/leaderboard/MinerCard.tsx
+++ b/src/components/leaderboard/MinerCard.tsx
@@ -487,7 +487,14 @@ const IssueStatsSection: React.FC<IssueStatsSectionProps> = ({
             >
               {label}
             </Typography>
-            <Typography sx={{ fontFamily: FONTS.mono, fontSize: '0.85rem', color, fontWeight: 600 }}>
+            <Typography
+              sx={{
+                fontFamily: FONTS.mono,
+                fontSize: '0.85rem',
+                color,
+                fontWeight: 600,
+              }}
+            >
               {value}
             </Typography>
           </Box>
@@ -496,7 +503,9 @@ const IssueStatsSection: React.FC<IssueStatsSectionProps> = ({
           sx={(theme) => ({
             textAlign: 'right',
             borderLeft: `1px solid ${
-              isEligible ? theme.palette.border.light : theme.palette.border.subtle
+              isEligible
+                ? theme.palette.border.light
+                : theme.palette.border.subtle
             }`,
             pl: 1.5,
           })}

--- a/src/components/leaderboard/MinerCard.tsx
+++ b/src/components/leaderboard/MinerCard.tsx
@@ -5,16 +5,17 @@ import ReactECharts from 'echarts-for-react';
 import { useMinerGithubData, useMinerPRs } from '../../api';
 import { CHART_COLORS, STATUS_COLORS } from '../../theme';
 import { getGithubAvatarSrc } from '../../utils/ExplorerUtils';
-import { type MinerStats, FONTS } from './types';
+import { type MinerStats, type LeaderboardVariant, FONTS } from './types';
 
 interface MinerCardProps {
   miner: MinerStats;
   onClick: () => void;
+  variant?: LeaderboardVariant;
 }
 
 const INACTIVE_OPACITY = 0.24;
 
-export const MinerCard: React.FC<MinerCardProps> = ({ miner, onClick }) => {
+export const MinerCard: React.FC<MinerCardProps> = ({ miner, onClick, variant = 'oss' }) => {
   const muiTheme = useTheme();
   const isNumericId = (value?: string) => !value || /^\d+$/.test(value);
   const shouldFetch = !!miner.githubId && isNumericId(miner.author);
@@ -305,42 +306,169 @@ export const MinerCard: React.FC<MinerCardProps> = ({ miner, onClick }) => {
         </Box>
       </Box>
 
+      <MinerCardFooter miner={miner} variant={variant} isEligible={isEligible} />
+    </Card>
+  );
+};
+
+interface MinerCardFooterProps {
+  miner: MinerStats;
+  variant: LeaderboardVariant;
+  isEligible: boolean;
+}
+
+const MinerCardFooter: React.FC<MinerCardFooterProps> = ({
+  miner,
+  variant,
+  isEligible,
+}) => {
+  const muiTheme = useTheme();
+
+  return (
+    <Box
+      sx={(theme) => ({
+        display: 'flex',
+        flexDirection: 'column',
+        gap: variant === 'discoveries' ? 0.75 : 0,
+        backgroundColor: isEligible
+          ? alpha(theme.palette.background.default, 0.2)
+          : theme.palette.surface.subtle,
+        opacity: isEligible ? 1 : 0.62,
+        borderRadius: 1.5,
+        p: 1,
+      })}
+    >
+      <PrimaryStatsRow miner={miner} isEligible={isEligible} />
+      {variant === 'discoveries' && (
+        <IssueStatsSection
+          miner={miner}
+          isEligible={isEligible}
+          textColor={alpha(muiTheme.palette.text.tertiary, INACTIVE_OPACITY)}
+        />
+      )}
+    </Box>
+  );
+};
+
+interface PrimaryStatsRowProps {
+  miner: MinerStats;
+  isEligible: boolean;
+}
+
+const PrimaryStatsRow: React.FC<PrimaryStatsRowProps> = ({
+  miner,
+  isEligible,
+}) => {
+  const muiTheme = useTheme();
+
+  return (
+    <Box sx={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr auto', gap: 1, alignItems: 'center' }}>
+      {[
+        {
+          label: 'Merged',
+          value: miner.totalMergedPrs ?? 0,
+          color: isEligible
+            ? STATUS_COLORS.merged
+            : alpha(muiTheme.palette.text.tertiary, INACTIVE_OPACITY),
+        },
+        {
+          label: 'Open',
+          value: miner.totalOpenPrs ?? 0,
+          color: isEligible
+            ? alpha(muiTheme.palette.text.primary, 0.84)
+            : alpha(muiTheme.palette.text.tertiary, INACTIVE_OPACITY),
+        },
+        {
+          label: 'Closed',
+          value: miner.totalClosedPrs ?? 0,
+          color: isEligible
+            ? muiTheme.palette.status.closed
+            : alpha(muiTheme.palette.text.tertiary, INACTIVE_OPACITY),
+        },
+      ].map(({ label, value, color }) => (
+        <Box key={label}>
+          <Typography
+            sx={(theme) => ({
+              fontFamily: FONTS.mono,
+              fontSize: '0.6rem',
+              color: isEligible
+                ? theme.palette.status.open
+                : alpha(muiTheme.palette.text.tertiary, INACTIVE_OPACITY),
+              textTransform: 'uppercase',
+              mb: 0.2,
+            })}
+          >
+            {label}
+          </Typography>
+          <Typography sx={{ fontFamily: FONTS.mono, fontSize: '0.85rem', color, fontWeight: 600 }}>
+            {value}
+          </Typography>
+        </Box>
+      ))}
       <Box
         sx={(theme) => ({
-          display: 'grid',
-          gridTemplateColumns: '1fr 1fr 1fr auto',
-          gap: 1,
-          backgroundColor: isEligible
-            ? alpha(theme.palette.background.default, 0.2)
-            : theme.palette.surface.subtle,
-          opacity: isEligible ? 1 : 0.62,
-          borderRadius: 1.5,
-          p: 1,
-          alignItems: 'center',
+          textAlign: 'right',
+          borderLeft: `1px solid ${
+            isEligible ? theme.palette.border.light : theme.palette.border.subtle
+          }`,
+          pl: 1.5,
         })}
       >
+        <Typography
+          sx={(theme) => ({
+            fontFamily: FONTS.mono,
+            fontSize: '0.6rem',
+            color: isEligible
+              ? theme.palette.status.open
+              : alpha(muiTheme.palette.text.tertiary, INACTIVE_OPACITY),
+            textTransform: 'uppercase',
+            mb: 0.2,
+          })}
+        >
+          Score
+        </Typography>
+        <Typography
+          sx={{
+            fontFamily: FONTS.mono,
+            fontSize: '0.9rem',
+            color: isEligible
+              ? muiTheme.palette.text.primary
+              : alpha(muiTheme.palette.text.tertiary, INACTIVE_OPACITY),
+            fontWeight: 700,
+          }}
+        >
+          {Number(miner.totalScore).toFixed(2)}
+        </Typography>
+      </Box>
+    </Box>
+  );
+};
+
+interface IssueStatsSectionProps {
+  miner: MinerStats;
+  isEligible: boolean;
+  textColor: string;
+}
+
+const IssueStatsSection: React.FC<IssueStatsSectionProps> = ({
+  miner,
+  isEligible,
+  textColor,
+}) => {
+  const muiTheme = useTheme();
+
+  return (
+    <Box sx={{ pt: 0.35, borderTop: '1px solid rgba(255,255,255,0.06)' }}>
+      <Typography
+        sx={{ fontFamily: FONTS.mono, fontSize: '0.7rem', fontWeight: 700, color: '#8b949e', minWidth: 28, textTransform: 'uppercase', mb: 0.35, letterSpacing: '0.04em' }}
+      >
+        Issues
+      </Typography>
+      <Box sx={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr auto', gap: 1, alignItems: 'center' }}>
         {[
-          {
-            label: 'Merged',
-            value: miner.totalMergedPrs ?? 0,
-            color: isEligible
-              ? STATUS_COLORS.merged
-              : alpha(muiTheme.palette.text.tertiary, INACTIVE_OPACITY),
-          },
-          {
-            label: 'Open',
-            value: miner.totalOpenPrs ?? 0,
-            color: isEligible
-              ? alpha(muiTheme.palette.text.primary, 0.84)
-              : alpha(muiTheme.palette.text.tertiary, INACTIVE_OPACITY),
-          },
-          {
-            label: 'Closed',
-            value: miner.totalClosedPrs ?? 0,
-            color: isEligible
-              ? muiTheme.palette.status.closed
-              : alpha(muiTheme.palette.text.tertiary, INACTIVE_OPACITY),
-          },
+          { label: 'Solved', value: miner.totalSolvedIssues ?? 0, color: isEligible ? STATUS_COLORS.merged : textColor },
+          { label: 'Open', value: miner.totalOpenIssues ?? 0, color: isEligible ? alpha(muiTheme.palette.text.primary, 0.84) : textColor },
+          { label: 'Closed', value: miner.totalClosedIssues ?? 0, color: isEligible ? muiTheme.palette.status.closed : textColor },
         ].map(({ label, value, color }) => (
           <Box key={label}>
             <Typography
@@ -356,14 +484,7 @@ export const MinerCard: React.FC<MinerCardProps> = ({ miner, onClick }) => {
             >
               {label}
             </Typography>
-            <Typography
-              sx={{
-                fontFamily: FONTS.mono,
-                fontSize: '0.85rem',
-                color,
-                fontWeight: 600,
-              }}
-            >
+            <Typography sx={{ fontFamily: FONTS.mono, fontSize: '0.85rem', color, fontWeight: 600 }}>
               {value}
             </Typography>
           </Box>
@@ -372,9 +493,7 @@ export const MinerCard: React.FC<MinerCardProps> = ({ miner, onClick }) => {
           sx={(theme) => ({
             textAlign: 'right',
             borderLeft: `1px solid ${
-              isEligible
-                ? theme.palette.border.light
-                : theme.palette.border.subtle
+              isEligible ? theme.palette.border.light : theme.palette.border.subtle
             }`,
             pl: 1.5,
           })}
@@ -390,22 +509,22 @@ export const MinerCard: React.FC<MinerCardProps> = ({ miner, onClick }) => {
               mb: 0.2,
             })}
           >
-            Score
+            Issues
           </Typography>
           <Typography
             sx={{
               fontFamily: FONTS.mono,
               fontSize: '0.9rem',
-              color: isEligible
-                ? muiTheme.palette.text.primary
-                : alpha(muiTheme.palette.text.tertiary, INACTIVE_OPACITY),
+              color: isEligible ? muiTheme.palette.text.primary : textColor,
               fontWeight: 700,
             }}
           >
-            {Number(miner.totalScore).toFixed(2)}
+            {(miner.totalSolvedIssues ?? 0) +
+              (miner.totalOpenIssues ?? 0) +
+              (miner.totalClosedIssues ?? 0)}
           </Typography>
         </Box>
       </Box>
-    </Card>
+    </Box>
   );
 };

--- a/src/components/leaderboard/MinerCard.tsx
+++ b/src/components/leaderboard/MinerCard.tsx
@@ -15,11 +15,7 @@ interface MinerCardProps {
 
 const INACTIVE_OPACITY = 0.24;
 
-export const MinerCard: React.FC<MinerCardProps> = ({
-  miner,
-  onClick,
-  variant = 'oss',
-}) => {
+export const MinerCard: React.FC<MinerCardProps> = ({ miner, onClick, variant = 'oss' }) => {
   const muiTheme = useTheme();
   const isNumericId = (value?: string) => !value || /^\d+$/.test(value);
   const shouldFetch = !!miner.githubId && isNumericId(miner.author);
@@ -334,9 +330,7 @@ const MinerCardFooter: React.FC<MinerCardFooterProps> = ({
         display: 'flex',
         flexDirection: 'column',
         gap: variant === 'discoveries' ? 0.75 : 0,
-        backgroundColor: isEligible
-          ? alpha(theme.palette.background.default, 0.2)
-          : theme.palette.surface.subtle,
+        backgroundColor: isEligible ? alpha(theme.palette.background.default, 0.2) : theme.palette.surface.subtle,
         opacity: isEligible ? 1 : 0.62,
         borderRadius: 1.5,
         p: 1,
@@ -366,35 +360,22 @@ const PrimaryStatsRow: React.FC<PrimaryStatsRowProps> = ({
   const muiTheme = useTheme();
 
   return (
-    <Box
-      sx={{
-        display: 'grid',
-        gridTemplateColumns: '1fr 1fr 1fr auto',
-        gap: 1,
-        alignItems: 'center',
-      }}
-    >
+    <Box sx={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr auto', gap: 1, alignItems: 'center' }}>
       {[
         {
           label: 'Merged',
           value: miner.totalMergedPrs ?? 0,
-          color: isEligible
-            ? STATUS_COLORS.merged
-            : alpha(muiTheme.palette.text.tertiary, INACTIVE_OPACITY),
+          color: isEligible ? STATUS_COLORS.merged : alpha(muiTheme.palette.text.tertiary, INACTIVE_OPACITY),
         },
         {
           label: 'Open',
           value: miner.totalOpenPrs ?? 0,
-          color: isEligible
-            ? alpha(muiTheme.palette.text.primary, 0.84)
-            : alpha(muiTheme.palette.text.tertiary, INACTIVE_OPACITY),
+          color: isEligible ? alpha(muiTheme.palette.text.primary, 0.84) : alpha(muiTheme.palette.text.tertiary, INACTIVE_OPACITY),
         },
         {
           label: 'Closed',
           value: miner.totalClosedPrs ?? 0,
-          color: isEligible
-            ? muiTheme.palette.status.closed
-            : alpha(muiTheme.palette.text.tertiary, INACTIVE_OPACITY),
+          color: isEligible ? muiTheme.palette.status.closed : alpha(muiTheme.palette.text.tertiary, INACTIVE_OPACITY),
         },
       ].map(({ label, value, color }) => (
         <Box key={label}>
@@ -402,23 +383,14 @@ const PrimaryStatsRow: React.FC<PrimaryStatsRowProps> = ({
             sx={(theme) => ({
               fontFamily: FONTS.mono,
               fontSize: '0.6rem',
-              color: isEligible
-                ? theme.palette.status.open
-                : alpha(muiTheme.palette.text.tertiary, INACTIVE_OPACITY),
+              color: isEligible ? theme.palette.status.open : alpha(muiTheme.palette.text.tertiary, INACTIVE_OPACITY),
               textTransform: 'uppercase',
               mb: 0.2,
             })}
           >
             {label}
           </Typography>
-          <Typography
-            sx={{
-              fontFamily: FONTS.mono,
-              fontSize: '0.85rem',
-              color,
-              fontWeight: 600,
-            }}
-          >
+          <Typography sx={{ fontFamily: FONTS.mono, fontSize: '0.85rem', color, fontWeight: 600 }}>
             {value}
           </Typography>
         </Box>
@@ -436,9 +408,7 @@ const PrimaryStatsRow: React.FC<PrimaryStatsRowProps> = ({
           sx={(theme) => ({
             fontFamily: FONTS.mono,
             fontSize: '0.6rem',
-            color: isEligible
-              ? theme.palette.status.open
-              : alpha(muiTheme.palette.text.tertiary, INACTIVE_OPACITY),
+            color: isEligible ? theme.palette.status.open : alpha(muiTheme.palette.text.tertiary, INACTIVE_OPACITY),
             textTransform: 'uppercase',
             mb: 0.2,
           })}
@@ -477,18 +447,7 @@ const IssueStatsSection: React.FC<IssueStatsSectionProps> = ({
 
   return (
     <Box sx={{ pt: 0.35, borderTop: '1px solid rgba(255,255,255,0.06)' }}>
-      <Typography
-        sx={{
-          fontFamily: FONTS.mono,
-          fontSize: '0.7rem',
-          fontWeight: 700,
-          color: '#8b949e',
-          minWidth: 28,
-          textTransform: 'uppercase',
-          mb: 0.35,
-          letterSpacing: '0.04em',
-        }}
-      >
+      <Typography sx={{ fontFamily: FONTS.mono, fontSize: '0.7rem', fontWeight: 700, color: '#8b949e', minWidth: 28, textTransform: 'uppercase', mb: 0.35, letterSpacing: '0.04em' }}>
         Issues
       </Typography>
       <Box
@@ -521,23 +480,14 @@ const IssueStatsSection: React.FC<IssueStatsSectionProps> = ({
               sx={(theme) => ({
                 fontFamily: FONTS.mono,
                 fontSize: '0.6rem',
-                color: isEligible
-                  ? theme.palette.status.open
-                  : alpha(muiTheme.palette.text.tertiary, INACTIVE_OPACITY),
+                color: isEligible ? theme.palette.status.open : alpha(muiTheme.palette.text.tertiary, INACTIVE_OPACITY),
                 textTransform: 'uppercase',
                 mb: 0.2,
               })}
             >
               {label}
             </Typography>
-            <Typography
-              sx={{
-                fontFamily: FONTS.mono,
-                fontSize: '0.85rem',
-                color,
-                fontWeight: 600,
-              }}
-            >
+            <Typography sx={{ fontFamily: FONTS.mono, fontSize: '0.85rem', color, fontWeight: 600 }}>
               {value}
             </Typography>
           </Box>
@@ -555,9 +505,7 @@ const IssueStatsSection: React.FC<IssueStatsSectionProps> = ({
             sx={(theme) => ({
               fontFamily: FONTS.mono,
               fontSize: '0.6rem',
-              color: isEligible
-                ? theme.palette.status.open
-                : alpha(muiTheme.palette.text.tertiary, INACTIVE_OPACITY),
+              color: isEligible ? theme.palette.status.open : alpha(muiTheme.palette.text.tertiary, INACTIVE_OPACITY),
               textTransform: 'uppercase',
               mb: 0.2,
             })}

--- a/src/components/leaderboard/MinerCard.tsx
+++ b/src/components/leaderboard/MinerCard.tsx
@@ -482,13 +482,18 @@ const IssueStatsSection: React.FC<IssueStatsSectionProps> = ({
   const muiTheme = useTheme();
 
   return (
-    <Box sx={{ pt: 0.35, borderTop: '1px solid rgba(255,255,255,0.06)' }}>
+    <Box
+      sx={(theme) => ({
+        pt: 0.35,
+        borderTop: `1px solid ${theme.palette.border.light}`,
+      })}
+    >
       <Typography
         sx={{
           fontFamily: FONTS.mono,
           fontSize: '0.7rem',
           fontWeight: 700,
-          color: '#8b949e',
+          color: muiTheme.palette.status.open,
           minWidth: 28,
           textTransform: 'uppercase',
           mb: 0.35,

--- a/src/components/leaderboard/MinerCard.tsx
+++ b/src/components/leaderboard/MinerCard.tsx
@@ -15,7 +15,11 @@ interface MinerCardProps {
 
 const INACTIVE_OPACITY = 0.24;
 
-export const MinerCard: React.FC<MinerCardProps> = ({ miner, onClick, variant = 'oss' }) => {
+export const MinerCard: React.FC<MinerCardProps> = ({
+  miner,
+  onClick,
+  variant = 'oss',
+}) => {
   const muiTheme = useTheme();
   const isNumericId = (value?: string) => !value || /^\d+$/.test(value);
   const shouldFetch = !!miner.githubId && isNumericId(miner.author);
@@ -306,7 +310,11 @@ export const MinerCard: React.FC<MinerCardProps> = ({ miner, onClick, variant = 
         </Box>
       </Box>
 
-      <MinerCardFooter miner={miner} variant={variant} isEligible={isEligible} />
+      <MinerCardFooter
+        miner={miner}
+        variant={variant}
+        isEligible={isEligible}
+      />
     </Card>
   );
 };
@@ -330,7 +338,9 @@ const MinerCardFooter: React.FC<MinerCardFooterProps> = ({
         display: 'flex',
         flexDirection: 'column',
         gap: variant === 'discoveries' ? 0.75 : 0,
-        backgroundColor: isEligible ? alpha(theme.palette.background.default, 0.2) : theme.palette.surface.subtle,
+        backgroundColor: isEligible
+          ? alpha(theme.palette.background.default, 0.2)
+          : theme.palette.surface.subtle,
         opacity: isEligible ? 1 : 0.62,
         borderRadius: 1.5,
         p: 1,
@@ -360,22 +370,35 @@ const PrimaryStatsRow: React.FC<PrimaryStatsRowProps> = ({
   const muiTheme = useTheme();
 
   return (
-    <Box sx={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr auto', gap: 1, alignItems: 'center' }}>
+    <Box
+      sx={{
+        display: 'grid',
+        gridTemplateColumns: '1fr 1fr 1fr auto',
+        gap: 1,
+        alignItems: 'center',
+      }}
+    >
       {[
         {
           label: 'Merged',
           value: miner.totalMergedPrs ?? 0,
-          color: isEligible ? STATUS_COLORS.merged : alpha(muiTheme.palette.text.tertiary, INACTIVE_OPACITY),
+          color: isEligible
+            ? STATUS_COLORS.merged
+            : alpha(muiTheme.palette.text.tertiary, INACTIVE_OPACITY),
         },
         {
           label: 'Open',
           value: miner.totalOpenPrs ?? 0,
-          color: isEligible ? alpha(muiTheme.palette.text.primary, 0.84) : alpha(muiTheme.palette.text.tertiary, INACTIVE_OPACITY),
+          color: isEligible
+            ? alpha(muiTheme.palette.text.primary, 0.84)
+            : alpha(muiTheme.palette.text.tertiary, INACTIVE_OPACITY),
         },
         {
           label: 'Closed',
           value: miner.totalClosedPrs ?? 0,
-          color: isEligible ? muiTheme.palette.status.closed : alpha(muiTheme.palette.text.tertiary, INACTIVE_OPACITY),
+          color: isEligible
+            ? muiTheme.palette.status.closed
+            : alpha(muiTheme.palette.text.tertiary, INACTIVE_OPACITY),
         },
       ].map(({ label, value, color }) => (
         <Box key={label}>
@@ -383,14 +406,23 @@ const PrimaryStatsRow: React.FC<PrimaryStatsRowProps> = ({
             sx={(theme) => ({
               fontFamily: FONTS.mono,
               fontSize: '0.6rem',
-              color: isEligible ? theme.palette.status.open : alpha(muiTheme.palette.text.tertiary, INACTIVE_OPACITY),
+              color: isEligible
+                ? theme.palette.status.open
+                : alpha(muiTheme.palette.text.tertiary, INACTIVE_OPACITY),
               textTransform: 'uppercase',
               mb: 0.2,
             })}
           >
             {label}
           </Typography>
-          <Typography sx={{ fontFamily: FONTS.mono, fontSize: '0.85rem', color, fontWeight: 600 }}>
+          <Typography
+            sx={{
+              fontFamily: FONTS.mono,
+              fontSize: '0.85rem',
+              color,
+              fontWeight: 600,
+            }}
+          >
             {value}
           </Typography>
         </Box>
@@ -399,7 +431,9 @@ const PrimaryStatsRow: React.FC<PrimaryStatsRowProps> = ({
         sx={(theme) => ({
           textAlign: 'right',
           borderLeft: `1px solid ${
-            isEligible ? theme.palette.border.light : theme.palette.border.subtle
+            isEligible
+              ? theme.palette.border.light
+              : theme.palette.border.subtle
           }`,
           pl: 1.5,
         })}
@@ -408,7 +442,9 @@ const PrimaryStatsRow: React.FC<PrimaryStatsRowProps> = ({
           sx={(theme) => ({
             fontFamily: FONTS.mono,
             fontSize: '0.6rem',
-            color: isEligible ? theme.palette.status.open : alpha(muiTheme.palette.text.tertiary, INACTIVE_OPACITY),
+            color: isEligible
+              ? theme.palette.status.open
+              : alpha(muiTheme.palette.text.tertiary, INACTIVE_OPACITY),
             textTransform: 'uppercase',
             mb: 0.2,
           })}
@@ -447,7 +483,18 @@ const IssueStatsSection: React.FC<IssueStatsSectionProps> = ({
 
   return (
     <Box sx={{ pt: 0.35, borderTop: '1px solid rgba(255,255,255,0.06)' }}>
-      <Typography sx={{ fontFamily: FONTS.mono, fontSize: '0.7rem', fontWeight: 700, color: '#8b949e', minWidth: 28, textTransform: 'uppercase', mb: 0.35, letterSpacing: '0.04em' }}>
+      <Typography
+        sx={{
+          fontFamily: FONTS.mono,
+          fontSize: '0.7rem',
+          fontWeight: 700,
+          color: '#8b949e',
+          minWidth: 28,
+          textTransform: 'uppercase',
+          mb: 0.35,
+          letterSpacing: '0.04em',
+        }}
+      >
         Issues
       </Typography>
       <Box
@@ -467,7 +514,9 @@ const IssueStatsSection: React.FC<IssueStatsSectionProps> = ({
           {
             label: 'Open',
             value: miner.totalOpenIssues ?? 0,
-            color: isEligible ? alpha(muiTheme.palette.text.primary, 0.84) : textColor,
+            color: isEligible
+              ? alpha(muiTheme.palette.text.primary, 0.84)
+              : textColor,
           },
           {
             label: 'Closed',
@@ -480,7 +529,9 @@ const IssueStatsSection: React.FC<IssueStatsSectionProps> = ({
               sx={(theme) => ({
                 fontFamily: FONTS.mono,
                 fontSize: '0.6rem',
-                color: isEligible ? theme.palette.status.open : alpha(muiTheme.palette.text.tertiary, INACTIVE_OPACITY),
+                color: isEligible
+                  ? theme.palette.status.open
+                  : alpha(muiTheme.palette.text.tertiary, INACTIVE_OPACITY),
                 textTransform: 'uppercase',
                 mb: 0.2,
               })}
@@ -514,7 +565,9 @@ const IssueStatsSection: React.FC<IssueStatsSectionProps> = ({
             sx={(theme) => ({
               fontFamily: FONTS.mono,
               fontSize: '0.6rem',
-              color: isEligible ? theme.palette.status.open : alpha(muiTheme.palette.text.tertiary, INACTIVE_OPACITY),
+              color: isEligible
+                ? theme.palette.status.open
+                : alpha(muiTheme.palette.text.tertiary, INACTIVE_OPACITY),
               textTransform: 'uppercase',
               mb: 0.2,
             })}

--- a/src/components/leaderboard/MinerCard.tsx
+++ b/src/components/leaderboard/MinerCard.tsx
@@ -15,7 +15,11 @@ interface MinerCardProps {
 
 const INACTIVE_OPACITY = 0.24;
 
-export const MinerCard: React.FC<MinerCardProps> = ({ miner, onClick, variant = 'oss' }) => {
+export const MinerCard: React.FC<MinerCardProps> = ({
+  miner,
+  onClick,
+  variant = 'oss',
+}) => {
   const muiTheme = useTheme();
   const isNumericId = (value?: string) => !value || /^\d+$/.test(value);
   const shouldFetch = !!miner.githubId && isNumericId(miner.author);
@@ -362,7 +366,14 @@ const PrimaryStatsRow: React.FC<PrimaryStatsRowProps> = ({
   const muiTheme = useTheme();
 
   return (
-    <Box sx={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr auto', gap: 1, alignItems: 'center' }}>
+    <Box
+      sx={{
+        display: 'grid',
+        gridTemplateColumns: '1fr 1fr 1fr auto',
+        gap: 1,
+        alignItems: 'center',
+      }}
+    >
       {[
         {
           label: 'Merged',
@@ -400,7 +411,14 @@ const PrimaryStatsRow: React.FC<PrimaryStatsRowProps> = ({
           >
             {label}
           </Typography>
-          <Typography sx={{ fontFamily: FONTS.mono, fontSize: '0.85rem', color, fontWeight: 600 }}>
+          <Typography
+            sx={{
+              fontFamily: FONTS.mono,
+              fontSize: '0.85rem',
+              color,
+              fontWeight: 600,
+            }}
+          >
             {value}
           </Typography>
         </Box>
@@ -460,15 +478,43 @@ const IssueStatsSection: React.FC<IssueStatsSectionProps> = ({
   return (
     <Box sx={{ pt: 0.35, borderTop: '1px solid rgba(255,255,255,0.06)' }}>
       <Typography
-        sx={{ fontFamily: FONTS.mono, fontSize: '0.7rem', fontWeight: 700, color: '#8b949e', minWidth: 28, textTransform: 'uppercase', mb: 0.35, letterSpacing: '0.04em' }}
+        sx={{
+          fontFamily: FONTS.mono,
+          fontSize: '0.7rem',
+          fontWeight: 700,
+          color: '#8b949e',
+          minWidth: 28,
+          textTransform: 'uppercase',
+          mb: 0.35,
+          letterSpacing: '0.04em',
+        }}
       >
         Issues
       </Typography>
-      <Box sx={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr auto', gap: 1, alignItems: 'center' }}>
+      <Box
+        sx={{
+          display: 'grid',
+          gridTemplateColumns: '1fr 1fr 1fr auto',
+          gap: 1,
+          alignItems: 'center',
+        }}
+      >
         {[
-          { label: 'Solved', value: miner.totalSolvedIssues ?? 0, color: isEligible ? STATUS_COLORS.merged : textColor },
-          { label: 'Open', value: miner.totalOpenIssues ?? 0, color: isEligible ? alpha(muiTheme.palette.text.primary, 0.84) : textColor },
-          { label: 'Closed', value: miner.totalClosedIssues ?? 0, color: isEligible ? muiTheme.palette.status.closed : textColor },
+          {
+            label: 'Solved',
+            value: miner.totalSolvedIssues ?? 0,
+            color: isEligible ? STATUS_COLORS.merged : textColor,
+          },
+          {
+            label: 'Open',
+            value: miner.totalOpenIssues ?? 0,
+            color: isEligible ? alpha(muiTheme.palette.text.primary, 0.84) : textColor,
+          },
+          {
+            label: 'Closed',
+            value: miner.totalClosedIssues ?? 0,
+            color: isEligible ? muiTheme.palette.status.closed : textColor,
+          },
         ].map(({ label, value, color }) => (
           <Box key={label}>
             <Typography
@@ -484,7 +530,14 @@ const IssueStatsSection: React.FC<IssueStatsSectionProps> = ({
             >
               {label}
             </Typography>
-            <Typography sx={{ fontFamily: FONTS.mono, fontSize: '0.85rem', color, fontWeight: 600 }}>
+            <Typography
+              sx={{
+                fontFamily: FONTS.mono,
+                fontSize: '0.85rem',
+                color,
+                fontWeight: 600,
+              }}
+            >
               {value}
             </Typography>
           </Box>

--- a/src/components/leaderboard/TopMinersTable.tsx
+++ b/src/components/leaderboard/TopMinersTable.tsx
@@ -5,7 +5,12 @@ import { SectionCard } from './SectionCard';
 import { MinerCard } from './MinerCard';
 import { SearchInput } from '../common/SearchInput';
 import { STATUS_COLORS } from '../../theme';
-import { type MinerStats, type SortOption, type LeaderboardVariant, FONTS } from './types';
+import {
+  type MinerStats,
+  type SortOption,
+  type LeaderboardVariant,
+  FONTS,
+} from './types';
 
 // Re-export MinerStats for backward compatibility
 export type { MinerStats } from './types';

--- a/src/components/leaderboard/TopMinersTable.tsx
+++ b/src/components/leaderboard/TopMinersTable.tsx
@@ -5,7 +5,7 @@ import { SectionCard } from './SectionCard';
 import { MinerCard } from './MinerCard';
 import { SearchInput } from '../common/SearchInput';
 import { STATUS_COLORS } from '../../theme';
-import { type MinerStats, type SortOption, FONTS } from './types';
+import { type MinerStats, type SortOption, type LeaderboardVariant, FONTS } from './types';
 
 // Re-export MinerStats for backward compatibility
 export type { MinerStats } from './types';
@@ -16,14 +16,14 @@ interface TopMinersTableProps {
   miners: MinerStats[];
   isLoading?: boolean;
   onSelectMiner: (githubId: string) => void;
-  activityLabel?: string;
+  variant?: LeaderboardVariant;
 }
 
 const TopMinersTable: React.FC<TopMinersTableProps> = ({
   miners,
   isLoading,
   onSelectMiner,
-  activityLabel = 'PRs',
+  variant = 'oss',
 }) => {
   const [searchQuery, setSearchQuery] = useState('');
   const [sortOption, setSortOption] = useState<SortOption>('totalScore');
@@ -40,6 +40,8 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
           return (b.usdPerDay ?? 0) - (a.usdPerDay ?? 0);
         case 'totalPRs':
           return b.totalPRs - a.totalPRs;
+        case 'totalIssues':
+          return (b.totalIssues ?? 0) - (a.totalIssues ?? 0);
         case 'credibility':
           return (b.credibility ?? 0) - (a.credibility ?? 0);
         default:
@@ -64,7 +66,10 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
       result = result.filter((m) => m.isEligible);
     }
 
-    return sortMinersList(result, sortOption);
+    return sortMinersList(result, sortOption).map((miner, index) => ({
+      ...miner,
+      rank: index + 1,
+    }));
   }, [miners, searchQuery, showEligibleOnly, sortOption]);
 
   useEffect(() => {
@@ -107,7 +112,7 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
             <SortButtons
               sortOption={sortOption}
               onSortChange={setSortOption}
-              activityLabel={activityLabel}
+              variant={variant}
             />
             <FilterButton
               label="Eligible"
@@ -140,6 +145,7 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
               <Grid item xs={12} sm={12} md={6} lg={4} xl={4} key={miner.id}>
                 <MinerCard
                   miner={miner}
+                  variant={variant}
                   onClick={() => onSelectMiner(miner.githubId)}
                 />
               </Grid>
@@ -207,13 +213,13 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
 interface SortButtonsProps {
   sortOption: SortOption;
   onSortChange: (option: SortOption) => void;
-  activityLabel: string;
+  variant: LeaderboardVariant;
 }
 
 const SortButtons: React.FC<SortButtonsProps> = ({
   sortOption,
   onSortChange,
-  activityLabel,
+  variant,
 }) => (
   <Box
     sx={{
@@ -226,7 +232,10 @@ const SortButtons: React.FC<SortButtonsProps> = ({
     {[
       { label: 'Score', value: 'totalScore' },
       { label: 'Earnings', value: 'usdPerDay' },
-      { label: activityLabel, value: 'totalPRs' },
+      { label: 'PRs', value: 'totalPRs' },
+      ...(variant === 'discoveries'
+        ? [{ label: 'Issues', value: 'totalIssues' as const }]
+        : []),
       { label: 'Credibility', value: 'credibility' },
     ].map((option) => (
       <Box

--- a/src/components/leaderboard/types.ts
+++ b/src/components/leaderboard/types.ts
@@ -7,6 +7,7 @@ export interface MinerStats {
   totalScore: number;
   baseTotalScore: number;
   totalPRs: number;
+  totalIssues?: number;
   linesChanged: number;
   linesAdded: number;
   linesDeleted: number;
@@ -19,12 +20,18 @@ export interface MinerStats {
   totalMergedPrs?: number;
   totalOpenPrs?: number;
   totalClosedPrs?: number;
+  totalSolvedIssues?: number;
+  totalOpenIssues?: number;
+  totalClosedIssues?: number;
 }
+
+export type LeaderboardVariant = 'oss' | 'discoveries';
 
 export type SortOption =
   | 'totalScore'
   | 'usdPerDay'
   | 'totalPRs'
+  | 'totalIssues'
   | 'credibility';
 
 export const FONTS = {

--- a/src/pages/DiscoveriesPage.tsx
+++ b/src/pages/DiscoveriesPage.tsx
@@ -28,7 +28,8 @@ const DiscoveriesPage: React.FC = () => {
       author: stat.githubUsername || undefined,
       totalScore: Number(stat.issueDiscoveryScore) || 0,
       baseTotalScore: Number(stat.baseTotalScore) || 0,
-      totalPRs:
+      totalPRs: Number(stat.totalPrs) || 0,
+      totalIssues:
         (Number(stat.totalSolvedIssues) || 0) +
         (Number(stat.totalClosedIssues) || 0),
       linesChanged: Number(stat.totalNodesScored) || 0,
@@ -39,10 +40,12 @@ const DiscoveriesPage: React.FC = () => {
       credibility: Number(stat.issueCredibility) || 0,
       isEligible: stat.isIssueEligible ?? false,
       usdPerDay: Number(stat.usdPerDay) || 0,
-      // Issue counts mapped to PR status fields
-      totalMergedPrs: Number(stat.totalSolvedIssues) || 0,
-      totalOpenPrs: Number(stat.totalOpenIssues) || 0,
-      totalClosedPrs: Number(stat.totalClosedIssues) || 0,
+      totalMergedPrs: Number(stat.totalMergedPrs) || 0,
+      totalOpenPrs: Number(stat.totalOpenPrs) || 0,
+      totalClosedPrs: Number(stat.totalClosedPrs) || 0,
+      totalSolvedIssues: Number(stat.totalSolvedIssues) || 0,
+      totalOpenIssues: Number(stat.totalOpenIssues) || 0,
+      totalClosedIssues: Number(stat.totalClosedIssues) || 0,
     }));
   }, [allMinersStats]);
 
@@ -122,7 +125,7 @@ const DiscoveriesPage: React.FC = () => {
               miners={sortedMinerStats}
               isLoading={isLoadingMinerStats}
               onSelectMiner={handleSelectMiner}
-              activityLabel="Issues"
+              variant="discoveries"
             />
           </Box>
         </Box>

--- a/src/pages/DiscoveriesPage.tsx
+++ b/src/pages/DiscoveriesPage.tsx
@@ -31,6 +31,7 @@ const DiscoveriesPage: React.FC = () => {
       totalPRs: Number(stat.totalPrs) || 0,
       totalIssues:
         (Number(stat.totalSolvedIssues) || 0) +
+        (Number(stat.totalOpenIssues) || 0) +
         (Number(stat.totalClosedIssues) || 0),
       linesChanged: Number(stat.totalNodesScored) || 0,
       linesAdded: Number(stat.totalAdditions) || 0,


### PR DESCRIPTION
## Summary

This PR is part of updating the `Issue Discovery` page to make issue leaderboard ordering clearer without removing the existing pull request views.

It adds issue-specific leaderboard data and sorting, and emphasizes rank ordering by issue discovery score on the `Discoveries` page. It also surfaces issue metrics as an additional section in the UI rather than replacing the current PR-focused sections.


## Related Issues

Related to the Discoveries leaderboard enhancement requests.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Enhancement
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Testing

Manual testing performed:
- Verified the `Discoveries` page still shows PR metrics
- Verified an additional issue-focused section appears on Discoveries
- Verified sorting supports both `PRs` and `Issues`
- Verified visible rank ordering is shown for issue discovery score
- Verified sidebar includes both PR and issue leaderboard views
- Ran `npm run build` successfully

## Checklist

- [x] Followed existing code patterns and architecture
- [x] Avoided unrelated file changes
- [x] Kept `package-lock.json` unchanged
- [x] Self-reviewed changes
- [x] Confirmed the project builds successfully
- [ ] Updated documentation if needed

Fixes: https://github.com/entrius/gittensor-ui/issues/172
<img width="1488" height="698" alt="image" src="https://github.com/user-attachments/assets/f474beea-b6bb-4f52-add9-8ae9c4a991df" />

