### PR TITLE
refactor(miners): replace hardcoded colors with theme tokens

### DIFF
--- a/src/components/miners/CredibilityChart.tsx
+++ b/src/components/miners/CredibilityChart.tsx
@@ -1,7 +1,6 @@
 import React, { useMemo } from 'react';
-import { Box, Typography } from '@mui/material';
+import { Box, Typography, alpha, useTheme } from '@mui/material';
 import ReactECharts from 'echarts-for-react';
-import { CHART_COLORS } from '../../theme';
 
 interface CredibilityChartProps {
   merged: number;
@@ -16,22 +15,24 @@ const CredibilityChart: React.FC<CredibilityChartProps> = ({
   closed,
   credibility,
 }) => {
+  const theme = useTheme();
+
   const chartOption = useMemo(
     () => ({
-      backgroundColor: 'transparent',
+      backgroundColor: theme.palette.surface.transparent,
       title: {
         text: `${(credibility * 100).toFixed(0)}%`,
         subtext: 'Credibility',
         left: 'center',
         top: '38%',
         textStyle: {
-          color: '#fff',
+          color: theme.palette.text.primary,
           fontSize: 28,
           fontWeight: 'bold',
           fontFamily: '"JetBrains Mono", monospace',
         },
         subtextStyle: {
-          color: 'rgba(255, 255, 255, 0.4)',
+          color: alpha(theme.palette.text.primary, 0.4),
           fontSize: 11,
           fontFamily: '"JetBrains Mono", monospace',
           fontWeight: 500,
@@ -40,11 +41,11 @@ const CredibilityChart: React.FC<CredibilityChartProps> = ({
       tooltip: {
         trigger: 'item',
         formatter: '{b}: {c} ({d}%)',
-        backgroundColor: 'rgba(0, 0, 0, 0.9)',
-        borderColor: 'rgba(255, 255, 255, 0.15)',
+        backgroundColor: theme.palette.surface.tooltip,
+        borderColor: alpha(theme.palette.text.primary, 0.15),
         borderWidth: 1,
         textStyle: {
-          color: '#fff',
+          color: theme.palette.text.primary,
           fontFamily: '"JetBrains Mono", monospace',
         },
       },
@@ -56,7 +57,7 @@ const CredibilityChart: React.FC<CredibilityChartProps> = ({
           avoidLabelOverlap: false,
           itemStyle: {
             borderRadius: 6,
-            borderColor: '#0d1117',
+            borderColor: theme.palette.background.paper,
             borderWidth: 3,
           },
           label: { show: false, position: 'center' },
@@ -66,23 +67,23 @@ const CredibilityChart: React.FC<CredibilityChartProps> = ({
             {
               value: merged,
               name: 'Merged',
-              itemStyle: { color: CHART_COLORS.merged },
+              itemStyle: { color: theme.palette.chart.merged },
             },
             {
               value: open,
               name: 'Open',
-              itemStyle: { color: CHART_COLORS.open },
+              itemStyle: { color: theme.palette.chart.open },
             },
             {
               value: closed,
               name: 'Closed',
-              itemStyle: { color: CHART_COLORS.closed },
+              itemStyle: { color: theme.palette.chart.closed },
             },
           ],
         },
       ],
     }),
-    [merged, open, closed, credibility],
+    [closed, credibility, merged, open, theme],
   );
 
   return (
@@ -96,7 +97,7 @@ const CredibilityChart: React.FC<CredibilityChartProps> = ({
       <Typography
         variant="monoSmall"
         sx={{
-          color: 'rgba(255, 255, 255, 0.4)',
+          color: alpha(theme.palette.text.primary, 0.4),
           mb: 0.75,
           textAlign: 'center',
         }}
@@ -121,9 +122,17 @@ const CredibilityChart: React.FC<CredibilityChartProps> = ({
           flexWrap: 'wrap',
         }}
       >
-        <LegendItem label="Merged" value={merged} color={CHART_COLORS.merged} />
-        <LegendItem label="Open" value={open} color={CHART_COLORS.open} />
-        <LegendItem label="Closed" value={closed} color={CHART_COLORS.closed} />
+        <LegendItem
+          label="Merged"
+          value={merged}
+          color={theme.palette.chart.merged}
+        />
+        <LegendItem label="Open" value={open} color={theme.palette.chart.open} />
+        <LegendItem
+          label="Closed"
+          value={closed}
+          color={theme.palette.chart.closed}
+        />
       </Box>
     </Box>
   );
@@ -145,7 +154,7 @@ const LegendItem: React.FC<{ label: string; value: number; color: string }> = ({
     />
     <Typography
       sx={{
-        color: 'rgba(255, 255, 255, 0.6)',
+        color: (theme) => alpha(theme.palette.text.primary, 0.6),
         fontSize: '0.65rem',
         fontFamily: '"JetBrains Mono", monospace',
       }}

--- a/src/components/miners/PerformanceRadar.tsx
+++ b/src/components/miners/PerformanceRadar.tsx
@@ -1,7 +1,6 @@
 import React, { useMemo } from 'react';
-import { Box, Typography } from '@mui/material';
+import { Box, Typography, alpha, useTheme } from '@mui/material';
 import ReactECharts from 'echarts-for-react';
-import { STATUS_COLORS } from '../../theme';
 
 interface PerformanceRadarProps {
   credibility: number;
@@ -20,9 +19,11 @@ const PerformanceRadar: React.FC<PerformanceRadarProps> = ({
   totalPRs,
   avgRepoWeight,
 }) => {
+  const theme = useTheme();
+
   const chartOption = useMemo(
     () => ({
-      backgroundColor: 'transparent',
+      backgroundColor: theme.palette.surface.transparent,
       radar: {
         indicator: [
           { name: 'Credibility', max: 100 },
@@ -37,19 +38,19 @@ const PerformanceRadar: React.FC<PerformanceRadarProps> = ({
         shape: 'circle',
         splitNumber: 5,
         axisName: {
-          color: 'rgba(255, 255, 255, 0.6)',
+          color: alpha(theme.palette.text.primary, 0.6),
           fontFamily: '"JetBrains Mono", monospace',
           fontSize: 9,
           lineHeight: 12,
         },
         splitLine: {
           lineStyle: {
-            color: Array(5).fill('rgba(255, 255, 255, 0.05)'),
+            color: Array(5).fill(theme.palette.border.subtle),
           },
         },
         splitArea: { show: false },
         axisLine: {
-          lineStyle: { color: 'rgba(255, 255, 255, 0.1)' },
+          lineStyle: { color: theme.palette.border.light },
         },
       },
       series: [
@@ -57,10 +58,10 @@ const PerformanceRadar: React.FC<PerformanceRadarProps> = ({
           type: 'radar',
           lineStyle: {
             width: 2,
-            color: STATUS_COLORS.merged,
+            color: theme.palette.chart.merged,
           },
           areaStyle: {
-            color: `${STATUS_COLORS.merged}33`,
+            color: alpha(theme.palette.chart.merged, 0.2),
           },
           data: [
             {
@@ -75,19 +76,20 @@ const PerformanceRadar: React.FC<PerformanceRadarProps> = ({
               name: 'Miner Stats',
               symbol: 'circle',
               symbolSize: 4,
-              itemStyle: { color: STATUS_COLORS.merged },
+              itemStyle: { color: theme.palette.chart.merged },
             },
           ],
         },
       ],
     }),
     [
+      avgRepoWeight,
       credibility,
       complexity,
       issuesSolved,
-      uniqueRepos,
+      theme,
       totalPRs,
-      avgRepoWeight,
+      uniqueRepos,
     ],
   );
 
@@ -101,7 +103,11 @@ const PerformanceRadar: React.FC<PerformanceRadarProps> = ({
     >
       <Typography
         variant="monoSmall"
-        sx={{ color: 'rgba(255, 255, 255, 0.4)', mb: 2, textAlign: 'center' }}
+        sx={{
+          color: alpha(theme.palette.text.primary, 0.4),
+          mb: 2,
+          textAlign: 'center',
+        }}
       >
         Performance Profile
       </Typography>

--- a/src/components/miners/TrustBadge.tsx
+++ b/src/components/miners/TrustBadge.tsx
@@ -1,12 +1,12 @@
 import React, { useMemo } from 'react';
-import { Chip } from '@mui/material';
+import { Chip, alpha, useTheme } from '@mui/material';
+import type { Theme } from '@mui/material/styles';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import WarningAmberIcon from '@mui/icons-material/WarningAmber';
 import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
 import WorkspacePremiumIcon from '@mui/icons-material/WorkspacePremium';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import BlockIcon from '@mui/icons-material/Block';
-import { STATUS_COLORS } from '../../theme';
 
 interface TrustBadgeProps {
   credibility: number;
@@ -25,6 +25,7 @@ interface RiskAssessment {
 const ICON_SIZE = { fontSize: 18 };
 
 export const getRiskAssessment = (
+  theme: Theme,
   credibility: number,
   totalPRs: number,
 ): RiskAssessment => {
@@ -32,9 +33,9 @@ export const getRiskAssessment = (
   if (credibility >= 1 && totalPRs >= 5) {
     return {
       level: 'elite',
-      color: STATUS_COLORS.success,
-      bgColor: `${STATUS_COLORS.success}1a`,
-      border: `3px double ${STATUS_COLORS.success}`,
+      color: theme.palette.status.success,
+      bgColor: alpha(theme.palette.status.success, 0.1),
+      border: `3px double ${theme.palette.status.success}`,
       icon: <WorkspacePremiumIcon sx={ICON_SIZE} />,
       message: 'Proven Expert - Prioritize Merge',
     };
@@ -44,9 +45,9 @@ export const getRiskAssessment = (
   if (credibility >= 0.7 && totalPRs >= 3) {
     return {
       level: 'low',
-      color: STATUS_COLORS.success,
-      bgColor: `${STATUS_COLORS.success}1a`,
-      border: `1px solid ${STATUS_COLORS.success}4d`,
+      color: theme.palette.status.success,
+      bgColor: alpha(theme.palette.status.success, 0.1),
+      border: `1px solid ${alpha(theme.palette.status.success, 0.3)}`,
       icon: <CheckCircleIcon sx={ICON_SIZE} />,
       message: 'High Trust - Expedite Code Review',
     };
@@ -56,9 +57,9 @@ export const getRiskAssessment = (
   if (credibility >= 0.5 && totalPRs < 3) {
     return {
       level: 'medium',
-      color: STATUS_COLORS.info,
-      bgColor: `${STATUS_COLORS.info}1a`,
-      border: `1px solid ${STATUS_COLORS.info}4d`,
+      color: theme.palette.status.info,
+      bgColor: alpha(theme.palette.status.info, 0.1),
+      border: `1px solid ${alpha(theme.palette.status.info, 0.3)}`,
       icon: <InfoOutlinedIcon sx={ICON_SIZE} />,
       message: 'New Contributor - Standard Code Review',
     };
@@ -68,9 +69,9 @@ export const getRiskAssessment = (
   if (credibility >= 0.5) {
     return {
       level: 'medium',
-      color: '#9ca3af',
-      bgColor: 'rgba(156, 163, 175, 0.1)',
-      border: '1px solid rgba(156, 163, 175, 0.25)',
+      color: theme.palette.status.neutral,
+      bgColor: alpha(theme.palette.status.neutral, 0.1),
+      border: `1px solid ${alpha(theme.palette.status.neutral, 0.25)}`,
       icon: <WarningAmberIcon sx={ICON_SIZE} />,
       message: 'Moderate Trust - Standard Code Review',
     };
@@ -80,9 +81,9 @@ export const getRiskAssessment = (
   if (credibility < 0.1) {
     return {
       level: 'critical',
-      color: STATUS_COLORS.closed,
-      bgColor: `${STATUS_COLORS.closed}26`,
-      border: `3px double ${STATUS_COLORS.closed}`,
+      color: theme.palette.status.closed,
+      bgColor: alpha(theme.palette.status.closed, 0.15),
+      border: `3px double ${theme.palette.status.closed}`,
       icon: <BlockIcon sx={ICON_SIZE} />,
       message: 'Untrusted - Heavy Code Review',
     };
@@ -91,18 +92,19 @@ export const getRiskAssessment = (
   // Low Priority: Low credibility (0.1 - 0.49)
   return {
     level: 'high',
-    color: STATUS_COLORS.closed,
-    bgColor: `${STATUS_COLORS.closed}1a`,
-    border: `1px solid ${STATUS_COLORS.closed}4d`,
+    color: theme.palette.status.closed,
+    bgColor: alpha(theme.palette.status.closed, 0.1),
+    border: `1px solid ${alpha(theme.palette.status.closed, 0.3)}`,
     icon: <ErrorOutlineIcon sx={ICON_SIZE} />,
     message: 'Low Trust - Strict Code Review',
   };
 };
 
 const TrustBadge: React.FC<TrustBadgeProps> = ({ credibility, totalPRs }) => {
+  const theme = useTheme();
   const assessment = useMemo(
-    () => getRiskAssessment(credibility, totalPRs),
-    [credibility, totalPRs],
+    () => getRiskAssessment(theme, credibility, totalPRs),
+    [credibility, theme, totalPRs],
   );
 
   return (

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -121,6 +121,11 @@ declare module '@mui/material/styles' {
       additions: string;
       deletions: string;
     };
+    chart: {
+      merged: string;
+      open: string;
+      closed: string;
+    };
     border: {
       subtle: string;
       light: string;
@@ -168,6 +173,11 @@ declare module '@mui/material/styles' {
     diff?: {
       additions: string;
       deletions: string;
+    };
+    chart?: {
+      merged: string;
+      open: string;
+      closed: string;
     };
     border?: {
       subtle: string;
@@ -275,6 +285,12 @@ const theme = createTheme({
     diff: {
       additions: DIFF_COLORS.additions,
       deletions: DIFF_COLORS.deletions,
+    },
+    // Chart colors for pie/radar visualizations
+    chart: {
+      merged: CHART_COLORS.merged,
+      open: CHART_COLORS.open,
+      closed: CHART_COLORS.closed,
     },
     // Border colors
     border: {


### PR DESCRIPTION
## Summary

Refactor the miner Activity visuals to use theme-backed color tokens instead of hardcoded values.

- Added typed `palette.chart` tokens in `src/theme.ts`, reusing the existing `CHART_COLORS` values.
- Updated `CredibilityChart` and `PerformanceRadar` to read chart, text, border, and surface colors from `theme.palette` with `alpha(...)` where needed.
- Updated `TrustBadge` to use theme `status.*` tokens for its semantic badge states and removed the remaining hardcoded neutral gray values.
- No intended layout or behavior changes; this is a consistency and maintainability refactor for visual theming.
- Verified locally with `npm run lint`, `npm run test`, and `npm run build`.

## Related Issues

N/A

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

<!-- Include before/after screenshots for Miner Details -> Activity -> Developer Activity, covering TrustBadge, CredibilityChart, and PerformanceRadar. -->

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [ ] Responsive/mobile checked
- [ ] Tested against the test API
- [ ] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [ ] Screenshots included for any UI/visual changes
***
