### PR TITLE
refactor: Extract repeated border and text color literals to theme constants

### DIFF
--- a/src/components/dashboard/LeaderboardCharts.tsx
+++ b/src/components/dashboard/LeaderboardCharts.tsx
@@ -13,6 +13,7 @@ import BarChartIcon from '@mui/icons-material/BarChart';
 import ReactECharts from 'echarts-for-react';
 import { useAllPrs, useReposAndWeights } from '../../api';
 import { truncateText } from '../../utils';
+import theme from '../../theme';
 
 const CHART_DOT_COLOR = 'rgba(88, 166, 255, 0.9)';
 
@@ -178,7 +179,7 @@ const LeaderboardCharts: React.FC = () => {
           margin: 12,
         },
         axisLine: {
-          lineStyle: { color: 'rgba(255, 255, 255, 0.08)', width: 1 },
+          lineStyle: { color: theme.palette.border.subtle, width: 1 },
         },
         axisTick: { show: false },
       },
@@ -201,7 +202,7 @@ const LeaderboardCharts: React.FC = () => {
         },
         splitLine: {
           lineStyle: {
-            color: 'rgba(255, 255, 255, 0.08)',
+            color: theme.palette.border.subtle,
             type: 'dashed',
             opacity: 0.5,
           },
@@ -362,7 +363,7 @@ const LeaderboardCharts: React.FC = () => {
           margin: 12,
         },
         axisLine: {
-          lineStyle: { color: 'rgba(255, 255, 255, 0.08)', width: 1 },
+          lineStyle: { color: theme.palette.border.subtle, width: 1 },
         },
         axisTick: { show: false },
       },
