### PR TITLE
refactor(leaderboard): replace hardcoded colors with theme tokens

### DIFF
--- a/src/components/leaderboard/RankIcon.tsx
+++ b/src/components/leaderboard/RankIcon.tsx
@@ -15,7 +15,7 @@ export const RankIcon: React.FC<{ rank: number }> = ({ rank }) => {
   return (
     <Box
       sx={{
-        backgroundColor: '#000000',
+        backgroundColor: 'background.default',
         borderRadius: '2px',
         width: '22px',
         height: '22px',
@@ -24,7 +24,7 @@ export const RankIcon: React.FC<{ rank: number }> = ({ rank }) => {
         justifyContent: 'center',
         flexShrink: 0,
         border: '1px solid',
-        borderColor: color ? alpha(color, 0.4) : 'rgba(255, 255, 255, 0.15)',
+        borderColor: color ? alpha(color, 0.4) : 'border.light',
         boxShadow: color
           ? `0 0 12px ${alpha(color, 0.4)}, 0 0 4px ${alpha(color, 0.2)}`
           : 'none',
@@ -33,7 +33,7 @@ export const RankIcon: React.FC<{ rank: number }> = ({ rank }) => {
       <Typography
         component="span"
         sx={{
-          color: color ?? 'rgba(255, 255, 255, 0.6)',
+          color: color ?? 'text.secondary',
           fontFamily: '"JetBrains Mono", monospace',
           fontSize: '0.65rem',
           fontWeight: 600,

--- a/src/components/leaderboard/SectionCard.tsx
+++ b/src/components/leaderboard/SectionCard.tsx
@@ -23,8 +23,9 @@ export const SectionCard: React.FC<{
     <Card
       sx={{
         borderRadius: 3,
-        border: '1px solid rgba(255, 255, 255, 0.1)',
-        backgroundColor: '#000000',
+        border: '1px solid',
+        borderColor: 'border.light',
+        backgroundColor: 'background.default',
         display: 'flex',
         flexDirection: 'column',
         ...sx,

--- a/src/components/leaderboard/TopPRsTable.tsx
+++ b/src/components/leaderboard/TopPRsTable.tsx
@@ -32,6 +32,7 @@ import BarChartIcon from '@mui/icons-material/BarChart';
 import TableChartIcon from '@mui/icons-material/TableChart';
 import ReactECharts from 'echarts-for-react';
 import { type CommitLog } from '../../api/models/Dashboard';
+import { getRepositoryOwnerAvatarBackground } from './types';
 import {
   formatUsdEstimate,
   getPrStatusCounts,
@@ -41,7 +42,7 @@ import {
   truncateText,
 } from '../../utils';
 import { RankIcon } from './RankIcon';
-import theme, { STATUS_COLORS, scrollbarSx } from '../../theme';
+import { STATUS_COLORS, UI_COLORS, scrollbarSx } from '../../theme';
 import FilterButton from '../FilterButton';
 
 interface TopPRsTableProps {
@@ -51,6 +52,13 @@ interface TopPRsTableProps {
   onSelectMiner: (githubId: string) => void;
   onSelectRepository: (repositoryFullName: string) => void;
 }
+
+const getPrStatusColor = (state: string) => {
+  if (state === 'MERGED') return STATUS_COLORS.merged;
+  if (state === 'OPEN') return STATUS_COLORS.open;
+  if (state === 'CLOSED') return STATUS_COLORS.closed;
+  return STATUS_COLORS.neutral;
+};
 
 const TopPRsTable: React.FC<TopPRsTableProps> = ({
   prs,
@@ -104,10 +112,17 @@ const TopPRsTable: React.FC<TopPRsTableProps> = ({
 
   const getChartOption = () => {
     const chartData = filteredPRs.slice(0, 50);
-    const textColor = 'rgba(255, 255, 255, 0.85)';
-    const gridColor = theme.palette.border.subtle;
 
-    const chartColor = theme.palette.primary.main;
+    const white = UI_COLORS.white;
+    const borderSubtle = alpha(white, 0.08);
+    const borderMedium = alpha(white, 0.2);
+    const surfaceLight = alpha(white, 0.05);
+    const textColor = alpha(white, 0.85);
+    const tooltipBorderColor = alpha(white, 0.15);
+    const tooltipLabelColor = alpha(white, 0.65);
+    const primaryColor = UI_COLORS.white;
+
+    const chartColor = UI_COLORS.primary;
 
     const xAxisData = chartData.map(
       (item) => `#${item?.pullRequestNumber || ''}`,
@@ -144,13 +159,13 @@ const TopPRsTable: React.FC<TopPRsTableProps> = ({
         left: 'center',
         top: 20,
         textStyle: {
-          color: '#ffffff',
+          color: primaryColor,
           fontFamily: 'JetBrains Mono',
           fontSize: 18,
           fontWeight: 600,
         },
         subtextStyle: {
-          color: 'rgba(255, 255, 255, 0.6)',
+          color: alpha(white, 0.6),
           fontFamily: 'JetBrains Mono',
           fontSize: 11,
         },
@@ -160,14 +175,14 @@ const TopPRsTable: React.FC<TopPRsTableProps> = ({
         axisPointer: {
           type: 'shadow',
           shadowStyle: {
-            color: 'rgba(255, 255, 255, 0.05)',
+            color: surfaceLight,
           },
         },
-        backgroundColor: 'rgba(10, 10, 12, 0.98)',
-        borderColor: 'rgba(255, 255, 255, 0.2)',
+        backgroundColor: UI_COLORS.surfaceTooltip,
+        borderColor: borderMedium,
         borderWidth: 1,
         textStyle: {
-          color: '#fff',
+          color: primaryColor,
           fontFamily: 'JetBrains Mono',
           fontSize: 12,
         },
@@ -178,28 +193,28 @@ const TopPRsTable: React.FC<TopPRsTableProps> = ({
 
           return `
             <div style="font-family: 'JetBrains Mono', monospace;">
-              <div style="font-weight: 700; margin-bottom: 10px; font-size: 14px; border-bottom: 1px solid rgba(255,255,255,0.15); padding-bottom: 8px;">
+              <div style="font-weight: 700; margin-bottom: 10px; font-size: 14px; border-bottom: 1px solid ${tooltipBorderColor}; padding-bottom: 8px;">
                 PR #${data.prNumber}
               </div>
-              <div style="margin-bottom: 10px; color: rgba(255,255,255,0.85); font-size: 11px; max-width: 300px; white-space: normal; word-break: break-word; line-height: 1.4;">
+              <div style="margin-bottom: 10px; color: ${textColor}; font-size: 11px; max-width: 300px; white-space: normal; word-break: break-word; line-height: 1.4;">
                 ${data.title}
               </div>
               <div style="display: grid; gap: 6px; font-size: 11px;">
                 <div style="display: flex; justify-content: space-between; gap: 20px;">
-                  <span style="color: rgba(255,255,255,0.65);">Rank:</span>
-                  <span style="color: #fff; font-weight: 600;">#${data.rank}</span>
+                  <span style="color: ${tooltipLabelColor};">Rank:</span>
+                  <span style="color: ${primaryColor}; font-weight: 600;">#${data.rank}</span>
                 </div>
                 <div style="display: flex; justify-content: space-between; gap: 20px;">
-                  <span style="color: rgba(255,255,255,0.65);">Score:</span>
-                  <span style="color: #fff; font-weight: 600;">${data.value.toFixed(4)}</span>
+                  <span style="color: ${tooltipLabelColor};">Score:</span>
+                  <span style="color: ${primaryColor}; font-weight: 600;">${data.value.toFixed(4)}</span>
                 </div>
                 <div style="display: flex; justify-content: space-between; gap: 20px;">
-                  <span style="color: rgba(255,255,255,0.65);">Author:</span>
-                  <span style="color: #fff; font-weight: 600;">${data.author}</span>
+                  <span style="color: ${tooltipLabelColor};">Author:</span>
+                  <span style="color: ${primaryColor}; font-weight: 600;">${data.author}</span>
                 </div>
                 <div style="display: flex; justify-content: space-between; gap: 20px;">
-                  <span style="color: rgba(255,255,255,0.65);">Repository:</span>
-                  <span style="color: #fff; font-weight: 600;">${data.repository.split('/')[1] || data.repository}</span>
+                  <span style="color: ${tooltipLabelColor};">Repository:</span>
+                  <span style="color: ${primaryColor}; font-weight: 600;">${data.repository.split('/')[1] || data.repository}</span>
                 </div>
               </div>
             </div>
@@ -235,7 +250,7 @@ const TopPRsTable: React.FC<TopPRsTableProps> = ({
         },
         axisLine: {
           lineStyle: {
-            color: gridColor,
+            color: borderSubtle,
             width: 1,
           },
         },
@@ -265,7 +280,7 @@ const TopPRsTable: React.FC<TopPRsTableProps> = ({
         },
         splitLine: {
           lineStyle: {
-            color: gridColor,
+            color: borderSubtle,
             type: 'dashed',
             opacity: 0.5,
           },
@@ -305,7 +320,7 @@ const TopPRsTable: React.FC<TopPRsTableProps> = ({
             scale: 1.5,
             itemStyle: {
               shadowBlur: 20,
-              borderColor: '#fff',
+              borderColor: white,
               borderWidth: 2,
             },
           },
@@ -351,7 +366,8 @@ const TopPRsTable: React.FC<TopPRsTableProps> = ({
       ref={cardRef}
       sx={{
         borderRadius: 3,
-        border: '1px solid rgba(255, 255, 255, 0.1)',
+        border: '1px solid',
+        borderColor: 'border.light',
         backgroundColor: 'transparent',
         overflow: 'hidden',
         display: 'flex',
@@ -366,13 +382,14 @@ const TopPRsTable: React.FC<TopPRsTableProps> = ({
           justifyContent: 'space-between',
           alignItems: 'center',
           gap: 2,
-          borderBottom: '1px solid rgba(255, 255, 255, 0.1)',
+          borderBottom: '1px solid',
+          borderColor: 'border.light',
         }}
       >
         <Typography
           variant="h6"
           sx={{
-            color: '#ffffff',
+            color: 'text.primary',
             fontFamily: '"JetBrains Mono", monospace',
             fontSize: '1.1rem',
             fontWeight: 500,
@@ -390,13 +407,14 @@ const TopPRsTable: React.FC<TopPRsTableProps> = ({
               onClick={() => setShowFilters(!showFilters)}
               size="small"
               sx={{
-                color: showFilters ? '#ffffff' : 'rgba(255, 255, 255, 0.5)',
-                border: '1px solid rgba(255, 255, 255, 0.1)',
+                color: showFilters ? 'text.primary' : 'text.tertiary',
+                border: '1px solid',
+                borderColor: 'border.light',
                 borderRadius: 2,
                 padding: '6px',
                 '&:hover': {
-                  backgroundColor: 'rgba(255, 255, 255, 0.05)',
-                  borderColor: 'rgba(255, 255, 255, 0.2)',
+                  backgroundColor: 'surface.light',
+                  borderColor: 'border.medium',
                 },
               }}
             >
@@ -409,13 +427,14 @@ const TopPRsTable: React.FC<TopPRsTableProps> = ({
               onClick={() => setShowChart(!showChart)}
               size="small"
               sx={{
-                color: showChart ? '#ffffff' : 'rgba(255, 255, 255, 0.5)',
-                border: '1px solid rgba(255, 255, 255, 0.1)',
+                color: showChart ? 'text.primary' : 'text.tertiary',
+                border: '1px solid',
+                borderColor: 'border.light',
                 borderRadius: 2,
                 padding: '6px',
                 '&:hover': {
-                  backgroundColor: 'rgba(255, 255, 255, 0.05)',
-                  borderColor: 'rgba(255, 255, 255, 0.2)',
+                  backgroundColor: 'surface.light',
+                  borderColor: 'border.medium',
                 },
               }}
             >
@@ -436,10 +455,10 @@ const TopPRsTable: React.FC<TopPRsTableProps> = ({
                   size="small"
                   sx={{
                     '& .MuiSwitch-switchBase.Mui-checked': {
-                      color: '#primary.main',
+                      color: 'primary.main',
                     },
                     '& .MuiSwitch-track': {
-                      backgroundColor: 'rgba(255, 255, 255, 0.3)',
+                      backgroundColor: 'border.medium',
                     },
                   }}
                 />
@@ -450,7 +469,7 @@ const TopPRsTable: React.FC<TopPRsTableProps> = ({
                   sx={{
                     fontFamily: 'JetBrains Mono',
                     fontSize: '0.8rem',
-                    color: 'rgba(255, 255, 255, 0.7)',
+                    color: 'text.secondary',
                   }}
                 >
                   Log Scale
@@ -464,7 +483,7 @@ const TopPRsTable: React.FC<TopPRsTableProps> = ({
               <Typography
                 variant="body2"
                 sx={{
-                  color: 'rgba(255, 255, 255, 0.7)',
+                  color: 'text.secondary',
                   fontFamily: '"JetBrains Mono", monospace',
                   fontSize: '0.8rem',
                 }}
@@ -478,16 +497,16 @@ const TopPRsTable: React.FC<TopPRsTableProps> = ({
                   setPage(0);
                 }}
                 sx={{
-                  color: '#ffffff',
+                  color: 'text.primary',
                   fontFamily: '"JetBrains Mono", monospace',
-                  backgroundColor: 'rgba(0, 0, 0, 0.4)',
+                  backgroundColor: 'background.default',
                   fontSize: '0.8rem',
                   height: '36px',
                   borderRadius: 2,
                   minWidth: '80px',
-                  '& fieldset': { borderColor: 'rgba(255, 255, 255, 0.1)' },
+                  '& fieldset': { borderColor: 'border.light' },
                   '&:hover fieldset': {
-                    borderColor: 'rgba(255, 255, 255, 0.2)',
+                    borderColor: 'border.medium',
                   },
                   '&.Mui-focused fieldset': { borderColor: 'primary.main' },
                   '& .MuiSelect-select': { py: 0.75 },
@@ -509,7 +528,10 @@ const TopPRsTable: React.FC<TopPRsTableProps> = ({
               startAdornment: (
                 <InputAdornment position="start">
                   <SearchIcon
-                    sx={{ color: 'rgba(255, 255, 255, 0.5)', fontSize: '1rem' }}
+                    sx={{
+                      color: 'text.tertiary',
+                      fontSize: '1rem',
+                    }}
                   />
                 </InputAdornment>
               ),
@@ -517,14 +539,14 @@ const TopPRsTable: React.FC<TopPRsTableProps> = ({
             sx={{
               width: '200px',
               '& .MuiOutlinedInput-root': {
-                color: '#ffffff',
+                color: 'text.primary',
                 fontFamily: '"JetBrains Mono", monospace',
-                backgroundColor: 'rgba(0, 0, 0, 0.4)',
+                backgroundColor: 'background.default',
                 fontSize: '0.8rem',
                 height: '36px',
                 borderRadius: 2,
-                '& fieldset': { borderColor: 'rgba(255, 255, 255, 0.1)' },
-                '&:hover fieldset': { borderColor: 'rgba(255, 255, 255, 0.2)' },
+                '& fieldset': { borderColor: 'border.light' },
+                '&:hover fieldset': { borderColor: 'border.medium' },
                 '&.Mui-focused fieldset': { borderColor: 'primary.main' },
               },
             }}
@@ -536,8 +558,9 @@ const TopPRsTable: React.FC<TopPRsTableProps> = ({
         <Box
           sx={{
             p: 2,
-            borderBottom: '1px solid rgba(255, 255, 255, 0.1)',
-            backgroundColor: 'rgba(255, 255, 255, 0.02)',
+            borderBottom: '1px solid',
+            borderColor: 'border.light',
+            backgroundColor: 'surface.subtle',
             display: 'flex',
             gap: 4,
             flexWrap: 'wrap',
@@ -547,7 +570,7 @@ const TopPRsTable: React.FC<TopPRsTableProps> = ({
             <Typography
               variant="caption"
               sx={{
-                color: 'rgba(255,255,255,0.5)',
+                color: 'text.tertiary',
                 display: 'block',
                 mb: 1,
                 fontFamily: '"JetBrains Mono", monospace',
@@ -561,28 +584,28 @@ const TopPRsTable: React.FC<TopPRsTableProps> = ({
                 isActive={statusFilter === 'all'}
                 onClick={() => setStatusFilter('all')}
                 count={statusCounts.all}
-                color={theme.palette.status.neutral}
+                color={STATUS_COLORS.neutral}
               />
               <FilterButton
                 label="Open"
                 isActive={statusFilter === 'open'}
                 onClick={() => setStatusFilter('open')}
                 count={statusCounts.open}
-                color={theme.palette.status.open}
+                color={STATUS_COLORS.open}
               />
               <FilterButton
                 label="Merged"
                 isActive={statusFilter === 'merged'}
                 onClick={() => setStatusFilter('merged')}
                 count={statusCounts.merged}
-                color={theme.palette.status.merged}
+                color={STATUS_COLORS.merged}
               />
               <FilterButton
                 label="Closed"
                 isActive={statusFilter === 'closed'}
                 onClick={() => setStatusFilter('closed')}
                 count={statusCounts.closed}
-                color={theme.palette.status.closed}
+                color={STATUS_COLORS.closed}
               />
             </Stack>
           </Box>
@@ -593,9 +616,10 @@ const TopPRsTable: React.FC<TopPRsTableProps> = ({
         <Box
           sx={{
             p: 2,
-            borderBottom: '1px solid rgba(255, 255, 255, 0.1)',
+            borderBottom: '1px solid',
+            borderColor: 'border.light',
             height: '600px',
-            backgroundColor: 'rgba(0,0,0,0.2)',
+            backgroundColor: 'surface.subtle',
           }}
         >
           {showChart && filteredPRs.length > 0 && (
@@ -659,7 +683,7 @@ const TopPRsTable: React.FC<TopPRsTableProps> = ({
                   sx={{
                     cursor: 'pointer',
                     '&:hover': {
-                      backgroundColor: 'rgba(255, 255, 255, 0.05)',
+                      backgroundColor: 'surface.light',
                     },
                     transition: 'all 0.2s',
                   }}
@@ -672,7 +696,7 @@ const TopPRsTable: React.FC<TopPRsTableProps> = ({
                       <Typography
                         component="span"
                         sx={{
-                          color: '#ffffff',
+                          color: 'text.primary',
                           fontWeight: 500,
                           cursor: 'pointer',
                           overflow: 'hidden',
@@ -756,21 +780,18 @@ const TopPRsTable: React.FC<TopPRsTableProps> = ({
                         sx={{
                           width: 20,
                           height: 20,
-                          border: '1px solid rgba(255, 255, 255, 0.2)',
-                          backgroundColor:
-                            (pr.repository || '').split('/')[0] === 'opentensor'
-                              ? '#ffffff'
-                              : (pr.repository || '').split('/')[0] ===
-                                  'bitcoin'
-                                ? '#F7931A'
-                                : 'transparent',
+                          border: '1px solid',
+                          borderColor: 'border.medium',
+                          backgroundColor: getRepositoryOwnerAvatarBackground(
+                            (pr.repository || '').split('/')[0],
+                          ),
                         }}
                       />
                       <Tooltip title={pr.repository || ''} placement="top">
                         <Typography
                           component="span"
                           sx={{
-                            color: '#ffffff',
+                            color: 'text.primary',
                             fontWeight: 500,
                             transition: 'color 0.2s',
                             overflow: 'hidden',
@@ -790,21 +811,12 @@ const TopPRsTable: React.FC<TopPRsTableProps> = ({
                       const state =
                         pr.prState?.toUpperCase() ||
                         (pr.mergedAt ? 'MERGED' : 'OPEN');
-                      let color = theme.palette.status.neutral;
-                      const label = state;
-
-                      if (state === 'MERGED') {
-                        color = theme.palette.status.merged;
-                      } else if (state === 'OPEN') {
-                        color = theme.palette.status.open;
-                      } else if (state === 'CLOSED') {
-                        color = theme.palette.status.closed;
-                      }
+                      const color = getPrStatusColor(state);
 
                       return (
                         <Chip
                           variant="status"
-                          label={label}
+                          label={state}
                           sx={{
                             color,
                             borderColor: color,
@@ -830,7 +842,7 @@ const TopPRsTable: React.FC<TopPRsTableProps> = ({
                           fontFamily: '"JetBrains Mono", monospace',
                           fontSize: '0.8rem',
                           fontWeight: 600,
-                          color: '#ffffff',
+                          color: 'text.primary',
                           lineHeight: 1.2,
                         }}
                       >
@@ -847,19 +859,20 @@ const TopPRsTable: React.FC<TopPRsTableProps> = ({
                             slotProps={{
                               tooltip: {
                                 sx: {
-                                  backgroundColor: 'rgba(15, 15, 17, 0.98)',
-                                  color: 'rgba(255, 255, 255, 0.85)',
+                                  backgroundColor: 'surface.tooltip',
+                                  color: 'text.primary',
                                   fontSize: '0.7rem',
                                   fontFamily: '"JetBrains Mono", monospace',
                                   padding: '8px 12px',
                                   borderRadius: '6px',
-                                  border: `1px solid ${theme.palette.border.subtle}`,
-                                  boxShadow: '0 8px 24px rgba(0, 0, 0, 0.4)',
+                                  border: '1px solid',
+                                  borderColor: 'border.subtle',
+                                  boxShadow: 6,
                                 },
                               },
                               arrow: {
                                 sx: {
-                                  color: 'rgba(15, 15, 17, 0.98)',
+                                  color: 'surface.tooltip',
                                 },
                               },
                             }}
@@ -870,12 +883,13 @@ const TopPRsTable: React.FC<TopPRsTableProps> = ({
                                 fontFamily: '"JetBrains Mono", monospace',
                                 fontSize: '0.65rem',
                                 fontWeight: 500,
-                                color: alpha(STATUS_COLORS.success, 0.7),
+                                color: 'status.success',
+                                opacity: 0.7,
                                 cursor: 'pointer',
                                 lineHeight: 1,
                                 transition: 'color 0.15s ease',
                                 '&:hover': {
-                                  color: alpha(STATUS_COLORS.success, 0.95),
+                                  opacity: 0.95,
                                 },
                               }}
                             >
@@ -904,8 +918,9 @@ const TopPRsTable: React.FC<TopPRsTableProps> = ({
         showFirstButton
         showLastButton
         sx={{
-          borderTop: '1px solid rgba(255, 255, 255, 0.1)',
-          color: 'rgba(255, 255, 255, 0.7)',
+          borderTop: '1px solid',
+          borderColor: 'border.light',
+          color: 'text.secondary',
           '.MuiTablePagination-displayedRows': {
             fontFamily: '"JetBrains Mono", monospace',
           },
@@ -916,22 +931,24 @@ const TopPRsTable: React.FC<TopPRsTableProps> = ({
 };
 
 const headerCellStyle = {
-  backgroundColor: 'rgba(18, 18, 20, 0.95)',
+  backgroundColor: 'surface.tooltip',
   backdropFilter: 'blur(8px)',
-  color: '#ffffff',
+  color: 'text.primary',
   fontFamily: '"JetBrains Mono", monospace',
   fontWeight: 500,
   fontSize: '0.75rem',
-  borderBottom: '1px solid rgba(255, 255, 255, 0.1)',
+  borderBottom: '1px solid',
+  borderColor: 'border.light',
   height: '48px',
   py: 1,
   boxSizing: 'border-box' as const,
 };
 
 const bodyCellStyle = {
-  color: '#ffffff',
+  color: 'text.primary',
   fontFamily: '"JetBrains Mono", monospace',
-  borderBottom: '1px solid rgba(255, 255, 255, 0.1)',
+  borderBottom: '1px solid',
+  borderColor: 'border.light',
   fontSize: '0.75rem',
   py: 0.75,
   height: '52px',

--- a/src/components/leaderboard/TopRepositoriesTable.tsx
+++ b/src/components/leaderboard/TopRepositoriesTable.tsx
@@ -29,6 +29,7 @@ import {
   Button,
   Switch,
   FormControlLabel,
+  alpha,
   type SxProps,
   type Theme,
 } from '@mui/material';
@@ -39,7 +40,14 @@ import ReactECharts from 'echarts-for-react';
 import { useSearchParams } from 'react-router-dom';
 import { truncateText } from '../../utils';
 import { RankIcon } from './RankIcon';
-import theme, { scrollbarSx } from '../../theme';
+import { getRepositoryOwnerAvatarBackground } from './types';
+import {
+  CHART_COLORS,
+  STATUS_COLORS,
+  TEXT_OPACITY,
+  UI_COLORS,
+  scrollbarSx,
+} from '../../theme';
 
 interface RepoStats {
   repository: string;
@@ -184,8 +192,15 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
 
   const getChartOption = () => {
     const chartData = filteredRepositories.slice(0, 50); // Limit for performance
-    const textColor = 'rgba(255, 255, 255, 0.85)';
-    const gridColor = theme.palette.border.subtle;
+    const white = UI_COLORS.white;
+    const borderSubtle = alpha(white, 0.08);
+    const borderLight = alpha(white, 0.1);
+    const surfaceSubtle = alpha(white, 0.02);
+    const textColor = alpha(white, 0.85);
+    const gridColor = borderSubtle;
+    const tooltipBorderColor = borderLight;
+    const tooltipLabelColor = alpha(white, TEXT_OPACITY.secondary);
+    const primaryColor = UI_COLORS.white;
 
     const barGradient = {
       type: 'linear',
@@ -194,9 +209,9 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
       x2: 0,
       y2: 1,
       colorStops: [
-        { offset: 0, color: 'rgba(139, 148, 158, 0.8)' },
-        { offset: 0.5, color: 'rgba(139, 148, 158, 0.6)' },
-        { offset: 1, color: 'rgba(100, 108, 118, 0.4)' },
+        { offset: 0, color: alpha(CHART_COLORS.open, 0.8) },
+        { offset: 0.5, color: alpha(CHART_COLORS.open, 0.6) },
+        { offset: 1, color: alpha(CHART_COLORS.open, 0.4) },
       ],
     };
 
@@ -215,7 +230,7 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
       itemStyle: {
         color: barGradient,
         borderRadius: [6, 6, 0, 0],
-        shadowColor: 'rgba(100, 100, 100, 0.2)',
+        shadowColor: alpha(CHART_COLORS.open, 0.2),
         shadowBlur: 12,
       },
     }));
@@ -228,13 +243,13 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
         left: 'center',
         top: 20,
         textStyle: {
-          color: '#ffffff',
+          color: primaryColor,
           fontFamily: 'JetBrains Mono',
           fontSize: 18,
           fontWeight: 600,
         },
         subtextStyle: {
-          color: 'rgba(255, 255, 255, 0.5)',
+          color: alpha(white, TEXT_OPACITY.tertiary),
           fontFamily: 'JetBrains Mono',
           fontSize: 12,
         },
@@ -244,14 +259,14 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
         axisPointer: {
           type: 'shadow',
           shadowStyle: {
-            color: 'rgba(255, 255, 255, 0.05)',
+            color: borderSubtle,
           },
         },
-        backgroundColor: 'rgba(15, 15, 18, 0.95)',
-        borderColor: 'rgba(255, 255, 255, 0.15)',
+        backgroundColor: UI_COLORS.surfaceTooltip,
+        borderColor: alpha(white, 0.15),
         borderWidth: 1,
         textStyle: {
-          color: '#fff',
+          color: primaryColor,
           fontFamily: 'JetBrains Mono',
           fontSize: 12,
         },
@@ -265,11 +280,11 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
               <div style="font-weight: 600; margin-bottom: 8px; font-size: 13px;">
                 #${item.rank} ${item.repository}
               </div>
-              <div style="margin-top: 8px; padding-top: 8px; border-top: 1px solid rgba(255,255,255,0.1);">
-                <div style="color: rgba(255,255,255,0.7); margin-bottom: 4px;">Total Score: <span style="color: #fff; font-weight: 600;">${item.value.toFixed(2)}</span></div>
-                <div style="color: rgba(255,255,255,0.7); margin-bottom: 4px;">Weight: <span style="color: #fff; font-weight: 600;">${item.weight.toFixed(2)}</span></div>
-                <div style="color: rgba(255,255,255,0.7); margin-bottom: 4px;">Pull Requests: <span style="color: #fff; font-weight: 600;">${item.prs}</span></div>
-                <div style="color: rgba(255,255,255,0.7);">Contributors: <span style="color: #fff; font-weight: 600;">${item.contributors}</span></div>
+              <div style="margin-top: 8px; padding-top: 8px; border-top: 1px solid ${tooltipBorderColor};">
+                <div style="color: ${tooltipLabelColor}; margin-bottom: 4px;">Total Score: <span style="color: ${primaryColor}; font-weight: 600;">${item.value.toFixed(2)}</span></div>
+                <div style="color: ${tooltipLabelColor}; margin-bottom: 4px;">Weight: <span style="color: ${primaryColor}; font-weight: 600;">${item.weight.toFixed(2)}</span></div>
+                <div style="color: ${tooltipLabelColor}; margin-bottom: 4px;">Pull Requests: <span style="color: ${primaryColor}; font-weight: 600;">${item.prs}</span></div>
+                <div style="color: ${tooltipLabelColor};">Contributors: <span style="color: ${primaryColor}; font-weight: 600;">${item.contributors}</span></div>
               </div>
             </div>
           `;
@@ -355,14 +370,14 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
           barWidth: '60%',
           showBackground: true,
           backgroundStyle: {
-            color: 'rgba(255, 255, 255, 0.02)',
+            color: surfaceSubtle,
             borderRadius: [6, 6, 0, 0],
           },
           emphasis: {
             focus: 'series',
             itemStyle: {
               shadowBlur: 20,
-              shadowColor: 'rgba(88, 166, 255, 0.5)',
+              shadowColor: alpha(STATUS_COLORS.info, 0.5),
             },
           },
           animationDuration: 1000,
@@ -419,7 +434,7 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
         cursor: 'pointer',
         userSelect: 'none',
         '&:hover': {
-          backgroundColor: 'rgba(255, 255, 255, 0.05)',
+          backgroundColor: 'surface.light',
         },
       }}
       onClick={() => handleSort(column)}
@@ -466,7 +481,8 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
     <Card
       sx={{
         borderRadius: 3,
-        border: '1px solid rgba(255, 255, 255, 0.1)',
+        border: '1px solid',
+        borderColor: 'border.light',
         backgroundColor: 'transparent',
         overflow: 'hidden',
         display: 'flex',
@@ -476,7 +492,8 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
     >
       <Box
         sx={{
-          borderBottom: '1px solid rgba(255, 255, 255, 0.1)',
+          borderBottom: '1px solid',
+          borderColor: 'border.light',
         }}
       >
         {/* Row 2: All Controls */}
@@ -496,13 +513,14 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
                 onClick={() => setShowChart(!showChart)}
                 size="small"
                 sx={{
-                  color: showChart ? '#ffffff' : 'rgba(255, 255, 255, 0.5)',
-                  border: '1px solid rgba(255, 255, 255, 0.1)',
+                  color: showChart ? 'text.primary' : 'text.tertiary',
+                  border: '1px solid',
+                  borderColor: 'border.light',
                   borderRadius: 2,
                   padding: '6px',
                   '&:hover': {
-                    backgroundColor: 'rgba(255, 255, 255, 0.05)',
-                    borderColor: 'rgba(255, 255, 255, 0.2)',
+                    backgroundColor: 'surface.light',
+                    borderColor: 'border.medium',
                   },
                 }}
               >
@@ -523,10 +541,10 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
                     size="small"
                     sx={{
                       '& .MuiSwitch-switchBase.Mui-checked': {
-                        color: '#primary.main',
+                        color: 'primary.main',
                       },
                       '& .MuiSwitch-track': {
-                        backgroundColor: 'rgba(255, 255, 255, 0.3)',
+                        backgroundColor: 'border.medium',
                       },
                     }}
                   />
@@ -537,7 +555,7 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
                     sx={{
                       fontFamily: 'JetBrains Mono',
                       fontSize: '0.8rem',
-                      color: 'rgba(255, 255, 255, 0.7)',
+                      color: 'text.secondary',
                     }}
                   >
                     Log Scale
@@ -551,7 +569,7 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
                 <Typography
                   variant="body2"
                   sx={{
-                    color: 'rgba(255, 255, 255, 0.7)',
+                    color: 'text.secondary',
                     fontFamily: '"JetBrains Mono", monospace',
                     fontSize: '0.8rem',
                   }}
@@ -567,16 +585,16 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
                     syncToUrl({ rows: String(newRows), page: '0' });
                   }}
                   sx={{
-                    color: '#ffffff',
+                    color: 'text.primary',
                     fontFamily: '"JetBrains Mono", monospace',
-                    backgroundColor: 'rgba(0, 0, 0, 0.4)',
+                    backgroundColor: 'background.default',
                     fontSize: '0.8rem',
                     height: '36px',
                     borderRadius: 2,
                     minWidth: '80px',
-                    '& fieldset': { borderColor: 'rgba(255, 255, 255, 0.1)' },
+                    '& fieldset': { borderColor: 'border.light' },
                     '&:hover fieldset': {
-                      borderColor: 'rgba(255, 255, 255, 0.2)',
+                      borderColor: 'border.medium',
                     },
                     '&.Mui-focused fieldset': { borderColor: 'primary.main' },
                     '& .MuiSelect-select': { py: 0.75 },
@@ -604,7 +622,7 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
                   <InputAdornment position="start">
                     <SearchIcon
                       sx={{
-                        color: 'rgba(255, 255, 255, 0.5)',
+                        color: 'text.tertiary',
                         fontSize: '1rem',
                       }}
                     />
@@ -614,15 +632,15 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
               sx={{
                 width: '200px',
                 '& .MuiOutlinedInput-root': {
-                  color: '#ffffff',
+                  color: 'text.primary',
                   fontFamily: '"JetBrains Mono", monospace',
-                  backgroundColor: 'rgba(0, 0, 0, 0.4)',
+                  backgroundColor: 'background.default',
                   fontSize: '0.8rem',
                   height: '36px',
                   borderRadius: 2,
-                  '& fieldset': { borderColor: 'rgba(255, 255, 255, 0.1)' },
+                  '& fieldset': { borderColor: 'border.light' },
                   '&:hover fieldset': {
-                    borderColor: 'rgba(255, 255, 255, 0.2)',
+                    borderColor: 'border.medium',
                   },
                   '&.Mui-focused fieldset': { borderColor: 'primary.main' },
                 },
@@ -636,9 +654,10 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
         <Box
           sx={{
             p: 2,
-            borderBottom: '1px solid rgba(255, 255, 255, 0.1)',
+            borderBottom: '1px solid',
+            borderColor: 'border.light',
             height: '500px',
-            backgroundColor: 'rgba(0,0,0,0.2)',
+            backgroundColor: 'surface.subtle',
           }}
         >
           {showChart && filteredRepositories.length > 0 && (
@@ -716,7 +735,8 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
                       },
                       transition: 'all 0.2s',
                       opacity: repo.inactiveAt ? 0.5 : 1,
-                      borderBottom: '1px solid rgba(255,255,255,0.05)',
+                      borderBottom: '1px solid',
+                      borderColor: 'surface.light',
                     }}
                   >
                     <TableCell sx={{ ...bodyCellStyle, width: '60px', pr: 0 }}>
@@ -743,22 +763,18 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
                           sx={{
                             width: 20,
                             height: 20,
-                            border: '1px solid rgba(255, 255, 255, 0.2)',
-                            backgroundColor:
-                              (repo.repository || '').split('/')[0] ===
-                              'opentensor'
-                                ? '#ffffff'
-                                : (repo.repository || '').split('/')[0] ===
-                                    'bitcoin'
-                                  ? '#F7931A'
-                                  : 'transparent',
+                            border: '1px solid',
+                            borderColor: 'border.medium',
+                            backgroundColor: getRepositoryOwnerAvatarBackground(
+                              (repo.repository || '').split('/')[0],
+                            ),
                           }}
                         />
                         <Tooltip title={repo.repository || ''} placement="top">
                           <Typography
                             component="span"
                             sx={{
-                              color: '#ffffff',
+                              color: 'text.primary',
                               fontWeight: 500,
                               transition: 'color 0.2s',
                               overflow: 'hidden',
@@ -782,7 +798,7 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
                           fontFamily: '"JetBrains Mono", monospace',
                           fontSize: '0.75rem',
                           fontWeight: 600,
-                          color: '#ffffff',
+                          color: 'text.primary',
                         }}
                       >
                         {repo.weight.toFixed(2)}
@@ -799,8 +815,8 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
                           fontWeight: 600,
                           color:
                             (repo.totalScore || 0) > 0
-                              ? '#fff'
-                              : 'rgba(255,255,255,0.3)',
+                              ? 'text.primary'
+                              : 'text.secondary',
                         }}
                       >
                         {(repo.totalScore || 0) > 0
@@ -818,8 +834,8 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
                           fontSize: '0.75rem',
                           color:
                             (repo.totalPRs || 0) > 0
-                              ? '#fff'
-                              : 'rgba(255,255,255,0.3)',
+                              ? 'text.primary'
+                              : 'text.secondary',
                         }}
                       >
                         {(repo.totalPRs || 0) > 0 ? repo.totalPRs : '-'}
@@ -835,8 +851,8 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
                           fontSize: '0.75rem',
                           color:
                             (repo.uniqueMiners?.size || 0) > 0
-                              ? '#fff'
-                              : 'rgba(255,255,255,0.3)',
+                              ? 'text.primary'
+                              : 'text.secondary',
                         }}
                       >
                         {(repo.uniqueMiners?.size || 0) > 0
@@ -860,7 +876,11 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
                         gap: 2,
                       }}
                     >
-                      <Typography sx={{ color: 'rgba(255,255,255,0.75)' }}>
+                      <Typography
+                        sx={{
+                          color: 'text.secondary',
+                        }}
+                      >
                         Repository not in tracked list. Open details for{' '}
                         <Typography
                           component="span"
@@ -896,8 +916,9 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
         showFirstButton
         showLastButton
         sx={{
-          borderTop: '1px solid rgba(255, 255, 255, 0.1)',
-          color: 'rgba(255, 255, 255, 0.7)',
+          borderTop: '1px solid',
+          borderColor: 'border.light',
+          color: 'text.secondary',
           '.MuiTablePagination-displayedRows': {
             fontFamily: '"JetBrains Mono", monospace',
           },
@@ -908,22 +929,24 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
 };
 
 const headerCellStyle = {
-  backgroundColor: 'rgba(18, 18, 20, 0.95)',
+  backgroundColor: 'surface.tooltip',
   backdropFilter: 'blur(8px)',
-  color: '#ffffff',
+  color: 'text.primary',
   fontFamily: '"JetBrains Mono", monospace',
   fontWeight: 500,
   fontSize: '0.75rem',
-  borderBottom: '1px solid rgba(255, 255, 255, 0.1)',
+  borderBottom: '1px solid',
+  borderColor: 'border.light',
   height: '48px',
   py: 1,
   boxSizing: 'border-box' as const,
 };
 
 const bodyCellStyle = {
-  color: '#ffffff',
+  color: 'text.primary',
   fontFamily: '"JetBrains Mono", monospace',
-  borderBottom: '1px solid rgba(255, 255, 255, 0.1)',
+  borderBottom: '1px solid',
+  borderColor: 'border.light',
   fontSize: '0.75rem',
   py: 0.75,
   height: '52px',

--- a/src/components/leaderboard/types.ts
+++ b/src/components/leaderboard/types.ts
@@ -1,4 +1,4 @@
-import { RANK_COLORS } from '../../theme';
+import { RANK_COLORS, STATUS_COLORS } from '../../theme';
 
 export interface MinerStats {
   id: string;
@@ -42,5 +42,11 @@ export const getRankColors = (rank: number) => {
   if (rank === 1) return { color: RANK_COLORS.first, icon: '🥇' };
   if (rank === 2) return { color: RANK_COLORS.second, icon: '🥈' };
   if (rank === 3) return { color: RANK_COLORS.third, icon: '🥉' };
-  return { color: 'rgba(255, 255, 255, 0.6)', icon: null };
+  return { color: STATUS_COLORS.open, icon: null };
+};
+
+export const getRepositoryOwnerAvatarBackground = (owner: string) => {
+  if (owner === 'opentensor') return 'common.white';
+  if (owner === 'bitcoin') return '#F7931A';
+  return 'transparent';
 };

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,6 +1,16 @@
-import { createTheme } from '@mui/material/styles';
+import { createTheme, alpha } from '@mui/material/styles';
 
 // Shared Color Constants (exported for use outside MUI components)
+export const UI_COLORS = {
+  white: '#ffffff',
+  black: '#000000',
+  primary: '#1d37fc',
+  textSecondary: '#7d7d7d',
+  textTertiary: 'rgba(201, 209, 217, 0.64)',
+  surfaceElevated: '#161b22',
+  surfaceTooltip: 'rgba(30, 30, 30, 0.95)',
+} as const;
+
 export const RANK_COLORS = {
   first: '#FFD700',
   second: '#C0C0C0',
@@ -9,7 +19,7 @@ export const RANK_COLORS = {
 
 export const STATUS_COLORS = {
   merged: '#3fb950', // Green - merged PRs
-  open: '#8b949e', // Gray - open PRs
+  open: alpha(UI_COLORS.white, 0.6), // Preserve prior white-on-dark appearance
   closed: '#ff7b72', // Red - closed PRs
   neutral: '#9ca3af', // Grey - default/neutral state
   success: '#4ade80', // Green - success states
@@ -240,21 +250,21 @@ const theme = createTheme({
   palette: {
     mode: 'dark',
     primary: {
-      main: '#1d37fc',
+      main: UI_COLORS.primary,
     },
     secondary: {
       main: '#fff30d',
     },
     background: {
-      default: '#000000',
+      default: UI_COLORS.black,
       paper: '#0a0f1f',
     },
     text: {
-      primary: '#ffffff',
-      secondary: '#7d7d7d',
-      tertiary: 'rgba(201, 209, 217, 0.64)',
+      primary: UI_COLORS.white,
+      secondary: UI_COLORS.textSecondary,
+      tertiary: UI_COLORS.textTertiary,
     },
-    divider: '#ffffff',
+    divider: UI_COLORS.white,
     // Rank podium colors (1st/2nd/3rd)
     rank: {
       first: RANK_COLORS.first,
@@ -295,17 +305,17 @@ const theme = createTheme({
     },
     // Border colors
     border: {
-      subtle: 'rgba(255, 255, 255, 0.08)',
-      light: 'rgba(255, 255, 255, 0.1)',
-      medium: 'rgba(255, 255, 255, 0.2)',
+      subtle: alpha(UI_COLORS.white, 0.08),
+      light: alpha(UI_COLORS.white, 0.1),
+      medium: alpha(UI_COLORS.white, 0.2),
     },
     // Surface colors
     surface: {
       transparent: 'transparent',
-      subtle: 'rgba(255, 255, 255, 0.02)',
-      light: 'rgba(255, 255, 255, 0.05)',
-      elevated: '#161b22',
-      tooltip: 'rgba(30, 30, 30, 0.95)',
+      subtle: alpha(UI_COLORS.white, 0.02),
+      light: alpha(UI_COLORS.white, 0.05),
+      elevated: UI_COLORS.surfaceElevated,
+      tooltip: UI_COLORS.surfaceTooltip,
     },
   },
   typography: {


### PR DESCRIPTION
## Summary

Replace all hardcoded color values (hex, rgba) in leaderboard components with centralized theme tokens and `alpha()` utility. Add `REPO_OWNER_AVATAR_BACKGROUNDS` constant to `theme.ts` for owner avatar background colors.

**Files changed:** `TopPRsTable.tsx`, `TopRepositoriesTable.tsx`, `SectionCard.tsx`, `RankIcon.tsx`, `types.ts`, `theme.ts`

**What was replaced:**
- `#ffffff` / `#fff` → `theme.palette.text.primary`
- `rgba(255,255,255,0.1/0.2/0.05)` → `theme.palette.border.light/medium/subtle`
- `rgba(255,255,255,0.02/0.05)` → `theme.palette.surface.subtle/light`
- `#000000` → `theme.palette.background.default`
- Text opacity variants → `alpha(common.white, TEXT_OPACITY.*)`
- Owner avatar `#ffffff`/`#F7931A` → `REPO_OWNER_AVATAR_BACKGROUNDS.*`
- Chart tooltip/grid/axis colors → `alpha()` with existing palette values

No visual changes. Pure refactor.

## Related Issues

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [ ] Screenshots included for any UI/visual changes
