### PR TITLE
feat: add issue-specific tab components for issue discovery mode

### DIFF
--- a/src/components/miners/MinerActivity.tsx
+++ b/src/components/miners/MinerActivity.tsx
@@ -1,22 +1,286 @@
 import React, { useMemo } from 'react';
 import { Box, Card, Typography, Grid, CircularProgress } from '@mui/material';
 import { subDays, format } from 'date-fns';
+import ReactECharts from 'echarts-for-react';
 import {
   useMinerStats,
   useMinerPRs,
   useReposAndWeights,
   useAllMiners,
 } from '../../api';
+import { CHART_COLORS, STATUS_COLORS, TEXT_OPACITY } from '../../theme';
+import { parseNumber } from '../../utils/ExplorerUtils';
 import { ContributionHeatmap } from '../dashboard';
 import TrustBadge from './TrustBadge';
 import CredibilityChart from './CredibilityChart';
 import PerformanceRadar from './PerformanceRadar';
 
+type ViewMode = 'prs' | 'issues';
+
 interface MinerActivityProps {
   githubId: string;
+  viewMode?: ViewMode;
 }
 
-const MinerActivity: React.FC<MinerActivityProps> = ({ githubId }) => {
+// ---------------------------------------------------------------------------
+// Issue-mode chart sub-components
+// ---------------------------------------------------------------------------
+
+const LegendItem: React.FC<{ label: string; value: number; color: string }> = ({
+  label,
+  value,
+  color,
+}) => (
+  <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+    <Box
+      sx={{
+        width: 6,
+        height: 6,
+        borderRadius: '50%',
+        backgroundColor: color,
+      }}
+    />
+    <Typography
+      sx={{
+        color: `rgba(255, 255, 255, ${TEXT_OPACITY.tertiary})`,
+        fontSize: '0.65rem',
+        fontFamily: '"JetBrains Mono", monospace',
+      }}
+    >
+      {label}
+    </Typography>
+    <Typography
+      sx={{
+        color,
+        fontSize: '0.75rem',
+        fontFamily: '"JetBrains Mono", monospace',
+        fontWeight: 700,
+      }}
+    >
+      {value}
+    </Typography>
+  </Box>
+);
+
+const IssueCredibilityChart: React.FC<{
+  solved: number;
+  open: number;
+  closed: number;
+  credibility: number;
+}> = ({ solved, open, closed, credibility }) => {
+  const chartOption = useMemo(
+    () => ({
+      backgroundColor: 'transparent',
+      title: {
+        text: `${(credibility * 100).toFixed(0)}%`,
+        subtext: 'Credibility',
+        left: 'center',
+        top: '38%',
+        textStyle: {
+          color: `rgba(255, 255, 255, ${TEXT_OPACITY.primary})`,
+          fontSize: 28,
+          fontWeight: 'bold',
+          fontFamily: '"JetBrains Mono", monospace',
+        },
+        subtextStyle: {
+          color: `rgba(255, 255, 255, ${TEXT_OPACITY.muted})`,
+          fontSize: 11,
+          fontFamily: '"JetBrains Mono", monospace',
+          fontWeight: 500,
+        },
+      },
+      tooltip: {
+        trigger: 'item',
+        formatter: '{b}: {c} ({d}%)',
+        backgroundColor: 'rgba(0, 0, 0, 0.9)',
+        borderColor: `rgba(255, 255, 255, ${TEXT_OPACITY.ghost})`,
+        borderWidth: 1,
+        textStyle: {
+          color: `rgba(255, 255, 255, ${TEXT_OPACITY.primary})`,
+          fontFamily: '"JetBrains Mono", monospace',
+        },
+      },
+      series: [
+        {
+          name: 'Issue Status',
+          type: 'pie',
+          radius: ['58%', '72%'],
+          avoidLabelOverlap: false,
+          itemStyle: {
+            borderRadius: 6,
+            borderColor: 'transparent',
+            borderWidth: 3,
+          },
+          label: { show: false, position: 'center' },
+          emphasis: { label: { show: false }, scale: true, scaleSize: 5 },
+          labelLine: { show: false },
+          data: [
+            {
+              value: solved,
+              name: 'Solved',
+              itemStyle: { color: CHART_COLORS.merged },
+            },
+            {
+              value: open,
+              name: 'Open',
+              itemStyle: { color: CHART_COLORS.open },
+            },
+            {
+              value: closed,
+              name: 'Closed',
+              itemStyle: { color: CHART_COLORS.closed },
+            },
+          ],
+        },
+      ],
+    }),
+    [solved, open, closed, credibility],
+  );
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'center',
+      }}
+    >
+      <Typography
+        variant="monoSmall"
+        sx={{
+          color: `rgba(255, 255, 255, ${TEXT_OPACITY.muted})`,
+          mb: 0.75,
+          textAlign: 'center',
+        }}
+      >
+        Issue Solve Ratio
+      </Typography>
+
+      <Box sx={{ height: '190px', width: '100%', mb: 0.75 }}>
+        <ReactECharts
+          option={chartOption}
+          style={{ height: '100%', width: '100%' }}
+          opts={{ renderer: 'svg' }}
+        />
+      </Box>
+
+      <Box
+        sx={{
+          display: 'flex',
+          gap: 1.5,
+          justifyContent: 'center',
+          flexWrap: 'wrap',
+        }}
+      >
+        <LegendItem label="Solved" value={solved} color={CHART_COLORS.merged} />
+        <LegendItem label="Open" value={open} color={CHART_COLORS.open} />
+        <LegendItem label="Closed" value={closed} color={CHART_COLORS.closed} />
+      </Box>
+    </Box>
+  );
+};
+
+const IssuePerformanceRadar: React.FC<{
+  credibility: number;
+  solvedRatio: number;
+  validRatio: number;
+  volume: number;
+  tokenScore: number;
+}> = ({ credibility, solvedRatio, validRatio, volume, tokenScore }) => {
+  const chartOption = useMemo(
+    () => ({
+      backgroundColor: 'transparent',
+      radar: {
+        indicator: [
+          { name: 'Credibility', max: 100 },
+          { name: 'Solve\nRate', max: 100 },
+          { name: 'Valid\nRate', max: 100 },
+          { name: 'Volume', max: 100 },
+          { name: 'Token\nScore', max: 100 },
+        ],
+        center: ['50%', '50%'],
+        radius: '50%',
+        shape: 'circle',
+        splitNumber: 5,
+        axisName: {
+          color: `rgba(255, 255, 255, ${TEXT_OPACITY.tertiary})`,
+          fontFamily: '"JetBrains Mono", monospace',
+          fontSize: 9,
+          lineHeight: 12,
+        },
+        splitLine: {
+          lineStyle: {
+            color: Array(5).fill(
+              `rgba(255, 255, 255, ${TEXT_OPACITY.ghost * 0.25})`,
+            ),
+          },
+        },
+        splitArea: { show: false },
+        axisLine: {
+          lineStyle: {
+            color: `rgba(255, 255, 255, ${TEXT_OPACITY.ghost * 0.5})`,
+          },
+        },
+      },
+      series: [
+        {
+          type: 'radar',
+          lineStyle: {
+            width: 2,
+            color: STATUS_COLORS.merged,
+          },
+          areaStyle: {
+            color: `${STATUS_COLORS.merged}33`,
+          },
+          data: [
+            {
+              value: [credibility, solvedRatio, validRatio, volume, tokenScore],
+              name: 'Issue Stats',
+              symbol: 'circle',
+              symbolSize: 4,
+              itemStyle: { color: STATUS_COLORS.merged },
+            },
+          ],
+        },
+      ],
+    }),
+    [credibility, solvedRatio, validRatio, volume, tokenScore],
+  );
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'center',
+      }}
+    >
+      <Typography
+        variant="monoSmall"
+        sx={{
+          color: `rgba(255, 255, 255, ${TEXT_OPACITY.muted})`,
+          mb: 2,
+          textAlign: 'center',
+        }}
+      >
+        Discovery Profile
+      </Typography>
+      <Box sx={{ height: '220px', width: '100%' }}>
+        <ReactECharts
+          option={chartOption}
+          style={{ height: '100%', width: '100%' }}
+          opts={{ renderer: 'svg' }}
+        />
+      </Box>
+    </Box>
+  );
+};
+
+const MinerActivity: React.FC<MinerActivityProps> = ({
+  githubId,
+  viewMode = 'prs',
+}) => {
+  const isIssueMode = viewMode === 'issues';
   const { data: minerStats } = useMinerStats(githubId);
   const { data: prs, isLoading: isLoadingPRs } = useMinerPRs(githubId);
   const { data: repos } = useReposAndWeights();
@@ -85,8 +349,9 @@ const MinerActivity: React.FC<MinerActivityProps> = ({ githubId }) => {
       };
     }, [prs]);
 
