### PR TITLE
refactor: extract duplicated conversation meta row to shared component

### DIFF
--- a/src/components/common/ConversationMetaRow.tsx
+++ b/src/components/common/ConversationMetaRow.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { Box, Chip, Link, Typography } from '@mui/material';
+import { STATUS_COLORS } from '../../theme';
+
+interface ConversationMetaRowProps {
+  login: string | null;
+  htmlUrl: string;
+  createdAt: string;
+  authorAssociation?: string;
+  isDescription?: boolean;
+  colors: {
+    fgDefault: string;
+    fgMuted: string;
+    borderDefault: string;
+  };
+}
+
+export const ConversationMetaRow: React.FC<ConversationMetaRowProps> = ({
+  login,
+  htmlUrl,
+  createdAt,
+  authorAssociation,
+  isDescription = false,
+  colors,
+}) => (
+  <>
+    <Box
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 1,
+        flexWrap: 'wrap',
+      }}
+    >
+      <Link
+        href={htmlUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        sx={{
+          color: colors.fgDefault,
+          fontWeight: 600,
+          textDecoration: 'none',
+          '&:hover': {
+            textDecoration: 'underline',
+            color: STATUS_COLORS.info,
+          },
+        }}
+      >
+        {login}
+      </Link>
+      <Typography component="span" sx={{ fontSize: 'inherit', color: 'inherit' }}>
+        commented
+      </Typography>
+      <Typography component="span" sx={{ fontSize: 'inherit', color: 'inherit' }}>
+        {new Date(createdAt).toLocaleDateString('en-US', {
+          month: 'short',
+          day: 'numeric',
+          year: 'numeric',
+        })}
+      </Typography>
+    </Box>
+
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+      {authorAssociation && authorAssociation !== 'NONE' && (
+        <Chip
+          variant="status"
+          label={authorAssociation.toLowerCase().replace('_', ' ')}
+          sx={{
+            color: colors.fgMuted,
+            borderColor: colors.borderDefault,
+            textTransform: 'capitalize',
+          }}
+        />
+      )}
+      {isDescription && (
+        <Chip
+          variant="status"
+          label="Description"
+          sx={{
+            color: STATUS_COLORS.info,
+            borderColor: 'rgba(56, 139, 253, 0.4)',
+          }}
+        />
+      )}
+    </Box>
+  </>
+);

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -1,1 +1,2 @@
 export * from './SearchInput';
+export * from './ConversationMetaRow';

--- a/src/components/issues/IssueConversation.tsx
+++ b/src/components/issues/IssueConversation.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
-import { Box, Typography, Avatar, Paper, Link, Chip } from '@mui/material';
+import { Box, Avatar, Paper, Link } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import rehypeRaw from 'rehype-raw';
 import { type IssueDetails } from '../../api/models/Issues';
+import { ConversationMetaRow } from '../common';
 import { STATUS_COLORS } from '../../theme';
 
 import 'github-markdown-css/github-markdown-dark.css';
@@ -161,76 +162,18 @@ const IssueConversation: React.FC<IssueConversationProps> = ({ issue }) => {
                 zIndex: 1, // Ensure above the arrow pseudo-element's main body
               }}
             >
