### PR TITLE
refactor: extract duplicated alpha USD estimate formatting

### DIFF
--- a/src/components/issues/IssueHeaderCard.tsx
+++ b/src/components/issues/IssueHeaderCard.tsx
@@ -3,7 +3,10 @@ import { Box, Card, Typography, Chip, Link, Stack } from '@mui/material';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import { IssueDetails } from '../../api/models/Issues';
 import { useStats } from '../../api';
-import { formatTokenAmount } from '../../utils/format';
+import {
+  formatAlphaUsdEstimate,
+  formatTokenAmount,
+} from '../../utils/format';
 import { STATUS_COLORS } from '../../theme';
 
 const getStatusBadge = (
@@ -62,14 +65,11 @@ const IssueHeaderCard: React.FC<IssueHeaderCardProps> = ({ issue }) => {
   const { data: dashStats } = useStats();
   const taoPrice = dashStats?.prices?.tao?.data?.price ?? 0;
   const alphaPrice = dashStats?.prices?.alpha?.data?.price ?? 0;
-
-  const usdEstimate = React.useMemo(() => {
-    if (taoPrice <= 0 || alphaPrice <= 0) return null;
-    const amount = parseFloat(issue.targetBounty);
-    if (isNaN(amount) || amount === 0) return null;
-    const usd = amount * alphaPrice * taoPrice;
-    return `~${usd.toLocaleString('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 })}`;
-  }, [issue.targetBounty, taoPrice, alphaPrice]);
+  const usdEstimate = formatAlphaUsdEstimate(
+    issue.targetBounty,
+    taoPrice,
+    alphaPrice,
+  );
 
   return (
     <Card

--- a/src/components/issues/IssueStats.tsx
+++ b/src/components/issues/IssueStats.tsx
@@ -3,20 +3,8 @@ import { Grid, Skeleton, Box } from '@mui/material';
 import { IssuesStats } from '../../api/models/Issues';
 import { useStats } from '../../api';
 import KpiCard from '../dashboard/KpiCard';
-import { formatTokenAmount } from '../../utils/format';
+import { formatAlphaUsdEstimate, formatTokenAmount } from '../../utils/format';
 import { STATUS_COLORS } from '../../theme';
-
-const formatUsd = (
-  alphaAmount: string | undefined,
-  taoPrice: number,
-  alphaPrice: number,
-): string | undefined => {
-  if (!alphaAmount) return undefined;
-  const amount = parseFloat(alphaAmount);
-  if (isNaN(amount) || amount === 0) return undefined;
-  const usd = amount * alphaPrice * taoPrice;
-  return `~${usd.toLocaleString('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 })}`;
-};
 
 interface IssueStatsProps {
   stats?: IssuesStats;
@@ -76,7 +64,11 @@ const IssueStats: React.FC<IssueStatsProps> = ({
           value={`${formatTokenAmount(stats?.totalBountyPool)} ل`}
           subtitle={
             hasPrices
-              ? (formatUsd(stats?.totalBountyPool, taoPrice, alphaPrice) ??
+              ? (formatAlphaUsdEstimate(
+                  stats?.totalBountyPool,
+                  taoPrice,
+                  alphaPrice,
+                ) ??
                 'Total available')
               : 'Total available'
           }
@@ -88,7 +80,11 @@ const IssueStats: React.FC<IssueStatsProps> = ({
           value={`${formatTokenAmount(stats?.totalPayouts)} ل`}
           subtitle={
             hasPrices
-              ? (formatUsd(stats?.totalPayouts, taoPrice, alphaPrice) ??
+              ? (formatAlphaUsdEstimate(
+                  stats?.totalPayouts,
+                  taoPrice,
+                  alphaPrice,
+                ) ??
                 'Paid to solvers')
               : 'Paid to solvers'
           }

--- a/src/components/issues/IssuesList.tsx
+++ b/src/components/issues/IssuesList.tsx
@@ -18,7 +18,10 @@ import {
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import { IssueBounty } from '../../api/models/Issues';
 import { useStats } from '../../api';
-import { formatTokenAmount } from '../../utils/format';
+import {
+  formatAlphaUsdEstimate,
+  formatTokenAmount,
+} from '../../utils/format';
 import { STATUS_COLORS } from '../../theme';
 import BountyProgress from './BountyProgress';
 
@@ -102,14 +105,6 @@ const IssuesList: React.FC<IssuesListProps> = ({
   const { data: dashStats } = useStats();
   const taoPrice = dashStats?.prices?.tao?.data?.price ?? 0;
   const alphaPrice = dashStats?.prices?.alpha?.data?.price ?? 0;
-
-  const toUsd = (alphaAmount: string): string | null => {
-    if (taoPrice <= 0 || alphaPrice <= 0) return null;
-    const amount = parseFloat(alphaAmount);
-    if (isNaN(amount) || amount === 0) return null;
-    const usd = amount * alphaPrice * taoPrice;
-    return `~${usd.toLocaleString('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 })}`;
-  };
   const headerCellSx = {
     fontFamily: '"JetBrains Mono", monospace',
     fontSize: '0.7rem',
@@ -372,7 +367,11 @@ const IssuesList: React.FC<IssuesListProps> = ({
                         >
                           {formatTokenAmount(issue.targetBounty)} ل
                         </Typography>
-                        {toUsd(issue.targetBounty) && (
+                        {formatAlphaUsdEstimate(
+                          issue.targetBounty,
+                          taoPrice,
+                          alphaPrice,
+                        ) && (
                           <Typography
                             sx={{
                               fontFamily: '"JetBrains Mono", monospace',
@@ -380,7 +379,11 @@ const IssuesList: React.FC<IssuesListProps> = ({
                               color: 'rgba(255, 255, 255, 0.35)',
                             }}
                           >
-                            {toUsd(issue.targetBounty)}
+                            {formatAlphaUsdEstimate(
+                              issue.targetBounty,
+                              taoPrice,
+                              alphaPrice,
+                            )}
                           </Typography>
                         )}
                       </TableCell>
@@ -415,7 +418,11 @@ const IssuesList: React.FC<IssuesListProps> = ({
                         >
                           {formatTokenAmount(issue.targetBounty)} ل
                         </Typography>
-                        {toUsd(issue.targetBounty) && (
+                        {formatAlphaUsdEstimate(
+                          issue.targetBounty,
+                          taoPrice,
+                          alphaPrice,
+                        ) && (
                           <Typography
                             sx={{
                               fontFamily: '"JetBrains Mono", monospace',
@@ -423,7 +430,11 @@ const IssuesList: React.FC<IssuesListProps> = ({
                               color: 'rgba(255, 255, 255, 0.35)',
                             }}
                           >
-                            {toUsd(issue.targetBounty)}
+                            {formatAlphaUsdEstimate(
+                              issue.targetBounty,
+                              taoPrice,
+                              alphaPrice,
+                            )}
                           </Typography>
                         )}
                       </TableCell>
@@ -467,7 +478,11 @@ const IssuesList: React.FC<IssuesListProps> = ({
                         >
                           {`${formatTokenAmount(issue.targetBounty)} ل`}
                         </Typography>
-                        {toUsd(issue.targetBounty) && (
+                        {formatAlphaUsdEstimate(
+                          issue.targetBounty,
+                          taoPrice,
+                          alphaPrice,
+                        ) && (
                           <Typography
                             sx={{
                               fontFamily: '"JetBrains Mono", monospace',
@@ -475,7 +490,11 @@ const IssuesList: React.FC<IssuesListProps> = ({
                               color: 'rgba(255, 255, 255, 0.35)',
                             }}
                           >
-                            {toUsd(issue.targetBounty)}
+                            {formatAlphaUsdEstimate(
+                              issue.targetBounty,
+                              taoPrice,
+                              alphaPrice,
+                            )}
                           </Typography>
                         )}
                       </TableCell>

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -33,6 +33,23 @@ export const truncateText = (text: string, maxLength: number): string => {
   return text.length > maxLength ? `${text.substring(0, maxLength)}...` : text;
 };
 
+export const formatAlphaUsdEstimate = (
+  alphaAmount: string | number | null | undefined,
+  taoPrice: number,
+  alphaPrice: number,
+): string | null => {
+  if (taoPrice <= 0 || alphaPrice <= 0) return null;
+
+  const amount =
+    typeof alphaAmount === 'string' ? parseFloat(alphaAmount) : alphaAmount;
+  if (amount === null || amount === undefined || isNaN(amount) || amount === 0)
+    return null;
+
+  return formatUsdEstimate(amount * alphaPrice * taoPrice, {
+    includeApproxPrefix: true,
+  });
+};
+
 export const formatUsdEstimate = (
   value: number | null | undefined,
   options?: { includeApproxPrefix?: boolean; showZero?: boolean },


### PR DESCRIPTION
The alpha-to-USD estimate formatting logic was duplicated across multiple issue components. Moved it to `src/utils/format.ts` and updated all consumers to use the shared helper.

- Added `formatAlphaUsdEstimate` to `src/utils/format.ts`
- Removed duplicated alpha-to-USD estimate logic from `IssueStats.tsx`
- Removed duplicated alpha-to-USD estimate logic from `IssueHeaderCard.tsx`
- Removed duplicated alpha-to-USD estimate logic from `IssuesList.tsx`