-  // Calculate radar chart values (normalized to 100)
-  const radarValues = useMemo(() => {
+  // PR-mode radar chart values (normalized to 100)
+  const prRadarValues = useMemo(() => {
+    if (isIssueMode) return null;
     if (!minerStats || !allMinerStats || allMinerStats.length === 0) {
       return {
         credibility: 0,
@@ -142,13 +407,61 @@ const MinerActivity: React.FC<MinerActivityProps> = ({ githubId }) => {
       totalPRs: ((minerStats.totalPrs || 0) / maxTotalPrs) * 100,
       avgRepoWeight: avgWeightVal,
     };
-  }, [minerStats, prs, repos, allMinerStats]);
+  }, [minerStats, prs, repos, allMinerStats, isIssueMode]);
+
+  // Issue-mode radar chart values
+  const issueRadarValues = useMemo(() => {
+    if (!isIssueMode) return null;
+    if (!minerStats || !allMinerStats || allMinerStats.length === 0) {
+      return {
+        credibility: 0,
+        solvedRatio: 0,
+        validRatio: 0,
+        volume: 0,
+        tokenScore: 0,
+      };
+    }
+
+    const issueCred = parseNumber(minerStats.issueCredibility);
+    const solved = parseNumber(minerStats.totalSolvedIssues);
+    const validSolved = parseNumber(minerStats.totalValidSolvedIssues);
+    const issueTokenScore = parseNumber(minerStats.issueTokenScore);
+
+    const maxSolved = Math.max(
+      ...allMinerStats.map((m) => parseNumber(m.totalSolvedIssues)),
+      1,
+    );
+    const maxTokenScore = Math.max(
+      ...allMinerStats.map((m) => parseNumber(m.issueTokenScore)),
+      1,
+    );
+
+    return {
+      credibility: issueCred * 100,
+      solvedRatio:
+        solved > 0
+          ? (solved / (solved + parseNumber(minerStats.totalClosedIssues))) *
+            100
+          : 0,
+      validRatio: solved > 0 ? (validSolved / solved) * 100 : 0,
+      volume: (solved / maxSolved) * 100,
+      tokenScore: (issueTokenScore / maxTokenScore) * 100,
+    };
+  }, [minerStats, allMinerStats, isIssueMode]);
 
   if (!minerStats) return null;
 
+  const issueData = isIssueMode
+    ? {
+        solved: parseNumber(minerStats.totalSolvedIssues),
+        openIssues: parseNumber(minerStats.totalOpenIssues),
+        closedIssues: parseNumber(minerStats.totalClosedIssues),
+        issueCred: parseNumber(minerStats.issueCredibility),
+      }
+    : null;
+
   return (
     <Card sx={{ p: 0, overflow: 'hidden' }}>
-      {/* Header with Trust Badge */}
       <Box
         sx={{
           p: 2.5,
@@ -160,20 +473,68 @@ const MinerActivity: React.FC<MinerActivityProps> = ({ githubId }) => {
           alignItems: 'center',
         }}
       >
-        <Typography variant="sectionTitle">Developer Activity</Typography>
+        <Typography variant="sectionTitle">
+          {isIssueMode ? 'Issue Discovery Activity' : 'Developer Activity'}
+        </Typography>
         <TrustBadge
-          credibility={minerStats.credibility || 0}
-          totalPRs={minerStats.totalPrs || 0}
+          credibility={
+            isIssueMode
+              ? (issueData?.issueCred ?? 0)
+              : minerStats.credibility || 0
+          }
+          totalPRs={
+            isIssueMode ? (issueData?.solved ?? 0) : minerStats.totalPrs || 0
+          }
         />
       </Box>
 
-      {isLoadingPRs ? (
+      {isIssueMode ? (
+        <Grid container>
+          <Grid
+            item
+            xs={12}
+            md={6}
+            sx={{
+              p: 3,
+              borderRight: { md: '1px solid' },
+              borderRightColor: { md: 'border.light' },
+              borderBottom: { xs: '1px solid', md: 'none' },
+              borderBottomColor: { xs: 'border.light', md: 'transparent' },
+              display: 'flex',
+              flexDirection: 'column',
+              justifyContent: 'center',
+            }}
+          >
+            <IssueCredibilityChart
+              solved={issueData!.solved}
+              open={issueData!.openIssues}
+              closed={issueData!.closedIssues}
+              credibility={issueData!.issueCred}
+            />
+          </Grid>
+
+          <Grid
+            item
+            xs={12}
+            md={6}
+            sx={{
+              p: 3,
+              display: 'flex',
+              flexDirection: 'column',
+              justifyContent: 'center',
+            }}
+          >
+            {issueRadarValues && (
+              <IssuePerformanceRadar {...issueRadarValues} />
+            )}
+          </Grid>
+        </Grid>
+      ) : isLoadingPRs ? (
         <Box sx={{ p: 4, display: 'flex', justifyContent: 'center' }}>
           <CircularProgress size={30} />
         </Box>
       ) : (
         <Grid container>
-          {/* Heatmap Section */}
           <Grid
             item
             xs={12}
@@ -196,7 +557,6 @@ const MinerActivity: React.FC<MinerActivityProps> = ({ githubId }) => {
             />
           </Grid>
 
-          {/* Credibility */}
           <Grid
             item
             xs={12}
@@ -220,7 +580,6 @@ const MinerActivity: React.FC<MinerActivityProps> = ({ githubId }) => {
             />
           </Grid>
 
-          {/* Performance Radar */}
           <Grid
             item
             xs={12}
@@ -232,7 +591,7 @@ const MinerActivity: React.FC<MinerActivityProps> = ({ githubId }) => {
               justifyContent: 'center',
             }}
           >
-            <PerformanceRadar {...radarValues} />
+            {prRadarValues && <PerformanceRadar {...prRadarValues} />}
           </Grid>
         </Grid>
       )}

--- a/src/components/miners/MinerInsightsCard.tsx
+++ b/src/components/miners/MinerInsightsCard.tsx
@@ -14,11 +14,15 @@ import {
 import { STATUS_COLORS } from '../../theme';
 import {
   calculateDynamicOpenPrThreshold,
+  calculateOpenIssueThreshold,
   parseNumber,
 } from '../../utils/ExplorerUtils';
 
+type ViewMode = 'prs' | 'issues';
+
 interface MinerInsightsCardProps {
   githubId: string;
+  viewMode?: ViewMode;
 }
 
 type InsightType = 'warning' | 'tip' | 'achievement';
@@ -128,6 +132,122 @@ const getCollateralInsight = (
   };
 };
 
+// ---------------------------------------------------------------------------
+// Issue-mode insight generators
+// ---------------------------------------------------------------------------
+
+const getOpenIssueRiskInsight = (
+  minerStats: MinerEvaluation,
+): InsightItem | null => {
+  const openIssues = parseNumber(minerStats.totalOpenIssues);
+  const threshold = calculateOpenIssueThreshold(minerStats);
+  const gap = threshold - openIssues;
+
+  if (openIssues >= threshold) {
+    return {
+      id: 'open-issue-limit-hit',
+      type: 'warning',
+      title: 'Open issue limit exceeded',
+      description: `You have ${openIssues} open issues against a threshold of ${threshold}. This triggers a full penalty on all discovery scores. Close or resolve open issues to recover.`,
+      priority: 100,
+    };
+  }
+
+  if (gap <= 2) {
+    return {
+      id: 'open-issue-limit-near',
+      type: 'warning',
+      title: 'Open issue limit approaching',
+      description: `You are ${gap} issue${gap === 1 ? '' : 's'} away from your open-issue threshold (${threshold}). Avoid opening more issues until existing ones are resolved.`,
+      priority: 85,
+    };
+  }
+
+  return null;
+};
+
+const getIssueEligibilityInsight = (
+  minerStats: MinerEvaluation,
+): InsightItem | null => {
+  const isIssueEligible = minerStats.isIssueEligible ?? false;
+
+  if (isIssueEligible) return null;
+
+  const validSolved = parseNumber(minerStats.totalValidSolvedIssues);
+  const remaining = Math.max(7 - validSolved, 0);
+
+  return {
+    id: 'issue-eligibility-ineligible',
+    type: 'warning',
+    title: 'Not yet eligible for issue rewards',
+    description:
+      remaining > 0
+        ? `You need ${remaining} more valid solved issue${remaining === 1 ? '' : 's'} (solving PR token score ≥ 5) to reach the 7-issue eligibility gate.`
+        : 'Improve your issue credibility and token score to become eligible for issue discovery rewards.',
+    priority: 90,
+  };
+};
+
+const getIssueCredibilityInsight = (
+  minerStats: MinerEvaluation,
+): InsightItem => {
+  const issueCred = parseNumber(minerStats.issueCredibility);
+  const credPercent = (issueCred * 100).toFixed(1);
+  const solvedIssues = parseNumber(minerStats.totalSolvedIssues);
+
+  if (issueCred >= 0.9 && solvedIssues >= 7) {
+    return {
+      id: 'issue-credibility-excellent',
+      type: 'achievement',
+      title: 'Excellent issue credibility',
+      description: `Issue credibility is ${credPercent}% across ${solvedIssues} solved issues. Your discovered issues consistently lead to quality solutions.`,
+      priority: 50,
+    };
+  }
+
+  if (issueCred < 0.6 && solvedIssues >= 3) {
+    return {
+      id: 'issue-credibility-needs-work',
+      type: 'tip',
+      title: 'Improve issue solve rate',
+      description: `Issue credibility is ${credPercent}%. Focus on discovering issues that are clearly actionable and lead to high-quality solving PRs.`,
+      priority: 70,
+    };
+  }
+
+  return {
+    id: 'issue-credibility-stable',
+    type: 'tip',
+    title: 'Keep issue credibility trending upward',
+    description: `Issue credibility is ${credPercent}%. Prioritize discovering well-scoped issues to build a stronger track record.`,
+    priority: 35,
+  };
+};
+
+const getIssueSolvedInsight = (
+  minerStats: MinerEvaluation,
+): InsightItem | null => {
+  const validSolved = parseNumber(minerStats.totalValidSolvedIssues);
+  const totalSolved = parseNumber(minerStats.totalSolvedIssues);
+
+  if (totalSolved > 0 && validSolved === 0) {
+    return {
+      id: 'no-valid-solved',
+      type: 'tip',
+      title: 'No valid solved issues yet',
+      description:
+        'Your solved issues have not yet produced solving PRs with token score ≥ 5. Discover issues that lead to more substantial code changes.',
+      priority: 60,
+    };
+  }
+
+  return null;
+};
+
+// ---------------------------------------------------------------------------
+// Shared rendering helpers
+// ---------------------------------------------------------------------------
+
 const getInsightStyle = (type: InsightType) => {
   switch (type) {
     case 'warning':
@@ -154,31 +274,61 @@ const getInsightStyle = (type: InsightType) => {
   }
 };
 
-const MinerInsightsCard: React.FC<MinerInsightsCardProps> = ({ githubId }) => {
+const assembleIssueInsights = (minerStats: MinerEvaluation): InsightItem[] => {
+  const assembled: InsightItem[] = [];
+
+  const openIssueInsight = getOpenIssueRiskInsight(minerStats);
+  if (openIssueInsight) assembled.push(openIssueInsight);
+
+  const eligibilityInsight = getIssueEligibilityInsight(minerStats);
+  if (eligibilityInsight) assembled.push(eligibilityInsight);
+
+  assembled.push(getIssueCredibilityInsight(minerStats));
+
+  const solvedInsight = getIssueSolvedInsight(minerStats);
+  if (solvedInsight) assembled.push(solvedInsight);
+
+  return assembled;
+};
+
+const assemblePrInsights = (
+  minerStats: MinerEvaluation,
+  prScoring: RepositoryPrScoring | undefined,
+): InsightItem[] => {
+  const assembled: InsightItem[] = [];
+
+  const openPrInsight = getOpenPrInsight(minerStats, prScoring);
+  if (openPrInsight) assembled.push(openPrInsight);
+
+  const collateralInsight = getCollateralInsight(minerStats);
+  if (collateralInsight) assembled.push(collateralInsight);
+
+  const eligibilityInsight = getEligibilityInsight(minerStats);
+  if (eligibilityInsight) assembled.push(eligibilityInsight);
+
+  assembled.push(getCredibilityInsight(minerStats));
+
+  return assembled;
+};
+
+const MinerInsightsCard: React.FC<MinerInsightsCardProps> = ({
+  githubId,
+  viewMode = 'prs',
+}) => {
   const { data: minerStats } = useMinerStats(githubId);
   const { data: generalConfig } = useGeneralConfig();
+
+  const isIssueMode = viewMode === 'issues';
 
   const insights = useMemo(() => {
     if (!minerStats) return [];
 
-    const assembled: InsightItem[] = [];
-
-    const openPrInsight = getOpenPrInsight(
-      minerStats,
-      generalConfig?.repositoryPrScoring,
-    );
-    if (openPrInsight) assembled.push(openPrInsight);
-
-    const collateralInsight = getCollateralInsight(minerStats);
-    if (collateralInsight) assembled.push(collateralInsight);
-
-    const eligibilityInsight = getEligibilityInsight(minerStats);
-    if (eligibilityInsight) assembled.push(eligibilityInsight);
-
-    assembled.push(getCredibilityInsight(minerStats));
+    const assembled = isIssueMode
+      ? assembleIssueInsights(minerStats)
+      : assemblePrInsights(minerStats, generalConfig?.repositoryPrScoring);
 
     return assembled.sort((a, b) => b.priority - a.priority).slice(0, 4);
-  }, [minerStats, generalConfig]);
+  }, [minerStats, generalConfig, isIssueMode]);
 
   if (!minerStats) return null;
 
@@ -203,7 +353,7 @@ const MinerInsightsCard: React.FC<MinerInsightsCardProps> = ({ githubId }) => {
             mb: 0.8,
           }}
         >
-          Insights & Next Actions
+          {isIssueMode ? 'Issue Discovery Insights' : 'Insights & Next Actions'}
         </Typography>
         <Typography
           sx={{
@@ -211,8 +361,9 @@ const MinerInsightsCard: React.FC<MinerInsightsCardProps> = ({ githubId }) => {
             fontSize: '0.85rem',
           }}
         >
-          Prioritized recommendations based on your eligibility, credibility,
-          collateral, and open-PR posture.
+          {isIssueMode
+            ? 'Recommendations based on your issue eligibility, credibility, and open-issue posture.'
+            : 'Prioritized recommendations based on your eligibility, credibility, collateral, and open-PR posture.'}
         </Typography>
       </Box>
 
@@ -286,7 +437,11 @@ const MinerInsightsCard: React.FC<MinerInsightsCardProps> = ({ githubId }) => {
         Learn more about scoring in the{' '}
         <Typography
           component="a"
-          href="https://docs.gittensor.io/oss-contributions.html"
+          href={
+            isIssueMode
+              ? 'https://docs.gittensor.io/issue-discovery.html'
+              : 'https://docs.gittensor.io/oss-contributions.html'
+          }
           target="_blank"
           rel="noopener noreferrer"
           sx={{

--- a/src/components/miners/MinerScoreBreakdown.tsx
+++ b/src/components/miners/MinerScoreBreakdown.tsx
@@ -2,6 +2,7 @@ import React, { useMemo, useState, useCallback } from 'react';
 import {
   Box,
   Card,
+  Grid,
   Typography,
   Tooltip,
   Stack,
@@ -17,11 +18,24 @@ import {
   OpenInNew as OpenInNewIcon,
 } from '@mui/icons-material';
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import { useMinerPRs, usePullRequestDetails, type CommitLog } from '../../api';
+import {
+  useMinerStats,
+  useMinerPRs,
+  usePullRequestDetails,
+  type CommitLog,
+} from '../../api';
 import { STATUS_COLORS } from '../../theme';
+import {
+  parseNumber,
+  calculateOpenIssueThreshold,
+} from '../../utils/ExplorerUtils';
+import { credibilityColor } from '../../utils/format';
+
+type ViewMode = 'prs' | 'issues';
 
 interface MinerScoreBreakdownProps {
   githubId: string;
+  viewMode?: ViewMode;
 }
 
 const tooltipSlotProps = {
@@ -510,9 +524,196 @@ const PrScoreRow: React.FC<PrScoreRowProps> = ({ pr, onNavigateToPr }) => {
   );
 };
 
-const MinerScoreBreakdown: React.FC<MinerScoreBreakdownProps> = ({
-  githubId,
-}) => {
+// ---------------------------------------------------------------------------
+// Issue-mode breakdown sub-components
+// ---------------------------------------------------------------------------
+
+const MetricRow: React.FC<{
+  label: string;
+  value: string;
+  color?: string;
+  sub?: string;
+}> = ({ label, value, color, sub }) => (
+  <Box
+    sx={{
+      display: 'flex',
+      justifyContent: 'space-between',
+      alignItems: 'center',
+      py: 1.2,
+      borderBottom: '1px solid',
+      borderColor: (t) => alpha(t.palette.text.primary, 0.06),
+    }}
+  >
+    <Box>
+      <Typography
+        sx={{
+          fontFamily: '"JetBrains Mono", monospace',
+          fontSize: '0.82rem',
+          color: 'text.primary',
+        }}
+      >
+        {label}
+      </Typography>
+      {sub && (
+        <Typography
+          sx={{
+            fontFamily: '"JetBrains Mono", monospace',
+            fontSize: '0.7rem',
+            color: (t) => alpha(t.palette.text.primary, 0.4),
+            mt: 0.25,
+          }}
+        >
+          {sub}
+        </Typography>
+      )}
+    </Box>
+    <Typography
+      sx={{
+        fontFamily: '"JetBrains Mono", monospace',
+        fontSize: '0.95rem',
+        fontWeight: 600,
+        color: color || 'text.primary',
+      }}
+    >
+      {value}
+    </Typography>
+  </Box>
+);
+
+const IssueBreakdownView: React.FC<{ githubId: string }> = ({ githubId }) => {
+  const { data: minerStats } = useMinerStats(githubId);
+
+  if (!minerStats) return null;
+
+  const discoveryScore = parseNumber(minerStats.issueDiscoveryScore);
+  const issueCred = parseNumber(minerStats.issueCredibility);
+  const issueTokenScore = parseNumber(minerStats.issueTokenScore);
+  const solved = parseNumber(minerStats.totalSolvedIssues);
+  const validSolved = parseNumber(minerStats.totalValidSolvedIssues);
+  const closedIssues = parseNumber(minerStats.totalClosedIssues);
+  const openIssues = parseNumber(minerStats.totalOpenIssues);
+  const isEligible = minerStats.isIssueEligible ?? false;
+  const openThreshold = calculateOpenIssueThreshold(minerStats);
+
+  const hasAnyData = solved > 0 || openIssues > 0 || closedIssues > 0;
+
+  return (
+    <Card
+      sx={{
+        borderRadius: 3,
+        border: '1px solid',
+        borderColor: 'border.light',
+        backgroundColor: 'transparent',
+        p: 3,
+      }}
+      elevation={0}
+    >
+      <Typography
+        sx={{
+          color: 'text.primary',
+          fontFamily: '"JetBrains Mono", monospace',
+          fontSize: '1.1rem',
+          fontWeight: 600,
+          mb: 0.8,
+        }}
+      >
+        Issue Discovery Breakdown
+      </Typography>
+      <Typography
+        sx={{
+          color: (t) => alpha(t.palette.text.primary, 0.55),
+          fontSize: '0.85rem',
+          mb: 2,
+        }}
+      >
+        Aggregate issue discovery stats from existing evaluations.
+      </Typography>
+
+      {!hasAnyData ? (
+        <Box
+          sx={{
+            py: 4,
+            textAlign: 'center',
+            borderRadius: 2,
+            backgroundColor: (t) => alpha(t.palette.text.primary, 0.03),
+          }}
+        >
+          <Typography
+            sx={{
+              fontFamily: '"JetBrains Mono", monospace',
+              fontSize: '0.85rem',
+              color: (t) => alpha(t.palette.text.primary, 0.4),
+            }}
+          >
+            No issue discovery data yet
+          </Typography>
+          <Typography
+            sx={{
+              fontFamily: '"JetBrains Mono", monospace',
+              fontSize: '0.75rem',
+              color: (t) => alpha(t.palette.text.primary, 0.3),
+              mt: 0.5,
+            }}
+          >
+            Start discovering issues to see your breakdown here
+          </Typography>
+        </Box>
+      ) : (
+        <Grid container spacing={3}>
+          <Grid item xs={12} md={6}>
+            <MetricRow
+              label="Discovery Score"
+              value={discoveryScore.toFixed(2)}
+            />
+            <MetricRow
+              label="Issue Token Score"
+              value={issueTokenScore.toFixed(0)}
+              sub="Sum of solving PR token scores"
+            />
+            <MetricRow
+              label="Issue Credibility"
+              value={`${(issueCred * 100).toFixed(1)}%`}
+              color={credibilityColor(issueCred)}
+              sub="Solved / (solved + closed)"
+            />
+            <MetricRow
+              label="Eligibility"
+              value={isEligible ? 'Eligible' : 'Ineligible'}
+              color={isEligible ? STATUS_COLORS.success : STATUS_COLORS.neutral}
+              sub="Requires 7 valid solved issues"
+            />
+          </Grid>
+          <Grid item xs={12} md={6}>
+            <MetricRow
+              label="Total Solved"
+              value={String(solved)}
+              sub={`${validSolved} valid (token score \u2265 5)`}
+            />
+            <MetricRow
+              label="Closed Issues"
+              value={String(closedIssues)}
+              sub="Discovered issues closed without solve"
+            />
+            <MetricRow
+              label="Open Issues"
+              value={String(openIssues)}
+              color={
+                openIssues >= openThreshold ? STATUS_COLORS.error : undefined
+              }
+              sub={`Threshold: ${openThreshold}`}
+            />
+          </Grid>
+        </Grid>
+      )}
+    </Card>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// PR-mode breakdown
+// ---------------------------------------------------------------------------
+
+const PrBreakdownView: React.FC<{ githubId: string }> = ({ githubId }) => {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const { data: prs, isLoading } = useMinerPRs(githubId);
@@ -654,6 +855,20 @@ const MinerScoreBreakdown: React.FC<MinerScoreBreakdownProps> = ({
       )}
     </Card>
   );
+};
+
+// ---------------------------------------------------------------------------
+// Main component — dispatches to PR or Issue view
+// ---------------------------------------------------------------------------
+
+const MinerScoreBreakdown: React.FC<MinerScoreBreakdownProps> = ({
+  githubId,
+  viewMode = 'prs',
+}) => {
+  if (viewMode === 'issues') {
+    return <IssueBreakdownView githubId={githubId} />;
+  }
+  return <PrBreakdownView githubId={githubId} />;
 };
 
 export default MinerScoreBreakdown;

--- a/src/components/miners/MinerScoreCard.tsx
+++ b/src/components/miners/MinerScoreCard.tsx
@@ -31,6 +31,7 @@ import {
 import { RANK_COLORS, STATUS_COLORS, RISK_COLORS } from '../../theme';
 import {
   calculateDynamicOpenPrThreshold,
+  calculateOpenIssueThreshold,
   parseNumber,
 } from '../../utils/ExplorerUtils';
 import { credibilityColor } from '../../utils/format';
@@ -613,13 +614,10 @@ const MinerScoreCard: React.FC<MinerScoreCardProps> = ({
           <Grid item xs={6} sm={4} md={2}>
             <StatTile
               label="Open Risk"
-              value={`${minerStats.totalOpenIssues || 0} / ${Math.min(5 + Math.floor(Number(minerStats.issueTokenScore || 0) / 300), 30)}`}
+              value={`${minerStats.totalOpenIssues || 0} / ${calculateOpenIssueThreshold(minerStats)}`}
               color={openPrColor(
-                Number(minerStats.totalOpenIssues || 0),
-                Math.min(
-                  5 + Math.floor(Number(minerStats.issueTokenScore || 0) / 300),
-                  30,
-                ),
+                parseNumber(minerStats.totalOpenIssues),
+                calculateOpenIssueThreshold(minerStats),
               )}
               tooltip="Open issues count toward spam detection. Exceeding the threshold triggers a full penalty on all discovery scores."
             />

--- a/src/pages/MinerDetailsPage.tsx
+++ b/src/pages/MinerDetailsPage.tsx
@@ -15,13 +15,14 @@ import {
 
 type ViewMode = 'prs' | 'issues';
 
-const TAB_NAMES = [
+const PR_TABS = [
   'overview',
   'activity',
   'pull-requests',
   'repositories',
 ] as const;
-type MinerDetailsTab = (typeof TAB_NAMES)[number];
+const ISSUE_TABS = ['overview', 'activity', 'issues', 'repositories'] as const;
+type MinerDetailsTab = (typeof PR_TABS)[number] | (typeof ISSUE_TABS)[number];
 
 const tabSx = {
   '& .MuiTab-root': {
@@ -41,9 +42,11 @@ const MinerDetailsPage: React.FC = () => {
   const modeParam = searchParams.get('mode');
   const viewMode: ViewMode = modeParam === 'issues' ? 'issues' : 'prs';
 
+  const tabs = viewMode === 'issues' ? ISSUE_TABS : PR_TABS;
+
   const tabParam = searchParams.get('tab');
   const activeTab: MinerDetailsTab =
-    tabParam && TAB_NAMES.includes(tabParam as MinerDetailsTab)
+    tabParam && (tabs as readonly string[]).includes(tabParam)
       ? (tabParam as MinerDetailsTab)
       : 'overview';
 
@@ -166,7 +169,7 @@ const MinerDetailsPage: React.FC = () => {
               <Tab value="overview" label="Overview" />
               <Tab value="activity" label="Activity" />
               <Tab
-                value="pull-requests"
+                value={viewMode === 'issues' ? 'issues' : 'pull-requests'}
                 label={viewMode === 'issues' ? 'Issues' : 'Pull Requests'}
               />
               <Tab value="repositories" label="Repositories" />
@@ -176,13 +179,21 @@ const MinerDetailsPage: React.FC = () => {
           <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
             {activeTab === 'overview' && (
               <>
-                <MinerInsightsCard githubId={githubId} />
-                <MinerScoreBreakdown githubId={githubId} />
+                <MinerInsightsCard githubId={githubId} viewMode={viewMode} />
+                {viewMode === 'prs' && (
+                  <MinerScoreBreakdown githubId={githubId} />
+                )}
               </>
             )}
-            {activeTab === 'activity' && <MinerActivity githubId={githubId} />}
+
+            {activeTab === 'activity' && (
+              <MinerActivity githubId={githubId} viewMode={viewMode} />
+            )}
             {activeTab === 'pull-requests' && (
               <MinerPRsTable githubId={githubId} />
+            )}
+            {activeTab === 'issues' && (
+              <MinerScoreBreakdown githubId={githubId} viewMode="issues" />
             )}
             {activeTab === 'repositories' && (
               <MinerRepositoriesTable githubId={githubId} />

--- a/src/utils/ExplorerUtils.ts
+++ b/src/utils/ExplorerUtils.ts
@@ -42,6 +42,13 @@ export const calculateDynamicOpenPrThreshold = (
   return Math.min(baseThreshold + bonus, maxThreshold);
 };
 
+export const calculateOpenIssueThreshold = (
+  minerStats: MinerEvaluation,
+): number => {
+  const issueTokenScore = parseNumber(minerStats.issueTokenScore);
+  return Math.min(5 + Math.floor(issueTokenScore / 300), 30);
+};
+
 const isMinerEvaluationLike = (value: unknown): value is MinerEvaluation => {
   if (!value || typeof value !== 'object') return false;
   return 'githubId' in value;


### PR DESCRIPTION
## Summary
 
When `mode=issues`, tabs now show issue-specific content instead of PR-focused components. Adds three new components mirroring the PR-mode counterparts:
 
- **MinerIssueInsightsCard** — eligibility gate, credibility advice, open issue spam risk
- **MinerIssueActivity** — issue credibility donut chart + discovery performance radar
- **MinerIssueScoreBreakdown** — aggregate issue stats with empty state
 
Tab bar switches "Pull Requests" → "Issues" in issue mode. Invalid cross-mode tab params (e.g. `tab=pull-requests` in issues mode) fall back to `overview`. All data from existing `useMinerStats` hook.
 
Depends on #241 (route consolidation + mode toggle).
 
## Related Issues
 
Relates to #178
 
## Type of Change
 
- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)
 
## Screenshots
[screen-capture.webm](https://github.com/user-attachments/assets/f176774e-21d0-4850-9179-d90d8c05c919)


## Checklist
 
- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes