### PR TITLE
feat: click-to-copy miner hotkey on MinerScoreCard

### DIFF
--- a/src/components/miners/MinerScoreCard.tsx
+++ b/src/components/miners/MinerScoreCard.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import {
   Card,
   Typography,
@@ -222,6 +222,7 @@ const MinerScoreCard: React.FC<MinerScoreCardProps> = ({ githubId }) => {
   const { data: githubData } = useMinerGithubData(githubId);
   const { data: generalConfig } = useGeneralConfig();
   const { data: allMinersStats } = useAllMiners();
+  const [hotkeyCopied, setHotkeyCopied] = useState(false);
 
   const username = githubData?.login || prs?.[0]?.author || githubId;
 
@@ -420,16 +421,28 @@ const MinerScoreCard: React.FC<MinerScoreCardProps> = ({ githubId }) => {
             >
               <GitHubIcon sx={{ fontSize: '1rem' }} />@{username}
             </Typography>
-            <Typography
-              sx={{
-                color: (t) => alpha(t.palette.text.primary, 0.45),
-                fontFamily: '"JetBrains Mono", monospace',
-                fontSize: { xs: '0.55rem', sm: '0.65rem' },
-                wordBreak: 'break-all',
-              }}
+            <Tooltip
+              title={hotkeyCopied ? 'Copied!' : 'Click to copy hotkey'}
+              placement="top"
             >
-              {minerStats.hotkey || ''}
-            </Typography>
+              <Typography
+                onClick={() => {
+                  if (!minerStats.hotkey) return;
+                  void navigator.clipboard.writeText(minerStats.hotkey);
+                  setHotkeyCopied(true);
+                  window.setTimeout(() => setHotkeyCopied(false), 1500);
+                }}
+                sx={{
+                  color: (t) => alpha(t.palette.text.primary, 0.45),
+                  fontFamily: '"JetBrains Mono", monospace',
+                  fontSize: { xs: '0.55rem', sm: '0.65rem' },
+                  wordBreak: 'break-all',
+                  cursor: minerStats.hotkey ? 'pointer' : 'default',
+                }}
+              >
+                {minerStats.hotkey || ''}
+              </Typography>
+            </Tooltip>
           </Box>
 
           {/* Bio / about me */}


### PR DESCRIPTION
## Summary
Implements the enhancement proposed in the issue - the miner hotkey on `MinerScoreCard` is now click-to-copy with tooltip feedback.

## Why
The hotkey is the miner's on-chain ss58 address and is needed constantly off-site (registering, staking, querying balance, signing, support tickets). Rendered as plain wrapped text with `wordBreak: 'break-all'`, accurate selection was painful - you can't double-click a whole ss58 and drag-select fails on narrow viewports. This matches the click-to-copy affordance that every wallet and block explorer provides for addresses.

## Changes
`src/components/miners/MinerScoreCard.tsx`:
- Add `useState` to the existing React import.
- Add a `copied` boolean state.
- Wrap the hotkey `<Typography>` in a `<Tooltip>` whose label toggles between "Click to copy hotkey" and "Copied!" for 1.5s.
- Add `onClick` that writes `minerStats.hotkey` to the clipboard via `navigator.clipboard.writeText`.
- Add `cursor: 'pointer'` to the existing `sx`.

## Type of Change
- [x] Enhancement / new feature

## Testing
- [ ] `npm run build`
- [ ] `npm run lint:fix`
- [ ] Manual on any miner detail page (e.g. `/miners/details?githubId=124189514`):
  - Hover hotkey --> tooltip shows "Click to copy hotkey"
  - Click hotkey --> tooltip swaps to "Copied!", clipboard contains the full ss58
  - After ~1.5s, tooltip reverts
  - Empty-hotkey case does not throw

## Checklist
- [x] No new dependencies (`Tooltip` already imported)
- [x] No behavior change on any other element of the card
- [x] Only one file touched (~10 added lines)
- [x] Follows existing conventions (JetBrains Mono, MUI `sx`, named state hooks)

Closes #235
