### PR TITLE
fix: normalize repo casing, refresh stale state, and stabilize repository PR row key

### DIFF
--- a/src/components/dashboard/LeaderboardCharts.tsx
+++ b/src/components/dashboard/LeaderboardCharts.tsx
@@ -56,7 +56,9 @@ const LeaderboardCharts: React.FC = () => {
     });
 
     statsMap.forEach((stats, repoName) => {
-      const repoData = repos.find((r) => r.fullName === repoName);
+      const repoData = repos.find(
+        (r) => r.fullName.toLowerCase() === repoName.toLowerCase(),
+      );
       if (repoData) {
         stats.weight = repoData.weight
           ? parseFloat(String(repoData.weight))

--- a/src/components/miners/MinerPRsTable.tsx
+++ b/src/components/miners/MinerPRsTable.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useCallback } from 'react';
+import React, { useState, useMemo, useCallback, useEffect } from 'react';
 import {
   Card,
   Typography,
@@ -83,6 +83,14 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
   const [searchQuery, setSearchQuery] = useState('');
   const [sortField, setSortField] = useState<PrSortField>('date');
   const [sortDir, setSortDir] = useState<SortDir>('desc');
+
+  useEffect(() => {
+    setSelectedAuthor(null);
+    setStatusFilter('all');
+    setSearchQuery('');
+    setSortField('date');
+    setSortDir('desc');
+  }, [githubId]);
 
   const page = parseInt(searchParams.get('prPage') || '0', 10);
   const setPage = useCallback(

--- a/src/components/repositories/RepositoryCheckTab.tsx
+++ b/src/components/repositories/RepositoryCheckTab.tsx
@@ -93,9 +93,9 @@ const RepositoryCheckTab: React.FC<RepositoryCheckTabProps> = ({
           setHelpWantedCount(hwRes.data.total_count);
         } catch (e) {
           console.warn('Failed to fetch issue counts', e);
-          // Fallback to repoData count if search fails, though it includes PRs
-          if (repoData && repoData.open_issues_count !== undefined) {
-            setOpenIssuesCount(repoData.open_issues_count);
+          // Fallback to repoRes.data (local variable) — repoData state is stale here
+          if (repoRes.data && repoRes.data.open_issues_count !== undefined) {
+            setOpenIssuesCount(repoRes.data.open_issues_count);
           }
         }
       } catch (err: unknown) {

--- a/src/components/repositories/RepositoryPRsTable.tsx
+++ b/src/components/repositories/RepositoryPRsTable.tsx
@@ -284,7 +284,7 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
             <TableBody>
               {sortedPRs.map((pr, index) => (
                 <TableRow
-                  key={`${pr.pullRequestNumber}-${index}`}
+                  key={`${pr.repository}-${pr.pullRequestNumber}`}
                   onClick={() => {
                     navigate(
                       `/miners/pr?repo=${encodeURIComponent(pr.repository)}&number=${pr.pullRequestNumber}`,

--- a/src/pages/RepositoriesPage.tsx
+++ b/src/pages/RepositoriesPage.tsx
@@ -211,12 +211,16 @@ const RepositoriesPage: React.FC = () => {
       repoScores.set(pr.repository, cur);
     });
 
-    const repoMap = new Map(reposWithWeights.map((r) => [r.fullName, r]));
+    const repoMap = new Map(
+      reposWithWeights.map((r) => [r.fullName.toLowerCase(), r]),
+    );
 
     return Array.from(repoScores.entries())
       .filter(
         ([name, s]) =>
-          repoMap.has(name) && s.recentScore > 0 && s.priorScore > 0,
+          repoMap.has(name.toLowerCase()) &&
+          s.recentScore > 0 &&
+          s.priorScore > 0,
       )
       .map(([name, s]) => ({
         name,
@@ -233,7 +237,9 @@ const RepositoriesPage: React.FC = () => {
   const topCollateralRepos = useMemo(() => {
     if (!allPRs || !reposWithWeights) return [];
 
-    const repoMap = new Map(reposWithWeights.map((r) => [r.fullName, r]));
+    const repoMap = new Map(
+      reposWithWeights.map((r) => [r.fullName.toLowerCase(), r]),
+    );
 
     // Sum collateral from open PRs per repo
     const repoCollateral = new Map<
@@ -243,7 +249,7 @@ const RepositoriesPage: React.FC = () => {
 
     allPRs.forEach((pr: CommitLog) => {
       if (!pr?.repository || pr.prState !== 'OPEN') return;
-      if (!repoMap.has(pr.repository)) return;
+      if (!repoMap.has(pr.repository.toLowerCase())) return;
       const collateral = parseFloat(pr.collateralScore || '0');
       if (collateral <= 0) return;
 

--- a/src/pages/RepositoryDetailsPage.tsx
+++ b/src/pages/RepositoryDetailsPage.tsx
@@ -83,7 +83,9 @@ const RepositoryDetailsPage: React.FC = () => {
   const tabValue = tabIndexFromSearchParam(searchParams.get('tab'));
   const { data: repos, isLoading: isLoadingRepos } = useReposAndWeights();
   const { data: bountySummary } = useRepoBountySummary(repo || '');
-  const trackedRepo = repos?.find((r) => r.fullName === repo);
+  const trackedRepo = repos?.find(
+    (r) => r.fullName.toLowerCase() === repo?.toLowerCase(),
+  );
   const isTrackedRepository = Boolean(trackedRepo);
 
   const owner = repo ? repo.split('/')[0] : '';


### PR DESCRIPTION
## Summary

A handful of small, related fixes across the miner and repository views. They all share the same theme: data that was technically present but silently didn't reach the UI correctly.

* Repository name lookups are now case-insensitive, so casing drift between a stored `fullName` and an incoming `pr.repository` no longer hides repos from widgets or mislabels them as untracked.
* The open-issues fallback in `RepositoryCheckTab` now reads the local response variable instead of a stale state reference, so it actually runs when the search API fails.
* `MinerPRsTable` now resets its filter, search, and sort state when `githubId` changes, so one miner's selections no longer leak into the next.
* The repository PR table uses a stable row key, so sorting reorders rows in place instead of remounting the entire body.

Closes #258 

## Changes

### Case-insensitive repository lookups

* `src/pages/RepositoryDetailsPage.tsx`: `.find((r) => r.fullName === repo)` now compares `r.fullName.toLowerCase() === repo?.toLowerCase()`. A mixed-casing URL no longer flips the page into the "not tracked" empty state.
* `src/components/dashboard/LeaderboardCharts.tsx`: same normalization inside the `.find(...)` that resolves repo weight, so weights no longer silently collapse to `0`.
* `src/pages/RepositoriesPage.tsx`: both the `trendingRepos` and `topCollateralRepos` memos build `repoMap` with `r.fullName.toLowerCase()` keys and look up with the lowercased `pr.repository`. Repos with casing drift are no longer excluded from those widgets.

The approach matches what `src/pages/search/searchData.ts` and the existing `repoStats` memo in `RepositoriesPage.tsx` already do.

### Stale React state

* `src/components/repositories/RepositoryCheckTab.tsx`: the catch block that runs when the search-issues requests fail read `repoData` from component state. Because `setRepoData(repoRes.data)` only schedules a re-render, the still-executing closure saw the initial `null` and the `if (repoData && ...)` branch never fired. Swapped the reference to `repoRes.data`, which holds the response captured from the first `await` in the same function. The fallback now populates `openIssuesCount` as intended.
* `src/components/miners/MinerPRsTable.tsx`: `selectedAuthor`, `statusFilter`, `searchQuery`, `sortField`, and `sortDir` were held as plain `useState` with no tie to `githubId`. Added a `useEffect` keyed on `githubId` that resets all five to their defaults when the prop changes. `useEffect` added to the React import.

### Stable row key in `RepositoryPRsTable`

* `src/components/repositories/RepositoryPRsTable.tsx`: row key was composed as `${pr.pullRequestNumber}-${index}`. Sorting reshuffled the array, so every row got a new key and React remounted the entire body. Swapped for `${pr.repository}-${pr.pullRequestNumber}`, which is unique across the dataset and stable under sort.