### PR TITLE
fix: repair Repo Check tab layout overflow and table alignment

### DIFF
--- a/src/components/repositories/RepositoryCheckTab.tsx
+++ b/src/components/repositories/RepositoryCheckTab.tsx
@@ -522,10 +522,11 @@ const RepositoryCheckTab: React.FC<RepositoryCheckTabProps> = ({
                         display: 'flex',
                         justifyContent: 'space-between',
                         alignItems: 'flex-start',
+                        gap: 1,
                         mb: 1,
                       }}
                     >
-                      <Box>
+                      <Box sx={{ minWidth: 0, flex: 1 }}>
                         <Typography
                           variant="h4"
                           sx={{
@@ -544,14 +545,19 @@ const RepositoryCheckTab: React.FC<RepositoryCheckTabProps> = ({
                             color: STATUS_COLORS.open,
                             fontSize: '12px',
                             fontWeight: 600,
-                            whiteSpace: 'nowrap',
+                            lineHeight: 1.3,
                           }}
                         >
                           Good First Issues
                         </Typography>
                       </Box>
                       <LaunchIcon
-                        sx={{ fontSize: 16, color: STATUS_COLORS.open, mt: 1 }}
+                        sx={{
+                          fontSize: 16,
+                          color: STATUS_COLORS.open,
+                          mt: 1,
+                          flexShrink: 0,
+                        }}
                       />
                     </Box>
                     <Typography
@@ -593,10 +599,11 @@ const RepositoryCheckTab: React.FC<RepositoryCheckTabProps> = ({
                         display: 'flex',
                         justifyContent: 'space-between',
                         alignItems: 'flex-start',
+                        gap: 1,
                         mb: 1,
                       }}
                     >
-                      <Box>
+                      <Box sx={{ minWidth: 0, flex: 1 }}>
                         <Typography
                           variant="h4"
                           sx={{
@@ -613,14 +620,19 @@ const RepositoryCheckTab: React.FC<RepositoryCheckTabProps> = ({
                             color: STATUS_COLORS.open,
                             fontSize: '12px',
                             fontWeight: 600,
-                            whiteSpace: 'nowrap',
+                            lineHeight: 1.3,
                           }}
                         >
                           Help Wanted
                         </Typography>
                       </Box>
                       <LaunchIcon
-                        sx={{ fontSize: 16, color: STATUS_COLORS.open, mt: 1 }}
+                        sx={{
+                          fontSize: 16,
+                          color: STATUS_COLORS.open,
+                          mt: 1,
+                          flexShrink: 0,
+                        }}
                       />
                     </Box>
                     <Typography

--- a/src/components/repositories/RepositoryContributorsTable.tsx
+++ b/src/components/repositories/RepositoryContributorsTable.tsx
@@ -129,7 +129,7 @@ const RepositoryContributorsTable: React.FC<
       <Box
         sx={{
           display: 'grid',
-          gridTemplateColumns: '32px 1fr 48px 75px',
+          gridTemplateColumns: '32px minmax(0, 1fr) 48px 75px',
           gap: 1,
           px: 1.5,
           py: 1,
@@ -174,7 +174,7 @@ const RepositoryContributorsTable: React.FC<
               key={contributor.githubId}
               sx={{
                 display: 'grid',
-                gridTemplateColumns: '32px 1fr 48px 75px',
+                gridTemplateColumns: '32px minmax(0, 1fr) 48px 75px',
                 gap: 1,
                 px: 1.5,
                 py: 1,


### PR DESCRIPTION
## Summary
Fixes #200 — the Repo Check tab had two layout defects:

1. **Issue Analysis action cards** — "Good First Issues" and "Help Wanted" labels used `whiteSpace: 'nowrap'` inside narrow `md={3}` grid items, overflowing the card and causing the `LaunchIcon` to overlap the adjacent card.
2. **Top Miner Contributors table** — the contributor column (`1fr`) refused to shrink below its content width, pushing the fixed-width PRS/SCORE columns out of alignment with their headers.

## Fix

### `RepositoryCheckTab.tsx`
- Drop `whiteSpace: 'nowrap'` on both action-card labels so they wrap instead of overflowing.
- Add `minWidth: 0, flex: 1` on the label column so it participates correctly in the flex parent's shrink calculation.
- Add `gap: 1` on the outer row and `flexShrink: 0` on the `LaunchIcon` so the icon is always fully visible and never touches the text.
- Add `lineHeight: 1.3` so the now-wrapping label has comfortable spacing.

### `RepositoryContributorsTable.tsx`
- Change both header and row `gridTemplateColumns` from `'32px 1fr 48px 75px'` to `'32px minmax(0, 1fr) 48px 75px'`. Plain `1fr` is equivalent to `minmax(auto, 1fr)` and will not shrink below intrinsic size, so long usernames were widening the grid and misaligning the fixed-width columns. `minmax(0, 1fr)` lets the column shrink; the existing `overflow: hidden` + ellipsis on the inner cell handles truncation.

## Type of Change
- [x] Bug fix

## Testing
- [ ] `npm run build`
- [ ] `npm run lint:fix`
- [ ] Manual at 2560×1600 @ 200% scale: `/miners/repository?name=infiniflow/ragflow` → Repo Check tab
  - Issue Analysis: labels wrap inside their cards, icons stay in the top-right of each card, no cross-card overlap
  - Top Miner Contributors: data cells sit directly under their headers for long usernames

## Checklist
- [x] No behavior changes beyond the reported visual bug
- [x] No new dependencies
- [x] Only `RepositoryCheckTab.tsx` and `RepositoryContributorsTable.tsx` touched
