### PR TITLE
refactor: Extract duplicated FilterButton into shared component

### DIFF
--- a/src/components/FilterButton.tsx
+++ b/src/components/FilterButton.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { Button } from '@mui/material';
+
+interface FilterButtonProps {
+  label: string;
+  isActive: boolean;
+  onClick: () => void;
+  count?: number;
+  color: string;
+  activeTextColor?: string;
+}
+
+const FilterButton: React.FC<FilterButtonProps> = ({
+  label,
+  isActive,
+  onClick,
+  count,
+  color,
+  activeTextColor = '#fff',
+}) => (
+  <Button
+    size="small"
+    onClick={onClick}
+    sx={{
+      color: isActive ? activeTextColor : 'rgba(255,255,255,0.5)',
+      backgroundColor: isActive ? 'rgba(255,255,255,0.1)' : 'transparent',
+      borderRadius: '6px',
+      px: 2,
+      minWidth: 'auto',
+      textTransform: 'none',
+      fontFamily: '"JetBrains Mono", monospace',
+      fontSize: '0.8rem',
+      border: isActive ? `1px solid ${color}` : '1px solid transparent',
+      '&:hover': {
+        backgroundColor: 'rgba(255,255,255,0.15)',
+      },
+    }}
+  >
+    {label}{' '}
+    {count !== undefined && (
+      <span style={{ opacity: 0.6, marginLeft: '6px', fontSize: '0.75rem' }}>
+        {count}
+      </span>
+    )}
+  </Button>
+);
+
+export default FilterButton;