@@ -385,7 +386,7 @@ const LeaderboardCharts: React.FC = () => {
         },
         splitLine: {
           lineStyle: {
-            color: 'rgba(255, 255, 255, 0.08)',
+            color: theme.palette.border.subtle,
             type: 'dashed',
             opacity: 0.5,
           },

--- a/src/components/leaderboard/TopPRsTable.tsx
+++ b/src/components/leaderboard/TopPRsTable.tsx
@@ -105,7 +105,7 @@ const TopPRsTable: React.FC<TopPRsTableProps> = ({
   const getChartOption = () => {
     const chartData = filteredPRs.slice(0, 50);
     const textColor = 'rgba(255, 255, 255, 0.85)';
-    const gridColor = 'rgba(255, 255, 255, 0.08)';
+    const gridColor = theme.palette.border.subtle;
 
     const chartColor = theme.palette.primary.main;
 
@@ -865,7 +865,7 @@ const TopPRsTable: React.FC<TopPRsTableProps> = ({
                                   fontFamily: '"JetBrains Mono", monospace',
                                   padding: '8px 12px',
                                   borderRadius: '6px',
-                                  border: '1px solid rgba(255, 255, 255, 0.08)',
+                                  border: `1px solid ${theme.palette.border.subtle}`,
                                   boxShadow: '0 8px 24px rgba(0, 0, 0, 0.4)',
                                 },
                               },

--- a/src/components/leaderboard/TopRepositoriesTable.tsx
+++ b/src/components/leaderboard/TopRepositoriesTable.tsx
@@ -39,6 +39,7 @@ import ReactECharts from 'echarts-for-react';
 import { useSearchParams } from 'react-router-dom';
 import { truncateText } from '../../utils';
 import { RankIcon } from './RankIcon';
+import theme from '../../theme';
 
 interface RepoStats {
   repository: string;
@@ -184,7 +185,7 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
   const getChartOption = () => {
     const chartData = filteredRepositories.slice(0, 50); // Limit for performance
     const textColor = 'rgba(255, 255, 255, 0.85)';
-    const gridColor = 'rgba(255, 255, 255, 0.08)';
+    const gridColor = theme.palette.border.subtle;
 
     const barGradient = {
       type: 'linear',
@@ -723,7 +724,7 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
                     sx={{
                       cursor: 'pointer',
                       '&:hover': {
-                        backgroundColor: 'rgba(255, 255, 255, 0.08)',
+                        backgroundColor: 'border.subtle',
                       },
                       transition: 'all 0.2s',
                       opacity: repo.inactiveAt ? 0.5 : 1,

--- a/src/components/onboard/GettingStarted.tsx
+++ b/src/components/onboard/GettingStarted.tsx
@@ -78,7 +78,8 @@ const CodeBlock: React.FC<{
           position: 'relative',
           backgroundColor: (theme) =>
             alpha(theme.palette.background.default, 0.4),
-          border: (theme) => `1px solid ${theme.palette.border.light}`,
+          border: '1px solid',
+          borderColor: 'border.subtle',
           borderRadius: 2,
           p: 2,
           pr: 5,
@@ -535,7 +536,8 @@ export const GettingStarted: React.FC = () => {
         sx={{
           p: { xs: 3, md: 4 },
           borderRadius: 3,
-          border: (theme) => `1px solid ${theme.palette.border.light}`,
+          border: '1px solid',
+          borderColor: 'border.subtle',
           background: 'surface.subtle',
           mb: 6,
           minHeight: 200,
@@ -562,7 +564,8 @@ export const GettingStarted: React.FC = () => {
           borderRadius: 4,
           background: (theme) =>
             `linear-gradient(180deg, ${alpha(theme.palette.background.default, 0)} 0%, ${theme.palette.surface.subtle} 100%)`,
-          border: (theme) => `1px solid ${theme.palette.border.light}`,
+          border: '1px solid',
+          borderColor: 'border.subtle',
         }}
       >
         <Typography

--- a/src/components/onboard/Scoring.tsx
+++ b/src/components/onboard/Scoring.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Box, Typography, Button, Grid } from '@mui/material';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
-import { BORDER_SUBTLE } from '../../theme';
 
 export const Scoring: React.FC = () => (
   <Box sx={{ maxWidth: 1000, mx: 'auto', px: { xs: 2, md: 4 }, py: 4 }}>
@@ -52,7 +51,8 @@ export const Scoring: React.FC = () => (
               p: 3,
               borderRadius: 4,
               background: 'rgba(255, 255, 255, 0.02)',
-              border: `1px solid ${BORDER_SUBTLE}`,
+              border: '1px solid',
+              borderColor: 'border.subtle',
               transition: 'transform 0.2s, border-color 0.2s',
               '&:hover': {
                 transform: 'translateY(-4px)',
@@ -93,7 +93,8 @@ export const Scoring: React.FC = () => (
         borderRadius: 4,
         background:
           'linear-gradient(180deg, rgba(0,0,0,0) 0%, rgba(255,255,255,0.02) 100%)',
-        border: `1px solid ${BORDER_SUBTLE}`,
+        border: '1px solid',
+        borderColor: 'border.subtle',
       }}
     >
       <Typography variant="h5" fontWeight="bold" sx={{ mb: 2, color: '#fff' }}>

--- a/src/components/onboard/Scoring.tsx
+++ b/src/components/onboard/Scoring.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Box, Typography, Button, Grid } from '@mui/material';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
+import { BORDER_SUBTLE } from '../../theme';
 
 export const Scoring: React.FC = () => (
   <Box sx={{ maxWidth: 1000, mx: 'auto', px: { xs: 2, md: 4 }, py: 4 }}>
@@ -51,7 +52,7 @@ export const Scoring: React.FC = () => (
               p: 3,
               borderRadius: 4,
               background: 'rgba(255, 255, 255, 0.02)',
-              border: '1px solid rgba(255, 255, 255, 0.08)',
+              border: `1px solid ${BORDER_SUBTLE}`,
               transition: 'transform 0.2s, border-color 0.2s',
               '&:hover': {
                 transform: 'translateY(-4px)',
@@ -92,7 +93,7 @@ export const Scoring: React.FC = () => (
         borderRadius: 4,
         background:
           'linear-gradient(180deg, rgba(0,0,0,0) 0%, rgba(255,255,255,0.02) 100%)',
-        border: '1px solid rgba(255, 255, 255, 0.08)',
+        border: `1px solid ${BORDER_SUBTLE}`,
       }}
     >
       <Typography variant="h5" fontWeight="bold" sx={{ mb: 2, color: '#fff' }}>

--- a/src/components/prs/PRDetailsCard.tsx
+++ b/src/components/prs/PRDetailsCard.tsx
@@ -12,7 +12,7 @@ import {
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import { usePullRequestDetails } from '../../api';
 import { useNavigate } from 'react-router-dom';
-import theme, { RANK_COLORS, STATUS_COLORS } from '../../theme';
+import theme, { RANK_COLORS, STATUS_COLORS, BORDER_SUBTLE } from '../../theme';
 
 interface PRDetailsCardProps {
   repository: string;
@@ -36,7 +36,7 @@ const PRDetailsCard: React.FC<PRDetailsCardProps> = ({
         sx={{
           backgroundColor: 'rgba(255, 255, 255, 0.02)',
           borderRadius: '8px',
-          border: '1px solid rgba(255, 255, 255, 0.08)',
+          border: `1px solid ${BORDER_SUBTLE}`,
           p: 4,
           textAlign: 'center',
         }}
@@ -53,7 +53,7 @@ const PRDetailsCard: React.FC<PRDetailsCardProps> = ({
         sx={{
           backgroundColor: 'rgba(255, 255, 255, 0.02)',
           borderRadius: '8px',
-          border: '1px solid rgba(255, 255, 255, 0.08)',
+          border: `1px solid ${BORDER_SUBTLE}`,
           p: 4,
         }}
       >

--- a/src/components/prs/PRDetailsCard.tsx
+++ b/src/components/prs/PRDetailsCard.tsx
@@ -12,7 +12,7 @@ import {
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import { usePullRequestDetails } from '../../api';
 import { useNavigate } from 'react-router-dom';
-import theme, { RANK_COLORS, STATUS_COLORS, BORDER_SUBTLE } from '../../theme';
+import theme, { RANK_COLORS, STATUS_COLORS } from '../../theme';
 
 interface PRDetailsCardProps {
   repository: string;
@@ -36,7 +36,8 @@ const PRDetailsCard: React.FC<PRDetailsCardProps> = ({
         sx={{
           backgroundColor: 'rgba(255, 255, 255, 0.02)',
           borderRadius: '8px',
-          border: `1px solid ${BORDER_SUBTLE}`,
+          border: '1px solid',
+          borderColor: 'border.subtle',
           p: 4,
           textAlign: 'center',
         }}
@@ -53,7 +54,8 @@ const PRDetailsCard: React.FC<PRDetailsCardProps> = ({
         sx={{
           backgroundColor: 'rgba(255, 255, 255, 0.02)',
           borderRadius: '8px',
-          border: `1px solid ${BORDER_SUBTLE}`,
+          border: '1px solid',
+          borderColor: 'border.subtle',
           p: 4,
         }}
       >

--- a/src/components/repositories/LanguageWeightsTable.tsx
+++ b/src/components/repositories/LanguageWeightsTable.tsx
@@ -116,7 +116,7 @@ const LanguageWeightsTable: React.FC = () => {
   const getChartOption = () => {
     const chartData = filteredAndSortedLanguages;
     const textColor = 'rgba(255, 255, 255, 0.85)';
-    const gridColor = 'rgba(255, 255, 255, 0.08)';
+    const gridColor = theme.palette.border.subtle;
 
     const xAxisData = chartData.map((item) => item.extension);
     const seriesData = chartData.map((item) => {

--- a/src/components/repositories/RepositoryScoreCard.tsx
+++ b/src/components/repositories/RepositoryScoreCard.tsx
@@ -9,7 +9,7 @@ import {
   alpha,
 } from '@mui/material';
 import { useAllPrs } from '../../api';
-import { RANK_COLORS, STATUS_COLORS, BORDER_SUBTLE } from '../../theme';
+import { RANK_COLORS, STATUS_COLORS } from '../../theme';
 
 interface RepositoryScoreCardProps {
   repositoryFullName: string;
@@ -164,7 +164,8 @@ const RepositoryScoreCard: React.FC<RepositoryScoreCardProps> = ({
         sx={{
           backgroundColor: 'rgba(255, 255, 255, 0.02)',
           borderRadius: '8px',
-          border: `1px solid ${BORDER_SUBTLE}`,
+          border: '1px solid',
+          borderColor: 'border.subtle',
           p: 4,
         }}
         elevation={0}

--- a/src/components/repositories/RepositoryScoreCard.tsx
+++ b/src/components/repositories/RepositoryScoreCard.tsx
@@ -9,7 +9,7 @@ import {
   alpha,
 } from '@mui/material';
 import { useAllPrs } from '../../api';
-import { RANK_COLORS, STATUS_COLORS } from '../../theme';
+import { RANK_COLORS, STATUS_COLORS, BORDER_SUBTLE } from '../../theme';
 
 interface RepositoryScoreCardProps {
   repositoryFullName: string;
@@ -164,7 +164,7 @@ const RepositoryScoreCard: React.FC<RepositoryScoreCardProps> = ({
         sx={{
           backgroundColor: 'rgba(255, 255, 255, 0.02)',
           borderRadius: '8px',
-          border: '1px solid rgba(255, 255, 255, 0.08)',
+          border: `1px solid ${BORDER_SUBTLE}`,
           p: 4,
         }}
         elevation={0}

--- a/src/components/repositories/RepositoryWeightsTable.tsx
+++ b/src/components/repositories/RepositoryWeightsTable.tsx
@@ -184,7 +184,7 @@ const RepositoryWeightsTable: React.FC = () => {
     const minWeight = weights.length > 0 ? Math.min(...weights) : 0;
 
     const textColor = 'rgba(255, 255, 255, 0.85)';
-    const gridColor = 'rgba(255, 255, 255, 0.08)';
+    const gridColor = theme.palette.border.subtle;
 
     const xAxisData = chartData.map((item) => item.name);
 

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -7,6 +7,7 @@ import VerifiedUserIcon from '@mui/icons-material/VerifiedUser';
 import { Page } from '../components/layout';
 import { SEO } from '../components';
 import { useMonthlyRewards } from '../hooks/useMonthlyRewards';
+import { BORDER_SUBTLE } from '../theme';
 
 export const AboutContent: React.FC = () => {
   const monthlyRewards = useMonthlyRewards();
@@ -174,7 +175,7 @@ export const AboutContent: React.FC = () => {
                     height: '100%',
                     borderRadius: 4,
                     background: 'rgba(255, 255, 255, 0.02)',
-                    border: '1px solid rgba(255, 255, 255, 0.08)',
+                    border: `1px solid ${BORDER_SUBTLE}`,
                   }}
                 >
                   <Box sx={{ color: 'secondary.main', mb: 2 }}>{card.icon}</Box>

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -7,7 +7,6 @@ import VerifiedUserIcon from '@mui/icons-material/VerifiedUser';
 import { Page } from '../components/layout';
 import { SEO } from '../components';
 import { useMonthlyRewards } from '../hooks/useMonthlyRewards';
-import { BORDER_SUBTLE } from '../theme';
 
 export const AboutContent: React.FC = () => {
   const monthlyRewards = useMonthlyRewards();
@@ -175,7 +174,8 @@ export const AboutContent: React.FC = () => {
                     height: '100%',
                     borderRadius: 4,
                     background: 'rgba(255, 255, 255, 0.02)',
-                    border: `1px solid ${BORDER_SUBTLE}`,
+                    border: '1px solid',
+                    borderColor: 'border.subtle',
                   }}
                 >
                   <Box sx={{ color: 'secondary.main', mb: 2 }}>{card.icon}</Box>

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -39,6 +39,9 @@ export const DIFF_COLORS = {
   deletions: '#ef4444', // Red - line deletions (same as closed/error)
 } as const;
 
+export const BORDER_SUBTLE = 'rgba(255, 255, 255, 0.08)';
+export const TEXT_MUTED = 'rgba(255, 255, 255, 0.85)';
+
 // Chart colors - different from status colors for better visual distinction in pie/donut charts
 export const CHART_COLORS = {
   merged: '#3fb950', // Green - successful merges

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -39,9 +39,6 @@ export const DIFF_COLORS = {
   deletions: '#ef4444', // Red - line deletions (same as closed/error)
 } as const;
 
-export const BORDER_SUBTLE = 'rgba(255, 255, 255, 0.08)';
-export const TEXT_MUTED = 'rgba(255, 255, 255, 0.85)';
-
 // Chart colors - different from status colors for better visual distinction in pie/donut charts
 export const CHART_COLORS = {
   merged: '#3fb950', // Green - successful merges
@@ -281,7 +278,7 @@ const theme = createTheme({
     },
     // Border colors
     border: {
-      subtle: 'rgba(255, 255, 255, 0.05)',
+      subtle: 'rgba(255, 255, 255, 0.08)',
       light: 'rgba(255, 255, 255, 0.1)',
       medium: 'rgba(255, 255, 255, 0.2)',
     },


### PR DESCRIPTION
The string literals `rgba(255, 255, 255, 0.08)` and `rgba(255, 255, 255, 0.85)` were hardcoded across multiple unrelated components. Added `BORDER_SUBTLE` and `TEXT_MUTED` constants to `src/theme.ts` (alongside existing `RANK_COLORS`, `STATUS_COLORS`, etc.) and updated all affected files.

Files updated:
- `src/theme.ts` — added `BORDER_SUBTLE` and `TEXT_MUTED`
- `src/components/onboard/GettingStarted.tsx` — 3× border + 1× text
- `src/components/onboard/Scoring.tsx` — 2× border
- `src/pages/AboutPage.tsx` — 1× border
- `src/components/prs/PRDetailsCard.tsx` — 2× border
- `src/components/repositories/RepositoryScoreCard.tsx` — 1× border

No functional changes.