### PR TITLE
fix: correct Getting Started Step 7 credibility threshold

### DIFF
--- a/src/components/onboard/GettingStarted.tsx
+++ b/src/components/onboard/GettingStarted.tsx
@@ -344,7 +344,7 @@ uv pip install -e .`}</CodeBlock>
               <strong>Repositories</strong> tab
             </li>
             <li>
-              Eligibility requires 5 merged PRs with token score &ge; 5, 75%
+              Eligibility requires 5 merged PRs with token score &ge; 5, 80%
               credibility, and a 180-day-old GitHub account
             </li>
             <li>


### PR DESCRIPTION
## Summary
- Update Onboard `Getting Started` Step 7 eligibility copy from `75%` to `80%` credibility.
- Align UI text with validator threshold (`MIN_CREDIBILITY = 0.80`) to prevent onboarding confusion.
- Scope is limited to the Step 7 content block referenced in #164.

## Test plan
- [x] Open `Onboard -> Getting Started -> Step 7 (Contribute)` and verify text says `80% credibility`.