### PR TITLE
fix: use singular 'day' when heatmap shows 1-day contribution window

### DIFF
--- a/src/components/dashboard/ContributionHeatmap.tsx
+++ b/src/components/dashboard/ContributionHeatmap.tsx
@@ -119,7 +119,7 @@ const ContributionHeatmap: React.FC<ContributionHeatmapProps> = ({
                 'Nov',
                 'Dec',
               ],
-              totalCount: `{{count}} contributions in the last ${totalDaysShown} days`,
+              totalCount: `{{count}} contributions in the last ${totalDaysShown} ${totalDaysShown === 1 ? 'day' : 'days'}`,
               weekdays: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
             }}
             blockSize={11}


### PR DESCRIPTION
## Summary
When `totalDaysShown` equals 1, the contribution heatmap displays "in the last 1 days" instead of "in the last 1 day". This fix adds a conditional to use the singular form.

## Related Issues
Fixes #163

## Type of Change
- [x] Bug fix

## Testing
- [x] Verified string output for `totalDaysShown = 1` → "1 day"
- [x] Verified string output for `totalDaysShown > 1` → "N days"

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed

cc @anderdc @landyndev