### PR TITLE
fix: repo casing, react state, unstable list key

### DIFF
--- a/src/components/dashboard/LeaderboardCharts.tsx
+++ b/src/components/dashboard/LeaderboardCharts.tsx
@@ -42,7 +42,8 @@ const LeaderboardCharts: React.FC = () => {
     const statsMap = new Map();
     allPRs.forEach((pr) => {
       if (!pr || !pr.repository) return;
-      const current = statsMap.get(pr.repository) || {
+      const repoKey = pr.repository.toLowerCase();
+      const current = statsMap.get(repoKey) || {
         repository: pr.repository,
         totalScore: 0,
         totalPRs: 0,
@@ -52,12 +53,13 @@ const LeaderboardCharts: React.FC = () => {
       current.totalScore += parseFloat(pr.score || '0');
       current.totalPRs += 1;
       if (pr.author) current.uniqueMiners.add(pr.author);
-      statsMap.set(pr.repository, current);
+      statsMap.set(repoKey, current);
     });
 
-    statsMap.forEach((stats, repoName) => {
-      const repoData = repos.find((r) => r.fullName === repoName);
+    statsMap.forEach((stats, repoKey) => {
+      const repoData = repos.find((r) => r.fullName.toLowerCase() === repoKey);
       if (repoData) {
+        stats.repository = repoData.fullName;
         stats.weight = repoData.weight
           ? parseFloat(String(repoData.weight))
           : 0;

--- a/src/components/miners/MinerPRsTable.tsx
+++ b/src/components/miners/MinerPRsTable.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useCallback } from 'react';
+import React, { useState, useMemo, useCallback, useEffect } from 'react';
 import {
   Card,
   Typography,
@@ -83,6 +83,14 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
   const [searchQuery, setSearchQuery] = useState('');
   const [sortField, setSortField] = useState<PrSortField>('date');
   const [sortDir, setSortDir] = useState<SortDir>('desc');
+
+  useEffect(() => {
+    setSelectedAuthor(null);
+    setStatusFilter('all');
+    setSearchQuery('');
+    setSortField('date');
+    setSortDir('desc');
+  }, [githubId]);
 
   const page = parseInt(searchParams.get('prPage') || '0', 10);
   const setPage = useCallback(

--- a/src/components/repositories/RepositoryCheckTab.tsx
+++ b/src/components/repositories/RepositoryCheckTab.tsx
@@ -93,9 +93,8 @@ const RepositoryCheckTab: React.FC<RepositoryCheckTabProps> = ({
           setHelpWantedCount(hwRes.data.total_count);
         } catch (e) {
           console.warn('Failed to fetch issue counts', e);
-          // Fallback to repoData count if search fails, though it includes PRs
-          if (repoData && repoData.open_issues_count !== undefined) {
-            setOpenIssuesCount(repoData.open_issues_count);
+          if (repoRes.data?.open_issues_count !== undefined) {
+            setOpenIssuesCount(repoRes.data.open_issues_count);
           }
         }
       } catch (err: unknown) {
@@ -109,7 +108,6 @@ const RepositoryCheckTab: React.FC<RepositoryCheckTabProps> = ({
     if (repositoryFullName) {
       fetchData();
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [repositoryFullName]);
 
   const checks: HealthCheck[] = useMemo(() => {

--- a/src/components/repositories/RepositoryPRsTable.tsx
+++ b/src/components/repositories/RepositoryPRsTable.tsx
@@ -282,9 +282,9 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
               </TableRow>
             </TableHead>
             <TableBody>
-              {sortedPRs.map((pr, index) => (
+              {sortedPRs.map((pr) => (
                 <TableRow
-                  key={`${pr.pullRequestNumber}-${index}`}
+                  key={`${pr.repository}-${pr.pullRequestNumber}`}
                   onClick={() => {
                     navigate(
                       `/miners/pr?repo=${encodeURIComponent(pr.repository)}&number=${pr.pullRequestNumber}`,

--- a/src/pages/RepositoriesPage.tsx
+++ b/src/pages/RepositoriesPage.tsx
@@ -195,8 +195,9 @@ const RepositoriesPage: React.FC = () => {
       const prDate = pr.mergedAt;
       if (!pr?.repository || !prDate) return;
       const score = parseFloat(pr.score || '0');
+      const repoKey = pr.repository.toLowerCase();
 
-      const cur = repoScores.get(pr.repository) || {
+      const cur = repoScores.get(repoKey) || {
         recentScore: 0,
         priorScore: 0,
         recentPRs: 0,
@@ -208,18 +209,19 @@ const RepositoriesPage: React.FC = () => {
       } else {
         cur.priorScore += score;
       }
-      repoScores.set(pr.repository, cur);
+      repoScores.set(repoKey, cur);
     });
 
-    const repoMap = new Map(reposWithWeights.map((r) => [r.fullName, r]));
+    const repoMap = new Map(
+      reposWithWeights.map((r) => [r.fullName.toLowerCase(), r]),
+    );
 
     return Array.from(repoScores.entries())
       .filter(
-        ([name, s]) =>
-          repoMap.has(name) && s.recentScore > 0 && s.priorScore > 0,
+        ([key, s]) => repoMap.has(key) && s.recentScore > 0 && s.priorScore > 0,
       )
-      .map(([name, s]) => ({
-        name,
+      .map(([key, s]) => ({
+        name: repoMap.get(key)!.fullName,
         recentScore: s.recentScore,
         priorScore: s.priorScore,
         pctIncrease: (s.recentScore / s.priorScore) * 100,
@@ -233,7 +235,9 @@ const RepositoriesPage: React.FC = () => {
   const topCollateralRepos = useMemo(() => {
     if (!allPRs || !reposWithWeights) return [];
 
-    const repoMap = new Map(reposWithWeights.map((r) => [r.fullName, r]));
+    const repoMap = new Map(
+      reposWithWeights.map((r) => [r.fullName.toLowerCase(), r]),
+    );
 
     // Sum collateral from open PRs per repo
     const repoCollateral = new Map<
@@ -243,22 +247,23 @@ const RepositoriesPage: React.FC = () => {
 
     allPRs.forEach((pr: CommitLog) => {
       if (!pr?.repository || pr.prState !== 'OPEN') return;
-      if (!repoMap.has(pr.repository)) return;
+      const repoKey = pr.repository.toLowerCase();
+      if (!repoMap.has(repoKey)) return;
       const collateral = parseFloat(pr.collateralScore || '0');
       if (collateral <= 0) return;
 
-      const cur = repoCollateral.get(pr.repository) || {
+      const cur = repoCollateral.get(repoKey) || {
         totalCollateral: 0,
         openPRs: 0,
       };
       cur.totalCollateral += collateral;
       cur.openPRs += 1;
-      repoCollateral.set(pr.repository, cur);
+      repoCollateral.set(repoKey, cur);
     });
 
     return Array.from(repoCollateral.entries())
-      .map(([name, data]) => ({
-        name,
+      .map(([key, data]) => ({
+        name: repoMap.get(key)!.fullName,
         collateral: data.totalCollateral,
         openPRs: data.openPRs,
       }))
@@ -270,7 +275,9 @@ const RepositoriesPage: React.FC = () => {
   const recentPrs = useMemo(() => {
     if (!allPRs || !reposWithWeights) return [];
 
-    const repoMap = new Map(reposWithWeights.map((r) => [r.fullName, r]));
+    const repoMap = new Map(
+      reposWithWeights.map((r) => [r.fullName.toLowerCase(), r]),
+    );
 
     const today = new Date();
     today.setHours(0, 0, 0, 0);
@@ -280,7 +287,7 @@ const RepositoriesPage: React.FC = () => {
         (pr) =>
           pr.repository &&
           pr.mergedAt &&
-          repoMap.has(pr.repository) &&
+          repoMap.has(pr.repository.toLowerCase()) &&
           new Date(pr.mergedAt) >= today,
       )
       .sort((a, b) => {
@@ -289,10 +296,10 @@ const RepositoriesPage: React.FC = () => {
         if (scoreB !== scoreA) return scoreB - scoreA;
         // Tiebreak by repo weight
         const weightA = parseFloat(
-          String(repoMap.get(a.repository)?.weight || '0'),
+          String(repoMap.get(a.repository?.toLowerCase() ?? '')?.weight || '0'),
         );
         const weightB = parseFloat(
-          String(repoMap.get(b.repository)?.weight || '0'),
+          String(repoMap.get(b.repository?.toLowerCase() ?? '')?.weight || '0'),
         );
         return weightB - weightA;
       })

--- a/src/pages/RepositoryDetailsPage.tsx
+++ b/src/pages/RepositoryDetailsPage.tsx
@@ -83,7 +83,9 @@ const RepositoryDetailsPage: React.FC = () => {
   const tabValue = tabIndexFromSearchParam(searchParams.get('tab'));
   const { data: repos, isLoading: isLoadingRepos } = useReposAndWeights();
   const { data: bountySummary } = useRepoBountySummary(repo || '');
-  const trackedRepo = repos?.find((r) => r.fullName === repo);
+  const trackedRepo = repos?.find(
+    (r) => r.fullName.toLowerCase() === (repo ?? '').toLowerCase(),
+  );
   const isTrackedRepository = Boolean(trackedRepo);
 
   const owner = repo ? repo.split('/')[0] : '';


### PR DESCRIPTION
## Summary

This PR fixes the bugs described in [#258](https://github.com/entrius/gittensor-ui/issues/258): GitHub-style case-insensitive repository identity across lookups and widgets, a stale React closure in the repository health-check tab, leaked miner PR table UI state on client-side navigation, and unstable table row keys causing unnecessary remounts when sorting.

Repository name casing

RepositoryDetailsPage: Resolving the tracked repo from useReposAndWeights() now compares fullName and the URL name query param case-insensitively, so a tracked repo is not shown as “not tracked” when casing differs (e.g. OWNER/REPO vs owner/repo).
LeaderboardCharts: Repo stats aggregate PRs by a normalized (lowercase) key and resolve weights with a case-insensitive match to the repos list; when a match exists, the displayed repository name uses the canonical fullName from the API.
RepositoriesPage: Trending, Most Collateral Staked, and Recent PRs use lowercase keys for internal maps and membership checks against reposWithWeights, and display names use the canonical fullName from the tracked repo map where applicable.
Stale state and keys

RepositoryCheckTab: When the GitHub Search API fails (rate limit, 4xx/5xx, etc.), the open-issues fallback now reads open_issues_count from the same repoRes.data returned by the basic /repos/{owner}/{repo} call, instead of the repoData React state variable (which was still stale in the catch closure).
MinerPRsTable: A useEffect keyed on githubId resets author filter, status filter, search query, sort field, and sort direction when switching miners so filters do not carry over via client-side routing.
RepositoryPRsTable: Table row key is ${pr.repository}-${pr.pullRequestNumber} instead of including the row index, so sorting reorders rows in place without remounting the whole body.

## Related Issues

fix #258 

## Type of Change

- Bug fix

## Testing

Manual checks recommended (test API per contributor workflow):
Repo details: Open /miners/repository?name=… with casing that differs from stored fullName; page should show tracked content, not the empty “not tracked” state.
Repositories widgets: Confirm Trending / Most Collateral / Recent PRs include repos that appear in the main table when PR repository strings differ only by case from fullName.
Leaderboard: Repo chart weights match tracked repos when PR repository casing differs from fullName.
Repository health tab: With Search API failing (or simulated), open-issues count still reflects open_issues_count from the basic repo response when available.
Miner PRs: On miner A, set filters/search/sort; navigate to miner B; table should reset to defaults.
Repository PRs: Sort columns; rows should update without a full flash/remount.


## Checklist


 New components are modularized/separated where sensible
 Uses predefined theme (e.g. no hardcoded colors)
 Responsive/mobile checked
 Tested against the test API
 npm run format and npm run lint:fix have been run
 npm run build passes
 Screenshots included for any UI/visual changes (N/A — no visual-only change)
