### PR TITLE
fix: correct hardcoded credibility thresholds across UI (75% and 90% → 80%)

### DIFF
--- a/src/components/miners/MinerScoreCard.tsx
+++ b/src/components/miners/MinerScoreCard.tsx
@@ -347,7 +347,7 @@ const MinerScoreCard: React.FC<MinerScoreCardProps> = ({ githubId }) => {
               {githubData?.name || username}
             </Typography>
             <Tooltip
-              title="Requires 5+ merged PRs with token score >= 5 and 90%+ credibility"
+              title="Requires 5+ merged PRs with token score >= 5 and 80%+ credibility"
               arrow
               placement="bottom"
               slotProps={tooltipSlotProps}

--- a/src/components/onboard/GettingStarted.tsx
+++ b/src/components/onboard/GettingStarted.tsx
@@ -344,7 +344,7 @@ uv pip install -e .`}</CodeBlock>
               <strong>Repositories</strong> tab
             </li>
             <li>
-              Eligibility requires 5 merged PRs with token score &ge; 5, 75%
+              Eligibility requires 5 merged PRs with token score &ge; 5, 80%
               credibility, and a 180-day-old GitHub account
             </li>
             <li>

--- a/src/components/onboard/Scoring.tsx
+++ b/src/components/onboard/Scoring.tsx
@@ -33,7 +33,7 @@ export const Scoring: React.FC = () => (
         },
         {
           title: 'Credibility',
-          desc: 'Keep your merge rate high. A strong ratio of merged vs. closed PRs increases your credibility. You need at least 75% credibility to become eligible for rewards.',
+          desc: 'Keep your merge rate high. A strong ratio of merged vs. closed PRs increases your credibility. You need at least 80% credibility to become eligible for rewards.',
         },
       ].map((item, index) => (
         <Grid item xs={12} md={3} key={index}>

--- a/src/pages/FAQPage.tsx
+++ b/src/pages/FAQPage.tsx
@@ -129,7 +129,7 @@ export const FAQContent: React.FC = () => (
           <>
             You must contribute to an incentivized repository listed in our
             master list. To become eligible for rewards, you need at least 5
-            merged PRs with a token score of 5 or higher, 75% credibility, and a
+            merged PRs with a token score of 5 or higher, 80% credibility, and a
             GitHub account that is at least 180 days old. Check the{' '}
             <a
               href="https://docs.gittensor.io/oss-contributions.html"


### PR DESCRIPTION
## Summary

The validator's MIN_CREDIBILITY is 0.80 but the UI had three different wrong values scattered across onboarding, FAQ, and tooltips. Some said 75%, the OSS Eligible tooltip said 90%. None of them matched the backend.

- Onboard Scoring tab: 75% → 80%
- Onboard Getting Started Step 7: 75% → 80%
- FAQ page: 75% → 80%
- OSS Eligible badge tooltip: 90% → 80%

This is a stopgap fix — #190 proposes pulling these from the backend so they can't drift again. But right now they're actively misleading miners about their eligibility status.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Test plan

- [x] Open /onboard?tab=scoring, verify Credibility card says 80%
- [x] Open /onboard?tab=getting-started, click Step 7, verify it says 80%
- [x] Open FAQ page, verify eligibility answer says 80%
- [x] Open any miner details page, hover OSS Eligible badge, verify tooltip says 80%

Fixes #164
Partial fix for #190, #151