### PR TITLE
fix: replace MUI Grid with CSS Grid for balanced mobile card spacing

### DIFF
--- a/src/components/issues/IssueStats.tsx
+++ b/src/components/issues/IssueStats.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Grid, Skeleton, Box } from '@mui/material';
+import { Skeleton, Box } from '@mui/material';
 import { IssuesStats } from '../../api/models/Issues';
 import { useStats } from '../../api';
 import KpiCard from '../dashboard/KpiCard';
@@ -34,72 +34,80 @@ const IssueStats: React.FC<IssueStatsProps> = ({
 
   if (isLoading) {
     return (
-      <Grid container spacing={2}>
+      <Box
+        sx={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(2, 1fr)',
+          gap: 2,
+          width: '100%',
+        }}
+      >
         {[1, 2, 3, 4].map((i) => (
-          <Grid item xs={6} sm={3} key={i}>
-            <Box
-              sx={{
-                p: 2,
-                backgroundColor: 'transparent',
-                border: '1px solid rgba(255, 255, 255, 0.1)',
-                borderRadius: 3,
-              }}
-            >
-              <Skeleton variant="text" width="60%" height={20} sx={{ mb: 1 }} />
-              <Skeleton variant="text" width="40%" height={36} />
-            </Box>
-          </Grid>
+          <Box
+            key={i}
+            sx={{
+              p: 2,
+              backgroundColor: 'transparent',
+              border: '1px solid rgba(255, 255, 255, 0.1)',
+              borderRadius: 3,
+            }}
+          >
+            <Skeleton variant="text" width="60%" height={20} sx={{ mb: 1 }} />
+            <Skeleton variant="text" width="40%" height={36} />
+          </Box>
         ))}
-      </Grid>
+      </Box>
     );
   }
 
   return (
-    <Grid container spacing={2}>
-      <Grid item xs={6} sm={3}>
-        <KpiCard
-          title="Total Issues"
-          value={stats?.totalIssues ?? 0}
-          subtitle="All registered issues"
-        />
-      </Grid>
-      <Grid item xs={6} sm={3}>
-        <KpiCard
-          title="Active Issues"
-          value={stats?.activeIssues ?? 0}
-          subtitle="Available for solving"
-        />
-      </Grid>
-      <Grid item xs={6} sm={3}>
-        <KpiCard
-          title="Bounty Pool"
-          value={`${formatTokenAmount(stats?.totalBountyPool)} ل`}
-          subtitle={
-            hasPrices
-              ? (formatUsd(stats?.totalBountyPool, taoPrice, alphaPrice) ??
-                'Total available')
-              : 'Total available'
-          }
-        />
-      </Grid>
-      <Grid item xs={6} sm={3}>
-        <KpiCard
-          title="Total Payouts"
-          value={`${formatTokenAmount(stats?.totalPayouts)} ل`}
-          subtitle={
-            hasPrices
-              ? (formatUsd(stats?.totalPayouts, taoPrice, alphaPrice) ??
-                'Paid to solvers')
-              : 'Paid to solvers'
-          }
-          sx={{
-            '& .MuiTypography-h4': {
-              color: STATUS_COLORS.merged,
-            },
-          }}
-        />
-      </Grid>
-    </Grid>
+    <Box
+      sx={{
+        display: 'grid',
+        gridTemplateColumns: {
+          xs: 'repeat(2, 1fr)',
+          sm: 'repeat(4, 1fr)',
+        },
+        gap: 2,
+        width: '100%',
+      }}
+    >
+      <KpiCard
+        title="Total Issues"
+        value={stats?.totalIssues ?? 0}
+        subtitle="All registered issues"
+      />
+      <KpiCard
+        title="Active Issues"
+        value={stats?.activeIssues ?? 0}
+        subtitle="Available for solving"
+      />
+      <KpiCard
+        title="Bounty Pool"
+        value={`${formatTokenAmount(stats?.totalBountyPool)} ل`}
+        subtitle={
+          hasPrices
+            ? (formatUsd(stats?.totalBountyPool, taoPrice, alphaPrice) ??
+              'Total available')
+            : 'Total available'
+        }
+      />
+      <KpiCard
+        title="Total Payouts"
+        value={`${formatTokenAmount(stats?.totalPayouts)} ل`}
+        subtitle={
+          hasPrices
+            ? (formatUsd(stats?.totalPayouts, taoPrice, alphaPrice) ??
+              'Paid to solvers')
+            : 'Paid to solvers'
+        }
+        sx={{
+          '& .MuiTypography-h4': {
+            color: STATUS_COLORS.merged,
+          },
+        }}
+      />
+    </Box>
   );
 };
 


### PR DESCRIPTION
## Summary
Fixes #223

## Problem
On mobile viewports (390×844), the 2×2 stats card grid on `/issues/available` has uneven horizontal spacing. The left and right outer padding looks inconsistent, making the grid appear off-center.

## Root Cause
MUI `Grid` with `spacing={2}` uses negative margins (-8px each side) to create gutters. These negative margins interact with the parent container's `px` padding, reducing the effective outer padding and creating a visual imbalance.

## Fix
Replaced MUI `Grid` with native CSS `Grid` using the `gap` property:

- **Equal left/right outer padding** — no negative margins
- **Consistent 16px gap** between columns via `gap: 2`
- **Responsive layout** — `repeat(2, 1fr)` on mobile, `repeat(4, 1fr)` on sm+ breakpoints
- **Same visual appearance** on desktop (4-column layout preserved)

## Testing
Tested at 390×844 viewport — card grid is now visually centered with uniform spacing.

## Files Changed
- `src/components/issues/IssueStats.tsx` — Replaced MUI Grid with CSS Grid, removed unused Grid import