### PR TITLE
fix: add rel="noopener noreferrer" to remaining target="_blank" links

### DIFF
--- a/src/components/miners/MinerScoreCard.tsx
+++ b/src/components/miners/MinerScoreCard.tsx
@@ -476,6 +476,7 @@ const MinerScoreCard: React.FC<MinerScoreCardProps> = ({ githubId }) => {
                       : `https://${githubData.blog}`
                   }
                   target="_blank"
+                  rel="noopener noreferrer"
                   icon={<WebsiteIcon />}
                   label="Website"
                   clickable

--- a/src/components/prs/PRFilesChanged.tsx
+++ b/src/components/prs/PRFilesChanged.tsx
@@ -1082,6 +1082,7 @@ const PRFileDiffViewer: React.FC<{
           component="a"
           href={file.blob_url}
           target="_blank"
+          rel="noopener noreferrer"
           sx={{
             color: STATUS_COLORS.info,
             fontSize: '0.85rem',

--- a/src/pages/RepositoryDetailsPage.tsx
+++ b/src/pages/RepositoryDetailsPage.tsx
@@ -225,6 +225,7 @@ const RepositoryDetailsPage: React.FC = () => {
                   startIcon={<GitHubIcon />}
                   href={`https://github.com/${repo}`}
                   target="_blank"
+                  rel="noopener noreferrer"
                   sx={{
                     borderColor: 'rgba(255,255,255,0.2)',
                     color: '#fff',


### PR DESCRIPTION
## Summary
Closes the small tabnabbing / referrer-leak gap on three external links that were missing `rel="noopener noreferrer"`. All three had `target="_blank"` but no `rel` attribute, while 20+ other external links in the codebase already follow the correct pattern.

One of the three (`MinerScoreCard` "Website" chip) opens a **user-controlled URL** — a miner's self-declared GitHub profile website — which turns this from a theoretical to a practical vector.

## What changed
Three single-line additions of `rel="noopener noreferrer"` after the existing `target="_blank"`:

- `src/components/miners/MinerScoreCard.tsx:478` — Website chip (`githubData.blog`)
- `src/pages/RepositoryDetailsPage.tsx:227` — "View on GitHub" button
- `src/components/prs/PRFilesChanged.tsx:1084` — "View file" blob link

## Why
- Defense in depth: even though modern Chromium-based browsers default `target="_blank"` to `noopener` for cross-origin URLs since v88 (2021), older browsers, WebViews, Electron hosts, and in-app mobile browsers do not. `noreferrer` is never the default and without it `document.referrer` leaks internal Gittensor URLs to the destination.
- Consistency: the rest of the codebase already uses this exact pattern; these three were drift.
- The `MinerScoreCard` Website chip opens a URL entered by the miner on their GitHub profile. Without `noopener`, a malicious miner can set their `blog` value to a page that does `window.opener.location = 'https://phishing.site'` and silently hijack the Gittensor tab.

## Type of Change
- [x] Bug fix (security / best practice)

## Testing
- [ ] `npm run build`
- [ ] `npm run lint:fix`
- [ ] Manual: click each of the three links, confirm they still open in a new tab and navigate to the correct URL. No user-facing behavior change expected.
- [ ] Static check: `grep -rn 'target="_blank"' src/ | grep -v "rel=\"noopener"` returns no results after the patch.

## Checklist
- [x] No behavior change for legitimate users
- [x] No new dependencies
- [x] Three files touched, three lines added

## Follow-up (out of scope)
Adding `eslint-plugin-react` and enabling `react/jsx-no-target-blank` would prevent regressions. That's a `package.json` + `eslint.config` change with a much larger surface area — happy to open it as a separate PR if the maintainers want.
