### PR TITLE
fix: correct back for repository page, and correct commiter

### DIFF
--- a/src/components/repositories/RepositoryCodeBrowser.tsx
+++ b/src/components/repositories/RepositoryCodeBrowser.tsx
@@ -28,10 +28,94 @@ interface RepositoryCodeBrowserProps {
 
 interface CommitInfo {
   message: string;
-  author: string;
+  /** GitHub REST `User.login` — same handle as `https://github.com/{login}`. */
+  committerLogin: string;
   avatarUrl: string;
   date: string;
   sha: string;
+}
+
+/** GitHub user on a commit (`login` matches the profile URL path). */
+type GhCommitUser = {
+  id?: number;
+  login?: string;
+  avatar_url?: string;
+};
+
+/**
+ * Commits done via the GitHub UI use @web-flow as committer; the human is on `author`.
+ * Showing `web-flow` does not match github.com, which attributes the real user.
+ */
+const MECHANICAL_COMMITTER_LOGINS = new Set(['web-flow']);
+
+function isMechanicalCommitter(login: string | undefined): boolean {
+  if (!login) return false;
+  return MECHANICAL_COMMITTER_LOGINS.has(login.toLowerCase());
+}
+
+async function fetchCommitPayload(
+  repositoryFullName: string,
+  listCommit: {
+    sha: string;
+    commit: unknown;
+    author?: GhCommitUser | null;
+    committer?: GhCommitUser | null;
+  },
+) {
+  let c = listCommit;
+  if (!c.committer?.id && !c.committer?.login && c.sha) {
+    try {
+      const { data } = await axios.get(
+        `https://api.github.com/repos/${repositoryFullName}/commits/${c.sha}`,
+      );
+      c = data;
+    } catch {
+      // keep list payload
+    }
+  }
+  return c;
+}
+
+function resolveGithubCommitAttribution(
+  ghCommitter: GhCommitUser | null | undefined,
+  ghAuthor: GhCommitUser | null | undefined,
+  commit: {
+    committer?: { name?: string; email?: string; date?: string };
+    author?: { name?: string; date?: string };
+  },
+): { login: string; avatarUrl: string } {
+  if (isMechanicalCommitter(ghCommitter?.login) && ghAuthor?.login) {
+    return {
+      login: ghAuthor.login,
+      avatarUrl: ghAuthor.avatar_url || '',
+    };
+  }
+
+  if (ghCommitter?.login) {
+    return {
+      login: ghCommitter.login,
+      avatarUrl: ghCommitter.avatar_url || '',
+    };
+  }
+
+  if (ghAuthor?.login) {
+    return {
+      login: ghAuthor.login,
+      avatarUrl: ghAuthor.avatar_url || '',
+    };
+  }
+
+  if (ghCommitter?.id != null) {
+    return {
+      login: String(ghCommitter.id),
+      avatarUrl: ghCommitter.avatar_url || '',
+    };
+  }
+
+  return {
+    login: commit.committer?.name ?? commit.author?.name ?? '',
+    avatarUrl: '',
+  };
 }
 
 const RepositoryCodeBrowser: React.FC<RepositoryCodeBrowserProps> = ({
@@ -104,14 +188,28 @@ const RepositoryCodeBrowser: React.FC<RepositoryCodeBrowserProps> = ({
         );
 
         if (response.data && response.data.length > 0) {
-          const c = response.data[0];
+          const listCommit = response.data[0];
+          const c = await fetchCommitPayload(repositoryFullName, listCommit);
+          const commit = c.commit as {
+            message: string;
+            committer?: { name?: string; email?: string; date?: string };
+            author?: { date?: string };
+          };
+          const ghCommitter = c.committer as GhCommitUser | null | undefined;
+          const ghAuthor = c.author as GhCommitUser | null | undefined;
+          const { login: committerLogin, avatarUrl } =
+            resolveGithubCommitAttribution(ghCommitter, ghAuthor, commit);
+          const date =
+            isMechanicalCommitter(ghCommitter?.login) && ghAuthor?.login
+              ? commit.author?.date || commit.committer?.date || ''
+              : commit.committer?.date || commit.author?.date || '';
           setPathCommits((prev) => ({
             ...prev,
             [pathKey]: {
-              message: c.commit.message,
-              author: c.commit.author.name,
-              avatarUrl: c.author?.avatar_url || '',
-              date: c.commit.author.date,
+              message: commit.message,
+              committerLogin,
+              avatarUrl,
+              date,
               sha: c.sha.substring(0, 7),
             },
           }));
@@ -281,7 +379,7 @@ const RepositoryCodeBrowser: React.FC<RepositoryCodeBrowserProps> = ({
                     whiteSpace: 'nowrap',
                   }}
                 >
-                  {currentCommit.author}
+                  {currentCommit.committerLogin}
                 </Typography>
                 <Typography
                   sx={{

--- a/src/pages/RepositoryDetailsPage.tsx
+++ b/src/pages/RepositoryDetailsPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { useSearchParams, useNavigate } from 'react-router-dom';
 import {
   Alert,
@@ -60,11 +60,27 @@ function CustomTabPanel(props: TabPanelProps) {
   );
 }
 
+/** Synced to the `tab` query param so back navigation from PR details restores the active tab. */
+const REPO_TAB_KEYS = [
+  'readme',
+  'code',
+  'issues',
+  'pull-requests',
+  'contributing',
+  'repo-check',
+] as const;
+
+function tabIndexFromSearchParam(tab: string | null): number {
+  if (!tab) return 0;
+  const idx = REPO_TAB_KEYS.indexOf(tab as (typeof REPO_TAB_KEYS)[number]);
+  return idx >= 0 ? idx : 0;
+}
+
 const RepositoryDetailsPage: React.FC = () => {
-  const [searchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
   const navigate = useNavigate();
   const repo = searchParams.get('name');
-  const [tabValue, setTabValue] = useState(0);
+  const tabValue = tabIndexFromSearchParam(searchParams.get('tab'));
   const { data: repos, isLoading: isLoadingRepos } = useReposAndWeights();
   const { data: bountySummary } = useRepoBountySummary(repo || '');
   const trackedRepo = repos?.find((r) => r.fullName === repo);
@@ -123,7 +139,20 @@ const RepositoryDetailsPage: React.FC = () => {
   }
 
   const handleTabChange = (_event: React.SyntheticEvent, newValue: number) => {
-    setTabValue(newValue);
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        if (!repo) return next;
+        next.set('name', repo);
+        if (newValue === 0) {
+          next.delete('tab');
+        } else {
+          next.set('tab', REPO_TAB_KEYS[newValue]);
+        }
+        return next;
+      },
+      { replace: true },
+    );
   };
 
   return (


### PR DESCRIPTION
## Summary

This PR fixes Issue #199 : the repository detail view now remembers the selected tab when returning from a PR via the back button, and the Code tab shows commit attribution that matches GitHub.com (human login, not GitHub’s web merge bot).

## Changes

Repository tabs ↔ URL
The active tab on /miners/repository is stored in the tab query parameter (readme, code, issues, pull-requests, contributing, repo-check). Tab changes update the URL with replace: true so history stays clean. Navigating to a PR and using Back restores the same URL, so the correct tab is shown after remount.

Code tab “latest commit” line
Attribution uses GitHub’s REST payload: prefer the committer’s login and avatar when they represent a real user. If the committer is GitHub’s web-flow account (common for web-based merges), the UI shows the author’s login and avatar instead, consistent with what users see on GitHub. Fallbacks remain for edge cases without linked GitHub users.

## Related Issues

Fixes #199

## Type of Change

- [x ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots


https://github.com/user-attachments/assets/11fd057e-62fb-484c-9a5d-ec2cbf101b5f



## Testing

Manually verified: open a tracked repo → Pull Requests → open a PR → Back → still on Pull Requests tab (not Readme).
Manually verified: Code tab shows the expected GitHub handle (e.g. matching https://github.com/{login}), not web-flow, for commits where GitHub attributes the human author.