-              <Box
-                sx={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: 1,
-                  flexWrap: 'wrap',
+              <ConversationMetaRow
+                login={item.user.login}
+                htmlUrl={item.user.htmlUrl}
+                createdAt={item.createdAt}
+                authorAssociation={item.authorAssociation}
+                isDescription={item.isDescription}
+                colors={{
+                  fgDefault: colors.fg.default,
+                  fgMuted: colors.fg.muted,
+                  borderDefault: colors.border.default,
                 }}
-              >
-                <Link
-                  href={item.user.htmlUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  sx={{
-                    color: colors.fg.default,
-                    fontWeight: 600,
-                    textDecoration: 'none',
-                    '&:hover': {
-                      textDecoration: 'underline',
-                      color: colors.accent.fg,
-                    },
-                  }}
-                >
-                  {item.user.login}
-                </Link>
-                <Typography
-                  component="span"
-                  sx={{ fontSize: 'inherit', color: 'inherit' }}
-                >
-                  commented
-                </Typography>
-                <Typography
-                  component="span"
-                  sx={{ fontSize: 'inherit', color: 'inherit' }}
-                >
-                  {new Date(item.createdAt).toLocaleDateString('en-US', {
-                    month: 'short',
-                    day: 'numeric',
-                    year: 'numeric',
-                  })}
-                </Typography>
-              </Box>
-
-              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                {/* Author Association Badge */}
-                {item.authorAssociation &&
-                  item.authorAssociation !== 'NONE' && (
-                    <Chip
-                      variant="status"
-                      label={item.authorAssociation
-                        .toLowerCase()
-                        .replace('_', ' ')}
-                      sx={{
-                        color: colors.fg.muted,
-                        borderColor: colors.border.default,
-                        textTransform: 'capitalize',
-                      }}
-                    />
-                  )}
-                {/* Description Badge - Special styling */}
-                {item.isDescription && (
-                  <Chip
-                    variant="status"
-                    label="Description"
-                    sx={{
-                      color: STATUS_COLORS.info,
-                      borderColor: 'rgba(56, 139, 253, 0.4)',
-                    }}
-                  />
-                )}
-              </Box>
+              />
             </Box>
 
             {/* Markdown Content */}

--- a/src/components/prs/PRComments.tsx
+++ b/src/components/prs/PRComments.tsx
@@ -6,7 +6,6 @@ import {
   Paper,
   Link,
   CircularProgress,
-  Chip,
 } from '@mui/material';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
@@ -16,6 +15,7 @@ import {
   type PullRequestComment,
   type PullRequestDetails,
 } from '../../api/models/Dashboard';
+import { ConversationMetaRow } from '../common';
 import { STATUS_COLORS } from '../../theme';
 import 'github-markdown-css/github-markdown-dark.css'; // Import standard GitHub Dark styles
 
@@ -197,76 +197,18 @@ const PRComments: React.FC<PRCommentsProps> = ({
                 zIndex: 1, // Ensure above the arrow pseudo-element's main body
               }}
             >
-              <Box
-                sx={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: 1,
-                  flexWrap: 'wrap',
+              <ConversationMetaRow
+                login={item.user.login}
+                htmlUrl={item.user.htmlUrl}
+                createdAt={item.createdAt}
+                authorAssociation={item.authorAssociation}
+                isDescription={item.isDescription}
+                colors={{
+                  fgDefault: colors.fg.default,
+                  fgMuted: colors.fg.muted,
+                  borderDefault: colors.border.default,
                 }}
-              >
-                <Link
-                  href={item.user.htmlUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  sx={{
-                    color: colors.fg.default,
-                    fontWeight: 600,
-                    textDecoration: 'none',
-                    '&:hover': {
-                      textDecoration: 'underline',
-                      color: colors.accent.fg,
-                    },
-                  }}
-                >
-                  {item.user.login}
-                </Link>
-                <Typography
-                  component="span"
-                  sx={{ fontSize: 'inherit', color: 'inherit' }}
-                >
-                  commented
-                </Typography>
-                <Typography
-                  component="span"
-                  sx={{ fontSize: 'inherit', color: 'inherit' }}
-                >
-                  {new Date(item.createdAt).toLocaleDateString('en-US', {
-                    month: 'short',
-                    day: 'numeric',
-                    year: 'numeric',
-                  })}
-                </Typography>
-              </Box>
-
-              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                {/* Author Association Badge */}
-                {item.authorAssociation &&
-                  item.authorAssociation !== 'NONE' && (
-                    <Chip
-                      variant="status"
-                      label={item.authorAssociation
-                        .toLowerCase()
-                        .replace('_', ' ')}
-                      sx={{
-                        color: colors.fg.muted,
-                        borderColor: colors.border.default,
-                        textTransform: 'capitalize',
-                      }}
-                    />
-                  )}
-                {/* Description Badge - Special styling */}
-                {item.isDescription && (
-                  <Chip
-                    variant="status"
-                    label="Description"
-                    sx={{
-                      color: STATUS_COLORS.info,
-                      borderColor: 'rgba(56, 139, 253, 0.4)',
-                    }}
-                  />
-                )}
-              </Box>
+              />
             </Box>
 
             {/* Markdown Content */}


### PR DESCRIPTION
The conversation header metadata row was duplicated across PR and issue conversation components. Moved it to a shared component and updated both consumers to use it.

- Added `ConversationMetaRow` to `src/components/common/ConversationMetaRow.tsx`
- Exported the shared component from `src/components/common/index.ts`
- Removed duplicated conversation header metadata rendering from `PRComments.tsx`
- Removed duplicated conversation header metadata rendering from `IssueConversation.tsx`