### PR TITLE
fix: add /bounties route that redirects to /issues

### DIFF
--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { matchPath, type PathRouteProps } from 'react-router-dom';
+import { Navigate, matchPath, type PathRouteProps } from 'react-router-dom';
 
 export type AppRoute = Omit<PathRouteProps, 'path'> & {
   name: string;
@@ -43,6 +43,11 @@ const routesArray: AppRoute[] = [
     name: 'issue-details',
     path: '/issues/details',
     element: <IssueDetailsPage />,
+  },
+  {
+    name: 'bounties',
+    path: '/bounties',
+    element: <Navigate to="/issues" replace />,
   },
   {
     name: 'issues',


### PR DESCRIPTION
## Summary
The navigation sidebar links to `/bounties` which returns a 404. The actual page is at `/issues`. This adds a redirect route from `/bounties` to `/issues` using React Router's `Navigate` component.

## Related Issues
Fixes #161

## Type of Change
- [x] Bug fix

## Testing
- [x] Navigating to `/bounties` now redirects to `/issues`
- [x] Existing `/issues` route unaffected

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed

cc @anderdc @landyndev