### PR TITLE
feat: add issue discovery Overview tab components

### DIFF
--- a/src/api/models/Issues.ts
+++ b/src/api/models/Issues.ts
@@ -17,6 +17,13 @@ export interface IssueBounty {
   updatedAt: string;
   completedAt: string | null;
   title?: string;
+  discoveryBaseScore?: string;
+  discoveryEarnedScore?: string;
+  discoveryReviewQualityMultiplier?: string;
+  discoveryRepoWeightMultiplier?: string;
+  discoveryTimeDecayMultiplier?: string;
+  discoveryCredibilityMultiplier?: string;
+  discoveryOpenIssueSpamMultiplier?: string;
 }
 
 export interface IssuesStats {

--- a/src/components/miners/MinerIssueInsightsCard.tsx
+++ b/src/components/miners/MinerIssueInsightsCard.tsx
@@ -1,0 +1,295 @@
+import React, { useMemo } from 'react';
+import { Box, Card, Chip, Typography, alpha } from '@mui/material';
+import {
+  CheckCircle as AchievementIcon,
+  ErrorOutline as WarningIcon,
+  Lightbulb as TipIcon,
+} from '@mui/icons-material';
+import { useMinerStats, type MinerEvaluation } from '../../api';
+import { STATUS_COLORS } from '../../theme';
+import { parseNumber } from '../../utils/ExplorerUtils';
+
+interface MinerIssueInsightsCardProps {
+  githubId: string;
+}
+
+type InsightType = 'warning' | 'tip' | 'achievement';
+
+interface InsightItem {
+  id: string;
+  type: InsightType;
+  title: string;
+  description: string;
+  priority: number;
+}
+
+const getOpenIssueInsight = (
+  minerStats: MinerEvaluation,
+): InsightItem | null => {
+  const openIssues = parseNumber(minerStats.totalOpenIssues);
+  const tokenScore = parseNumber(minerStats.issueTokenScore);
+  const threshold = Math.min(5 + Math.floor(tokenScore / 300), 30);
+  const gap = threshold - openIssues;
+
+  if (openIssues >= threshold) {
+    return {
+      id: 'open-issue-limit-hit',
+      type: 'warning',
+      title: 'Open issue limit exceeded',
+      description: `You currently have ${openIssues} open issues against a threshold of ${threshold}. This triggers a full penalty on all discovery scores. Close or resolve pending issues to recover.`,
+      priority: 100,
+    };
+  }
+
+  if (gap <= 2) {
+    return {
+      id: 'open-issue-limit-near',
+      type: 'warning',
+      title: 'Open issue risk approaching',
+      description: `You are ${gap} issue${gap === 1 ? '' : 's'} away from your open-issue threshold (${threshold}). Exceeding it triggers a full penalty on all discovery scores.`,
+      priority: 85,
+    };
+  }
+
+  return null;
+};
+
+const getIssueCredibilityInsight = (
+  minerStats: MinerEvaluation,
+): InsightItem => {
+  const credibility = parseNumber(minerStats.issueCredibility);
+  const credibilityPercent = (credibility * 100).toFixed(1);
+  const solvedIssues = parseNumber(minerStats.totalSolvedIssues);
+
+  if (credibility >= 0.8 && solvedIssues >= 7) {
+    return {
+      id: 'issue-credibility-excellent',
+      type: 'achievement',
+      title: 'Strong issue credibility',
+      description: `Your issue credibility is ${credibilityPercent}% — well above the 80% eligibility threshold. Quality issue filing is being rewarded.`,
+      priority: 50,
+    };
+  }
+
+  if (credibility < 0.8 && solvedIssues >= 3) {
+    return {
+      id: 'issue-credibility-needs-work',
+      type: 'tip',
+      title: 'Improve issue credibility',
+      description: `Issue credibility is currently ${credibilityPercent}%. You need 80%+ for eligibility. Focus on filing well-scoped, actionable issues that are more likely to be solved.`,
+      priority: 70,
+    };
+  }
+
+  return {
+    id: 'issue-credibility-stable',
+    type: 'tip',
+    title: 'Keep issue credibility trending upward',
+    description: `Issue credibility is ${credibilityPercent}%. File quality issues to move toward the top credibility band.`,
+    priority: 35,
+  };
+};
+
+const getIssueEligibilityInsight = (
+  minerStats: MinerEvaluation,
+): InsightItem | null => {
+  const isEligible = minerStats.isIssueEligible ?? false;
+  const validSolved = parseNumber(minerStats.totalValidSolvedIssues);
+  const credibility = parseNumber(minerStats.issueCredibility);
+
+  if (isEligible) {
+    return {
+      id: 'issue-eligible',
+      type: 'achievement',
+      title: 'Issue discovery eligible',
+      description: `You meet all eligibility requirements: ${validSolved} valid solved issues (need 7) and ${(credibility * 100).toFixed(1)}% credibility (need 80%).`,
+      priority: 40,
+    };
+  }
+
+  const needs: string[] = [];
+  if (validSolved < 7)
+    needs.push(`${7 - validSolved} more valid solved issues`);
+  if (credibility < 0.8) needs.push('80%+ issue credibility');
+
+  return {
+    id: 'issue-eligibility-progress',
+    type: 'tip',
+    title: 'Issue discovery progress',
+    description: `You have ${validSolved} valid solved issues (need 7) and ${(credibility * 100).toFixed(1)}% credibility (need 80%). Still need: ${needs.join(', ')}.`,
+    priority: 90,
+  };
+};
+
+const getInsightStyle = (type: InsightType) => {
+  switch (type) {
+    case 'warning':
+      return {
+        color: STATUS_COLORS.warningOrange,
+        border: alpha(STATUS_COLORS.warningOrange, 0.3),
+        background: alpha(STATUS_COLORS.warningOrange, 0.09),
+        icon: <WarningIcon sx={{ fontSize: '1rem' }} />,
+      };
+    case 'achievement':
+      return {
+        color: STATUS_COLORS.success,
+        border: alpha(STATUS_COLORS.success, 0.35),
+        background: alpha(STATUS_COLORS.success, 0.1),
+        icon: <AchievementIcon sx={{ fontSize: '1rem' }} />,
+      };
+    default:
+      return {
+        color: STATUS_COLORS.info,
+        border: alpha(STATUS_COLORS.info, 0.35),
+        background: alpha(STATUS_COLORS.info, 0.1),
+        icon: <TipIcon sx={{ fontSize: '1rem' }} />,
+      };
+  }
+};
+
+const MinerIssueInsightsCard: React.FC<MinerIssueInsightsCardProps> = ({
+  githubId,
+}) => {
+  const { data: minerStats } = useMinerStats(githubId);
+
+  const insights = useMemo(() => {
+    if (!minerStats) return [];
+
+    const assembled: InsightItem[] = [];
+
+    const openIssueInsight = getOpenIssueInsight(minerStats);
+    if (openIssueInsight) assembled.push(openIssueInsight);
+
+    const eligibilityInsight = getIssueEligibilityInsight(minerStats);
+    if (eligibilityInsight) assembled.push(eligibilityInsight);
+
+    assembled.push(getIssueCredibilityInsight(minerStats));
+
+    return assembled.sort((a, b) => b.priority - a.priority).slice(0, 4);
+  }, [minerStats]);
+
+  if (!minerStats) return null;
+
+  return (
+    <Card
+      sx={{
+        borderRadius: 3,
+        border: '1px solid',
+        borderColor: 'border.light',
+        backgroundColor: 'transparent',
+        p: 3,
+      }}
+      elevation={0}
+    >
+      <Box sx={{ mb: 2 }}>
+        <Typography
+          sx={{
+            color: 'text.primary',
+            fontFamily: '"JetBrains Mono", monospace',
+            fontSize: '1.1rem',
+            fontWeight: 600,
+            mb: 0.8,
+          }}
+        >
+          Insights & Next Actions
+        </Typography>
+        <Typography
+          sx={{
+            color: (t) => alpha(t.palette.text.primary, 0.55),
+            fontSize: '0.85rem',
+          }}
+        >
+          Recommendations based on your issue discovery eligibility,
+          credibility, and open issue posture.
+        </Typography>
+      </Box>
+
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.2 }}>
+        {insights.map((insight) => {
+          const style = getInsightStyle(insight.type);
+          return (
+            <Box
+              key={insight.id}
+              sx={{
+                borderRadius: 1.7,
+                px: 1.5,
+                py: 1.2,
+                border: `1px solid ${style.border}`,
+                backgroundColor: style.background,
+                display: 'flex',
+                alignItems: 'flex-start',
+                gap: 1.1,
+              }}
+            >
+              <Box sx={{ color: style.color, mt: 0.15 }}>{style.icon}</Box>
+              <Box sx={{ flexGrow: 1 }}>
+                <Typography
+                  sx={{
+                    color: style.color,
+                    fontFamily: '"JetBrains Mono", monospace',
+                    fontSize: '0.83rem',
+                    fontWeight: 600,
+                  }}
+                >
+                  {insight.title}
+                </Typography>
+                <Typography
+                  sx={{
+                    color: (t) => alpha(t.palette.text.primary, 0.68),
+                    fontSize: '0.8rem',
+                    mt: 0.4,
+                    lineHeight: 1.45,
+                  }}
+                >
+                  {insight.description}
+                </Typography>
+              </Box>
+              <Chip
+                size="small"
+                label={insight.type}
+                sx={{
+                  textTransform: 'uppercase',
+                  fontFamily: '"JetBrains Mono", monospace',
+                  fontSize: '0.62rem',
+                  color: style.color,
+                  backgroundColor: alpha(style.color, 0.12),
+                  border: `1px solid ${alpha(style.color, 0.35)}`,
+                  height: 22,
+                }}
+              />
+            </Box>
+          );
+        })}
+      </Box>
+
+      <Typography
+        sx={{
+          mt: 2,
+          textAlign: 'right',
+          fontSize: '0.72rem',
+          fontFamily: '"JetBrains Mono", monospace',
+          color: (t) => alpha(t.palette.text.primary, 0.35),
+        }}
+      >
+        Learn more about issue discovery in the{' '}
+        <Typography
+          component="a"
+          href="https://docs.gittensor.io/issue-discovery.html"
+          target="_blank"
+          rel="noopener noreferrer"
+          sx={{
+            color: 'primary.main',
+            fontSize: 'inherit',
+            fontFamily: 'inherit',
+            textDecoration: 'none',
+            '&:hover': { textDecoration: 'underline' },
+          }}
+        >
+          docs
+        </Typography>
+      </Typography>
+    </Card>
+  );
+};
+
+export default MinerIssueInsightsCard;

