### PR TITLE
fix: correct hardcoded credibility thresholds (75% → 80%)

### DIFF
--- a/src/components/onboard/Scoring.tsx
+++ b/src/components/onboard/Scoring.tsx
@@ -33,7 +33,7 @@ export const Scoring: React.FC = () => (
         },
         {
           title: 'Credibility',
-          desc: 'Keep your merge rate high. A strong ratio of merged vs. closed PRs increases your credibility. You need at least 75% credibility to become eligible for rewards.',
+          desc: 'Keep your merge rate high. A strong ratio of merged vs. closed PRs increases your credibility. You need at least 80% credibility to become eligible for rewards.',
         },
       ].map((item, index) => (
         <Grid item xs={12} md={3} key={index}>

--- a/src/pages/FAQPage.tsx
+++ b/src/pages/FAQPage.tsx
@@ -129,7 +129,7 @@ export const FAQContent: React.FC = () => (
           <>
             You must contribute to an incentivized repository listed in our
             master list. To become eligible for rewards, you need at least 5
-            merged PRs with a token score of 5 or higher, 75% credibility, and a
+            merged PRs with a token score of 5 or higher, 80% credibility, and a
             GitHub account that is at least 180 days old. Check the{' '}
             <a
               href="https://docs.gittensor.io/oss-contributions.html"


### PR DESCRIPTION
## Summary

Step 7 was already fixed by #188. These two spots still say 75%:

- Onboard Scoring tab
- FAQ page

Updated both to 80% to match `MIN_CREDIBILITY = 0.80`.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Test plan

- [x] Open /onboard?tab=scoring, verify Credibility card says 80%
- [x] Open FAQ page, verify eligibility answer says 80%

Partial fix for #190