### PR TITLE
fix: repo check tab of repository page

### DIFF
--- a/src/components/repositories/RepositoryCheckTab.tsx
+++ b/src/components/repositories/RepositoryCheckTab.tsx
@@ -422,8 +422,8 @@ const RepositoryCheckTab: React.FC<RepositoryCheckTabProps> = ({
               </Box>
 
               <Grid container spacing={2}>
-                {/* Stat: Open Issues */}
-                <Grid item xs={6} md={3}>
+                {/* Stat: Open Issues — 2×2 from md until lg so link cards have room; 4 across on lg+ */}
+                <Grid item xs={6} md={6} lg={3}>
                   <Box
                     sx={{
                       p: 2,
@@ -459,7 +459,7 @@ const RepositoryCheckTab: React.FC<RepositoryCheckTabProps> = ({
                 </Grid>
 
                 {/* Stat: Forks */}
-                <Grid item xs={6} md={3}>
+                <Grid item xs={6} md={6} lg={3}>
                   <Box
                     sx={{
                       p: 2,
@@ -493,22 +493,26 @@ const RepositoryCheckTab: React.FC<RepositoryCheckTabProps> = ({
                 </Grid>
 
                 {/* Action: Good First Issues */}
-                <Grid item xs={12} md={3}>
+                <Grid item xs={6} md={6} lg={3}>
                   <Box
                     component="a"
                     href={`https://github.com/${repositoryFullName}/issues?q=is%3Aissue+is%3Aopen+label%3A"good+first+issue"`}
                     target="_blank"
+                    rel="noopener noreferrer"
                     sx={{
                       p: 2,
                       borderRadius: 1,
                       bgcolor: 'rgba(255,255,255,0.03)',
                       border: '1px solid rgba(255,255,255,0.05)',
                       height: '100%',
+                      minWidth: 0,
                       display: 'flex',
                       flexDirection: 'column',
                       justifyContent: 'space-between',
                       textDecoration: 'none',
                       cursor: 'pointer',
+                      overflow: 'hidden',
+                      boxSizing: 'border-box',
                       transition: 'all 0.2s',
                       '&:hover': {
                         bgcolor: 'rgba(255,255,255,0.08)',
@@ -522,10 +526,12 @@ const RepositoryCheckTab: React.FC<RepositoryCheckTabProps> = ({
                         display: 'flex',
                         justifyContent: 'space-between',
                         alignItems: 'flex-start',
+                        gap: 1,
                         mb: 1,
+                        minWidth: 0,
                       }}
                     >
-                      <Box>
+                      <Box sx={{ minWidth: 0, flex: 1 }}>
                         <Typography
                           variant="h4"
                           sx={{
@@ -544,14 +550,20 @@ const RepositoryCheckTab: React.FC<RepositoryCheckTabProps> = ({
                             color: STATUS_COLORS.open,
                             fontSize: '12px',
                             fontWeight: 600,
-                            whiteSpace: 'nowrap',
+                            lineHeight: 1.25,
+                            wordBreak: 'break-word',
                           }}
                         >
                           Good First Issues
                         </Typography>
                       </Box>
                       <LaunchIcon
-                        sx={{ fontSize: 16, color: STATUS_COLORS.open, mt: 1 }}
+                        sx={{
+                          fontSize: 16,
+                          color: STATUS_COLORS.open,
+                          mt: 0.25,
+                          flexShrink: 0,
+                        }}
                       />
                     </Box>
                     <Typography
@@ -564,22 +576,26 @@ const RepositoryCheckTab: React.FC<RepositoryCheckTabProps> = ({
                 </Grid>
 
                 {/* Action: Help Wanted */}
-                <Grid item xs={12} md={3}>
+                <Grid item xs={6} md={6} lg={3}>
                   <Box
                     component="a"
                     href={`https://github.com/${repositoryFullName}/issues?q=is%3Aissue+is%3Aopen+label%3A"help+wanted"`}
                     target="_blank"
+                    rel="noopener noreferrer"
                     sx={{
                       p: 2,
                       borderRadius: 1,
                       bgcolor: 'rgba(255,255,255,0.03)',
                       border: '1px solid rgba(255,255,255,0.05)',
                       height: '100%',
+                      minWidth: 0,
                       display: 'flex',
                       flexDirection: 'column',
                       justifyContent: 'space-between',
                       textDecoration: 'none',
                       cursor: 'pointer',
+                      overflow: 'hidden',
+                      boxSizing: 'border-box',
                       transition: 'all 0.2s',
                       '&:hover': {
                         bgcolor: 'rgba(255,255,255,0.08)',
@@ -593,10 +609,12 @@ const RepositoryCheckTab: React.FC<RepositoryCheckTabProps> = ({
                         display: 'flex',
                         justifyContent: 'space-between',
                         alignItems: 'flex-start',
+                        gap: 1,
                         mb: 1,
+                        minWidth: 0,
                       }}
                     >
-                      <Box>
+                      <Box sx={{ minWidth: 0, flex: 1 }}>
                         <Typography
                           variant="h4"
                           sx={{
@@ -613,14 +631,20 @@ const RepositoryCheckTab: React.FC<RepositoryCheckTabProps> = ({
                             color: STATUS_COLORS.open,
                             fontSize: '12px',
                             fontWeight: 600,
-                            whiteSpace: 'nowrap',
+                            lineHeight: 1.25,
+                            wordBreak: 'break-word',
                           }}
                         >
                           Help Wanted
                         </Typography>
                       </Box>
                       <LaunchIcon
-                        sx={{ fontSize: 16, color: STATUS_COLORS.open, mt: 1 }}
+                        sx={{
+                          fontSize: 16,
+                          color: STATUS_COLORS.open,
+                          mt: 0.25,
+                          flexShrink: 0,
+                        }}
                       />
                     </Box>
                     <Typography

--- a/src/components/repositories/RepositoryContributorsTable.tsx
+++ b/src/components/repositories/RepositoryContributorsTable.tsx
@@ -125,12 +125,15 @@ const RepositoryContributorsTable: React.FC<
         </Typography>
       </Box>
 
-      {/* Header Row */}
+      {/* Header Row — minmax(0,1fr) prevents the miner column from forcing PRS/SCORE off-alignment */}
       <Box
         sx={{
           display: 'grid',
-          gridTemplateColumns: '32px 1fr 48px 75px',
-          gap: 1,
+          gridTemplateColumns:
+            '32px minmax(0, 1fr) minmax(3rem, auto) minmax(4.5rem, auto)',
+          columnGap: 1,
+          rowGap: 0,
+          alignItems: 'center',
           px: 1.5,
           py: 1,
           borderBottom: '1px solid rgba(255,255,255,0.1)',
@@ -147,6 +150,7 @@ const RepositoryContributorsTable: React.FC<
             fontSize: '11px',
             color: 'text.secondary',
             textAlign: 'right',
+            fontVariantNumeric: 'tabular-nums',
           }}
         >
           PRS
@@ -156,6 +160,7 @@ const RepositoryContributorsTable: React.FC<
             fontSize: '11px',
             color: 'text.secondary',
             textAlign: 'right',
+            fontVariantNumeric: 'tabular-nums',
           }}
         >
           SCORE
@@ -174,12 +179,15 @@ const RepositoryContributorsTable: React.FC<
               key={contributor.githubId}
               sx={{
                 display: 'grid',
-                gridTemplateColumns: '32px 1fr 48px 75px',
-                gap: 1,
+                gridTemplateColumns:
+                  '32px minmax(0, 1fr) minmax(3rem, auto) minmax(4.5rem, auto)',
+                columnGap: 1,
+                rowGap: 0,
                 px: 1.5,
                 py: 1,
                 borderBottom: '1px solid rgba(255,255,255,0.05)',
                 alignItems: 'center',
+                minWidth: 0,
                 opacity: isInactive ? 0.5 : 1,
                 '&:hover': {
                   backgroundColor: 'rgba(255,255,255,0.04)',
@@ -274,6 +282,8 @@ const RepositoryContributorsTable: React.FC<
                   fontSize: '12px',
                   color: '#c9d1d9',
                   fontFamily: '"JetBrains Mono", monospace',
+                  fontVariantNumeric: 'tabular-nums',
+                  minWidth: 0,
                 }}
               >
                 {contributor.prs}
@@ -286,6 +296,8 @@ const RepositoryContributorsTable: React.FC<
                   fontSize: '12px',
                   color: '#c9d1d9',
                   fontFamily: '"JetBrains Mono", monospace',
+                  fontVariantNumeric: 'tabular-nums',
+                  minWidth: 0,
                 }}
               >
                 {contributor.score.toFixed(2)}


### PR DESCRIPTION
## Summary

Fixes layout bugs on the repository **Repo Check** tab reported in #200:
- **Issue Analysis:** “Good First Issues” and “Help Wanted” cards could overflow their boxes and overlap the external-link icons because labels used `nowrap` and flex children lacked a proper minimum width. The four stat tiles were also too narrow in a single row at common desktop widths.
- **Top Miner Contributors:** The miner column used an unconstrained `1fr` track, so minimum content sizing could squeeze PRS/SCORE columns and misalign headers with numeric cells.

## Changes

- `RepositoryCheckTab.tsx`: Use `xs={6} md={6} lg={3}` for all four Issue Analysis tiles (2×2 from `md` until `lg`, four columns from `lg` up). Link cards: `minWidth: 0`, `overflow: hidden`, wrapping labels, `flexShrink: 0` on icons, `gap` between text and icon, `rel="noopener noreferrer"` on external links.
- `RepositoryContributorsTable.tsx`: `gridTemplateColumns: 32px minmax(0, 1fr) minmax(3rem, auto) minmax(4.5rem, auto)` for header and rows; `columnGap`; `tabular-nums` for PRS/SCORE; `minWidth: 0` where needed.


## Related Issues

Fixes #200

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Screenshots

<img width="687" height="485" alt="image" src="https://github.com/user-attachments/assets/a1ef189b-1422-46a1-9584-fea80296615d" />
<img width="622" height="554" alt="image" src="https://github.com/user-attachments/assets/a12c77a9-ba9e-42ea-b220-a1e505696507" />



## Testing

- Manually verified on repository page → **Repo Check** tab: Issue Analysis tiles stay inside borders; both link icons visible; no overlap.
- Checked **Top Miner Contributors** in the sidebar: PRS and SCORE line up under their headers with varied miner name lengths.
- `npm run build` passes.

## Checklist

- [x] New components are modularized/separated where sensible (N/A — layout fixes in existing components)
- [x] Uses predefined theme (e.g. no hardcoded colors) — existing `STATUS_COLORS` / patterns preserved
- [x] Responsive/mobile checked (Issue Analysis 2×2 / 4-col; table sidebar)
- [x] Tested against the test API (UI-only; GitHub API calls unchanged)
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [ ] Screenshots included for any UI/visual changes

