### PR TITLE
fix: correct Step 7 credibility threshold to 80%

### DIFF
--- a/src/components/onboard/GettingStarted.tsx
+++ b/src/components/onboard/GettingStarted.tsx
@@ -344,7 +344,7 @@ uv pip install -e .`}</CodeBlock>
               <strong>Repositories</strong> tab
             </li>
             <li>
-              Eligibility requires 5 merged PRs with token score &ge; 5, 75%
+              Eligibility requires 5 merged PRs with token score &ge; 5, 80%
               credibility, and a 180-day-old GitHub account
             </li>
             <li>


### PR DESCRIPTION
### Summary
- Updates Onboard `Getting Started` Step 7 eligibility copy from `75%` to `80%` credibility.
- Aligns UI text with the validator threshold (`MIN_CREDIBILITY = 0.80`) to avoid confusion for miners in the 76–79% range.
- Keeps scope intentionally limited to the Step 7 content block referenced in [Issue #164](https://github.com/entrius/gittensor-ui/issues/164).

### Test plan
- [x] Open `Onboard -> Getting Started -> Step 7 (Contribute)` and verify it now reads `80% credibility`.

Closes #164