### PR TITLE
fix: persist Miner PR list pagination

### DIFF
--- a/src/components/miners/MinerPRsTable.tsx
+++ b/src/components/miners/MinerPRsTable.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useCallback } from 'react';
+import React, { useState, useMemo, useCallback, useEffect } from 'react';
 import {
   Card,
   Typography,
@@ -26,7 +26,7 @@ import {
   NavigateNext as NextIcon,
 } from '@mui/icons-material';
 import { useMinerPRs, type CommitLog } from '../../api';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import ExplorerFilterButton from './ExplorerFilterButton';
 import { type MinerStatusFilter } from '../../utils/ExplorerUtils';
 
@@ -76,7 +76,23 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
   const [searchQuery, setSearchQuery] = useState('');
   const [sortField, setSortField] = useState<PrSortField>('date');
   const [sortDir, setSortDir] = useState<SortDir>('desc');
-  const [page, setPage] = useState(0);
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [page, setPage] = useState(() => {
+    const p = parseInt(searchParams.get('prsPage') || '', 10);
+    return Number.isFinite(p) && p >= 0 ? p : 0;
+  });
+
+  useEffect(() => {
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        if (page > 0) next.set('prsPage', String(page));
+        else next.delete('prsPage');
+        return next;
+      },
+      { replace: true },
+    );
+  }, [page, setSearchParams]);
 
   const handleSort = useCallback(
     (field: PrSortField) => {


### PR DESCRIPTION
## Summary
Fixes #231 - the Miner Details --> Overview tab PR list reset to page 1 every time the user returned from a PR detail page. Now the current page is persisted in the URL and restored on back navigation.

## Root cause
`src/components/miners/MinerPRsTable.tsx` stored pagination as local `useState`. The `BackButton` on `PRDetailsPage` uses `navigate(-1)`, which restores the URL but not ephemeral component state, so every return remounted the table at page 0.

## Fix
Read/write the current page from a `prsPage` URL search param using `useSearchParams`, preserving all other params on the route (`githubId`, `tab`, etc.) via a functional update:

- Initialize `page` from `prsPage` query param on mount.
- On every `page` change, write it back to the URL with `{ replace: true }` so the history stack stays clean. `prsPage=0` is omitted to keep canonical URLs tidy.

The param name is namespaced (`prsPage`) to avoid colliding with any other table that may later live on the same miner details route.

No other state (search/sort/filter) is moved to the URL in this PR - the issue is scoped to page preservation and the user's reproduction specifically calls out page number.

## Type of Change
- [x] Bug fix

## Testing
- [ ] `npm run build`
- [ ] `npm run lint:fix`
- [ ] Manual (per issue repro):
  1. Open `/miners/details?githubId=124189514&tab=overview`
  2. Jump to the last page of the PR list (e.g. page 8)
  3. Click a PR row --> PR Details page
  4. Click "Back to Repositories"
  5. Verify the PR list is still on page 8 (URL now ends with `&prsPage=7` - zero-indexed)
- [ ] Direct URL load with `&prsPage=3` opens the table at page 4
- [ ] Refresh preserves page
- [ ] Page 0 doesn't add `prsPage=0` to the URL

## Checklist
- [x] No behavior changes outside pagination persistence
- [x] No new dependencies
- [x] Only `src/components/miners/MinerPRsTable.tsx` touched
- [x] Existing `githubId` / `tab` query params are preserved

## Notes
A sibling issue #196 reports the same bug for the Repository --> Pull Requests tab, which uses a different component (`RepositoryPRsTable`). Happy to follow up with a matching fix in a separate PR if this approach is accepted.