--- a/src/components/FilterButton.tsx
+++ b/src/components/FilterButton.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Button } from '@mui/material';
+import { Button, Box } from '@mui/material';
 
 interface FilterButtonProps {
   label: string;
@@ -16,14 +16,14 @@ const FilterButton: React.FC<FilterButtonProps> = ({
   onClick,
   count,
   color,
-  activeTextColor = '#fff',
+  activeTextColor = 'text.primary',
 }) => (
   <Button
     size="small"
     onClick={onClick}
     sx={{
-      color: isActive ? activeTextColor : 'rgba(255,255,255,0.5)',
-      backgroundColor: isActive ? 'rgba(255,255,255,0.1)' : 'transparent',
+      color: isActive ? activeTextColor : 'text.tertiary',
+      backgroundColor: isActive ? 'border.subtle' : 'transparent',
       borderRadius: '6px',
       px: 2,
       minWidth: 'auto',
@@ -32,15 +32,18 @@ const FilterButton: React.FC<FilterButtonProps> = ({
       fontSize: '0.8rem',
       border: isActive ? `1px solid ${color}` : '1px solid transparent',
       '&:hover': {
-        backgroundColor: 'rgba(255,255,255,0.15)',
+        backgroundColor: 'border.light',
       },
     }}
   >
     {label}{' '}
     {count !== undefined && (
-      <span style={{ opacity: 0.6, marginLeft: '6px', fontSize: '0.75rem' }}>
+      <Box
+        component="span"
+        sx={{ opacity: 0.6, ml: '6px', fontSize: '0.75rem' }}
+      >
         {count}
-      </span>
+      </Box>
     )}
   </Button>
 );

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -8,3 +8,4 @@ export * from './common';
 export { default as FAQ } from './FAQ';
 export { default as BackButton } from './BackButton';
 export { SEO } from './SEO';
+export { default as FilterButton } from './FilterButton';

--- a/src/components/leaderboard/TopPRsTable.tsx
+++ b/src/components/leaderboard/TopPRsTable.tsx
@@ -20,7 +20,6 @@ import {
   Select,
   MenuItem,
   FormControl,
-  Button,
   Stack,
   Chip,
   Switch,
@@ -36,6 +35,7 @@ import { type CommitLog } from '../../api/models/Dashboard';
 import { formatUsdEstimate, truncateText } from '../../utils';
 import { RankIcon } from './RankIcon';
 import theme, { STATUS_COLORS } from '../../theme';
+import FilterButton from '../FilterButton';
 
 interface TopPRsTableProps {
   prs: CommitLog[];
@@ -114,48 +114,6 @@ const TopPRsTable: React.FC<TopPRsTableProps> = ({
         .length,
     }),
     [rankedPRs],
-  );
-
-  const FilterButton = ({
-    label,
-    value,
-    count,
-    color,
-  }: {
-    label: string;
-    value: typeof statusFilter;
-    count?: number;
-    color: string;
-  }) => (
-    <Button
-      size="small"
-      onClick={() => setStatusFilter(value)}
-      sx={{
-        color: statusFilter === value ? '#fff' : 'rgba(255,255,255,0.5)',
-        backgroundColor:
-          statusFilter === value ? 'rgba(255,255,255,0.1)' : 'transparent',
-        borderRadius: '6px',
-        px: 2,
-        minWidth: 'auto',
-        textTransform: 'none',
-        fontFamily: '"JetBrains Mono", monospace',
-        fontSize: '0.8rem',
-        border:
-          statusFilter === value
-            ? `1px solid ${color}`
-            : '1px solid transparent',
-        '&:hover': {
-          backgroundColor: 'rgba(255,255,255,0.15)',
-        },
-      }}
-    >
-      {label}{' '}
-      {count !== undefined && (
-        <span style={{ opacity: 0.6, marginLeft: '6px', fontSize: '0.75rem' }}>
-          {count}
-        </span>
-      )}
-    </Button>
   );
 
   const getChartOption = () => {
@@ -614,25 +572,29 @@ const TopPRsTable: React.FC<TopPRsTableProps> = ({
             <Stack direction="row" spacing={1}>
               <FilterButton
                 label="All"
-                value="all"
+                isActive={statusFilter === 'all'}
+                onClick={() => setStatusFilter('all')}
                 count={statusCounts.all}
                 color={theme.palette.status.neutral}
               />
               <FilterButton
                 label="Open"
-                value="open"
+                isActive={statusFilter === 'open'}
+                onClick={() => setStatusFilter('open')}
                 count={statusCounts.open}
                 color={theme.palette.status.open}
               />
               <FilterButton
                 label="Merged"
-                value="merged"
+                isActive={statusFilter === 'merged'}
+                onClick={() => setStatusFilter('merged')}
                 count={statusCounts.merged}
                 color={theme.palette.status.merged}
               />
               <FilterButton
                 label="Closed"
-                value="closed"
+                isActive={statusFilter === 'closed'}
+                onClick={() => setStatusFilter('closed')}
                 count={statusCounts.closed}
                 color={theme.palette.status.closed}
               />

--- a/src/components/repositories/RepositoryIssuesTable.tsx
+++ b/src/components/repositories/RepositoryIssuesTable.tsx
@@ -12,7 +12,6 @@ import {
   TableRow,
   CircularProgress,
   Chip,
-  Button,
   Stack,
 } from '@mui/material';
 import { useRepositoryIssues, useRepoIssues } from '../../api';
@@ -22,6 +21,7 @@ import RadioButtonUncheckedIcon from '@mui/icons-material/RadioButtonUnchecked';
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
 import { formatTokenAmount } from '../../utils/format';
 import { STATUS_COLORS } from '../../theme';
+import FilterButton from '../FilterButton';
 
 interface RepositoryIssuesTableProps {
   repositoryFullName: string;
@@ -61,46 +61,6 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
         return dateB - dateA;
       }),
     [filteredIssues],
-  );
-
-  const FilterButton = ({
-    label,
-    value,
-    count,
-    color,
-  }: {
-    label: string;
-    value: typeof filter;
-    count?: number;
-    color: string;
-  }) => (
-    <Button
-      size="small"
-      onClick={() => setFilter(value)}
-      sx={{
-        color: filter === value ? 'text.primary' : 'rgba(255,255,255,0.5)',
-        backgroundColor:
-          filter === value ? 'rgba(255,255,255,0.1)' : 'transparent',
-        borderRadius: '6px',
-        px: 2,
-        minWidth: 'auto',
-        textTransform: 'none',
-        fontFamily: '"JetBrains Mono", monospace',
-        fontSize: '0.8rem',
-        border:
-          filter === value ? `1px solid ${color}` : '1px solid transparent',
-        '&:hover': {
-          backgroundColor: 'rgba(255,255,255,0.15)',
-        },
-      }}
-    >
-      {label}{' '}
-      {count !== undefined && (
-        <span style={{ opacity: 0.6, marginLeft: '6px', fontSize: '0.75rem' }}>
-          {count}
-        </span>
-      )}
-    </Button>
   );
 
   if (isLoading) {
@@ -384,21 +344,27 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
           <Stack direction="row" spacing={1}>
             <FilterButton
               label="All"
-              value="all"
+              isActive={filter === 'all'}
+              onClick={() => setFilter('all')}
               count={counts.total}
               color={STATUS_COLORS.open}
+              activeTextColor="text.primary"
             />
             <FilterButton
               label="Open"
-              value="open"
+              isActive={filter === 'open'}
+              onClick={() => setFilter('open')}
               count={counts.open}
               color={STATUS_COLORS.open}
+              activeTextColor="text.primary"
             />
             <FilterButton
               label="Closed"
-              value="closed"
+              isActive={filter === 'closed'}
+              onClick={() => setFilter('closed')}
               count={counts.closed}
               color={STATUS_COLORS.merged}
+              activeTextColor="text.primary"
             />
           </Stack>
         </Box>

--- a/src/components/repositories/RepositoryPRsTable.tsx
+++ b/src/components/repositories/RepositoryPRsTable.tsx
@@ -13,11 +13,11 @@ import {
   Avatar,
   Chip,
   Stack,
-  Button,
 } from '@mui/material';
 import { useAllPrs } from '../../api';
 import { useNavigate } from 'react-router-dom';
 import theme from '../../theme';
+import FilterButton from '../FilterButton';
 
 interface RepositoryPRsTableProps {
   repositoryFullName: string;
@@ -80,46 +80,6 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
     [filteredPRs],
   );
 
-  const FilterButton = ({
-    label,
-    value,
-    count,
-    color,
-  }: {
-    label: string;
-    value: typeof filter;
-    count?: number;
-    color: string;
-  }) => (
-    <Button
-      size="small"
-      onClick={() => setFilter(value)}
-      sx={{
-        color: filter === value ? '#fff' : 'rgba(255,255,255,0.5)',
-        backgroundColor:
-          filter === value ? 'rgba(255,255,255,0.1)' : 'transparent',
-        borderRadius: '6px',
-        px: 2,
-        minWidth: 'auto',
-        textTransform: 'none',
-        fontFamily: '"JetBrains Mono", monospace',
-        fontSize: '0.8rem',
-        border:
-          filter === value ? `1px solid ${color}` : '1px solid transparent',
-        '&:hover': {
-          backgroundColor: 'rgba(255,255,255,0.15)',
-        },
-      }}
-    >
-      {label}{' '}
-      {count !== undefined && (
-        <span style={{ opacity: 0.6, marginLeft: '6px', fontSize: '0.75rem' }}>
-          {count}
-        </span>
-      )}
-    </Button>
-  );
-
   if (isLoading) {
     return (
       <Card
@@ -142,25 +102,29 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
           <Stack direction="row" spacing={1}>
             <FilterButton
               label="All"
-              value="all"
+              isActive={filter === 'all'}
+              onClick={() => setFilter('all')}
               count={counts.all}
               color={theme.palette.status.neutral}
             />
             <FilterButton
               label="Open"
-              value="open"
+              isActive={filter === 'open'}
+              onClick={() => setFilter('open')}
               count={counts.open}
               color={theme.palette.status.open}
             />
             <FilterButton
               label="Merged"
-              value="merged"
+              isActive={filter === 'merged'}
+              onClick={() => setFilter('merged')}
               count={counts.merged}
               color={theme.palette.status.merged}
             />
             <FilterButton
               label="Closed"
-              value="closed"
+              isActive={filter === 'closed'}
+              onClick={() => setFilter('closed')}
               count={counts.closed}
               color={theme.palette.status.closed}
             />
@@ -210,25 +174,29 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
         <Stack direction="row" spacing={1}>
           <FilterButton
             label="All"
-            value="all"
+            isActive={filter === 'all'}
+            onClick={() => setFilter('all')}
             count={counts.all}
             color={theme.palette.status.neutral}
           />
           <FilterButton
             label="Open"
-            value="open"
+            isActive={filter === 'open'}
+            onClick={() => setFilter('open')}
             count={counts.open}
             color={theme.palette.status.open}
           />
           <FilterButton
             label="Merged"
-            value="merged"
+            isActive={filter === 'merged'}
+            onClick={() => setFilter('merged')}
             count={counts.merged}
             color={theme.palette.status.merged}
           />
           <FilterButton
             label="Closed"
-            value="closed"
+            isActive={filter === 'closed'}
+            onClick={() => setFilter('closed')}
             count={counts.closed}
             color={theme.palette.status.closed}
           />


### PR DESCRIPTION
The `FilterButton` component was defined identically (same styling, same props) inside three separate components. Extracted it to `src/components/FilterButton.tsx` and updated all consumers to import from the shared location.

- Removed local definition from `TopPRsTable.tsx`
- Removed local definition from `RepositoryPRsTable.tsx` (also removed unused `Button` import)
- Removed local definition from `RepositoryIssuesTable.tsx` (also removed unused `Button` import)
- Exported from `src/components/index.ts`

Call sites now pass `isActive` and `onClick` props instead of `value`, decoupling the component from internal state. No functional changes.