--- a/src/components/miners/MinerIssueScoreBreakdown.tsx
+++ b/src/components/miners/MinerIssueScoreBreakdown.tsx
@@ -1,0 +1,606 @@
+import React, { useMemo, useState } from 'react';
+import {
+  Box,
+  Card,
+  Typography,
+  Stack,
+  Tooltip,
+  alpha,
+  Collapse,
+  IconButton,
+  Button,
+} from '@mui/material';
+import {
+  ExpandMore as ExpandMoreIcon,
+  ExpandLess as ExpandLessIcon,
+  GitHub as GitHubIcon,
+} from '@mui/icons-material';
+import { useMinerStats, useIssues } from '../../api';
+import { type IssueBounty } from '../../api/models/Issues';
+import { STATUS_COLORS } from '../../theme';
+
+interface MinerIssueScoreBreakdownProps {
+  githubId: string;
+}
+
+const PAGE_SIZE = 10;
+
+const tooltipSlotProps = {
+  tooltip: {
+    sx: {
+      backgroundColor: 'surface.tooltip',
+      color: 'text.primary',
+      fontSize: '0.72rem',
+      fontFamily: '"JetBrains Mono", monospace',
+      padding: '8px 12px',
+      borderRadius: '6px',
+      border: '1px solid',
+      borderColor: 'border.light',
+      maxWidth: 280,
+    },
+  },
+  arrow: { sx: { color: 'surface.tooltip' } },
+};
+
+interface MultiplierPillProps {
+  label: string;
+  value: number;
+  tooltip: React.ReactNode;
+  format?: 'multiplier' | 'value' | 'percent';
+  pillColor?: string;
+}
+
+const MultiplierPill: React.FC<MultiplierPillProps> = ({
+  label,
+  value,
+  tooltip,
+  format = 'multiplier',
+  pillColor,
+}) => {
+  const color =
+    pillColor ??
+    (format === 'multiplier'
+      ? value === 1
+        ? STATUS_COLORS.neutral
+        : value > 1
+          ? STATUS_COLORS.success
+          : STATUS_COLORS.warningOrange
+      : STATUS_COLORS.neutral);
+
+  const display =
+    format === 'percent'
+      ? `${(value * 100).toFixed(1)}%`
+      : format === 'value'
+        ? Number(value).toFixed(2)
+        : `×${Number(value).toFixed(2)}`;
+
+  return (
+    <Tooltip title={tooltip} arrow placement="top" slotProps={tooltipSlotProps}>
+      <Box
+        sx={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: 0.5,
+          px: 1,
+          py: 0.25,
+          borderRadius: 1,
+          border: `1px solid ${alpha(color, 0.25)}`,
+          backgroundColor: alpha(color, 0.06),
+          cursor: 'pointer',
+        }}
+      >
+        <Typography
+          sx={{
+            fontFamily: '"JetBrains Mono", monospace',
+            fontSize: '0.62rem',
+            color: STATUS_COLORS.neutral,
+            textTransform: 'uppercase',
+          }}
+        >
+          {label}
+        </Typography>
+        <Typography
+          sx={{
+            fontFamily: '"JetBrains Mono", monospace',
+            fontSize: '0.72rem',
+            fontWeight: 600,
+            color,
+          }}
+        >
+          {display}
+        </Typography>
+      </Box>
+    </Tooltip>
+  );
+};
+
+const MULTIPLIER_PILL_DEFS = [
+  {
+    key: 'discoveryCredibilityMultiplier' as const,
+    label: 'cred',
+    title: 'Credibility',
+    desc: 'Based on your issue solve rate, scaled to reward consistency.',
+  },
+  {
+    key: 'discoveryRepoWeightMultiplier' as const,
+    label: 'repo wt',
+    title: 'Repo Weight',
+    desc: 'Based on repository weight and activity.',
+  },
+  {
+    key: 'discoveryTimeDecayMultiplier' as const,
+    label: 'decay',
+    title: 'Time Decay',
+    desc: 'Recent issues score higher. Sigmoid decay with 10-day midpoint.',
+  },
+  {
+    key: 'discoveryReviewQualityMultiplier' as const,
+    label: 'review',
+    title: 'Review Quality',
+    desc: 'Clean merge bonus (1.1×) or penalty per change-request round (-0.15×).',
+  },
+  {
+    key: 'discoveryOpenIssueSpamMultiplier' as const,
+    label: 'spam',
+    title: 'Open Issue Spam',
+    desc: 'Penalty for exceeding open issue threshold.',
+  },
+] as const;
+
+const buildMultiplierPillData = (issue: IssueBounty) =>
+  MULTIPLIER_PILL_DEFS.map((def) => ({
+    ...def,
+    raw: issue[def.key],
+  }));
+
+const buildStatLine = (issue: IssueBounty): string[] =>
+  [
+    issue.discoveryBaseScore &&
+      parseFloat(issue.discoveryBaseScore) > 0 &&
+      `base ${parseFloat(issue.discoveryBaseScore).toFixed(2)}`,
+    issue.discoveryEarnedScore &&
+      `earned ${parseFloat(issue.discoveryEarnedScore).toFixed(4)}`,
+    `bounty ${parseFloat(issue.bountyAmount || '0').toFixed(2)}`,
+    issue.winningPrNumber && `winning PR #${issue.winningPrNumber}`,
+    issue.completedAt &&
+      `completed ${new Date(issue.completedAt).toLocaleDateString()}`,
+    !issue.completedAt &&
+      `created ${new Date(issue.createdAt).toLocaleDateString()}`,
+  ].filter((s): s is string => !!s);
+
+const getStatusColor = (status: string) => {
+  switch (status) {
+    case 'completed':
+      return STATUS_COLORS.merged;
+    case 'active':
+    case 'registered':
+      return STATUS_COLORS.info;
+    case 'cancelled':
+      return STATUS_COLORS.closed;
+    default:
+      return STATUS_COLORS.neutral;
+  }
+};
+
+const getStatusLabel = (status: string) => {
+  switch (status) {
+    case 'registered':
+      return 'Active';
+    default:
+      return status.charAt(0).toUpperCase() + status.slice(1);
+  }
+};
+
+interface IssueScoreRowProps {
+  issue: IssueBounty;
+}
+
+const IssueScoreRow: React.FC<IssueScoreRowProps> = ({ issue }) => {
+  const [expanded, setExpanded] = useState(false);
+
+  const isScored = issue.status === 'completed';
+  const isCancelled = issue.status === 'cancelled';
+  const isActive = issue.status === 'active' || issue.status === 'registered';
+  const statusColor = getStatusColor(issue.status);
+  const statusLabel = getStatusLabel(issue.status);
+  const repoName =
+    issue.repositoryFullName.split('/').pop() || issue.repositoryFullName;
+  const score = parseFloat(issue.bountyAmount || '0');
+
+  return (
+    <Box
+      sx={{
+        borderBottom: '1px solid',
+        borderColor: 'border.subtle',
+        '&:last-child': { borderBottom: 'none' },
+      }}
+    >
+      <Box
+        onClick={() => setExpanded(!expanded)}
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 1.5,
+          py: 1.2,
+          px: 1.5,
+          cursor: 'pointer',
+          '&:hover': { backgroundColor: 'surface.subtle' },
+          transition: 'background-color 0.15s',
+        }}
+      >
+        {/* Issue number + title */}
+        <Box sx={{ flex: 1, minWidth: 0 }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <Typography
+              sx={{
+                fontFamily: '"JetBrains Mono", monospace',
+                fontSize: '0.78rem',
+                fontWeight: 600,
+                color: 'text.primary',
+                flexShrink: 0,
+              }}
+            >
+              #{issue.issueNumber}
+            </Typography>
+            <Typography
+              sx={{
+                fontFamily: '"JetBrains Mono", monospace',
+                fontSize: '0.72rem',
+                color: (t) => alpha(t.palette.text.primary, 0.6),
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+              }}
+            >
+              {issue.title || `Issue #${issue.issueNumber}`}
+            </Typography>
+          </Box>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mt: 0.25 }}>
+            <Typography
+              sx={{
+                fontFamily: '"JetBrains Mono", monospace',
+                fontSize: '0.62rem',
+                color: (t) => alpha(t.palette.text.primary, 0.5),
+              }}
+            >
+              {repoName}
+            </Typography>
+            <Box
+              sx={{
+                width: 4,
+                height: 4,
+                borderRadius: '50%',
+                backgroundColor: statusColor,
+                flexShrink: 0,
+              }}
+            />
+            <Typography
+              sx={{
+                fontFamily: '"JetBrains Mono", monospace',
+                fontSize: '0.62rem',
+                color: statusColor,
+              }}
+            >
+              {statusLabel}
+            </Typography>
+          </Box>
+        </Box>
+
+        {/* Score */}
+        <Typography
+          sx={{
+            fontFamily: '"JetBrains Mono", monospace',
+            fontSize: '0.9rem',
+            fontWeight: 600,
+            color: isCancelled
+              ? (t) => alpha(t.palette.text.primary, 0.3)
+              : isActive
+                ? STATUS_COLORS.info
+                : 'text.primary',
+            flexShrink: 0,
+          }}
+        >
+          {isCancelled ? '—' : isActive ? 'Pending' : score.toFixed(4)}
+        </Typography>
+
+        <IconButton
+          size="small"
+          sx={{ color: (t) => alpha(t.palette.text.primary, 0.3), p: 0.5 }}
+        >
+          {expanded ? (
+            <ExpandLessIcon sx={{ fontSize: '1rem' }} />
+          ) : (
+            <ExpandMoreIcon sx={{ fontSize: '1rem' }} />
+          )}
+        </IconButton>
+      </Box>
+
+      <Collapse in={expanded}>
+        <Box
+          sx={{
+            px: 1.5,
+            pb: 1.5,
+            pt: 1,
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 1,
+          }}
+        >
+          {isScored && (
+            <Box
+              sx={{
+                display: 'flex',
+                flexWrap: 'wrap',
+                gap: 0.75,
+                alignItems: 'center',
+              }}
+            >
+              {buildMultiplierPillData(issue).map(
+                (pill) =>
+                  pill.raw != null && (
+                    <MultiplierPill
+                      key={pill.label}
+                      label={pill.label}
+                      value={parseFloat(pill.raw)}
+                      tooltip={
+                        <Stack direction="column">
+                          <Typography variant="tooltipLabel">
+                            {pill.title} {Number(pill.raw).toFixed(4)}×
+                          </Typography>
+                          <Typography variant="tooltipDesc">
+                            {pill.desc}
+                          </Typography>
+                        </Stack>
+                      }
+                    />
+                  ),
+              )}
+            </Box>
+          )}
+
+          <Box
+            sx={{
+              display: 'flex',
+              flexWrap: 'wrap',
+              alignItems: 'center',
+              gap: 0.5,
+            }}
+          >
+            {buildStatLine(issue).map((stat, i, arr) => (
+              <React.Fragment key={i}>
+                <Typography
+                  component="span"
+                  sx={{
+                    fontFamily: '"JetBrains Mono", monospace',
+                    fontSize: '0.65rem',
+                    color: (t) => alpha(t.palette.text.primary, 0.4),
+                  }}
+                >
+                  {stat}
+                </Typography>
+                {i < arr.length - 1 && (
+                  <Typography
+                    component="span"
+                    sx={{
+                      fontFamily: '"JetBrains Mono", monospace',
+                      fontSize: '0.65rem',
+                      color: (t) => alpha(t.palette.text.primary, 0.2),
+                      mx: 0.25,
+                    }}
+                  >
+                    ·
+                  </Typography>
+                )}
+              </React.Fragment>
+            ))}
+          </Box>
+
+          <Box sx={{ display: 'flex', gap: 1, mt: 0.5 }}>
+            <Button
+              size="small"
+              startIcon={<GitHubIcon sx={{ fontSize: '0.85rem' }} />}
+              component="a"
+              href={issue.githubUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={(e) => e.stopPropagation()}
+              sx={{
+                fontFamily: '"JetBrains Mono", monospace',
+                fontSize: '0.65rem',
+                textTransform: 'none',
+                color: (t) => alpha(t.palette.text.primary, 0.5),
+                px: 1,
+                py: 0.25,
+                minWidth: 'auto',
+                '&:hover': {
+                  backgroundColor: 'surface.subtle',
+                  color: 'text.primary',
+                },
+              }}
+            >
+              GitHub
+            </Button>
+          </Box>
+        </Box>
+      </Collapse>
+    </Box>
+  );
+};
+
+const MinerIssueScoreBreakdown: React.FC<MinerIssueScoreBreakdownProps> = ({
+  githubId,
+}) => {
+  const { data: minerStats } = useMinerStats(githubId);
+  const { data: allIssues, isLoading } = useIssues();
+  const [page, setPage] = useState(0);
+
+  const hotkey = minerStats?.hotkey || '';
+
+  const minerIssues = useMemo(() => {
+    if (!allIssues || !hotkey) return [];
+    return allIssues
+      .filter((issue) => issue.solverHotkey === hotkey)
+      .sort((a, b) => {
+        // Completed first, then by bounty amount desc
+        if (a.status === 'completed' && b.status !== 'completed') return -1;
+        if (a.status !== 'completed' && b.status === 'completed') return 1;
+        return (
+          parseFloat(b.bountyAmount || '0') - parseFloat(a.bountyAmount || '0')
+        );
+      });
+  }, [allIssues, hotkey]);
+
+  if (isLoading) {
+    return (
+      <Card sx={{ p: 4, textAlign: 'center' }} elevation={0}>
+        <Typography
+          sx={{
+            color: (t) => alpha(t.palette.text.primary, 0.4),
+            fontFamily: '"JetBrains Mono", monospace',
+            fontSize: '0.85rem',
+          }}
+        >
+          Loading issue scores...
+        </Typography>
+      </Card>
+    );
+  }
+
+  const totalPages = Math.ceil(minerIssues.length / PAGE_SIZE);
+  const displayIssues = minerIssues.slice(
+    page * PAGE_SIZE,
+    (page + 1) * PAGE_SIZE,
+  );
+
+  return (
+    <Card sx={{ p: 0, overflow: 'hidden' }} elevation={0}>
+      <Box
+        sx={{
+          p: 2.5,
+          borderBottom: '1px solid',
+          borderColor: 'border.subtle',
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+        }}
+      >
+        <Box>
+          <Typography
+            sx={{
+              fontFamily: '"JetBrains Mono", monospace',
+              fontSize: '1rem',
+              fontWeight: 600,
+              color: 'text.primary',
+            }}
+          >
+            Score Breakdown
+          </Typography>
+          <Typography
+            sx={{
+              fontFamily: '"JetBrains Mono", monospace',
+              fontSize: '0.72rem',
+              color: (t) => alpha(t.palette.text.primary, 0.45),
+              mt: 0.25,
+            }}
+          >
+            Click any issue to see details
+          </Typography>
+        </Box>
+      </Box>
+
+      {/* Issue list */}
+      {minerIssues.length === 0 ? (
+        <Box sx={{ textAlign: 'center', py: 6 }}>
+          <Typography
+            sx={{
+              color: (t) => alpha(t.palette.text.primary, 0.4),
+              fontFamily: '"JetBrains Mono", monospace',
+              fontSize: '0.85rem',
+            }}
+          >
+            No issue scores yet
+          </Typography>
+          <Typography
+            sx={{
+              color: (t) => alpha(t.palette.text.primary, 0.25),
+              fontFamily: '"JetBrains Mono", monospace',
+              fontSize: '0.75rem',
+              mt: 0.5,
+            }}
+          >
+            Issues will appear here when you solve bounty issues.
+          </Typography>
+        </Box>
+      ) : (
+        <Box>
+          {displayIssues.map((issue, i) => (
+            <IssueScoreRow
+              key={`${issue.repositoryFullName}-${issue.issueNumber}-${i}`}
+              issue={issue}
+            />
+          ))}
+        </Box>
+      )}
+
+      {/* Pagination */}
+      {totalPages > 1 && (
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: 2,
+            py: 1.2,
+            borderTop: '1px solid',
+            borderColor: 'border.subtle',
+          }}
+        >
+          <Typography
+            onClick={() => setPage((p) => Math.max(0, p - 1))}
+            sx={{
+              fontFamily: '"JetBrains Mono", monospace',
+              fontSize: '0.72rem',
+              color:
+                page === 0
+                  ? (t) => alpha(t.palette.text.primary, 0.2)
+                  : 'primary.main',
+              cursor: page === 0 ? 'default' : 'pointer',
+              userSelect: 'none',
+              '&:hover': page > 0 ? { textDecoration: 'underline' } : {},
+            }}
+          >
+            ← Prev
+          </Typography>
+          <Typography
+            sx={{
+              fontFamily: '"JetBrains Mono", monospace',
+              fontSize: '0.72rem',
+              color: (t) => alpha(t.palette.text.primary, 0.5),
+            }}
+          >
+            {page + 1} / {totalPages}
+          </Typography>
+          <Typography
+            onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
+            sx={{
+              fontFamily: '"JetBrains Mono", monospace',
+              fontSize: '0.72rem',
+              color:
+                page >= totalPages - 1
+                  ? (t) => alpha(t.palette.text.primary, 0.2)
+                  : 'primary.main',
+              cursor: page >= totalPages - 1 ? 'default' : 'pointer',
+              userSelect: 'none',
+              '&:hover':
+                page < totalPages - 1 ? { textDecoration: 'underline' } : {},
+            }}
+          >
+            Next →
+          </Typography>
+        </Box>
+      )}
+    </Card>
+  );
+};
+
+export default MinerIssueScoreBreakdown;

