### PR TITLE
refactor: Extract duplicated formatDate to shared utils

### DIFF
--- a/src/components/issues/IssueHeaderCard.tsx
+++ b/src/components/issues/IssueHeaderCard.tsx
@@ -3,19 +3,9 @@ import { Box, Card, Typography, Chip, Link, Stack } from '@mui/material';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import { IssueDetails } from '../../api/models/Issues';
 import { useStats } from '../../api';
-import { formatTokenAmount } from '../../utils/format';
+import { formatTokenAmount, formatDate } from '../../utils/format';
 import { getIssueStatusMeta } from '../../utils/issueStatus';
 import { STATUS_COLORS } from '../../theme';
-
-const formatDate = (dateStr: string | null | undefined): string => {
-  if (!dateStr) return '-';
-  const date = new Date(dateStr);
-  return date.toLocaleDateString('en-US', {
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric',
-  });
-};
 
 interface IssueHeaderCardProps {
   issue: IssueDetails;

--- a/src/components/issues/IssueSubmissionsTable.tsx
+++ b/src/components/issues/IssueSubmissionsTable.tsx
@@ -17,16 +17,7 @@ import {
 import EmojiEventsIcon from '@mui/icons-material/EmojiEvents';
 import { IssueSubmission } from '../../api/models/Issues';
 import { STATUS_COLORS } from '../../theme';
-
-const formatDate = (dateStr: string | null | undefined): string => {
-  if (!dateStr) return '-';
-  const date = new Date(dateStr);
-  return date.toLocaleDateString('en-US', {
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric',
-  });
-};
+import { formatDate } from '../../utils/format';
 
 const headerCellSx = {
   fontFamily: '"JetBrains Mono", monospace',

--- a/src/components/issues/IssuesList.tsx
+++ b/src/components/issues/IssuesList.tsx
@@ -32,7 +32,6 @@ interface IssuesListProps {
   onSelectIssue?: (id: number) => void;
 }
 
-
 /**
  * Truncate wallet address for display
  */

--- a/src/components/issues/IssuesList.tsx
+++ b/src/components/issues/IssuesList.tsx
@@ -18,7 +18,7 @@ import {
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import { IssueBounty } from '../../api/models/Issues';
 import { useStats } from '../../api';
-import { formatTokenAmount } from '../../utils/format';
+import { formatTokenAmount, formatDate } from '../../utils/format';
 import { getIssueStatusMeta } from '../../utils/issueStatus';
 import { STATUS_COLORS } from '../../theme';
 import BountyProgress from './BountyProgress';
@@ -32,18 +32,6 @@ interface IssuesListProps {
   onSelectIssue?: (id: number) => void;
 }
 
-/**
- * Format date for display
- */
-const formatDate = (dateStr: string | null | undefined): string => {
-  if (!dateStr) return '-';
-  const date = new Date(dateStr);
-  return date.toLocaleDateString('en-US', {
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric',
-  });
-};
 
 /**
  * Truncate wallet address for display

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,3 +1,4 @@
+import { format } from 'date-fns';
 import { CREDIBILITY_COLORS } from '../theme';
 
 /**
@@ -37,12 +38,7 @@ export const truncateText = (text: string, maxLength: number): string => {
 
 export const formatDate = (dateStr: string | null | undefined): string => {
   if (!dateStr) return '-';
-  const date = new Date(dateStr);
-  return date.toLocaleDateString('en-US', {
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric',
-  });
+  return format(new Date(dateStr), 'MMM d, yyyy');
 };
 
 export const formatUsdEstimate = (

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -35,6 +35,16 @@ export const truncateText = (text: string, maxLength: number): string => {
   return text.length > maxLength ? `${text.substring(0, maxLength)}...` : text;
 };
 
+export const formatDate = (dateStr: string | null | undefined): string => {
+  if (!dateStr) return '-';
+  const date = new Date(dateStr);
+  return date.toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+};
+
 export const formatUsdEstimate = (
   value: number | null | undefined,
   options?: { includeApproxPrefix?: boolean; showZero?: boolean },


### PR DESCRIPTION
The `formatDate` function was copy-pasted identically across three issue components. Moved it to `src/utils/format.ts` and updated all consumers to import from the shared location.

- Removed duplicate from `IssueHeaderCard.tsx`
- Removed duplicate from `IssueSubmissionsTable.tsx`
- Removed duplicate from `IssuesList.tsx`

No functional changes.