### PR TITLE
feat(miner): click-to-copy hotkey on MinerScoreCard

### DIFF
--- a/src/components/miners/MinerScoreCard.tsx
+++ b/src/components/miners/MinerScoreCard.tsx
@@ -1,5 +1,6 @@
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import {
+  ButtonBase,
   Card,
   Typography,
   Box,
@@ -212,6 +213,88 @@ const StatTile: React.FC<StatTileProps> = ({
   </Box>
 );
 
+const COPY_FEEDBACK_MS = 1500;
+
+const CopyableHotkey: React.FC<{ hotkey: string }> = ({ hotkey }) => {
+  const [copied, setCopied] = useState(false);
+  const timerRef = useRef<number | null>(null);
+
+  useEffect(
+    () => () => {
+      if (timerRef.current !== null) {
+        window.clearTimeout(timerRef.current);
+      }
+    },
+    [],
+  );
+
+  if (!hotkey) return null;
+
+  const handleCopy = async () => {
+    try {
+      if (!navigator.clipboard?.writeText) {
+        throw new Error('clipboard-unavailable');
+      }
+      await navigator.clipboard.writeText(hotkey);
+      setCopied(true);
+      if (timerRef.current !== null) {
+        window.clearTimeout(timerRef.current);
+      }
+      timerRef.current = window.setTimeout(() => {
+        setCopied(false);
+        timerRef.current = null;
+      }, COPY_FEEDBACK_MS);
+    } catch {
+      // The ss58 text remains selectable, so users can copy manually if
+      // the Clipboard API is unavailable (e.g. http:// or a restricted
+      // iframe).
+    }
+  };
+
+  return (
+    <ButtonBase
+      onClick={handleCopy}
+      aria-label={
+        copied ? 'Hotkey copied to clipboard' : 'Copy hotkey to clipboard'
+      }
+      aria-live="polite"
+      disableRipple
+      sx={{
+        display: 'block',
+        textAlign: 'left',
+        borderRadius: '4px',
+        color: (t) =>
+          copied
+            ? t.palette.status.success
+            : alpha(t.palette.text.primary, 0.45),
+        transition: 'color 0.15s ease',
+        '&:hover': {
+          color: (t) =>
+            copied
+              ? t.palette.status.success
+              : alpha(t.palette.text.primary, 0.8),
+        },
+        '&:focus-visible': {
+          outline: (t) => `2px solid ${t.palette.primary.main}`,
+          outlineOffset: '2px',
+        },
+      }}
+    >
+      <Typography
+        component="span"
+        sx={{
+          color: 'inherit',
+          fontFamily: '"JetBrains Mono", monospace',
+          fontSize: { xs: '0.55rem', sm: '0.65rem' },
+          wordBreak: 'break-all',
+        }}
+      >
+        {copied ? '✓ Copied to clipboard' : hotkey}
+      </Typography>
+    </ButtonBase>
+  );
+};
+
 interface MinerScoreCardProps {
   githubId: string;
 }
@@ -420,16 +503,7 @@ const MinerScoreCard: React.FC<MinerScoreCardProps> = ({ githubId }) => {
             >
               <GitHubIcon sx={{ fontSize: '1rem' }} />@{username}
             </Typography>
-            <Typography
-              sx={{
-                color: (t) => alpha(t.palette.text.primary, 0.45),
-                fontFamily: '"JetBrains Mono", monospace',
-                fontSize: { xs: '0.55rem', sm: '0.65rem' },
-                wordBreak: 'break-all',
-              }}
-            >
-              {minerStats.hotkey || ''}
-            </Typography>
+            <CopyableHotkey hotkey={minerStats.hotkey || ''} />
           </Box>
 
           {/* Bio / about me */}


### PR DESCRIPTION
## Summary

The ss58 miner hotkey on `MinerScoreCard` is now click-to-copy with inline feedback. On click, the hotkey text itself swaps to `✓ Copied to clipboard` in success green for 1.5s, then restores. No tooltip popover — the feedback happens in the same place the click happened, so it never overlaps the eligibility chips above.

## Related Issues

Closes #235

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

https://github.com/user-attachments/assets/7408e62e-ce37-46fd-b3e5-778a7c4269ef

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes

## Implementation notes

Extracted a local `CopyableHotkey` component in the same file (not a shared util — single call site, issue explicitly scopes to `MinerScoreCard.tsx`).

**Why no MUI `<Tooltip>`:** an earlier draft wrapped the button in a tooltip showing "Click to copy hotkey" on hover. With `placement="top"`, the tooltip rendered directly over the "OSS Eligible" / "Issues Eligible" chips that sit on the row above the hotkey. `placement="bottom"` would have covered the bio/followers row. Since the inline text swap already communicates the state change, the tooltip was redundant — removed it entirely. This matches the convention used by subscan, etherscan, polkadot.js, Phantom, Talisman, and every other wallet/block-explorer pattern for on-chain addresses.

**Behaviors:**
- Default: dim gray hotkey text (`alpha 0.45`), `cursor: pointer`
- Hover: text brightens to `alpha 0.8` with a 150ms transition — signals clickability
- Click: text swaps to `✓ Copied to clipboard` in `palette.status.success` for 1.5s, then restores
- Keyboard: `Tab`-focusable, activates on `Enter`/`Space`, `:focus-visible` primary-color outline
- Screen readers: `aria-label` swaps between "Copy hotkey to clipboard" and "Hotkey copied to clipboard"; `aria-live="polite"` announces the state change

**Edge cases handled:**
- Empty hotkey → component returns `null`, parent flex row stays clean
- `navigator.clipboard === undefined` (http:// contexts, restricted iframes) → caught by a single `try`/`catch`; the ss58 text remains selectable so users can still copy manually
- Unmount during the 1.5s feedback window → `useRef` + `useEffect` cleanup clears the timer
- Rapid repeat clicks → each click clears the pending timer before setting a new one, so the feedback always shows for the full 1.5s