### PR TITLE
refactor(dashboard): replace hardcoded colors with theme tokens

### DIFF
--- a/src/components/dashboard/CommitTrendChart.tsx
+++ b/src/components/dashboard/CommitTrendChart.tsx
@@ -38,8 +38,8 @@ const CommitTrendChart: React.FC = () => {
         const data = params[0];
         return `${formatUtcYmd(data.axisValue)} UTC<br/>Lines Committed: ${data.value.toLocaleString()}`;
       },
-      backgroundColor: 'rgba(18, 18, 20, 0.95)',
-      borderColor: 'rgba(255, 255, 255, 0.1)',
+      backgroundColor: theme.palette.surface.tooltip,
+      borderColor: theme.palette.border.light,
       borderWidth: 1,
       textStyle: {
         color: theme.palette.text.primary,
@@ -148,7 +148,7 @@ const CommitTrendChart: React.FC = () => {
     <Card
       sx={{
         borderRadius: 3,
-        border: '1px solid rgba(255, 255, 255, 0.1)',
+        border: `1px solid ${theme.palette.border.light}`,
         backgroundColor: 'transparent',
         height: '100%',
         display: 'flex',

--- a/src/components/dashboard/ContributionHeatmap.tsx
+++ b/src/components/dashboard/ContributionHeatmap.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { Box, Card, Typography, Tooltip } from '@mui/material';
+import { Box, Card, Typography, Tooltip, alpha, useTheme } from '@mui/material';
 import { ActivityCalendar } from 'react-activity-calendar';
+import { CONTRIBUTION_HEATMAP_SCALE, TEXT_OPACITY } from '../../theme';
 
 interface ContributionData {
   date: string;
@@ -19,11 +20,6 @@ interface ContributionHeatmapProps {
   bare?: boolean;
 }
 
-const HEATMAP_THEME = {
-  light: ['#161b22', '#0e4429', '#006d32', '#26a641', '#39d353'],
-  dark: ['#161b22', '#0e4429', '#006d32', '#26a641', '#39d353'],
-};
-
 const ContributionHeatmap: React.FC<ContributionHeatmapProps> = ({
   data,
   contributionsLast30Days,
@@ -34,6 +30,9 @@ const ContributionHeatmap: React.FC<ContributionHeatmapProps> = ({
   emptySubtitle = 'Activity will appear here once PRs are merged',
   bare = false,
 }) => {
+  const theme = useTheme();
+  const heatmapLevels = [...CONTRIBUTION_HEATMAP_SCALE];
+  const heatmapTheme = { light: heatmapLevels, dark: heatmapLevels };
   const isEmpty = data.length === 0;
 
   const content = (
@@ -41,7 +40,7 @@ const ContributionHeatmap: React.FC<ContributionHeatmapProps> = ({
       <Box sx={{ mb: 2.5 }}>
         <Typography
           sx={{
-            color: '#fff',
+            color: 'text.primary',
             fontFamily: '"JetBrains Mono", monospace',
             fontWeight: 700,
             fontSize: '2.5rem',
@@ -53,7 +52,7 @@ const ContributionHeatmap: React.FC<ContributionHeatmapProps> = ({
         <Typography
           variant="body2"
           sx={{
-            color: 'rgba(255, 255, 255, 0.4)',
+            color: alpha(theme.palette.common.white, TEXT_OPACITY.faint),
             fontFamily: '"JetBrains Mono", monospace',
             fontSize: '0.85rem',
             mt: 0.5,
@@ -77,7 +76,7 @@ const ContributionHeatmap: React.FC<ContributionHeatmapProps> = ({
           >
             <Typography
               sx={{
-                color: 'rgba(255, 255, 255, 0.5)',
+                color: alpha(theme.palette.common.white, TEXT_OPACITY.muted),
                 fontFamily: '"JetBrains Mono", monospace',
                 fontSize: '0.85rem',
                 textAlign: 'center',
@@ -88,7 +87,7 @@ const ContributionHeatmap: React.FC<ContributionHeatmapProps> = ({
             {emptySubtitle && (
               <Typography
                 sx={{
-                  color: 'rgba(255, 255, 255, 0.3)',
+                  color: alpha(theme.palette.common.white, TEXT_OPACITY.ghost),
                   fontFamily: '"JetBrains Mono", monospace',
                   fontSize: '0.75rem',
                   textAlign: 'center',
@@ -102,7 +101,7 @@ const ContributionHeatmap: React.FC<ContributionHeatmapProps> = ({
         ) : (
           <ActivityCalendar
             data={data}
-            theme={HEATMAP_THEME}
+            theme={heatmapTheme}
             labels={{
               legend: { less: 'Less', more: 'More' },
               months: [
@@ -125,7 +124,7 @@ const ContributionHeatmap: React.FC<ContributionHeatmapProps> = ({
             blockSize={11}
             blockMargin={3}
             fontSize={11}
-            style={{ color: '#fff' }}
+            style={{ color: theme.palette.text.primary }}
             showWeekdayLabels={false}
             renderBlock={(block, activity) => (
               <Tooltip
@@ -144,7 +143,7 @@ const ContributionHeatmap: React.FC<ContributionHeatmapProps> = ({
         <Typography
           variant="caption"
           sx={{
-            color: 'rgba(255, 255, 255, 0.25)',
+            color: alpha(theme.palette.common.white, 0.25),
             display: 'block',
             fontStyle: 'italic',
             fontSize: '0.7rem',

--- a/src/components/dashboard/GlobalActivity.tsx
+++ b/src/components/dashboard/GlobalActivity.tsx
@@ -6,16 +6,19 @@ import {
   Grid,
   CircularProgress,
   Chip,
+  alpha,
+  useTheme,
 } from '@mui/material';
 import PublicIcon from '@mui/icons-material/Public';
 import CodeOffIcon from '@mui/icons-material/CodeOff';
 import { subDays, format } from 'date-fns';
 import { useAllMiners, useAllPrs } from '../../api';
-import { STATUS_COLORS } from '../../theme';
+import { TEXT_OPACITY } from '../../theme';
 import ContributionHeatmap from './ContributionHeatmap';
 import PRStatusChart from './PRStatusChart';
 
 const GlobalActivity: React.FC = () => {
+  const theme = useTheme();
   const { data: allMinerStats, isLoading: isLoadingStats } = useAllMiners();
   const { data: allPrs, isLoading: isLoadingPRs } = useAllPrs();
 
@@ -157,9 +160,9 @@ const GlobalActivity: React.FC = () => {
           icon={<PublicIcon />}
           label="Active Network - Continuous Development"
           sx={{
-            color: STATUS_COLORS.success,
-            borderColor: `${STATUS_COLORS.success}4d`,
-            '& .MuiChip-icon': { color: STATUS_COLORS.success },
+            color: theme.palette.status.success,
+            borderColor: alpha(theme.palette.status.success, 0.3),
+            '& .MuiChip-icon': { color: theme.palette.status.success },
           }}
         />
       </Box>
@@ -175,11 +178,15 @@ const GlobalActivity: React.FC = () => {
           }}
         >
           <CodeOffIcon
-            sx={{ fontSize: 48, color: 'rgba(255, 255, 255, 0.2)', mb: 2 }}
+            sx={{
+              fontSize: 48,
+              color: alpha(theme.palette.common.white, TEXT_OPACITY.ghost),
+              mb: 2,
+            }}
           />
           <Typography
             sx={{
-              color: 'rgba(255, 255, 255, 0.5)',
+              color: alpha(theme.palette.common.white, TEXT_OPACITY.muted),
               fontFamily: '"JetBrains Mono", monospace',
               fontSize: '0.9rem',
               textAlign: 'center',

--- a/src/components/dashboard/KpiCard.tsx
+++ b/src/components/dashboard/KpiCard.tsx
@@ -6,6 +6,7 @@ import {
   type SxProps,
   type Theme,
   useMediaQuery,
+  useTheme,
 } from '@mui/material';
 import theme from '../../theme';
 
@@ -24,6 +25,7 @@ const KpiCard: React.FC<KpiCardProps> = ({
   variant = 'medium',
   sx,
 }) => {
+  const muiTheme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
   const isLarge = variant === 'large';
   const padding = isLarge
@@ -46,7 +48,7 @@ const KpiCard: React.FC<KpiCardProps> = ({
     <Card
       sx={{
         borderRadius: 3,
-        border: '1px solid rgba(255, 255, 255, 0.1)',
+        border: `1px solid ${muiTheme.palette.border.light}`,
         backgroundColor: 'transparent',
         height: '100%',
         ...sx,
@@ -63,7 +65,7 @@ const KpiCard: React.FC<KpiCardProps> = ({
         <Typography
           variant="dataLabel"
           fontSize={titleSize}
-          color="#ffffff"
+          color="text.primary"
           gutterBottom
           sx={{ mb: isLarge ? 1 : 0.5 }}
         >
@@ -90,7 +92,7 @@ const KpiCard: React.FC<KpiCardProps> = ({
         {subtitle && (
           <Typography
             variant="body2"
-            color="rgba(255, 255, 255, 0.5)"
+            color="text.secondary"
             sx={{
               mt: isLarge ? 0.5 : 0.25,
               fontSize: isLarge ? (isMobile ? 12 : 14) : isMobile ? 11 : 12,

--- a/src/components/dashboard/LeaderboardCharts.tsx
+++ b/src/components/dashboard/LeaderboardCharts.tsx
@@ -514,7 +514,10 @@ const LeaderboardCharts: React.FC = () => {
               sx={{
                 fontFamily: 'JetBrains Mono',
                 fontSize: '0.8rem',
-                color: alpha(theme.palette.common.white, TEXT_OPACITY.secondary),
+                color: alpha(
+                  theme.palette.common.white,
+                  TEXT_OPACITY.secondary,
+                ),
                 whiteSpace: 'nowrap',
               }}
             >

--- a/src/components/dashboard/LeaderboardCharts.tsx
+++ b/src/components/dashboard/LeaderboardCharts.tsx
@@ -8,16 +8,19 @@ import {
   Switch,
   Typography,
   CircularProgress,
+  alpha,
+  useTheme,
 } from '@mui/material';
 import BarChartIcon from '@mui/icons-material/BarChart';
 import ReactECharts from 'echarts-for-react';
 import { useAllPrs, useReposAndWeights } from '../../api';
 import { truncateText } from '../../utils';
-import theme from '../../theme';
-
-const CHART_DOT_COLOR = 'rgba(88, 166, 255, 0.9)';
+import { REPO_OWNER_AVATAR_BACKGROUNDS, TEXT_OPACITY } from '../../theme';
 
 const LeaderboardCharts: React.FC = () => {
+  const theme = useTheme();
+  const chartAccent = alpha(theme.palette.status.info, 0.9);
+  const axisLabelStrong = alpha(theme.palette.common.white, 0.85);
   const [activeTab, setActiveTab] = useState(0);
   const [useLogScale, setUseLogScale] = useState(true);
 
@@ -89,9 +92,9 @@ const LeaderboardCharts: React.FC = () => {
       prNumber: item?.pullRequestNumber || 0,
       rank: item?.rank || 0,
       itemStyle: {
-        color: CHART_DOT_COLOR,
+        color: chartAccent,
         shadowBlur: 10,
-        shadowColor: CHART_DOT_COLOR,
+        shadowColor: chartAccent,
       },
     }));
 
@@ -103,13 +106,13 @@ const LeaderboardCharts: React.FC = () => {
         left: 'center',
         top: 20,
         textStyle: {
-          color: '#ffffff',
+          color: theme.palette.text.primary,
           fontFamily: 'JetBrains Mono',
           fontSize: 18,
           fontWeight: 600,
         },
         subtextStyle: {
-          color: 'rgba(255, 255, 255, 0.6)',
+          color: alpha(theme.palette.common.white, TEXT_OPACITY.secondary),
           fontFamily: 'JetBrains Mono',
           fontSize: 11,
         },
@@ -118,13 +121,15 @@ const LeaderboardCharts: React.FC = () => {
         trigger: 'axis',
         axisPointer: {
           type: 'shadow',
-          shadowStyle: { color: 'rgba(255, 255, 255, 0.05)' },
+          shadowStyle: {
+            color: alpha(theme.palette.common.white, TEXT_OPACITY.faint),
+          },
         },
-        backgroundColor: 'rgba(10, 10, 12, 0.98)',
-        borderColor: 'rgba(255, 255, 255, 0.2)',
+        backgroundColor: alpha(theme.palette.background.default, 0.98),
+        borderColor: theme.palette.border.medium,
         borderWidth: 1,
         textStyle: {
-          color: '#fff',
+          color: theme.palette.text.primary,
           fontFamily: 'JetBrains Mono',
           fontSize: 12,
         },
@@ -134,28 +139,28 @@ const LeaderboardCharts: React.FC = () => {
           if (!data) return '';
           return `
             <div style="font-family: 'JetBrains Mono', monospace;">
-              <div style="display: flex; align-items: center; gap: 10px; margin-bottom: 10px; padding-bottom: 8px; border-bottom: 1px solid rgba(255,255,255,0.15);">
-                <img src="https://avatars.githubusercontent.com/${data.author}" style="width: 32px; height: 32px; border-radius: 50%; border: 2px solid ${CHART_DOT_COLOR};" />
+              <div style="display: flex; align-items: center; gap: 10px; margin-bottom: 10px; padding-bottom: 8px; border-bottom: 1px solid ${theme.palette.border.light};">
+                <img src="https://avatars.githubusercontent.com/${data.author}" style="width: 32px; height: 32px; border-radius: 50%; border: 2px solid ${chartAccent};" />
                 <div>
-                  <div style="font-weight: 700; font-size: 14px; color: #fff;">PR #${data.prNumber}</div>
-                  <div style="font-size: 11px; color: rgba(255,255,255,0.6);">${data.author}</div>
+                  <div style="font-weight: 700; font-size: 14px; color: ${theme.palette.text.primary};">PR #${data.prNumber}</div>
+                  <div style="font-size: 11px; color: ${alpha(theme.palette.common.white, TEXT_OPACITY.secondary)};">${data.author}</div>
                 </div>
               </div>
-              <div style="margin-bottom: 10px; color: rgba(255,255,255,0.85); font-size: 11px; max-width: 300px; white-space: normal; word-break: break-word; line-height: 1.4;">
+              <div style="margin-bottom: 10px; color: ${alpha(theme.palette.common.white, 0.85)}; font-size: 11px; max-width: 300px; white-space: normal; word-break: break-word; line-height: 1.4;">
                 ${data.title}
               </div>
               <div style="display: grid; gap: 6px; font-size: 11px;">
                 <div style="display: flex; justify-content: space-between; gap: 20px;">
-                  <span style="color: rgba(255,255,255,0.65);">Rank:</span>
-                  <span style="color: #fff; font-weight: 600;">#${data.rank}</span>
+                  <span style="color: ${alpha(theme.palette.common.white, 0.65)};">Rank:</span>
+                  <span style="color: ${theme.palette.text.primary}; font-weight: 600;">#${data.rank}</span>
                 </div>
                 <div style="display: flex; justify-content: space-between; gap: 20px;">
-                  <span style="color: rgba(255,255,255,0.65);">Score:</span>
-                  <span style="color: #fff; font-weight: 600;">${data.value.toFixed(4)}</span>
+                  <span style="color: ${alpha(theme.palette.common.white, 0.65)};">Score:</span>
+                  <span style="color: ${theme.palette.text.primary}; font-weight: 600;">${data.value.toFixed(4)}</span>
                 </div>
                 <div style="display: flex; justify-content: space-between; gap: 20px;">
-                  <span style="color: rgba(255,255,255,0.65);">Repository:</span>
-                  <span style="color: #fff; font-weight: 600;">${data.repository}</span>
+                  <span style="color: ${alpha(theme.palette.common.white, 0.65)};">Repository:</span>
+                  <span style="color: ${theme.palette.text.primary}; font-weight: 600;">${data.repository}</span>
                 </div>
               </div>
             </div>
@@ -173,7 +178,7 @@ const LeaderboardCharts: React.FC = () => {
         type: 'category',
         data: xAxisData,
         axisLabel: {
-          color: 'rgba(255, 255, 255, 0.85)',
+          color: axisLabelStrong,
           fontFamily: 'JetBrains Mono',
           fontSize: 11,
           interval: 0,
@@ -191,12 +196,12 @@ const LeaderboardCharts: React.FC = () => {
         logBase: 10,
         name: 'PR Score',
         nameTextStyle: {
-          color: 'rgba(255, 255, 255, 0.85)',
+          color: axisLabelStrong,
           fontFamily: 'JetBrains Mono',
           fontSize: 12,
         },
         axisLabel: {
-          color: 'rgba(255, 255, 255, 0.85)',
+          color: axisLabelStrong,
           fontFamily: 'JetBrains Mono',
           fontSize: 11,
           formatter: (value: number) =>
@@ -219,7 +224,7 @@ const LeaderboardCharts: React.FC = () => {
           data: dotData.map((item) => ({
             ...item,
             itemStyle: {
-              color: CHART_DOT_COLOR,
+              color: chartAccent,
               opacity: 0.4,
               borderRadius: [2, 2, 0, 0],
             },
@@ -238,7 +243,11 @@ const LeaderboardCharts: React.FC = () => {
           z: 2,
           emphasis: {
             scale: 1.5,
-            itemStyle: { shadowBlur: 20, borderColor: '#fff', borderWidth: 2 },
+            itemStyle: {
+              shadowBlur: 20,
+              borderColor: theme.palette.common.white,
+              borderWidth: 2,
+            },
           },
           animationDuration: 1000,
           animationEasing: 'cubicOut',
@@ -264,9 +273,9 @@ const LeaderboardCharts: React.FC = () => {
       weight: item.weight,
       rank: item.rank,
       itemStyle: {
-        color: CHART_DOT_COLOR,
+        color: chartAccent,
         shadowBlur: 10,
-        shadowColor: CHART_DOT_COLOR,
+        shadowColor: chartAccent,
       },
     }));
 
@@ -278,13 +287,13 @@ const LeaderboardCharts: React.FC = () => {
         left: 'center',
         top: 20,
         textStyle: {
-          color: '#ffffff',
+          color: theme.palette.text.primary,
           fontFamily: 'JetBrains Mono',
           fontSize: 18,
           fontWeight: 600,
         },
         subtextStyle: {
-          color: 'rgba(255, 255, 255, 0.6)',
+          color: alpha(theme.palette.common.white, TEXT_OPACITY.secondary),
           fontFamily: 'JetBrains Mono',
           fontSize: 11,
         },
@@ -293,13 +302,15 @@ const LeaderboardCharts: React.FC = () => {
         trigger: 'axis',
         axisPointer: {
           type: 'shadow',
-          shadowStyle: { color: 'rgba(255, 255, 255, 0.05)' },
+          shadowStyle: {
+            color: alpha(theme.palette.common.white, TEXT_OPACITY.faint),
+          },
         },
-        backgroundColor: 'rgba(10, 10, 12, 0.98)',
-        borderColor: 'rgba(255, 255, 255, 0.2)',
+        backgroundColor: alpha(theme.palette.background.default, 0.98),
+        borderColor: theme.palette.border.medium,
         borderWidth: 1,
         textStyle: {
-          color: '#fff',
+          color: theme.palette.text.primary,
           fontFamily: 'JetBrains Mono',
           fontSize: 12,
         },
@@ -311,35 +322,35 @@ const LeaderboardCharts: React.FC = () => {
           const repoName = data.repository.split('/')[1] || data.repository;
           const avatarBg =
             repoOwner === 'opentensor'
-              ? '#ffffff'
+              ? REPO_OWNER_AVATAR_BACKGROUNDS.opentensor
               : repoOwner === 'bitcoin'
-                ? '#F7931A'
-                : 'transparent';
+                ? REPO_OWNER_AVATAR_BACKGROUNDS.bitcoin
+                : theme.palette.surface.transparent;
           return `
             <div style="font-family: 'JetBrains Mono', monospace;">
-              <div style="display: flex; align-items: center; gap: 10px; margin-bottom: 10px; padding-bottom: 8px; border-bottom: 1px solid rgba(255,255,255,0.15);">
-                <img src="https://avatars.githubusercontent.com/${repoOwner}" style="width: 32px; height: 32px; border-radius: 50%; border: 2px solid ${CHART_DOT_COLOR}; background-color: ${avatarBg};" onerror="this.style.display='none'" />
+              <div style="display: flex; align-items: center; gap: 10px; margin-bottom: 10px; padding-bottom: 8px; border-bottom: 1px solid ${theme.palette.border.light};">
+                <img src="https://avatars.githubusercontent.com/${repoOwner}" style="width: 32px; height: 32px; border-radius: 50%; border: 2px solid ${chartAccent}; background-color: ${avatarBg};" onerror="this.style.display='none'" />
                 <div>
-                  <div style="font-weight: 700; font-size: 14px; color: #fff;">${repoName}</div>
-                  <div style="font-size: 11px; color: rgba(255,255,255,0.6);">${repoOwner}</div>
+                  <div style="font-weight: 700; font-size: 14px; color: ${theme.palette.text.primary};">${repoName}</div>
+                  <div style="font-size: 11px; color: ${alpha(theme.palette.common.white, TEXT_OPACITY.secondary)};">${repoOwner}</div>
                 </div>
               </div>
               <div style="display: grid; gap: 6px; font-size: 11px;">
                 <div style="display: flex; justify-content: space-between; gap: 20px;">
-                  <span style="color: rgba(255,255,255,0.65);">Rank:</span>
-                  <span style="color: #fff; font-weight: 600;">#${data.rank}</span>
+                  <span style="color: ${alpha(theme.palette.common.white, 0.65)};">Rank:</span>
+                  <span style="color: ${theme.palette.text.primary}; font-weight: 600;">#${data.rank}</span>
                 </div>
                 <div style="display: flex; justify-content: space-between; gap: 20px;">
-                  <span style="color: rgba(255,255,255,0.65);">Total Score:</span>
-                  <span style="color: #fff; font-weight: 600;">${data.value.toFixed(2)}</span>
+                  <span style="color: ${alpha(theme.palette.common.white, 0.65)};">Total Score:</span>
+                  <span style="color: ${theme.palette.text.primary}; font-weight: 600;">${data.value.toFixed(2)}</span>
                 </div>
                 <div style="display: flex; justify-content: space-between; gap: 20px;">
-                  <span style="color: rgba(255,255,255,0.65);">Total PRs:</span>
-                  <span style="color: #fff; font-weight: 600;">${data.totalPRs}</span>
+                  <span style="color: ${alpha(theme.palette.common.white, 0.65)};">Total PRs:</span>
+                  <span style="color: ${theme.palette.text.primary}; font-weight: 600;">${data.totalPRs}</span>
                 </div>
                 <div style="display: flex; justify-content: space-between; gap: 20px;">
-                  <span style="color: rgba(255,255,255,0.65);">Contributors:</span>
-                  <span style="color: #fff; font-weight: 600;">${data.uniqueMiners}</span>
+                  <span style="color: ${alpha(theme.palette.common.white, 0.65)};">Contributors:</span>
+                  <span style="color: ${theme.palette.text.primary}; font-weight: 600;">${data.uniqueMiners}</span>
                 </div>
               </div>
             </div>
@@ -357,7 +368,7 @@ const LeaderboardCharts: React.FC = () => {
         type: 'category',
         data: xAxisData,
         axisLabel: {
-          color: 'rgba(255, 255, 255, 0.85)',
+          color: axisLabelStrong,
           fontFamily: 'JetBrains Mono',
           fontSize: 11,
           interval: 0,
@@ -375,12 +386,12 @@ const LeaderboardCharts: React.FC = () => {
         logBase: 10,
         name: 'Total Score',
         nameTextStyle: {
-          color: 'rgba(255, 255, 255, 0.85)',
+          color: axisLabelStrong,
           fontFamily: 'JetBrains Mono',
           fontSize: 12,
         },
         axisLabel: {
-          color: 'rgba(255, 255, 255, 0.85)',
+          color: axisLabelStrong,
           fontFamily: 'JetBrains Mono',
           fontSize: 11,
           formatter: (value: number) =>
@@ -403,7 +414,7 @@ const LeaderboardCharts: React.FC = () => {
           data: dotData.map((item) => ({
             ...item,
             itemStyle: {
-              color: CHART_DOT_COLOR,
+              color: chartAccent,
               opacity: 0.4,
               borderRadius: [2, 2, 0, 0],
             },
@@ -422,7 +433,11 @@ const LeaderboardCharts: React.FC = () => {
           z: 2,
           emphasis: {
             scale: 1.5,
-            itemStyle: { shadowBlur: 20, borderColor: '#fff', borderWidth: 2 },
+            itemStyle: {
+              shadowBlur: 20,
+              borderColor: theme.palette.common.white,
+              borderWidth: 2,
+            },
           },
           animationDuration: 1000,
           animationEasing: 'cubicOut',
@@ -436,7 +451,7 @@ const LeaderboardCharts: React.FC = () => {
     <Card
       sx={{
         borderRadius: 3,
-        border: '1px solid rgba(255, 255, 255, 0.1)',
+        border: `1px solid ${theme.palette.border.light}`,
         backgroundColor: 'transparent',
         overflow: 'hidden',
         height: '100%',
@@ -447,7 +462,7 @@ const LeaderboardCharts: React.FC = () => {
     >
       <Box
         sx={{
-          borderBottom: '1px solid rgba(255, 255, 255, 0.1)',
+          borderBottom: `1px solid ${theme.palette.border.light}`,
           display: 'flex',
           flexDirection: { xs: 'column', lg: 'row' },
           justifyContent: 'space-between',
@@ -462,14 +477,14 @@ const LeaderboardCharts: React.FC = () => {
           sx={{
             minHeight: 'auto',
             '& .MuiTab-root': {
-              color: 'rgba(255, 255, 255, 0.6)',
+              color: alpha(theme.palette.common.white, TEXT_OPACITY.secondary),
               fontFamily: '"JetBrains Mono", monospace',
               fontSize: '0.85rem',
               fontWeight: 500,
               textTransform: 'none',
               minHeight: 'auto',
               py: 1,
-              '&.Mui-selected': { color: '#fff' },
+              '&.Mui-selected': { color: theme.palette.text.primary },
             },
             '& .MuiTabs-indicator': { backgroundColor: 'primary.main' },
           }}
@@ -488,7 +503,7 @@ const LeaderboardCharts: React.FC = () => {
                   color: 'primary.main',
                 },
                 '& .MuiSwitch-track': {
-                  backgroundColor: 'rgba(255, 255, 255, 0.3)',
+                  backgroundColor: alpha(theme.palette.common.white, 0.3),
                 },
               }}
             />
@@ -499,7 +514,7 @@ const LeaderboardCharts: React.FC = () => {
               sx={{
                 fontFamily: 'JetBrains Mono',
                 fontSize: '0.8rem',
-                color: 'rgba(255, 255, 255, 0.7)',
+                color: alpha(theme.palette.common.white, TEXT_OPACITY.secondary),
                 whiteSpace: 'nowrap',
               }}
             >
@@ -509,7 +524,13 @@ const LeaderboardCharts: React.FC = () => {
           sx={{ ml: 'auto' }}
         />
       </Box>
-      <Box sx={{ flex: 1, p: 2, backgroundColor: 'rgba(0,0,0,0.2)' }}>
+      <Box
+        sx={{
+          flex: 1,
+          p: 2,
+          backgroundColor: alpha(theme.palette.common.black, 0.2),
+        }}
+      >
         {isLoading ? (
           <Box
             sx={{
@@ -534,13 +555,13 @@ const LeaderboardCharts: React.FC = () => {
             <BarChartIcon
               sx={{
                 fontSize: 48,
-                color: 'rgba(255, 255, 255, 0.2)',
+                color: alpha(theme.palette.common.white, TEXT_OPACITY.ghost),
                 mb: 2,
               }}
             />
             <Typography
               sx={{
-                color: 'rgba(255, 255, 255, 0.5)',
+                color: alpha(theme.palette.common.white, TEXT_OPACITY.muted),
                 fontFamily: '"JetBrains Mono", monospace',
                 fontSize: '0.9rem',
               }}
@@ -549,7 +570,7 @@ const LeaderboardCharts: React.FC = () => {
             </Typography>
             <Typography
               sx={{
-                color: 'rgba(255, 255, 255, 0.3)',
+                color: alpha(theme.palette.common.white, TEXT_OPACITY.faint),
                 fontFamily: '"JetBrains Mono", monospace',
                 fontSize: '0.75rem',
                 mt: 0.5,

--- a/src/components/dashboard/LiveCommitLog.tsx
+++ b/src/components/dashboard/LiveCommitLog.tsx
@@ -12,7 +12,7 @@ import {
   Chip,
 } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
-import theme from '../../theme';
+import theme, { REPO_OWNER_AVATAR_BACKGROUNDS } from '../../theme';
 import { useInfiniteCommitLog, usePullRequestDetails } from '../../api';
 
 const MONTH_SHORT = [
@@ -58,10 +58,10 @@ interface CommitLogEntry {
 
 const getScoreColor = (score: string) => {
   const scoreNum = parseFloat(score);
-  if (isNaN(scoreNum)) return theme.palette.grey[500];
-  if (scoreNum >= 10) return '#ffffff';
-  if (scoreNum >= 5) return '#b0b0b0';
-  return '#7d7d7d';
+  if (isNaN(scoreNum)) return theme.palette.text.secondary;
+  if (scoreNum >= 10) return theme.palette.text.primary;
+  if (scoreNum >= 5) return alpha(theme.palette.common.white, 0.69);
+  return theme.palette.text.secondary;
 };
 
 const CommitLogItem: React.FC<{
@@ -113,8 +113,8 @@ const CommitLogItem: React.FC<{
         border: '1px solid',
         borderColor: isNew
           ? theme.palette.secondary.main
-          : 'rgba(255, 255, 255, 0.1)',
-        backgroundColor: 'rgba(255,255,255,0.02)',
+          : theme.palette.border.light,
+        backgroundColor: theme.palette.surface.subtle,
         backdropFilter: 'blur(8px)',
         transition: 'all 0.2s cubic-bezier(0.4, 0, 0.2, 1)',
         animation: isNew ? 'slideIn 0.5s ease-out' : undefined,
@@ -159,13 +159,13 @@ const CommitLogItem: React.FC<{
               sx={{
                 width: 16,
                 height: 16,
-                border: '1px solid rgba(255,255,255,0.2)',
+                border: `1px solid ${theme.palette.border.medium}`,
                 backgroundColor:
                   entry.repository.split('/')[0] === 'opentensor'
-                    ? '#ffffff'
+                    ? REPO_OWNER_AVATAR_BACKGROUNDS.opentensor
                     : entry.repository.split('/')[0] === 'bitcoin'
-                      ? '#F7931A'
-                      : 'transparent',
+                      ? REPO_OWNER_AVATAR_BACKGROUNDS.bitcoin
+                      : theme.palette.surface.transparent,
               }}
             />
             <Typography
@@ -213,7 +213,7 @@ const CommitLogItem: React.FC<{
           </Stack>
           <Typography
             sx={{
-              color: '#fff',
+              color: 'text.primary',
               fontSize: '0.9rem',
               fontWeight: 500,
               lineHeight: 1.4,
@@ -232,7 +232,10 @@ const CommitLogItem: React.FC<{
           direction="row"
           justifyContent="space-between"
           alignItems="center"
-          sx={{ pt: 1, borderTop: '1px solid rgba(255,255,255,0.05)' }}
+          sx={{
+            pt: 1,
+            borderTop: `1px solid ${theme.palette.border.subtle}`,
+          }}
         >
           <Typography variant="caption" sx={{ color: 'text.secondary' }}>
             by {entry.author}
@@ -363,7 +366,7 @@ const LiveCommitLog: React.FC = () => {
     <Card
       sx={{
         borderRadius: 3,
-        border: '1px solid rgba(255, 255, 255, 0.1)',
+        border: `1px solid ${theme.palette.border.light}`,
         backgroundColor: 'transparent',
         height: '100%',
         display: 'flex',
@@ -448,9 +451,9 @@ const LiveCommitLog: React.FC = () => {
               '&::-webkit-scrollbar': { width: '6px' },
               '&::-webkit-scrollbar-track': { backgroundColor: 'transparent' },
               '&::-webkit-scrollbar-thumb': {
-                backgroundColor: 'rgba(255, 255, 255, 0.1)',
+                backgroundColor: theme.palette.border.light,
                 borderRadius: '3px',
-                '&:hover': { backgroundColor: 'rgba(255, 255, 255, 0.2)' },
+                '&:hover': { backgroundColor: theme.palette.border.medium },
               },
             }}
           >

--- a/src/components/dashboard/PRStatusChart.tsx
+++ b/src/components/dashboard/PRStatusChart.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react';
-import { Box, Stack, Typography } from '@mui/material';
+import { Box, Stack, Typography, alpha, useTheme } from '@mui/material';
 import ReactECharts from 'echarts-for-react';
-import { CHART_COLORS, STATUS_COLORS } from '../../theme';
+import { CHART_COLORS, TEXT_OPACITY } from '../../theme';
 
 interface PRStats {
   merged: number;
@@ -23,6 +23,7 @@ const PRStatusChart: React.FC<PRStatusChartProps> = ({
   subtitle,
   variant = 'primary',
 }) => {
+  const theme = useTheme();
   const { merged, open, closed, credibility } = stats;
   const credibilityPercent = credibility * 100;
   const isPrimary = variant === 'primary';
@@ -35,7 +36,9 @@ const PRStatusChart: React.FC<PRStatusChartProps> = ({
         left: 'center',
         top: '28%',
         textStyle: {
-          color: isPrimary ? '#fff' : 'rgba(255, 255, 255, 0.7)',
+          color: isPrimary
+            ? theme.palette.text.primary
+            : alpha(theme.palette.common.white, TEXT_OPACITY.secondary),
           fontSize: isPrimary ? 28 : 24,
           fontWeight: 'bold',
           fontFamily: '"JetBrains Mono", monospace',
@@ -45,10 +48,13 @@ const PRStatusChart: React.FC<PRStatusChartProps> = ({
       tooltip: {
         trigger: 'item',
         formatter: '{b}: {c} ({d}%)',
-        backgroundColor: 'rgba(0, 0, 0, 0.9)',
-        borderColor: 'rgba(255, 255, 255, 0.15)',
+        backgroundColor: alpha(theme.palette.common.black, 0.9),
+        borderColor: alpha(theme.palette.common.white, 0.15),
         borderWidth: 1,
-        textStyle: { color: '#fff', fontFamily: '"JetBrains Mono", monospace' },
+        textStyle: {
+          color: theme.palette.text.primary,
+          fontFamily: '"JetBrains Mono", monospace',
+        },
       },
       series: [
         {
@@ -59,7 +65,7 @@ const PRStatusChart: React.FC<PRStatusChartProps> = ({
           avoidLabelOverlap: false,
           itemStyle: {
             borderRadius: 4,
-            borderColor: '#0d1117',
+            borderColor: theme.palette.background.paper,
             borderWidth: 2,
           },
           label: { show: false, position: 'center' },
@@ -94,7 +100,7 @@ const PRStatusChart: React.FC<PRStatusChartProps> = ({
         },
       ],
     }),
-    [merged, open, closed, credibilityPercent, isPrimary],
+    [merged, open, closed, credibilityPercent, isPrimary, theme],
   );
 
   return (
@@ -109,7 +115,9 @@ const PRStatusChart: React.FC<PRStatusChartProps> = ({
     >
       <Typography
         sx={{
-          color: isPrimary ? STATUS_COLORS.success : 'rgba(255, 255, 255, 0.5)',
+          color: isPrimary
+            ? theme.palette.status.success
+            : alpha(theme.palette.common.white, TEXT_OPACITY.muted),
           fontSize: '0.85rem',
           fontWeight: 700,
           fontFamily: '"JetBrains Mono", monospace',

--- a/src/components/dashboard/RepositoriesTable.tsx
+++ b/src/components/dashboard/RepositoriesTable.tsx
@@ -20,10 +20,16 @@ import {
   TextField,
   InputAdornment,
   Avatar,
+  alpha,
+  useTheme,
 } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
 import SearchIcon from '@mui/icons-material/Search';
-import theme, { scrollbarSx } from '../../theme';
+import {
+  REPO_OWNER_AVATAR_BACKGROUNDS,
+  TEXT_OPACITY,
+  scrollbarSx,
+} from '../../theme';
 import { useRepoChanges } from '../../api';
 import { format } from 'date-fns';
 
@@ -38,6 +44,7 @@ type SortOrder = 'asc' | 'desc';
 
 const RepositoriesTable: React.FC = () => {
   const navigate = useNavigate();
+  const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
   const isMedium = useMediaQuery(theme.breakpoints.down('md'));
   const isLarge = useMediaQuery(theme.breakpoints.down('lg'));
@@ -195,7 +202,7 @@ const RepositoriesTable: React.FC = () => {
     <Card
       sx={{
         borderRadius: 3,
-        border: '1px solid rgba(255, 255, 255, 0.1)',
+        border: `1px solid ${theme.palette.border.light}`,
         backgroundColor: 'transparent',
         height: '100%',
         display: 'flex',
@@ -245,7 +252,10 @@ const RepositoriesTable: React.FC = () => {
               startAdornment: (
                 <InputAdornment position="start">
                   <SearchIcon
-                    sx={{ color: 'rgba(255, 255, 255, 0.5)', fontSize: '1rem' }}
+                    sx={{
+                      color: alpha(theme.palette.common.white, TEXT_OPACITY.muted),
+                      fontSize: '1rem',
+                    }}
                   />
                 </InputAdornment>
               ),
@@ -253,14 +263,14 @@ const RepositoriesTable: React.FC = () => {
             sx={{
               width: isMobile ? '100%' : '200px',
               '& .MuiOutlinedInput-root': {
-                color: '#ffffff',
+                color: theme.palette.text.primary,
                 fontFamily: '"JetBrains Mono", monospace',
-                backgroundColor: 'rgba(0, 0, 0, 0.4)',
+                backgroundColor: alpha(theme.palette.common.black, 0.4),
                 fontSize: '0.8rem',
                 height: '36px',
                 borderRadius: 2,
-                '& fieldset': { borderColor: 'rgba(255, 255, 255, 0.1)' },
-                '&:hover fieldset': { borderColor: 'rgba(255, 255, 255, 0.2)' },
+                '& fieldset': { borderColor: theme.palette.border.light },
+                '&:hover fieldset': { borderColor: theme.palette.border.medium },
                 '&.Mui-focused fieldset': { borderColor: 'primary.main' },
               },
             }}
@@ -287,9 +297,9 @@ const RepositoriesTable: React.FC = () => {
                 <TableRow>
                   <TableCell
                     sx={{
-                      backgroundColor: 'rgba(18, 18, 20, 0.95)',
+                      backgroundColor: alpha(theme.palette.background.paper, 0.95),
                       backdropFilter: 'blur(8px)',
-                      borderBottom: '1px solid rgba(255, 255, 255, 0.1)',
+                      borderBottom: `1px solid ${theme.palette.border.light}`,
                       minWidth: isMobile ? 120 : 180,
                       maxWidth: isMobile ? 200 : 300,
                       width: isMobile ? 150 : 250,
@@ -322,9 +332,9 @@ const RepositoriesTable: React.FC = () => {
                     <TableCell
                       align="right"
                       sx={{
-                        backgroundColor: 'rgba(18, 18, 20, 0.95)',
+                        backgroundColor: alpha(theme.palette.background.paper, 0.95),
                         backdropFilter: 'blur(8px)',
-                        borderBottom: '1px solid rgba(255, 255, 255, 0.1)',
+                        borderBottom: `1px solid ${theme.palette.border.light}`,
                         width: '12%',
                       }}
                     >
@@ -354,9 +364,9 @@ const RepositoriesTable: React.FC = () => {
                     <TableCell
                       align="right"
                       sx={{
-                        backgroundColor: 'rgba(18, 18, 20, 0.95)',
+                        backgroundColor: alpha(theme.palette.background.paper, 0.95),
                         backdropFilter: 'blur(8px)',
-                        borderBottom: '1px solid rgba(255, 255, 255, 0.1)',
+                        borderBottom: `1px solid ${theme.palette.border.light}`,
                         width: '15%',
                       }}
                     >
@@ -388,9 +398,9 @@ const RepositoriesTable: React.FC = () => {
                     <TableCell
                       align="right"
                       sx={{
-                        backgroundColor: 'rgba(18, 18, 20, 0.95)',
+                        backgroundColor: alpha(theme.palette.background.paper, 0.95),
                         backdropFilter: 'blur(8px)',
-                        borderBottom: '1px solid rgba(255, 255, 255, 0.1)',
+                        borderBottom: `1px solid ${theme.palette.border.light}`,
                         width: '15%',
                       }}
                     >
@@ -421,9 +431,9 @@ const RepositoriesTable: React.FC = () => {
                   <TableCell
                     align="right"
                     sx={{
-                      backgroundColor: 'rgba(18, 18, 20, 0.95)',
+                      backgroundColor: alpha(theme.palette.background.paper, 0.95),
                       backdropFilter: 'blur(8px)',
-                      borderBottom: '1px solid rgba(255, 255, 255, 0.1)',
+                      borderBottom: `1px solid ${theme.palette.border.light}`,
                       width: isMobile ? '25%' : '15%',
                     }}
                   >
@@ -454,9 +464,9 @@ const RepositoriesTable: React.FC = () => {
                     <TableCell
                       align="right"
                       sx={{
-                        backgroundColor: 'rgba(18, 18, 20, 0.95)',
+                        backgroundColor: alpha(theme.palette.background.paper, 0.95),
                         backdropFilter: 'blur(8px)',
-                        borderBottom: '1px solid rgba(255, 255, 255, 0.1)',
+                        borderBottom: `1px solid ${theme.palette.border.light}`,
                         width: '12%',
                       }}
                     >
@@ -506,11 +516,11 @@ const RepositoriesTable: React.FC = () => {
                         hover
                         sx={{
                           backgroundColor: isInactive
-                            ? 'rgba(211, 47, 47, 0.08)'
+                            ? alpha(theme.palette.error.main, 0.08)
                             : 'inherit',
                           '&:hover': {
                             backgroundColor: isInactive
-                              ? 'rgba(211, 47, 47, 0.12)'
+                              ? alpha(theme.palette.error.main, 0.12)
                               : undefined,
                           },
                         }}
@@ -539,17 +549,17 @@ const RepositoriesTable: React.FC = () => {
                               sx={{
                                 width: 20,
                                 height: 20,
-                                border: '1px solid rgba(255, 255, 255, 0.2)',
+                                border: `1px solid ${theme.palette.border.medium}`,
                                 backgroundColor:
                                   (repo.repositoryFullName || '').split(
                                     '/',
                                   )[0] === 'opentensor'
-                                    ? '#ffffff'
+                                    ? REPO_OWNER_AVATAR_BACKGROUNDS.opentensor
                                     : (repo.repositoryFullName || '').split(
                                           '/',
                                         )[0] === 'bitcoin'
-                                      ? '#F7931A'
-                                      : 'transparent',
+                                      ? REPO_OWNER_AVATAR_BACKGROUNDS.bitcoin
+                                      : theme.palette.surface.transparent,
                               }}
                             />
                             <Typography

--- a/src/components/dashboard/RepositoriesTable.tsx
+++ b/src/components/dashboard/RepositoriesTable.tsx
@@ -253,7 +253,10 @@ const RepositoriesTable: React.FC = () => {
                 <InputAdornment position="start">
                   <SearchIcon
                     sx={{
-                      color: alpha(theme.palette.common.white, TEXT_OPACITY.muted),
+                      color: alpha(
+                        theme.palette.common.white,
+                        TEXT_OPACITY.muted,
+                      ),
                       fontSize: '1rem',
                     }}
                   />
@@ -270,7 +273,9 @@ const RepositoriesTable: React.FC = () => {
                 height: '36px',
                 borderRadius: 2,
                 '& fieldset': { borderColor: theme.palette.border.light },
-                '&:hover fieldset': { borderColor: theme.palette.border.medium },
+                '&:hover fieldset': {
+                  borderColor: theme.palette.border.medium,
+                },
                 '&.Mui-focused fieldset': { borderColor: 'primary.main' },
               },
             }}
@@ -297,7 +302,10 @@ const RepositoriesTable: React.FC = () => {
                 <TableRow>
                   <TableCell
                     sx={{
-                      backgroundColor: alpha(theme.palette.background.paper, 0.95),
+                      backgroundColor: alpha(
+                        theme.palette.background.paper,
+                        0.95,
+                      ),
                       backdropFilter: 'blur(8px)',
                       borderBottom: `1px solid ${theme.palette.border.light}`,
                       minWidth: isMobile ? 120 : 180,
@@ -332,7 +340,10 @@ const RepositoriesTable: React.FC = () => {
                     <TableCell
                       align="right"
                       sx={{
-                        backgroundColor: alpha(theme.palette.background.paper, 0.95),
+                        backgroundColor: alpha(
+                          theme.palette.background.paper,
+                          0.95,
+                        ),
                         backdropFilter: 'blur(8px)',
                         borderBottom: `1px solid ${theme.palette.border.light}`,
                         width: '12%',
@@ -364,7 +375,10 @@ const RepositoriesTable: React.FC = () => {
                     <TableCell
                       align="right"
                       sx={{
-                        backgroundColor: alpha(theme.palette.background.paper, 0.95),
+                        backgroundColor: alpha(
+                          theme.palette.background.paper,
+                          0.95,
+                        ),
                         backdropFilter: 'blur(8px)',
                         borderBottom: `1px solid ${theme.palette.border.light}`,
                         width: '15%',
@@ -398,7 +412,10 @@ const RepositoriesTable: React.FC = () => {
                     <TableCell
                       align="right"
                       sx={{
-                        backgroundColor: alpha(theme.palette.background.paper, 0.95),
+                        backgroundColor: alpha(
+                          theme.palette.background.paper,
+                          0.95,
+                        ),
                         backdropFilter: 'blur(8px)',
                         borderBottom: `1px solid ${theme.palette.border.light}`,
                         width: '15%',
@@ -431,7 +448,10 @@ const RepositoriesTable: React.FC = () => {
                   <TableCell
                     align="right"
                     sx={{
-                      backgroundColor: alpha(theme.palette.background.paper, 0.95),
+                      backgroundColor: alpha(
+                        theme.palette.background.paper,
+                        0.95,
+                      ),
                       backdropFilter: 'blur(8px)',
                       borderBottom: `1px solid ${theme.palette.border.light}`,
                       width: isMobile ? '25%' : '15%',
@@ -464,7 +484,10 @@ const RepositoriesTable: React.FC = () => {
                     <TableCell
                       align="right"
                       sx={{
-                        backgroundColor: alpha(theme.palette.background.paper, 0.95),
+                        backgroundColor: alpha(
+                          theme.palette.background.paper,
+                          0.95,
+                        ),
                         backdropFilter: 'blur(8px)',
                         borderBottom: `1px solid ${theme.palette.border.light}`,
                         width: '12%',

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -63,6 +63,21 @@ export const scrollbarSx = {
   },
 } as const;
 
+/** Git-style contribution calendar levels (empty → most active) */
+export const CONTRIBUTION_HEATMAP_SCALE = [
+  '#161b22',
+  '#0e4429',
+  '#006d32',
+  '#26a641',
+  '#39d353',
+] as const;
+
+/** Known org avatars on GitHub that need a non-transparent backdrop */
+export const REPO_OWNER_AVATAR_BACKGROUNDS = {
+  opentensor: '#ffffff',
+  bitcoin: '#F7931A',
+} as const;
+
 export const TEXT_OPACITY = {
   primary: 1,
   secondary: 0.7,


### PR DESCRIPTION
## Summary

- Refactors dashboard components to remove hardcoded color values and route styling through src/theme.ts.
- Replaces inline #... and rgba(...) usage with theme.palette, TEXT_OPACITY, and alpha(...)-based theme values.
- Adds reusable theme constants for shared dashboard visuals:
  - CONTRIBUTION_HEATMAP_SCALE
  - REPO_OWNER_AVATAR_BACKGROUNDS

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Scope

- src/components/dashboard/CommitTrendChart.tsx
- src/components/dashboard/ContributionHeatmap.tsx
- src/components/dashboard/GlobalActivity.tsx
- src/components/dashboard/KpiCard.tsx
- src/components/dashboard/LeaderboardCharts.tsx
- src/components/dashboard/LiveCommitLog.tsx
- src/components/dashboard/PRStatusChart.tsx
- src/components/dashboard/RepositoriesTable.tsx
- src/theme.ts

## Why

- Improves consistency and maintainability of dashboard styling.
- Ensures color behavior is centrally controlled via theme tokens.
- Makes future design updates safer and faster by avoiding scattered hardcoded values.


## Checklist

- [ ] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [ ] Responsive/mobile checked
- [ ] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [ ] Screenshots included for any UI/visual changes