--- a/src/components/miners/index.ts
+++ b/src/components/miners/index.ts
@@ -5,6 +5,8 @@ export { default as ExplorerFilterButton } from './ExplorerFilterButton';
 export { default as MinerActivity } from './MinerActivity';
 export { default as MinerFocusCard } from './MinerFocusCard';
 export { default as MinerInsightsCard } from './MinerInsightsCard';
+export { default as MinerIssueInsightsCard } from './MinerIssueInsightsCard';
+export { default as MinerIssueScoreBreakdown } from './MinerIssueScoreBreakdown';
 export { default as MinerPRsTable } from './MinerPRsTable';
 export { default as MinerRepositoriesTable } from './MinerRepositoriesTable';
 export { default as MinerScoreBreakdown } from './MinerScoreBreakdown';

--- a/src/pages/MinerDetailsPage.tsx
+++ b/src/pages/MinerDetailsPage.tsx
@@ -6,6 +6,8 @@ import {
   BackButton,
   MinerActivity,
   MinerInsightsCard,
+  MinerIssueInsightsCard,
+  MinerIssueScoreBreakdown,
   MinerPRsTable,
   MinerRepositoriesTable,
   MinerScoreBreakdown,
@@ -174,12 +176,18 @@ const MinerDetailsPage: React.FC = () => {
           </Box>
 
           <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
-            {activeTab === 'overview' && (
-              <>
-                <MinerInsightsCard githubId={githubId} />
-                <MinerScoreBreakdown githubId={githubId} />
-              </>
-            )}
+            {activeTab === 'overview' &&
+              (viewMode === 'issues' ? (
+                <>
+                  <MinerIssueInsightsCard githubId={githubId} />
+                  <MinerIssueScoreBreakdown githubId={githubId} />
+                </>
+              ) : (
+                <>
+                  <MinerInsightsCard githubId={githubId} />
+                  <MinerScoreBreakdown githubId={githubId} />
+                </>
+              ))}
             {activeTab === 'activity' && <MinerActivity githubId={githubId} />}
             {activeTab === 'pull-requests' && (
               <MinerPRsTable githubId={githubId} />


### PR DESCRIPTION
## Summary

Add `MinerIssueInsightsCard` and `MinerIssueScoreBreakdown` for the issue discovery mode Overview tab. Depending on toggle PR https://github.com/entrius/gittensor-ui/pull/179

- **MinerIssueInsightsCard**: Actionable insights based on issue eligibility, credibility, and open issue posture
- **MinerIssueScoreBreakdown**: Expandable issue rows with scoring details, multiplier chips, and GitHub links
- Add optional discovery scoring fields to `IssueBounty` model (ready for when backend includes them)
- Wire into `MinerDetailsPage` issues mode Overview tab

Uses only existing API data (`useMinerStats`, `useIssues`) - no new endpoints required. Discovery multiplier pills will render automatically once the backend includes those fields in the `/issues` response.

## Related Issues

Closes https://github.com/entrius/gittensor-ui/issues/178

## Video

https://github.com/user-attachments/assets/fc5d1062-5e16-4af5-8802-d61441f5dbc0

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
