### PR TITLE
fix: preserve repository tab on back navigation and show correct committer

### DIFF
--- a/src/components/repositories/RepositoryCodeBrowser.tsx
+++ b/src/components/repositories/RepositoryCodeBrowser.tsx
@@ -109,9 +109,9 @@ const RepositoryCodeBrowser: React.FC<RepositoryCodeBrowserProps> = ({
             ...prev,
             [pathKey]: {
               message: c.commit.message,
-              author: c.commit.author.name,
+              author: c.author?.login || c.commit.author.name,
               avatarUrl: c.author?.avatar_url || '',
-              date: c.commit.author.date,
+              date: c.commit.committer?.date || c.commit.author.date,
               sha: c.sha.substring(0, 7),
             },
           }));

--- a/src/pages/RepositoryDetailsPage.tsx
+++ b/src/pages/RepositoryDetailsPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { useSearchParams, useNavigate } from 'react-router-dom';
 import {
   Alert,
@@ -61,10 +61,22 @@ function CustomTabPanel(props: TabPanelProps) {
 }
 
 const RepositoryDetailsPage: React.FC = () => {
-  const [searchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
   const navigate = useNavigate();
   const repo = searchParams.get('name');
-  const [tabValue, setTabValue] = useState(0);
+
+  const TAB_NAMES = [
+    'readme',
+    'code',
+    'issues',
+    'pull-requests',
+    'contributing',
+    'repo-check',
+  ] as const;
+  const tabParam = searchParams.get('tab');
+  const tabValue = tabParam
+    ? Math.max(0, TAB_NAMES.indexOf(tabParam as (typeof TAB_NAMES)[number]))
+    : 0;
   const { data: repos, isLoading: isLoadingRepos } = useReposAndWeights();
   const { data: bountySummary } = useRepoBountySummary(repo || '');
   const trackedRepo = repos?.find((r) => r.fullName === repo);
@@ -123,7 +135,10 @@ const RepositoryDetailsPage: React.FC = () => {
   }
 
   const handleTabChange = (_event: React.SyntheticEvent, newValue: number) => {
-    setTabValue(newValue);
+    const newParams = new URLSearchParams(searchParams);
+    if (newValue === 0) newParams.delete('tab');
+    else newParams.set('tab', TAB_NAMES[newValue]);
+    setSearchParams(newParams);
   };
 
   return (


### PR DESCRIPTION
## Summary

1. Persist active repository tab in URL search params (`?tab=pull-requests`) so navigating to PR detail and back preserves the selected tab instead of resetting to Readme.

2. Show GitHub account login (`c.author.login`) instead of git author name (`c.commit.author.name`) on the Code tab, matching GitHub's own commit display.

## Related Issues

Fixes #199

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Video

https://github.com/user-attachments/assets/d9a394d3-0aa9-48b9-8b98-a2d721108fd8

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes