### PR TITLE
fix: persist PR list page number across navigation

### DIFF
--- a/src/components/miners/MinerPRsTable.tsx
+++ b/src/components/miners/MinerPRsTable.tsx
@@ -26,7 +26,7 @@ import {
   NavigateNext as NextIcon,
 } from '@mui/icons-material';
 import { useMinerPRs, type CommitLog } from '../../api';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import ExplorerFilterButton from './ExplorerFilterButton';
 import { type MinerStatusFilter } from '../../utils/ExplorerUtils';
 
@@ -70,13 +70,27 @@ interface MinerPRsTableProps {
 const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
   const theme = useTheme();
   const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
   const { data: prs, isLoading } = useMinerPRs(githubId);
   const [selectedAuthor, setSelectedAuthor] = useState<string | null>(null);
   const [statusFilter, setStatusFilter] = useState<MinerStatusFilter>('all');
   const [searchQuery, setSearchQuery] = useState('');
   const [sortField, setSortField] = useState<PrSortField>('date');
   const [sortDir, setSortDir] = useState<SortDir>('desc');
-  const [page, setPage] = useState(0);
+
+  const page = parseInt(searchParams.get('prPage') || '0', 10);
+  const setPage = useCallback(
+    (updater: number | ((prev: number) => number)) => {
+      const next = typeof updater === 'function' ? updater(page) : updater;
+      setSearchParams((prev) => {
+        const p = new URLSearchParams(prev);
+        if (next === 0) p.delete('prPage');
+        else p.set('prPage', String(next));
+        return p;
+      });
+    },
+    [page, setSearchParams],
+  );
 
   const handleSort = useCallback(
     (field: PrSortField) => {
@@ -88,7 +102,7 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
       }
       setPage(0);
     },
-    [sortField],
+    [sortField, setPage],
   );
 
   const filteredPRs = useMemo(() => {


### PR DESCRIPTION
## Summary

Persist PR list page number in URL search params so navigating to a PR detail page and back preserves the current page instead of resetting to page 1.

Replaces `useState(0)` with `useSearchParams`-backed `prPage` parameter. Page 0 keeps the URL clean (no param); other pages set `prPage=N`. Browser back navigation restores the previous URL including the page param.

## Related Issues

Fixes #196

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Video

https://github.com/user-attachments/assets/7121ec98-f979-43d3-b79e-0d3b8042da7a

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
