### PR TITLE
fix: use 'day(s)' in contribution heatmap label

### DIFF
--- a/src/components/dashboard/ContributionHeatmap.tsx
+++ b/src/components/dashboard/ContributionHeatmap.tsx
@@ -119,7 +119,7 @@ const ContributionHeatmap: React.FC<ContributionHeatmapProps> = ({
                 'Nov',
                 'Dec',
               ],
-              totalCount: `{{count}} contributions in the last ${totalDaysShown} days`,
+              totalCount: `{{count}} contributions in the last ${totalDaysShown} day(s)`,
               weekdays: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
             }}
             blockSize={11}


### PR DESCRIPTION
## Summary
- Fixes the grammar issue where the heatmap label says "last 1 days" for new miners
- Changes `days` to `day(s)` so it reads correctly for both singular and plural counts

Fixes #163

## Test plan
- [ ] Check a miner with 1 day of history — label should read "0 contributions in the last 1 day(s)"
- [ ] Check a miner with multiple days — label should read "N contributions in the last X day(s)"