### PR TITLE
fix: rename /issues route to /bounties

### DIFF
--- a/src/components/layout/GlobalSearchBar.tsx
+++ b/src/components/layout/GlobalSearchBar.tsx
@@ -432,7 +432,7 @@ const GlobalSearchBar: React.FC = () => {
                       }
                       subtitle={`${issue.repositoryFullName} · #${issue.issueNumber}`}
                       onClick={() =>
-                        navigateAndClose(`/issues/details?id=${issue.id}`)
+                        navigateAndClose(`/bounties/details?id=${issue.id}`)
                       }
                     />
                   ))}

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -26,7 +26,7 @@ const Sidebar: React.FC<SidebarProps> = ({ onNavigate }) => {
     { label: 'dashboard', path: '/dashboard' },
     { label: 'oss contributions', path: '/top-miners' },
     { label: 'discoveries', path: '/discoveries', badge: 'new' },
-    { label: 'bounties', path: '/issues' },
+    { label: 'bounties', path: '/bounties' },
     { label: 'repositories', path: '/repositories' },
     { label: 'onboard', path: '/onboard' },
   ];

--- a/src/components/repositories/RepositoryIssuesTable.tsx
+++ b/src/components/repositories/RepositoryIssuesTable.tsx
@@ -240,7 +240,7 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
                     <Box
                       key={bounty.id}
                       onClick={() =>
-                        navigate(`/issues/details?id=${bounty.id}`, {
+                        navigate(`/bounties/details?id=${bounty.id}`, {
                           state: { backLabel: `Back to ${repositoryFullName}` },
                         })
                       }

--- a/src/pages/IssueDetailsPage.tsx
+++ b/src/pages/IssueDetailsPage.tsx
@@ -34,7 +34,7 @@ const IssueDetailsPage: React.FC = () => {
   // If no ID is provided, redirect to issues page
   if (!idParam) {
     if (typeof window !== 'undefined') {
-      navigate('/issues');
+      navigate('/bounties');
     }
     return null;
   }
@@ -75,7 +75,7 @@ const IssueDetailsPage: React.FC = () => {
           <Typography variant="h6" color="error">
             Issue not found
           </Typography>
-          <BackButton to="/issues" label="Back to Issues" />
+          <BackButton to="/bounties" label="Back to Bounties" />
         </Box>
       ) : (
         <Box
@@ -89,7 +89,7 @@ const IssueDetailsPage: React.FC = () => {
           }}
         >
           <Stack spacing={3}>
-            <BackButton to="/issues" label="Back to Issues" mb={0} />
+            <BackButton to="/bounties" label="Back to Bounties" mb={0} />
             <IssueHeaderCard issue={issue} />
 
             {/* Tabs */}

--- a/src/pages/IssuesPage.tsx
+++ b/src/pages/IssuesPage.tsx
@@ -31,7 +31,7 @@ const IssuesPage: React.FC = () => {
   const historyIssuesQuery = useIssues('completed,cancelled');
 
   const handleTabChange = (_event: React.SyntheticEvent, newValue: number) => {
-    navigate(`/issues/${TAB_SLUGS[newValue]}`, { replace: true });
+    navigate(`/bounties/${TAB_SLUGS[newValue]}`, { replace: true });
   };
 
   return (
@@ -98,7 +98,7 @@ const IssuesPage: React.FC = () => {
                 isLoading={activeIssuesQuery.isLoading}
                 listType="available"
                 onSelectIssue={(id) =>
-                  navigate(`/issues/details?id=${id}`, {
+                  navigate(`/bounties/details?id=${id}`, {
                     state: { backLabel: 'Back to Bounties' },
                   })
                 }
@@ -110,7 +110,7 @@ const IssuesPage: React.FC = () => {
                 isLoading={registeredIssuesQuery.isLoading}
                 listType="pending"
                 onSelectIssue={(id) =>
-                  navigate(`/issues/details?id=${id}`, {
+                  navigate(`/bounties/details?id=${id}`, {
                     state: { backLabel: 'Back to Bounties' },
                   })
                 }
@@ -122,7 +122,7 @@ const IssuesPage: React.FC = () => {
                 isLoading={historyIssuesQuery.isLoading}
                 listType="history"
                 onSelectIssue={(id) =>
-                  navigate(`/issues/details?id=${id}`, {
+                  navigate(`/bounties/details?id=${id}`, {
                     state: { backLabel: 'Back to Bounties' },
                   })
                 }

--- a/src/pages/search/SearchPage.tsx
+++ b/src/pages/search/SearchPage.tsx
@@ -187,7 +187,7 @@ const SearchPage: React.FC = () => {
   };
 
   const handleSelectIssue = (id: number) => {
-    navigate(`/issues/details?id=${id}`, {
+    navigate(`/bounties/details?id=${id}`, {
       state: searchBackState,
     });
   };

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -41,12 +41,12 @@ const routesArray: AppRoute[] = [
   },
   {
     name: 'issue-details',
-    path: '/issues/details',
+    path: '/bounties/details',
     element: <IssueDetailsPage />,
   },
   {
     name: 'issues',
-    path: '/issues/:tab?',
+    path: '/bounties/:tab?',
     element: <IssuesPage />,
     showGlobalSearch: true,
   },


### PR DESCRIPTION
## Summary
- Renames the UI route from `/issues` to `/bounties` so the URL matches the sidebar label
- Updates all internal `navigate()` calls and `BackButton` links across 7 files
- No backend changes needed — API endpoints are independent of client-side routes

Closes #161