### PR TITLE
fix: persist Overview tab score breakdown page number across navigation

### DIFF
--- a/src/components/miners/MinerScoreBreakdown.tsx
+++ b/src/components/miners/MinerScoreBreakdown.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useMemo, useState, useCallback } from 'react';
 import {
   Box,
   Card,
@@ -16,7 +16,7 @@ import {
   GitHub as GitHubIcon,
   OpenInNew as OpenInNewIcon,
 } from '@mui/icons-material';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useMinerPRs, usePullRequestDetails, type CommitLog } from '../../api';
 import { STATUS_COLORS } from '../../theme';
 
@@ -514,9 +514,23 @@ const MinerScoreBreakdown: React.FC<MinerScoreBreakdownProps> = ({
   githubId,
 }) => {
   const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
   const { data: prs, isLoading } = useMinerPRs(githubId);
-  const [page, setPage] = useState(0);
   const PAGE_SIZE = 10;
+
+  const page = parseInt(searchParams.get('scorePage') || '0', 10);
+  const setPage = useCallback(
+    (updater: number | ((prev: number) => number)) => {
+      const next = typeof updater === 'function' ? updater(page) : updater;
+      setSearchParams((prev) => {
+        const p = new URLSearchParams(prev);
+        if (next === 0) p.delete('scorePage');
+        else p.set('scorePage', String(next));
+        return p;
+      });
+    },
+    [page, setSearchParams],
+  );
 
   const handleNavigateToPr = (repo: string, prNumber: number) => {
     navigate(`/miners/pr?repo=${encodeURIComponent(repo)}&number=${prNumber}`);


### PR DESCRIPTION
## Summary

Persist the Overview tab's Score Breakdown page number in URL search params (`scorePage`) so navigating to a PR detail page and back preserves the current page instead of resetting to page 1.

Same approach as PR #198 but for the Overview tab's `MinerScoreBreakdown` component.

## Related Issues

Fixes #197

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

https://github.com/user-attachments/assets/da272a6a-64a6-4960-b3bf-a974c752118c

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
