### PR TITLE
refactor: extract duplicated issue status metadata to shared utils

### DIFF
--- a/src/components/issues/IssueHeaderCard.tsx
+++ b/src/components/issues/IssueHeaderCard.tsx
@@ -4,44 +4,8 @@ import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import { IssueDetails } from '../../api/models/Issues';
 import { useStats } from '../../api';
 import { formatTokenAmount } from '../../utils/format';
+import { getIssueStatusMeta } from '../../utils/issueStatus';
 import { STATUS_COLORS } from '../../theme';
-
-const getStatusBadge = (
-  status: string,
-): { color: string; bgColor: string; text: string } => {
-  switch (status) {
-    case 'registered':
-      return {
-        color: STATUS_COLORS.warning,
-        bgColor: 'rgba(245, 158, 11, 0.15)',
-        text: 'Pending',
-      };
-    case 'active':
-      return {
-        color: STATUS_COLORS.info,
-        bgColor: 'rgba(88, 166, 255, 0.15)',
-        text: 'Available',
-      };
-    case 'completed':
-      return {
-        color: STATUS_COLORS.merged,
-        bgColor: 'rgba(63, 185, 80, 0.15)',
-        text: 'Completed',
-      };
-    case 'cancelled':
-      return {
-        color: STATUS_COLORS.error,
-        bgColor: 'rgba(239, 68, 68, 0.15)',
-        text: 'Cancelled',
-      };
-    default:
-      return {
-        color: STATUS_COLORS.open,
-        bgColor: 'rgba(139, 148, 158, 0.15)',
-        text: status,
-      };
-  }
-};
 
 const formatDate = (dateStr: string | null | undefined): string => {
   if (!dateStr) return '-';
@@ -58,7 +22,7 @@ interface IssueHeaderCardProps {
 }
 
 const IssueHeaderCard: React.FC<IssueHeaderCardProps> = ({ issue }) => {
-  const statusBadge = getStatusBadge(issue.status);
+  const statusBadge = getIssueStatusMeta(issue.status);
   const { data: dashStats } = useStats();
   const taoPrice = dashStats?.prices?.tao?.data?.price ?? 0;
   const alphaPrice = dashStats?.prices?.alpha?.data?.price ?? 0;

--- a/src/components/issues/IssuesList.tsx
+++ b/src/components/issues/IssuesList.tsx
@@ -19,6 +19,7 @@ import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import { IssueBounty } from '../../api/models/Issues';
 import { useStats } from '../../api';
 import { formatTokenAmount } from '../../utils/format';
+import { getIssueStatusMeta } from '../../utils/issueStatus';
 import { STATUS_COLORS } from '../../theme';
 import BountyProgress from './BountyProgress';
 
@@ -30,46 +31,6 @@ interface IssuesListProps {
   listType: ListType;
   onSelectIssue?: (id: number) => void;
 }
-
-/**
- * Get status badge color and text
- */
-const getStatusBadge = (
-  status: IssueBounty['status'],
-): { color: string; bgColor: string; text: string } => {
-  switch (status) {
-    case 'registered':
-      return {
-        color: STATUS_COLORS.warning,
-        bgColor: 'rgba(245, 158, 11, 0.15)',
-        text: 'Pending',
-      };
-    case 'active':
-      return {
-        color: STATUS_COLORS.info,
-        bgColor: 'rgba(88, 166, 255, 0.15)',
-        text: 'Available',
-      };
-    case 'completed':
-      return {
-        color: STATUS_COLORS.merged,
-        bgColor: 'rgba(63, 185, 80, 0.15)',
-        text: 'Completed',
-      };
-    case 'cancelled':
-      return {
-        color: STATUS_COLORS.error,
-        bgColor: 'rgba(239, 68, 68, 0.15)',
-        text: 'Cancelled',
-      };
-    default:
-      return {
-        color: STATUS_COLORS.open,
-        bgColor: 'rgba(139, 148, 158, 0.15)',
-        text: status,
-      };
-  }
-};
 
 /**
  * Format date for display
@@ -264,7 +225,7 @@ const IssuesList: React.FC<IssuesListProps> = ({
           </TableHead>
           <TableBody>
             {issues.map((issue) => {
-              const statusBadge = getStatusBadge(issue.status);
+              const statusBadge = getIssueStatusMeta(issue.status);
 
               return (
                 <TableRow

--- a/src/pages/search/IssuesTab.tsx
+++ b/src/pages/search/IssuesTab.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { alpha, type Theme } from '@mui/material/styles';
+import { alpha } from '@mui/material/styles';
 import { type IssueBounty } from '../../api/models/Issues';
-import { getGithubAvatarSrc } from '../../utils';
+import { getGithubAvatarSrc, getIssueStatusMeta } from '../../utils';
 import SearchResultsTable, {
   type SearchResultsTableColumn,
 } from './SearchResultsTable';
@@ -10,26 +10,6 @@ import {
   SearchStatusChip,
   SearchTruncatedText,
 } from './SearchTableCells';
-
-const getStatusMeta = (
-  status: IssueBounty['status'],
-): {
-  tone: keyof Theme['palette']['status'];
-  text: string;
-} => {
-  switch (status) {
-    case 'registered':
-      return { tone: 'warning', text: 'Pending' };
-    case 'active':
-      return { tone: 'info', text: 'Available' };
-    case 'completed':
-      return { tone: 'merged', text: 'Completed' };
-    case 'cancelled':
-      return { tone: 'error', text: 'Cancelled' };
-    default:
-      return { tone: 'open', text: status };
-  }
-};
 
 const issueColumns: SearchResultsTableColumn<IssueBounty>[] = [
   {
@@ -88,7 +68,7 @@ const issueColumns: SearchResultsTableColumn<IssueBounty>[] = [
     width: '18%',
     align: 'center',
     renderCell: (issue: IssueBounty) => {
-      const statusMeta = getStatusMeta(issue.status);
+      const statusMeta = getIssueStatusMeta(issue.status);
 
       return (
         <SearchStatusChip

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,2 +1,3 @@
 export * from './format';
 export * from './ExplorerUtils';
+export * from './issueStatus';

--- a/src/utils/issueStatus.ts
+++ b/src/utils/issueStatus.ts
@@ -1,0 +1,48 @@
+import { STATUS_COLORS } from '../theme';
+
+export interface IssueStatusMeta {
+  bgColor: string;
+  color: string;
+  text: string;
+  tone: 'warning' | 'info' | 'merged' | 'error' | 'open';
+}
+
+export const getIssueStatusMeta = (status: string): IssueStatusMeta => {
+  switch (status) {
+    case 'registered':
+      return {
+        bgColor: 'rgba(245, 158, 11, 0.15)',
+        color: STATUS_COLORS.warning,
+        text: 'Pending',
+        tone: 'warning',
+      };
+    case 'active':
+      return {
+        bgColor: 'rgba(88, 166, 255, 0.15)',
+        color: STATUS_COLORS.info,
+        text: 'Available',
+        tone: 'info',
+      };
+    case 'completed':
+      return {
+        bgColor: 'rgba(63, 185, 80, 0.15)',
+        color: STATUS_COLORS.merged,
+        text: 'Completed',
+        tone: 'merged',
+      };
+    case 'cancelled':
+      return {
+        bgColor: 'rgba(239, 68, 68, 0.15)',
+        color: STATUS_COLORS.error,
+        text: 'Cancelled',
+        tone: 'error',
+      };
+    default:
+      return {
+        bgColor: 'rgba(139, 148, 158, 0.15)',
+        color: STATUS_COLORS.open,
+        text: status,
+        tone: 'open',
+      };
+  }
+};


### PR DESCRIPTION
The issue status metadata logic was duplicated across multiple issue surfaces. Moved it to a shared utility and updated all consumers to use the shared helper.

- Added `getIssueStatusMeta` to `src/utils/issueStatus.ts`
- Exported the helper from `src/utils/index.ts`
- Removed duplicated issue status metadata logic from `IssueHeaderCard.tsx`
- Removed duplicated issue status metadata logic from `IssuesList.tsx`
- Removed duplicated issue status metadata logic from `IssuesTab.tsx`