### PR TITLE
refactor(issues): dedupe shared status/date/usd formatting

### DIFF
--- a/src/components/issues/IssueHeaderCard.tsx
+++ b/src/components/issues/IssueHeaderCard.tsx
@@ -5,70 +5,24 @@ import { IssueDetails } from '../../api/models/Issues';
 import { useStats } from '../../api';
 import { formatTokenAmount } from '../../utils/format';
 import { STATUS_COLORS } from '../../theme';
-
-const getStatusBadge = (
-  status: string,
-): { color: string; bgColor: string; text: string } => {
-  switch (status) {
-    case 'registered':
-      return {
-        color: STATUS_COLORS.warning,
-        bgColor: 'rgba(245, 158, 11, 0.15)',
-        text: 'Pending',
-      };
-    case 'active':
-      return {
-        color: STATUS_COLORS.info,
-        bgColor: 'rgba(88, 166, 255, 0.15)',
-        text: 'Available',
-      };
-    case 'completed':
-      return {
-        color: STATUS_COLORS.merged,
-        bgColor: 'rgba(63, 185, 80, 0.15)',
-        text: 'Completed',
-      };
-    case 'cancelled':
-      return {
-        color: STATUS_COLORS.error,
-        bgColor: 'rgba(239, 68, 68, 0.15)',
-        text: 'Cancelled',
-      };
-    default:
-      return {
-        color: STATUS_COLORS.open,
-        bgColor: 'rgba(139, 148, 158, 0.15)',
-        text: status,
-      };
-  }
-};
-
-const formatDate = (dateStr: string | null | undefined): string => {
-  if (!dateStr) return '-';
-  const date = new Date(dateStr);
-  return date.toLocaleDateString('en-US', {
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric',
-  });
-};
+import {
+  formatIssueDate,
+  formatIssueUsdEstimate,
+  getIssueStatusBadge,
+} from './issueFormatting';
 
 interface IssueHeaderCardProps {
   issue: IssueDetails;
 }
 
 const IssueHeaderCard: React.FC<IssueHeaderCardProps> = ({ issue }) => {
-  const statusBadge = getStatusBadge(issue.status);
+  const statusBadge = getIssueStatusBadge(issue.status);
   const { data: dashStats } = useStats();
   const taoPrice = dashStats?.prices?.tao?.data?.price ?? 0;
   const alphaPrice = dashStats?.prices?.alpha?.data?.price ?? 0;
 
   const usdEstimate = React.useMemo(() => {
-    if (taoPrice <= 0 || alphaPrice <= 0) return null;
-    const amount = parseFloat(issue.targetBounty);
-    if (isNaN(amount) || amount === 0) return null;
-    const usd = amount * alphaPrice * taoPrice;
-    return `~${usd.toLocaleString('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 })}`;
+    return formatIssueUsdEstimate(issue.targetBounty, taoPrice, alphaPrice);
   }, [issue.targetBounty, taoPrice, alphaPrice]);
 
   return (
@@ -276,7 +230,7 @@ const IssueHeaderCard: React.FC<IssueHeaderCardProps> = ({ issue }) => {
                 color: '#ffffff',
               }}
             >
-              {formatDate(issue.createdAt)}
+              {formatIssueDate(issue.createdAt)}
             </Typography>
           </Box>
         </Box>

--- a/src/components/issues/IssueStats.tsx
+++ b/src/components/issues/IssueStats.tsx
@@ -5,18 +5,7 @@ import { useStats } from '../../api';
 import KpiCard from '../dashboard/KpiCard';
 import { formatTokenAmount } from '../../utils/format';
 import { STATUS_COLORS } from '../../theme';
-
-const formatUsd = (
-  alphaAmount: string | undefined,
-  taoPrice: number,
-  alphaPrice: number,
-): string | undefined => {
-  if (!alphaAmount) return undefined;
-  const amount = parseFloat(alphaAmount);
-  if (isNaN(amount) || amount === 0) return undefined;
-  const usd = amount * alphaPrice * taoPrice;
-  return `~${usd.toLocaleString('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 })}`;
-};
+import { formatIssueUsdEstimate } from './issueFormatting';
 
 interface IssueStatsProps {
   stats?: IssuesStats;
@@ -76,7 +65,11 @@ const IssueStats: React.FC<IssueStatsProps> = ({
           value={`${formatTokenAmount(stats?.totalBountyPool)} ل`}
           subtitle={
             hasPrices
-              ? (formatUsd(stats?.totalBountyPool, taoPrice, alphaPrice) ??
+              ? (formatIssueUsdEstimate(
+                  stats?.totalBountyPool,
+                  taoPrice,
+                  alphaPrice,
+                ) ??
                 'Total available')
               : 'Total available'
           }
@@ -88,7 +81,11 @@ const IssueStats: React.FC<IssueStatsProps> = ({
           value={`${formatTokenAmount(stats?.totalPayouts)} ل`}
           subtitle={
             hasPrices
-              ? (formatUsd(stats?.totalPayouts, taoPrice, alphaPrice) ??
+              ? (formatIssueUsdEstimate(
+                  stats?.totalPayouts,
+                  taoPrice,
+                  alphaPrice,
+                ) ??
                 'Paid to solvers')
               : 'Paid to solvers'
           }

--- a/src/components/issues/IssueStats.tsx
+++ b/src/components/issues/IssueStats.tsx
@@ -69,8 +69,7 @@ const IssueStats: React.FC<IssueStatsProps> = ({
                   stats?.totalBountyPool,
                   taoPrice,
                   alphaPrice,
-                ) ??
-                'Total available')
+                ) ?? 'Total available')
               : 'Total available'
           }
         />
@@ -85,8 +84,7 @@ const IssueStats: React.FC<IssueStatsProps> = ({
                   stats?.totalPayouts,
                   taoPrice,
                   alphaPrice,
-                ) ??
-                'Paid to solvers')
+                ) ?? 'Paid to solvers')
               : 'Paid to solvers'
           }
           sx={{

--- a/src/components/issues/IssueSubmissionsTable.tsx
+++ b/src/components/issues/IssueSubmissionsTable.tsx
@@ -17,16 +17,7 @@ import {
 import EmojiEventsIcon from '@mui/icons-material/EmojiEvents';
 import { IssueSubmission } from '../../api/models/Issues';
 import { STATUS_COLORS } from '../../theme';
-
-const formatDate = (dateStr: string | null | undefined): string => {
-  if (!dateStr) return '-';
-  const date = new Date(dateStr);
-  return date.toLocaleDateString('en-US', {
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric',
-  });
-};
+import { formatIssueDate } from './issueFormatting';
 
 const headerCellSx = {
   fontFamily: '"JetBrains Mono", monospace',
@@ -247,7 +238,7 @@ const IssueSubmissionsTable: React.FC<IssueSubmissionsTableProps> = ({
                         color: 'rgba(255, 255, 255, 0.6)',
                       }}
                     >
-                      {formatDate(submission.prCreatedAt)}
+                      {formatIssueDate(submission.prCreatedAt)}
                     </Typography>
                   </TableCell>
                 </TableRow>

--- a/src/components/issues/IssuesList.tsx
+++ b/src/components/issues/IssuesList.tsx
@@ -21,6 +21,11 @@ import { useStats } from '../../api';
 import { formatTokenAmount } from '../../utils/format';
 import { STATUS_COLORS } from '../../theme';
 import BountyProgress from './BountyProgress';
+import {
+  formatIssueDate,
+  formatIssueUsdEstimate,
+  getIssueStatusBadge,
+} from './issueFormatting';
 
 type ListType = 'available' | 'pending' | 'history';
 
@@ -30,59 +35,6 @@ interface IssuesListProps {
   listType: ListType;
   onSelectIssue?: (id: number) => void;
 }
-
-/**
- * Get status badge color and text
- */
-const getStatusBadge = (
-  status: IssueBounty['status'],
-): { color: string; bgColor: string; text: string } => {
-  switch (status) {
-    case 'registered':
-      return {
-        color: STATUS_COLORS.warning,
-        bgColor: 'rgba(245, 158, 11, 0.15)',
-        text: 'Pending',
-      };
-    case 'active':
-      return {
-        color: STATUS_COLORS.info,
-        bgColor: 'rgba(88, 166, 255, 0.15)',
-        text: 'Available',
-      };
-    case 'completed':
-      return {
-        color: STATUS_COLORS.merged,
-        bgColor: 'rgba(63, 185, 80, 0.15)',
-        text: 'Completed',
-      };
-    case 'cancelled':
-      return {
-        color: STATUS_COLORS.error,
-        bgColor: 'rgba(239, 68, 68, 0.15)',
-        text: 'Cancelled',
-      };
-    default:
-      return {
-        color: STATUS_COLORS.open,
-        bgColor: 'rgba(139, 148, 158, 0.15)',
-        text: status,
-      };
-  }
-};
-
-/**
- * Format date for display
- */
-const formatDate = (dateStr: string | null | undefined): string => {
-  if (!dateStr) return '-';
-  const date = new Date(dateStr);
-  return date.toLocaleDateString('en-US', {
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric',
-  });
-};
 
 /**
  * Truncate wallet address for display
@@ -103,13 +55,8 @@ const IssuesList: React.FC<IssuesListProps> = ({
   const taoPrice = dashStats?.prices?.tao?.data?.price ?? 0;
   const alphaPrice = dashStats?.prices?.alpha?.data?.price ?? 0;
 
-  const toUsd = (alphaAmount: string): string | null => {
-    if (taoPrice <= 0 || alphaPrice <= 0) return null;
-    const amount = parseFloat(alphaAmount);
-    if (isNaN(amount) || amount === 0) return null;
-    const usd = amount * alphaPrice * taoPrice;
-    return `~${usd.toLocaleString('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 })}`;
-  };
+  const toUsd = (alphaAmount: string): string | null =>
+    formatIssueUsdEstimate(alphaAmount, taoPrice, alphaPrice);
   const headerCellSx = {
     fontFamily: '"JetBrains Mono", monospace',
     fontSize: '0.7rem',
@@ -264,7 +211,7 @@ const IssuesList: React.FC<IssuesListProps> = ({
           </TableHead>
           <TableBody>
             {issues.map((issue) => {
-              const statusBadge = getStatusBadge(issue.status);
+              const statusBadge = getIssueStatusBadge(issue.status);
 
               return (
                 <TableRow
@@ -526,7 +473,7 @@ const IssuesList: React.FC<IssuesListProps> = ({
                             color: 'rgba(255, 255, 255, 0.6)',
                           }}
                         >
-                          {formatDate(issue.completedAt || issue.updatedAt)}
+                          {formatIssueDate(issue.completedAt || issue.updatedAt)}
                         </Typography>
                       </TableCell>
                     </>

--- a/src/components/issues/IssuesList.tsx
+++ b/src/components/issues/IssuesList.tsx
@@ -473,7 +473,9 @@ const IssuesList: React.FC<IssuesListProps> = ({
                             color: 'rgba(255, 255, 255, 0.6)',
                           }}
                         >
-                          {formatIssueDate(issue.completedAt || issue.updatedAt)}
+                          {formatIssueDate(
+                            issue.completedAt || issue.updatedAt,
+                          )}
                         </Typography>
                       </TableCell>
                     </>

--- a/src/components/issues/issueFormatting.ts
+++ b/src/components/issues/issueFormatting.ts
@@ -1,0 +1,78 @@
+import { type IssueBounty } from '../../api/models/Issues';
+import { STATUS_COLORS } from '../../theme';
+
+export type IssueStatusBadge = {
+  color: string;
+  bgColor: string;
+  text: string;
+};
+
+export const getIssueStatusBadge = (
+  status: IssueBounty['status'] | string,
+): IssueStatusBadge => {
+  switch (status) {
+    case 'registered':
+      return {
+        color: STATUS_COLORS.warning,
+        bgColor: 'rgba(245, 158, 11, 0.15)',
+        text: 'Pending',
+      };
+    case 'active':
+      return {
+        color: STATUS_COLORS.info,
+        bgColor: 'rgba(88, 166, 255, 0.15)',
+        text: 'Available',
+      };
+    case 'completed':
+      return {
+        color: STATUS_COLORS.merged,
+        bgColor: 'rgba(63, 185, 80, 0.15)',
+        text: 'Completed',
+      };
+    case 'cancelled':
+      return {
+        color: STATUS_COLORS.error,
+        bgColor: 'rgba(239, 68, 68, 0.15)',
+        text: 'Cancelled',
+      };
+    default:
+      return {
+        color: STATUS_COLORS.open,
+        bgColor: 'rgba(139, 148, 158, 0.15)',
+        text: status,
+      };
+  }
+};
+
+export const formatIssueDate = (
+  dateStr: string | null | undefined,
+): string => {
+  if (!dateStr) return '-';
+  const date = new Date(dateStr);
+  return date.toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+};
+
+export const formatIssueUsdEstimate = (
+  alphaAmount: string | number | null | undefined,
+  taoPrice: number,
+  alphaPrice: number,
+): string | null => {
+  if (taoPrice <= 0 || alphaPrice <= 0) return null;
+
+  const amount =
+    typeof alphaAmount === 'string'
+      ? parseFloat(alphaAmount)
+      : (alphaAmount ?? NaN);
+  if (isNaN(amount) || amount === 0) return null;
+
+  const usd = amount * alphaPrice * taoPrice;
+  return `~${usd.toLocaleString('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits: 0,
+  })}`;
+};

--- a/src/components/issues/issueFormatting.ts
+++ b/src/components/issues/issueFormatting.ts
@@ -44,9 +44,7 @@ export const getIssueStatusBadge = (
   }
 };
 
-export const formatIssueDate = (
-  dateStr: string | null | undefined,
-): string => {
+export const formatIssueDate = (dateStr: string | null | undefined): string => {
   if (!dateStr) return '-';
   const date = new Date(dateStr);
   return date.toLocaleDateString('en-US', {


### PR DESCRIPTION
## Summary
- extract duplicated issue UI formatting logic into a shared helper module
- replace per-component status/date/USD formatting helpers
- keep existing display behavior while reducing duplication

## Changes
- add src/components/issues/issueFormatting.ts with:
  - getIssueStatusBadge
  - formatIssueDate
  - formatIssueUsdEstimate
- update:
  - src/components/issues/IssueHeaderCard.tsx
  - src/components/issues/IssuesList.tsx
  - src/components/issues/IssueStats.tsx
  - src/components/issues/IssueSubmissionsTable.tsx

## Validation
- npx eslint src/components/issues/issueFormatting.ts src/components/issues/IssueHeaderCard.tsx src/components/issues/IssuesList.tsx src/components/issues/IssueStats.tsx src/components/issues/IssueSubmissionsTable.tsx
- npm run lint
- npm run build
