### PR TITLE
fix: NaN numeric rendering and standardize integer parsing

### DIFF
--- a/src/components/leaderboard/TopRepositoriesTable.tsx
+++ b/src/components/leaderboard/TopRepositoriesTable.tsx
@@ -83,8 +83,8 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
   const [searchParams, setSearchParams] = useSearchParams();
 
   // Read initial state from URL params, falling back to defaults
-  const urlRows = parseInt(searchParams.get('rows') || '', 10);
-  const urlPage = parseInt(searchParams.get('page') || '', 10);
+  const urlRows = parseInt(searchParams.get('rows') || '0', 10);
+  const urlPage = parseInt(searchParams.get('page') || '0', 10);
   const urlSort = searchParams.get('sort') as SortColumn;
   const urlDir = searchParams.get('dir') as SortDirection;
   const urlSearch = searchParams.get('search') || '';

--- a/src/components/miners/MinerPRsTable.tsx
+++ b/src/components/miners/MinerPRsTable.tsx
@@ -599,7 +599,7 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
                                 color: theme.palette.status.warningOrange,
                               }}
                             >
-                              {parseFloat(pr.collateralScore).toFixed(4)}
+                              {parseFloat(pr.collateralScore || '0').toFixed(4)}
                             </Typography>
                           ) : scoreTooltip ? (
                             <Tooltip
@@ -616,7 +616,7 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
                                   cursor: 'pointer',
                                 }}
                               >
-                                {parseFloat(pr.score).toFixed(4)}
+                                {parseFloat(pr.score || '0').toFixed(4)}
                               </Typography>
                             </Tooltip>
                           ) : (
@@ -627,7 +627,7 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
                                 fontWeight: 600,
                               }}
                             >
-                              {parseFloat(pr.score).toFixed(4)}
+                              {parseFloat(pr.score || '0').toFixed(4)}
                             </Typography>
                           )}
                           {!pr.mergedAt &&

--- a/src/components/repositories/RepositoryStats.tsx
+++ b/src/components/repositories/RepositoryStats.tsx
@@ -8,6 +8,7 @@ import {
   useRepositoryConfig,
 } from '../../api';
 import { RANK_COLORS, STATUS_COLORS } from '../../theme';
+import { formatTokenAmount } from '../../utils/format';
 
 interface RepositoryStatsProps {
   repositoryFullName: string;
@@ -254,13 +255,7 @@ const RepositoryStats: React.FC<RepositoryStatsProps> = ({
                     fontSize: '13px',
                   }}
                 >
-                  {parseFloat(bountySummary.totalAvailable).toLocaleString(
-                    undefined,
-                    {
-                      maximumFractionDigits: 2,
-                    },
-                  )}{' '}
-                  α
+                  {formatTokenAmount(bountySummary.totalAvailable, 2)} α
                 </Typography>
               </Box>
             )}
@@ -289,13 +284,7 @@ const RepositoryStats: React.FC<RepositoryStatsProps> = ({
                     fontWeight: 500,
                   }}
                 >
-                  {parseFloat(bountySummary.totalPaidOut).toLocaleString(
-                    undefined,
-                    {
-                      maximumFractionDigits: 2,
-                    },
-                  )}{' '}
-                  α
+                  {formatTokenAmount(bountySummary.totalPaidOut, 2)} α
                 </Typography>
               </Box>
             )}


### PR DESCRIPTION
## Summary

- Prevent NaN from rendering in miner PR score cells by adding safe parseFloat(value || '0') fallbacks in src/components/miners/MinerPRsTable.tsx.
- Prevent NaN α in repository bounty totals by using the existing shared formatter formatTokenAmount in src/components/repositories/RepositoryStats.tsx.
- Standardize URL param parsing for rows/page to use the consistent parseInt(value || '0', 10) fallback pattern in src/components/leaderboard/TopRepositoriesTable.tsx.


## Related Issues

Fixes #253 

## Type of Change

- Bug fix

## Test Plan

- Open a miner PR table with missing score / collateralScore values and confirm Score renders 0.0000 (or - where applicable), not NaN.
- Open a repository page where totalAvailable / totalPaidOut are missing or non-numeric and confirm bounty rows render 0.00 α, not NaN α.
- Load /repositories with no rows/page params and with invalid values (e.g. ?rows=&page=) and confirm pagination defaults behave normally.
- Run npm run build.
