### PR TITLE
fix: align PR details repo weight with repositories page

### DIFF
--- a/src/components/prs/PRDetailsCard.tsx
+++ b/src/components/prs/PRDetailsCard.tsx
@@ -10,7 +10,7 @@ import {
   Tooltip,
 } from '@mui/material';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
-import { usePullRequestDetails } from '../../api';
+import { usePullRequestDetails, useReposAndWeights } from '../../api';
 import { useNavigate } from 'react-router-dom';
 import theme, { RANK_COLORS, STATUS_COLORS } from '../../theme';
 
@@ -29,6 +29,7 @@ const PRDetailsCard: React.FC<PRDetailsCardProps> = ({
   // Fetch detailed PR data directly
   const { data: prDetails, isLoading: isDetailsLoading } =
     usePullRequestDetails(repository, pullRequestNumber);
+  const { data: reposWithWeights } = useReposAndWeights();
 
   if (isDetailsLoading) {
     return (
@@ -71,6 +72,12 @@ const PRDetailsCard: React.FC<PRDetailsCardProps> = ({
   }
 
   const [owner] = repository.split('/');
+  const canonicalRepoWeight = reposWithWeights?.find(
+    (repo) => repo.fullName.toLowerCase() === repository.toLowerCase(),
+  )?.weight;
+  const repoWeightValue = parseFloat(
+    canonicalRepoWeight ?? prDetails.repoWeightMultiplier ?? '0',
+  ).toFixed(2);
 
   const isOpenPR = prDetails.prState === 'OPEN';
 
@@ -116,7 +123,7 @@ const PRDetailsCard: React.FC<PRDetailsCardProps> = ({
     ? [
         {
           label: 'Repo Weight',
-          value: `${parseFloat(prDetails.repoWeightMultiplier ?? '0').toFixed(2)}x`,
+          value: `${repoWeightValue}x`,
         },
         {
           label: 'Issue Bonus',
@@ -130,7 +137,7 @@ const PRDetailsCard: React.FC<PRDetailsCardProps> = ({
     : [
         {
           label: 'Repo Weight',
-          value: `${parseFloat(prDetails.repoWeightMultiplier ?? '0').toFixed(2)}x`,
+          value: `${repoWeightValue}x`,
         },
         {
           label: 'Issue Bonus',


### PR DESCRIPTION
## Summary
- Use canonical repository weight from `/dash/repos` in PR details.
- Align `Repo Weight` shown on PR details with the value displayed on the Repositories page.
- Keep a fallback to `repoWeightMultiplier` from PR details when a repository entry is unavailable.

## Root cause
PR details was reading `repoWeightMultiplier` from `/prs/details`, while the Repositories page reads weight from `/dash/repos`. These can diverge for some PRs, causing inconsistent UI values.

## Test plan
- [x] Open Repositories page and note the weight for a repo (e.g. `janhq/jan`).
- [x] Open PR details for a PR in that same repo.
- [x] Verify the `Repo Weight` value matches the Repositories page.
- [x] Verify no regressions for repos that are missing from `/dash/repos` (fallback still renders a value).

Closes #183