### PR TITLE
feat: make list items real links so they support new-tab navigation

### DIFF
--- a/src/components/dashboard/LiveCommitLog.tsx
+++ b/src/components/dashboard/LiveCommitLog.tsx
@@ -11,7 +11,7 @@ import {
   Avatar,
   Chip,
 } from '@mui/material';
-import { useNavigate } from 'react-router-dom';
+import { Link as RouterLink } from 'react-router-dom';
 import theme from '../../theme';
 import { useInfiniteCommitLog, usePullRequestDetails } from '../../api';
 
@@ -69,7 +69,6 @@ const CommitLogItem: React.FC<{
   isNew: boolean;
   innerRef?: React.Ref<HTMLDivElement>;
 }> = ({ entry, isNew, innerRef }) => {
-  const navigate = useNavigate();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
   const isTablet = useMediaQuery(theme.breakpoints.between('sm', 'md'));
 
@@ -101,13 +100,13 @@ const CommitLogItem: React.FC<{
   const content = (
     <Box
       ref={innerRef}
-      onClick={() =>
-        navigate(
-          `/miners/pr?repo=${entry.repository}&number=${entry.pullRequestNumber}`,
-          { state: { backLabel: 'Back to Dashboard' } },
-        )
-      }
+      component={RouterLink}
+      to={`/miners/pr?repo=${entry.repository}&number=${entry.pullRequestNumber}`}
+      state={{ backLabel: 'Back to Dashboard' }}
       sx={{
+        display: 'block',
+        textDecoration: 'none',
+        color: 'inherit',
         p: isMobile ? 0.75 : isTablet ? 1.25 : 1,
         borderRadius: 3,
         border: '1px solid',

--- a/src/components/dashboard/RepositoriesTable.tsx
+++ b/src/components/dashboard/RepositoriesTable.tsx
@@ -21,7 +21,7 @@ import {
   InputAdornment,
   Avatar,
 } from '@mui/material';
-import { useNavigate } from 'react-router-dom';
+import { Link as RouterLink } from 'react-router-dom';
 import SearchIcon from '@mui/icons-material/Search';
 import theme from '../../theme';
 import { useRepoChanges } from '../../api';
@@ -37,7 +37,6 @@ type SortField =
 type SortOrder = 'asc' | 'desc';
 
 const RepositoriesTable: React.FC = () => {
-  const navigate = useNavigate();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
   const isMedium = useMediaQuery(theme.breakpoints.down('md'));
   const isLarge = useMediaQuery(theme.breakpoints.down('lg'));
@@ -567,17 +566,15 @@ const RepositoriesTable: React.FC = () => {
                             <Typography
                               variant="body2"
                               fontWeight="medium"
-                              onClick={() =>
-                                navigate(
-                                  `/miners/repository?name=${repo.repositoryFullName}`,
-                                  { state: { backLabel: 'Back to Dashboard' } },
-                                )
-                              }
+                              component={RouterLink}
+                              to={`/miners/repository?name=${repo.repositoryFullName}`}
+                              state={{ backLabel: 'Back to Dashboard' }}
                               sx={{
                                 color: isInactive
                                   ? 'error.dark'
                                   : 'text.primary',
                                 cursor: 'pointer',
+                                textDecoration: 'none',
                                 '&:hover': {
                                   textDecoration: 'underline',
                                   color: 'primary.main',

--- a/src/components/issues/IssueSubmissionsTable.tsx
+++ b/src/components/issues/IssueSubmissionsTable.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { Link as RouterLink, useNavigate } from 'react-router-dom';
 import {
   Box,
   Card,
@@ -124,14 +124,13 @@ const IssueSubmissionsTable: React.FC<IssueSubmissionsTableProps> = ({
               {submissions.map((submission) => (
                 <TableRow
                   key={`${submission.repositoryFullName}-${submission.number}`}
-                  onClick={() =>
-                    navigate(
-                      `/miners/pr?repo=${encodeURIComponent(submission.repositoryFullName)}&number=${submission.number}`,
-                      backLabel ? { state: { backLabel } } : undefined,
-                    )
-                  }
+                  component={RouterLink}
+                  to={`/miners/pr?repo=${encodeURIComponent(submission.repositoryFullName)}&number=${submission.number}`}
+                  state={backLabel ? { backLabel } : undefined}
                   sx={{
                     cursor: 'pointer',
+                    textDecoration: 'none',
+                    color: 'inherit',
                     transition: 'background-color 0.2s',
                     '&:hover': {
                       backgroundColor: 'rgba(255, 255, 255, 0.03)',
@@ -170,7 +169,16 @@ const IssueSubmissionsTable: React.FC<IssueSubmissionsTableProps> = ({
                       <Typography
                         component="span"
                         onClick={(e) => {
+                          e.preventDefault();
                           e.stopPropagation();
+                          if (e.metaKey || e.ctrlKey) {
+                            window.open(
+                              `/miners/details?githubId=${submission.authorGithubId}`,
+                              '_blank',
+                              'noopener,noreferrer',
+                            );
+                            return;
+                          }
                           navigate(
                             `/miners/details?githubId=${submission.authorGithubId}`,
                             backLabel ? { state: { backLabel } } : undefined,

--- a/src/components/issues/IssuesList.tsx
+++ b/src/components/issues/IssuesList.tsx
@@ -16,6 +16,7 @@ import {
   Avatar,
 } from '@mui/material';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
+import { Link as RouterLink } from 'react-router-dom';
 import { IssueBounty } from '../../api/models/Issues';
 import { useStats } from '../../api';
 import { formatTokenAmount } from '../../utils/format';
@@ -29,7 +30,7 @@ interface IssuesListProps {
   issues: IssueBounty[];
   isLoading?: boolean;
   listType: ListType;
-  onSelectIssue?: (id: number) => void;
+  backLabel?: string;
 }
 
 /**
@@ -58,8 +59,9 @@ const IssuesList: React.FC<IssuesListProps> = ({
   issues,
   isLoading = false,
   listType,
-  onSelectIssue,
+  backLabel,
 }) => {
+  const linkState = backLabel ? { backLabel } : undefined;
   const { data: dashStats } = useStats();
   const taoPrice = dashStats?.prices?.tao?.data?.price ?? 0;
   const alphaPrice = dashStats?.prices?.alpha?.data?.price ?? 0;
@@ -230,9 +232,13 @@ const IssuesList: React.FC<IssuesListProps> = ({
               return (
                 <TableRow
                   key={issue.id}
-                  onClick={() => onSelectIssue?.(issue.id)}
+                  component={RouterLink}
+                  to={`/bounties/details?id=${issue.id}`}
+                  state={linkState}
                   sx={{
-                    cursor: onSelectIssue ? 'pointer' : 'default',
+                    cursor: 'pointer',
+                    textDecoration: 'none',
+                    color: 'inherit',
                     transition: 'background-color 0.2s',
                     '&:hover': {
                       backgroundColor: 'rgba(255, 255, 255, 0.03)',

--- a/src/components/leaderboard/LeaderboardSidebar.tsx
+++ b/src/components/leaderboard/LeaderboardSidebar.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo, useState } from 'react';
 import { Box, Stack, Typography, Avatar } from '@mui/material';
 import { alpha } from '@mui/material/styles';
+import { Link as RouterLink } from 'react-router-dom';
 import { SectionCard } from './SectionCard';
 import { STATUS_COLORS } from '../../theme';
 import { getGithubAvatarSrc } from '../../utils/ExplorerUtils';
@@ -11,13 +12,15 @@ export type { MinerStats } from './types';
 
 interface LeaderboardSidebarProps {
   miners: MinerStats[];
-  onSelectMiner: (githubId: string) => void;
+  getMinerHref: (githubId: string) => string;
+  linkState?: unknown;
   variant?: 'oss' | 'discoveries';
 }
 
 export const LeaderboardSidebar: React.FC<LeaderboardSidebarProps> = ({
   miners,
-  onSelectMiner,
+  getMinerHref,
+  linkState,
   variant = 'oss',
 }) => {
   // State for toggling lists
@@ -115,9 +118,8 @@ export const LeaderboardSidebar: React.FC<LeaderboardSidebarProps> = ({
                 rank={i + 1}
                 type={leaderboardType}
                 variant={variant}
-                onClick={() =>
-                  onSelectMiner(miner.githubId || miner.author || '')
-                }
+                href={getMinerHref(miner.githubId || miner.author || '')}
+                linkState={linkState}
               />
             ),
           )}
@@ -290,7 +292,8 @@ interface LeaderboardRowProps {
   rank: number;
   type: 'earners' | 'active';
   variant?: 'oss' | 'discoveries';
-  onClick: () => void;
+  href: string;
+  linkState?: unknown;
 }
 
 const LeaderboardRow: React.FC<LeaderboardRowProps> = ({
@@ -298,15 +301,20 @@ const LeaderboardRow: React.FC<LeaderboardRowProps> = ({
   rank,
   type,
   variant = 'oss',
-  onClick,
+  href,
+  linkState,
 }) => (
   <Box
-    onClick={onClick}
+    component={RouterLink}
+    to={href}
+    state={linkState}
     sx={(theme) => ({
       display: 'flex',
       alignItems: 'center',
       py: 1,
       cursor: 'pointer',
+      textDecoration: 'none',
+      color: 'inherit',
       '&:hover': {
         backgroundColor: alpha(theme.palette.text.primary, 0.03),
         borderRadius: 1,

--- a/src/components/leaderboard/MinerCard.tsx
+++ b/src/components/leaderboard/MinerCard.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Box, Card, Typography, Avatar } from '@mui/material';
 import { alpha, useTheme } from '@mui/material/styles';
+import { Link as RouterLink } from 'react-router-dom';
 import ReactECharts from 'echarts-for-react';
 import { useMinerGithubData, useMinerPRs } from '../../api';
 import { CHART_COLORS, STATUS_COLORS } from '../../theme';
@@ -9,7 +10,8 @@ import { type MinerStats, type LeaderboardVariant, FONTS } from './types';
 
 interface MinerCardProps {
   miner: MinerStats;
-  onClick: () => void;
+  href: string;
+  linkState?: unknown;
   variant?: LeaderboardVariant;
 }
 
@@ -17,7 +19,8 @@ const INACTIVE_OPACITY = 0.24;
 
 export const MinerCard: React.FC<MinerCardProps> = ({
   miner,
-  onClick,
+  href,
+  linkState,
   variant = 'oss',
 }) => {
   const muiTheme = useTheme();
@@ -39,9 +42,13 @@ export const MinerCard: React.FC<MinerCardProps> = ({
 
   return (
     <Card
-      onClick={onClick}
+      component={RouterLink}
+      to={href}
+      state={linkState}
       sx={(theme) => ({
         p: 1,
+        textDecoration: 'none',
+        color: 'inherit',
         backgroundColor: isEligible
           ? theme.palette.background.default
           : theme.palette.surface.subtle,

--- a/src/components/leaderboard/TopMinersTable.tsx
+++ b/src/components/leaderboard/TopMinersTable.tsx
@@ -20,14 +20,16 @@ const MINERS_PAGE_SIZE = 60;
 interface TopMinersTableProps {
   miners: MinerStats[];
   isLoading?: boolean;
-  onSelectMiner: (githubId: string) => void;
+  getMinerHref: (githubId: string) => string;
+  linkState?: unknown;
   variant?: LeaderboardVariant;
 }
 
 const TopMinersTable: React.FC<TopMinersTableProps> = ({
   miners,
   isLoading,
-  onSelectMiner,
+  getMinerHref,
+  linkState,
   variant = 'oss',
 }) => {
   const [searchQuery, setSearchQuery] = useState('');
@@ -151,7 +153,8 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
                 <MinerCard
                   miner={miner}
                   variant={variant}
-                  onClick={() => onSelectMiner(miner.githubId)}
+                  href={getMinerHref(miner.githubId)}
+                  linkState={linkState}
                 />
               </Grid>
             ))}

--- a/src/components/leaderboard/TopPRsTable.tsx
+++ b/src/components/leaderboard/TopPRsTable.tsx
@@ -27,6 +27,7 @@ import {
   FormControlLabel,
   alpha,
 } from '@mui/material';
+import { Link as RouterLink, useNavigate } from 'react-router-dom';
 import SearchIcon from '@mui/icons-material/Search';
 import FilterListIcon from '@mui/icons-material/FilterList';
 import BarChartIcon from '@mui/icons-material/BarChart';
@@ -47,18 +48,35 @@ import theme, { STATUS_COLORS } from '../../theme';
 interface TopPRsTableProps {
   prs: CommitLog[];
   isLoading?: boolean;
-  onSelectPR: (repository: string, pullRequestNumber: number) => void;
-  onSelectMiner: (githubId: string) => void;
-  onSelectRepository: (repositoryFullName: string) => void;
+  backLabel?: string;
 }
+
+const buildPrHref = (repository: string, pullRequestNumber: number) =>
+  `/miners/pr?repo=${encodeURIComponent(repository)}&number=${pullRequestNumber}`;
+const buildMinerHref = (githubId: string) =>
+  `/miners/details?githubId=${encodeURIComponent(githubId)}`;
+const buildRepoHref = (repositoryFullName: string) =>
+  `/miners/repository?name=${encodeURIComponent(repositoryFullName)}`;
 
 const TopPRsTable: React.FC<TopPRsTableProps> = ({
   prs,
   isLoading,
-  onSelectPR,
-  onSelectMiner,
-  onSelectRepository,
+  backLabel,
 }) => {
+  const navigate = useNavigate();
+  const linkState = backLabel ? { backLabel } : undefined;
+  const navigateTo = (
+    e: React.MouseEvent,
+    href: string,
+  ) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (e.metaKey || e.ctrlKey || e.button === 1) {
+      window.open(href, '_blank', 'noopener,noreferrer');
+      return;
+    }
+    navigate(href, { state: linkState });
+  };
   const [searchQuery, setSearchQuery] = useState('');
   const [showFilters, setShowFilters] = useState(false);
   const [showChart, setShowChart] = useState(false);
@@ -703,11 +721,13 @@ const TopPRsTable: React.FC<TopPRsTableProps> = ({
                 <TableRow
                   key={`${pr.repository}-${pr.pullRequestNumber}`}
                   hover
-                  onClick={() =>
-                    onSelectPR(pr.repository || '', pr.pullRequestNumber)
-                  }
+                  component={RouterLink}
+                  to={buildPrHref(pr.repository || '', pr.pullRequestNumber)}
+                  state={linkState}
                   sx={{
                     cursor: 'pointer',
+                    textDecoration: 'none',
+                    color: 'inherit',
                     '&:hover': {
                       backgroundColor: 'rgba(255, 255, 255, 0.05)',
                     },
@@ -741,10 +761,12 @@ const TopPRsTable: React.FC<TopPRsTableProps> = ({
                   </TableCell>
                   <TableCell sx={{ ...bodyCellStyle, width: '20%' }}>
                     <Box
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        onSelectMiner(pr.githubId || pr.author || '');
-                      }}
+                      onClick={(e) =>
+                        navigateTo(
+                          e,
+                          buildMinerHref(pr.githubId || pr.author || ''),
+                        )
+                      }
                       sx={{
                         display: 'flex',
                         alignItems: 'center',
@@ -783,10 +805,9 @@ const TopPRsTable: React.FC<TopPRsTableProps> = ({
                   </TableCell>
                   <TableCell sx={{ ...bodyCellStyle, width: '20%' }}>
                     <Box
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        onSelectRepository(pr.repository || '');
-                      }}
+                      onClick={(e) =>
+                        navigateTo(e, buildRepoHref(pr.repository || ''))
+                      }
                       sx={{
                         display: 'flex',
                         alignItems: 'center',

--- a/src/components/leaderboard/TopPRsTable.tsx
+++ b/src/components/leaderboard/TopPRsTable.tsx
@@ -65,10 +65,7 @@ const TopPRsTable: React.FC<TopPRsTableProps> = ({
 }) => {
   const navigate = useNavigate();
   const linkState = backLabel ? { backLabel } : undefined;
-  const navigateTo = (
-    e: React.MouseEvent,
-    href: string,
-  ) => {
+  const navigateTo = (e: React.MouseEvent, href: string) => {
     e.preventDefault();
     e.stopPropagation();
     if (e.metaKey || e.ctrlKey || e.button === 1) {

--- a/src/components/leaderboard/TopRepositoriesTable.tsx
+++ b/src/components/leaderboard/TopRepositoriesTable.tsx
@@ -36,7 +36,11 @@ import SearchIcon from '@mui/icons-material/Search';
 import BarChartIcon from '@mui/icons-material/BarChart';
 import TableChartIcon from '@mui/icons-material/TableChart';
 import ReactECharts from 'echarts-for-react';
-import { useSearchParams } from 'react-router-dom';
+import {
+  Link as RouterLink,
+  useNavigate,
+  useSearchParams,
+} from 'react-router-dom';
 import { truncateText } from '../../utils';
 import { RankIcon } from './RankIcon';
 
@@ -62,8 +66,11 @@ type SortDirection = 'asc' | 'desc';
 interface TopRepositoriesTableProps {
   repositories: RepoStats[];
   isLoading?: boolean;
-  onSelectRepository: (repositoryFullName: string) => void;
+  backLabel?: string;
 }
+
+const buildRepoHref = (repositoryFullName: string) =>
+  `/miners/repository?name=${encodeURIComponent(repositoryFullName)}`;
 
 const VALID_SORT_COLUMNS: SortColumn[] = [
   'rank',
@@ -78,9 +85,13 @@ const VALID_ROWS = [10, 25, 50];
 const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
   repositories,
   isLoading,
-  onSelectRepository,
+  backLabel,
 }) => {
+  const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
+  const linkState = backLabel ? { backLabel } : undefined;
+  const openRepository = (repositoryFullName: string) =>
+    navigate(buildRepoHref(repositoryFullName), { state: linkState });
 
   // Read initial state from URL params, falling back to defaults
   const urlRows = parseInt(searchParams.get('rows') || '0', 10);
@@ -595,7 +606,7 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
               onChange={(e) => setSearchQuery(e.target.value)}
               onKeyDown={(e) => {
                 if (e.key === 'Enter' && isDirectRepoInput) {
-                  onSelectRepository(trimmedSearch);
+                  openRepository(trimmedSearch);
                 }
               }}
               InputProps={{
@@ -719,9 +730,13 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
                   <TableRow
                     key={repo.repository}
                     hover
-                    onClick={() => onSelectRepository(repo.repository || '')}
+                    component={RouterLink}
+                    to={buildRepoHref(repo.repository || '')}
+                    state={linkState}
                     sx={{
                       cursor: 'pointer',
+                      textDecoration: 'none',
+                      color: 'inherit',
                       '&:hover': {
                         backgroundColor: 'rgba(255, 255, 255, 0.08)',
                       },
@@ -884,7 +899,7 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
                       <Button
                         size="small"
                         variant="outlined"
-                        onClick={() => onSelectRepository(trimmedSearch)}
+                        onClick={() => openRepository(trimmedSearch)}
                         sx={{ textTransform: 'none' }}
                       >
                         Open repository

--- a/src/components/miners/MinerPRsTable.tsx
+++ b/src/components/miners/MinerPRsTable.tsx
@@ -32,7 +32,7 @@ import {
   isMergedPr,
   isOpenPr,
 } from '../../utils';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { Link as RouterLink, useSearchParams } from 'react-router-dom';
 import ExplorerFilterButton from './ExplorerFilterButton';
 import { type MinerStatusFilter } from '../../utils/ExplorerUtils';
 
@@ -75,7 +75,6 @@ interface MinerPRsTableProps {
 
 const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
   const theme = useTheme();
-  const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const { data: prs, isLoading } = useMinerPRs(githubId);
   const [selectedAuthor, setSelectedAuthor] = useState<string | null>(null);
@@ -449,18 +448,15 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
                   return (
                     <TableRow
                       key={`${pr.repository}-${pr.pullRequestNumber}-${index}`}
-                      onClick={() => {
-                        navigate(
-                          `/miners/pr?repo=${encodeURIComponent(pr.repository)}&number=${pr.pullRequestNumber}`,
-                          {
-                            state: {
-                              backLabel: `Back to ${prs?.[0]?.author || githubId}`,
-                            },
-                          },
-                        );
+                      component={RouterLink}
+                      to={`/miners/pr?repo=${encodeURIComponent(pr.repository)}&number=${pr.pullRequestNumber}`}
+                      state={{
+                        backLabel: `Back to ${prs?.[0]?.author || githubId}`,
                       }}
                       sx={{
                         cursor: 'pointer',
+                        textDecoration: 'none',
+                        color: 'inherit',
                         '&:hover': {
                           backgroundColor: 'surface.subtle',
                         },

--- a/src/components/miners/MinerRepositoriesTable.tsx
+++ b/src/components/miners/MinerRepositoriesTable.tsx
@@ -18,7 +18,7 @@ import {
 } from '@mui/material';
 import { Search as SearchIcon } from '@mui/icons-material';
 import { useMinerPRs, useReposAndWeights } from '../../api';
-import { useNavigate } from 'react-router-dom';
+import { Link as RouterLink } from 'react-router-dom';
 import SortableHeaderCell from './SortableHeaderCell';
 import RankBadge from './RankBadge';
 import EmptyStateMessage from './EmptyStateMessage';
@@ -51,7 +51,6 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
   githubId,
 }) => {
   const theme = useTheme();
-  const navigate = useNavigate();
   const { data: prs, isLoading: isLoadingPRs } = useMinerPRs(githubId);
   const { data: repos, isLoading: isLoadingRepos } = useReposAndWeights();
   const [sortField, setSortField] = useState<RepoSortField>('score');
@@ -302,7 +301,6 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
                       bodyCellStyle={bodyCellStyle}
                       prs={prs}
                       githubId={githubId}
-                      navigate={navigate}
                     />
                   );
                 })}
@@ -331,7 +329,6 @@ interface RepoTableRowProps {
   bodyCellStyle: Record<string, unknown>;
   prs: { author?: string }[] | undefined;
   githubId: string;
-  navigate: ReturnType<typeof useNavigate>;
 }
 
 const RepoTableRow: React.FC<RepoTableRowProps> = ({
@@ -340,7 +337,6 @@ const RepoTableRow: React.FC<RepoTableRowProps> = ({
   bodyCellStyle,
   prs,
   githubId,
-  navigate,
 }) => {
   const owner = repo.repository.split('/')[0];
   const avatarBgColor = getAvatarBgColor(owner);
@@ -360,22 +356,19 @@ const RepoTableRow: React.FC<RepoTableRowProps> = ({
       </TableCell>
       <TableCell sx={bodyCellStyle}>
         <Box
-          onClick={() =>
-            navigate(
-              `/miners/repository?name=${encodeURIComponent(repo.repository)}`,
-              {
-                state: {
-                  backLabel: `Back to ${prs?.[0]?.author || githubId}`,
-                },
-              },
-            )
-          }
+          component={RouterLink}
+          to={`/miners/repository?name=${encodeURIComponent(repo.repository)}`}
+          state={{
+            backLabel: `Back to ${prs?.[0]?.author || githubId}`,
+          }}
           sx={{
             display: 'flex',
             alignItems: 'center',
             gap: 1.5,
             cursor: 'pointer',
             minWidth: 0,
+            textDecoration: 'none',
+            color: 'inherit',
             '&:hover': {
               color: 'primary.main',
               '& .MuiTypography-root': {

--- a/src/components/miners/MinerScoreBreakdown.tsx
+++ b/src/components/miners/MinerScoreBreakdown.tsx
@@ -16,7 +16,7 @@ import {
   GitHub as GitHubIcon,
   OpenInNew as OpenInNewIcon,
 } from '@mui/icons-material';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { Link as RouterLink, useSearchParams } from 'react-router-dom';
 import { useMinerPRs, usePullRequestDetails, type CommitLog } from '../../api';
 import { STATUS_COLORS } from '../../theme';
 
@@ -115,10 +115,9 @@ const MultiplierPill: React.FC<MultiplierPillProps> = ({
 
 interface PrScoreRowProps {
   pr: CommitLog;
-  onNavigateToPr: (repo: string, prNumber: number) => void;
 }
 
-const PrScoreRow: React.FC<PrScoreRowProps> = ({ pr, onNavigateToPr }) => {
+const PrScoreRow: React.FC<PrScoreRowProps> = ({ pr }) => {
   const [expanded, setExpanded] = useState(false);
 
   // Fetch full PR details (with all multipliers) — cached by React Query
@@ -461,10 +460,11 @@ const PrScoreRow: React.FC<PrScoreRowProps> = ({ pr, onNavigateToPr }) => {
           <Box sx={{ display: 'flex', gap: 1, mt: 0.5 }}>
             <Button
               size="small"
+              component={RouterLink}
+              to={`/miners/pr?repo=${encodeURIComponent(pr.repository)}&number=${pr.pullRequestNumber}`}
               startIcon={<OpenInNewIcon sx={{ fontSize: '0.85rem' }} />}
               onClick={(e) => {
                 e.stopPropagation();
-                onNavigateToPr(pr.repository, pr.pullRequestNumber);
               }}
               sx={{
                 fontFamily: '"JetBrains Mono", monospace',
@@ -513,7 +513,6 @@ const PrScoreRow: React.FC<PrScoreRowProps> = ({ pr, onNavigateToPr }) => {
 const MinerScoreBreakdown: React.FC<MinerScoreBreakdownProps> = ({
   githubId,
 }) => {
-  const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const { data: prs, isLoading } = useMinerPRs(githubId);
   const PAGE_SIZE = 10;
@@ -531,10 +530,6 @@ const MinerScoreBreakdown: React.FC<MinerScoreBreakdownProps> = ({
     },
     [page, setSearchParams],
   );
-
-  const handleNavigateToPr = (repo: string, prNumber: number) => {
-    navigate(`/miners/pr?repo=${encodeURIComponent(repo)}&number=${prNumber}`);
-  };
 
   const sortedPrs = useMemo(() => {
     if (!prs) return [];
@@ -590,7 +585,6 @@ const MinerScoreBreakdown: React.FC<MinerScoreBreakdownProps> = ({
           <PrScoreRow
             key={`${pr.repository}-${pr.pullRequestNumber}-${i}`}
             pr={pr}
-            onNavigateToPr={handleNavigateToPr}
           />
         ))}
       </Box>

--- a/src/components/prs/PRDetailsCard.tsx
+++ b/src/components/prs/PRDetailsCard.tsx
@@ -11,7 +11,7 @@ import {
 } from '@mui/material';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import { usePullRequestDetails } from '../../api';
-import { useNavigate } from 'react-router-dom';
+import { Link as RouterLink } from 'react-router-dom';
 import theme, { RANK_COLORS, STATUS_COLORS } from '../../theme';
 
 interface PRDetailsCardProps {
@@ -25,7 +25,10 @@ const PRDetailsCard: React.FC<PRDetailsCardProps> = ({
   pullRequestNumber,
   hideHeader = false,
 }) => {
-  const navigate = useNavigate();
+  const backLinkState = {
+    backLabel: `Back to PR #${pullRequestNumber}`,
+  };
+  const repoHref = `/miners/repository?name=${encodeURIComponent(repository)}`;
   // Fetch detailed PR data directly
   const { data: prDetails, isLoading: isDetailsLoading } =
     usePullRequestDetails(repository, pullRequestNumber);
@@ -165,14 +168,14 @@ const PRDetailsCard: React.FC<PRDetailsCardProps> = ({
       {!hideHeader && (
         <Box sx={{ mb: 3, display: 'flex', alignItems: 'center', gap: 2 }}>
           <Box
-            onClick={() =>
-              navigate(
-                `/miners/repository?name=${encodeURIComponent(repository)}`,
-                { state: { backLabel: `Back to PR #${pullRequestNumber}` } },
-              )
-            }
+            component={RouterLink}
+            to={repoHref}
+            state={backLinkState}
             sx={{
               cursor: 'pointer',
+              textDecoration: 'none',
+              color: 'inherit',
+              display: 'inline-flex',
               transition: 'transform 0.2s',
               '&:hover': {
                 transform: 'scale(1.05)',
@@ -255,19 +258,15 @@ const PRDetailsCard: React.FC<PRDetailsCardProps> = ({
             </Typography>
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
               <Typography
-                onClick={() =>
-                  navigate(
-                    `/miners/repository?name=${encodeURIComponent(repository)}`,
-                    {
-                      state: { backLabel: `Back to PR #${pullRequestNumber}` },
-                    },
-                  )
-                }
+                component={RouterLink}
+                to={repoHref}
+                state={backLinkState}
                 sx={{
                   color: 'rgba(255, 255, 255, 0.5)',
                   fontFamily: '"JetBrains Mono", monospace',
                   fontSize: '0.85rem',
                   cursor: 'pointer',
+                  textDecoration: 'none',
                   transition: 'color 0.2s',
                   '&:hover': {
                     color: 'primary.main',
@@ -567,16 +566,16 @@ const PRDetailsCard: React.FC<PRDetailsCardProps> = ({
               Author
             </Typography>
             <Box
-              onClick={() =>
-                navigate(`/miners/details?githubId=${prDetails.githubId}`, {
-                  state: { backLabel: `Back to PR #${pullRequestNumber}` },
-                })
-              }
+              component={RouterLink}
+              to={`/miners/details?githubId=${prDetails.githubId}`}
+              state={backLinkState}
               sx={{
                 display: 'flex',
                 alignItems: 'center',
                 gap: 1.5,
                 cursor: 'pointer',
+                textDecoration: 'none',
+                color: 'inherit',
                 '&:hover': {
                   '& .MuiTypography-root': {
                     color: 'primary.main',

--- a/src/components/prs/PRHeader.tsx
+++ b/src/components/prs/PRHeader.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Box, Typography, Avatar, Tooltip, alpha } from '@mui/material';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
-import { useNavigate } from 'react-router-dom';
+import { Link as RouterLink } from 'react-router-dom';
 import { formatUsdEstimate } from '../../utils';
 import { type PullRequestDetails } from '../../api/models/Dashboard';
 import theme, { STATUS_COLORS } from '../../theme';
@@ -16,8 +16,11 @@ const PRHeader: React.FC<PRHeaderProps> = ({
   pullRequestNumber,
   prDetails,
 }) => {
-  const navigate = useNavigate();
   const [owner] = repository.split('/');
+  const repoHref = `/miners/repository?name=${encodeURIComponent(repository)}`;
+  const backLinkState = {
+    backLabel: `Back to PR #${pullRequestNumber}`,
+  };
 
   const isOpenPR = prDetails.prState === 'OPEN';
   const isClosed = prDetails.prState === 'CLOSED';
@@ -28,14 +31,14 @@ const PRHeader: React.FC<PRHeaderProps> = ({
   return (
     <Box sx={{ mb: 3, display: 'flex', alignItems: 'flex-start', gap: 2 }}>
       <Box
-        onClick={() =>
-          navigate(
-            `/miners/repository?name=${encodeURIComponent(repository)}`,
-            { state: { backLabel: `Back to PR #${pullRequestNumber}` } },
-          )
-        }
+        component={RouterLink}
+        to={repoHref}
+        state={backLinkState}
         sx={{
           cursor: 'pointer',
+          textDecoration: 'none',
+          color: 'inherit',
+          display: 'inline-flex',
           transition: 'transform 0.2s',
           '&:hover': {
             transform: 'scale(1.05)',
@@ -116,17 +119,15 @@ const PRHeader: React.FC<PRHeaderProps> = ({
         </Typography>
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
           <Typography
-            onClick={() =>
-              navigate(
-                `/miners/repository?name=${encodeURIComponent(repository)}`,
-                { state: { backLabel: `Back to PR #${pullRequestNumber}` } },
-              )
-            }
+            component={RouterLink}
+            to={repoHref}
+            state={backLinkState}
             sx={{
               color: 'rgba(255, 255, 255, 0.5)',
               fontFamily: '"JetBrains Mono", monospace',
               fontSize: '0.85rem',
               cursor: 'pointer',
+              textDecoration: 'none',
               transition: 'color 0.2s',
               '&:hover': {
                 color: 'primary.main',

--- a/src/components/repositories/RepositoryContributorsTable.tsx
+++ b/src/components/repositories/RepositoryContributorsTable.tsx
@@ -3,7 +3,7 @@ import { Box, Typography, CircularProgress, Avatar } from '@mui/material';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
 import { useAllPrs, useAllMiners } from '../../api';
-import { useNavigate } from 'react-router-dom';
+import { Link as RouterLink } from 'react-router-dom';
 import { STATUS_COLORS } from '../../theme';
 
 interface RepositoryContributorsTableProps {
@@ -13,7 +13,6 @@ interface RepositoryContributorsTableProps {
 const RepositoryContributorsTable: React.FC<
   RepositoryContributorsTableProps
 > = ({ repositoryFullName }) => {
-  const navigate = useNavigate();
   const { data: allPRs, isLoading } = useAllPrs();
   const { data: allMinersStats } = useAllMiners();
 
@@ -210,17 +209,17 @@ const RepositoryContributorsTable: React.FC<
 
               {/* Contributor */}
               <Box
-                onClick={() =>
-                  navigate(`/miners/details?githubId=${contributor.githubId}`, {
-                    state: { backLabel: `Back to ${repositoryFullName}` },
-                  })
-                }
+                component={RouterLink}
+                to={`/miners/details?githubId=${contributor.githubId}`}
+                state={{ backLabel: `Back to ${repositoryFullName}` }}
                 sx={{
                   display: 'flex',
                   alignItems: 'center',
                   gap: 1.5,
                   overflow: 'hidden',
                   cursor: 'pointer',
+                  textDecoration: 'none',
+                  color: 'inherit',
                   '&:hover .contributor-name': {
                     color: STATUS_COLORS.info,
                     textDecoration: 'underline',

--- a/src/components/repositories/RepositoryIssuesTable.tsx
+++ b/src/components/repositories/RepositoryIssuesTable.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { Link as RouterLink } from 'react-router-dom';
 import {
   Card,
   Typography,
@@ -30,7 +30,6 @@ interface RepositoryIssuesTableProps {
 const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
   repositoryFullName,
 }) => {
-  const navigate = useNavigate();
   const { data: issues, isLoading } = useRepositoryIssues(repositoryFullName);
   const { data: bounties } = useRepoIssues(repositoryFullName);
   const [filter, setFilter] = useState<'all' | 'open' | 'closed'>('all');
@@ -239,11 +238,9 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
                   return (
                     <Box
                       key={bounty.id}
-                      onClick={() =>
-                        navigate(`/bounties/details?id=${bounty.id}`, {
-                          state: { backLabel: `Back to ${repositoryFullName}` },
-                        })
-                      }
+                      component={RouterLink}
+                      to={`/bounties/details?id=${bounty.id}`}
+                      state={{ backLabel: `Back to ${repositoryFullName}` }}
                       sx={{
                         display: 'flex',
                         alignItems: 'center',
@@ -253,6 +250,8 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
                         border: '1px solid rgba(255, 255, 255, 0.06)',
                         backgroundColor: 'rgba(255, 255, 255, 0.02)',
                         cursor: 'pointer',
+                        textDecoration: 'none',
+                        color: 'inherit',
                         transition: 'all 0.2s ease',
                         '&:hover': {
                           backgroundColor: 'rgba(255, 255, 255, 0.05)',
@@ -457,18 +456,18 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
                   return (
                     <TableRow
                       key={`${issue.number}-${index}`}
+                      component="a"
+                      href={`https://github.com/${issue.repositoryFullName}/issues/${issue.number}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
                       sx={{
                         cursor: 'pointer',
+                        textDecoration: 'none',
+                        color: 'inherit',
                         '&:hover': {
                           backgroundColor: 'rgba(255, 255, 255, 0.05)',
                         },
                         transition: 'background-color 0.2s',
-                      }}
-                      onClick={() => {
-                        window.open(
-                          `https://github.com/${issue.repositoryFullName}/issues/${issue.number}`,
-                          '_blank',
-                        );
                       }}
                     >
                       <TableCell sx={bodyCellStyle}>

--- a/src/components/repositories/RepositoryPRsTable.tsx
+++ b/src/components/repositories/RepositoryPRsTable.tsx
@@ -16,7 +16,7 @@ import {
   Button,
 } from '@mui/material';
 import { useAllPrs } from '../../api';
-import { useNavigate } from 'react-router-dom';
+import { Link as RouterLink } from 'react-router-dom';
 import {
   getPrStatusCounts,
   isClosedUnmergedPr,
@@ -34,7 +34,6 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
   repositoryFullName,
   state = 'all',
 }) => {
-  const navigate = useNavigate();
   const [filter, setFilter] = useState<'all' | 'open' | 'closed' | 'merged'>(
     state,
   );
@@ -285,14 +284,13 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
               {sortedPRs.map((pr, index) => (
                 <TableRow
                   key={`${pr.pullRequestNumber}-${index}`}
-                  onClick={() => {
-                    navigate(
-                      `/miners/pr?repo=${encodeURIComponent(pr.repository)}&number=${pr.pullRequestNumber}`,
-                      { state: { backLabel: `Back to ${repositoryFullName}` } },
-                    );
-                  }}
+                  component={RouterLink}
+                  to={`/miners/pr?repo=${encodeURIComponent(pr.repository)}&number=${pr.pullRequestNumber}`}
+                  state={{ backLabel: `Back to ${repositoryFullName}` }}
                   sx={{
                     cursor: 'pointer',
+                    textDecoration: 'none',
+                    color: 'inherit',
                     '&:hover': {
                       backgroundColor: 'rgba(255, 255, 255, 0.05)',
                     },

--- a/src/pages/DiscoveriesPage.tsx
+++ b/src/pages/DiscoveriesPage.tsx
@@ -1,23 +1,18 @@
 import React, { useMemo } from 'react';
 import { useMediaQuery, Box, Typography, alpha } from '@mui/material';
-import { useNavigate } from 'react-router-dom';
 import { Page } from '../components/layout';
 import { TopMinersTable, LeaderboardSidebar, SEO } from '../components';
 import { useAllMiners } from '../api';
 import theme from '../theme';
 
-const DiscoveriesPage: React.FC = () => {
-  const navigate = useNavigate();
+const getMinerHref = (githubId: string) =>
+  `/miners/details?githubId=${encodeURIComponent(githubId)}&mode=issues`;
+const minerLinkState = { backLabel: 'Back to Discoveries' };
 
+const DiscoveriesPage: React.FC = () => {
   const allMinerStatsQuery = useAllMiners();
   const allMinersStats = allMinerStatsQuery?.data;
   const isLoadingMinerStats = allMinerStatsQuery?.isLoading;
-
-  const handleSelectMiner = (githubId: string) => {
-    navigate(`/miners/details?githubId=${githubId}&mode=issues`, {
-      state: { backLabel: 'Back to Discoveries' },
-    });
-  };
 
   // Process miner stats for TopMinersTable, using issue discovery fields
   const minerStats = useMemo(() => {
@@ -125,7 +120,8 @@ const DiscoveriesPage: React.FC = () => {
             <TopMinersTable
               miners={sortedMinerStats}
               isLoading={isLoadingMinerStats}
-              onSelectMiner={handleSelectMiner}
+              getMinerHref={getMinerHref}
+              linkState={minerLinkState}
               variant="discoveries"
             />
           </Box>
@@ -145,7 +141,8 @@ const DiscoveriesPage: React.FC = () => {
         >
           <LeaderboardSidebar
             miners={minerStats}
-            onSelectMiner={handleSelectMiner}
+            getMinerHref={getMinerHref}
+            linkState={minerLinkState}
             variant="discoveries"
           />
         </Box>

--- a/src/pages/IssuesPage.tsx
+++ b/src/pages/IssuesPage.tsx
@@ -97,11 +97,7 @@ const IssuesPage: React.FC = () => {
                 issues={activeIssuesQuery.data || []}
                 isLoading={activeIssuesQuery.isLoading}
                 listType="available"
-                onSelectIssue={(id) =>
-                  navigate(`/bounties/details?id=${id}`, {
-                    state: { backLabel: 'Back to Bounties' },
-                  })
-                }
+                backLabel="Back to Bounties"
               />
             )}
             {tabIndex === 1 && (
@@ -109,11 +105,7 @@ const IssuesPage: React.FC = () => {
                 issues={registeredIssuesQuery.data || []}
                 isLoading={registeredIssuesQuery.isLoading}
                 listType="pending"
-                onSelectIssue={(id) =>
-                  navigate(`/bounties/details?id=${id}`, {
-                    state: { backLabel: 'Back to Bounties' },
-                  })
-                }
+                backLabel="Back to Bounties"
               />
             )}
             {tabIndex === 2 && (
@@ -121,11 +113,7 @@ const IssuesPage: React.FC = () => {
                 issues={historyIssuesQuery.data || []}
                 isLoading={historyIssuesQuery.isLoading}
                 listType="history"
-                onSelectIssue={(id) =>
-                  navigate(`/bounties/details?id=${id}`, {
-                    state: { backLabel: 'Back to Bounties' },
-                  })
-                }
+                backLabel="Back to Bounties"
               />
             )}
           </Box>

--- a/src/pages/RepositoriesPage.tsx
+++ b/src/pages/RepositoriesPage.tsx
@@ -2,7 +2,7 @@ import React, { useMemo } from 'react';
 
 import { Avatar, Box, Card, Tooltip, Typography } from '@mui/material';
 
-import { useNavigate } from 'react-router-dom';
+import { Link as RouterLink } from 'react-router-dom';
 import { Page } from '../components/layout';
 import { TopRepositoriesTable, SEO } from '../components';
 import { useAllPrs, useReposAndWeights } from '../api';
@@ -14,14 +14,17 @@ const FONTS = { mono: '"JetBrains Mono", monospace' } as const;
 const ROW_HEIGHT = 40; // px – keeps every row exactly the same across cards
 
 const HighlightRow: React.FC<{
-  onClick: () => void;
+  href: string;
+  linkState?: unknown;
   avatar: string;
   avatarBg?: string;
   label: React.ReactNode;
   right: React.ReactNode;
-}> = ({ onClick, avatar, avatarBg = 'transparent', label, right }) => (
+}> = ({ href, linkState, avatar, avatarBg = 'transparent', label, right }) => (
   <Box
-    onClick={onClick}
+    component={RouterLink}
+    to={href}
+    state={linkState}
     sx={{
       display: 'flex',
       alignItems: 'center',
@@ -31,6 +34,8 @@ const HighlightRow: React.FC<{
       px: 1,
       borderRadius: 1,
       cursor: 'pointer',
+      textDecoration: 'none',
+      color: 'inherit',
       transition: 'background 0.15s',
       mx: -1,
       '&:hover': { backgroundColor: 'rgba(255,255,255,0.05)' },
@@ -104,9 +109,9 @@ const cardSx = {
 };
 
 // ── Page ────────────────────────────────────────────────────────────────────
-const RepositoriesPage: React.FC = () => {
-  const navigate = useNavigate();
+const REPO_LINK_STATE = { backLabel: 'Back to Repositories' };
 
+const RepositoriesPage: React.FC = () => {
   const formatRelativeTime = (date: Date) => {
     const now = new Date();
     if (date > now) return 'just now';
@@ -127,13 +132,6 @@ const RepositoriesPage: React.FC = () => {
     useReposAndWeights();
 
   const isLoading = isLoadingPRs || isLoadingRepos;
-
-  const handleSelectRepository = (repositoryFullName: string) => {
-    navigate(
-      `/miners/repository?name=${encodeURIComponent(repositoryFullName)}`,
-      { state: { backLabel: 'Back to Repositories' } },
-    );
-  };
 
   // ── Main table stats ────────────────────────────────────────────────────
   const repoStats = useMemo(() => {
@@ -352,7 +350,8 @@ const RepositoriesPage: React.FC = () => {
                     trendingRepos.map((repo) => (
                       <HighlightRow
                         key={repo.name}
-                        onClick={() => handleSelectRepository(repo.name)}
+                        href={`/miners/repository?name=${encodeURIComponent(repo.name)}`}
+                        linkState={REPO_LINK_STATE}
                         avatar={`https://avatars.githubusercontent.com/${repo.name.split('/')[0]}`}
                         avatarBg={getAvatarBg(repo.name)}
                         label={
@@ -417,7 +416,8 @@ const RepositoriesPage: React.FC = () => {
                     topCollateralRepos.map((repo) => (
                       <HighlightRow
                         key={repo.name}
-                        onClick={() => handleSelectRepository(repo.name)}
+                        href={`/miners/repository?name=${encodeURIComponent(repo.name)}`}
+                        linkState={REPO_LINK_STATE}
                         avatar={`https://avatars.githubusercontent.com/${repo.name.split('/')[0]}`}
                         avatarBg={getAvatarBg(repo.name)}
                         label={
@@ -479,12 +479,8 @@ const RepositoriesPage: React.FC = () => {
                     recentPrs.map((pr) => (
                       <HighlightRow
                         key={`${pr.name}-${pr.number}`}
-                        onClick={() =>
-                          navigate(
-                            `/miners/pr?repo=${encodeURIComponent(pr.name)}&number=${pr.number}`,
-                            { state: { backLabel: 'Back to Repositories' } },
-                          )
-                        }
+                        href={`/miners/pr?repo=${encodeURIComponent(pr.name)}&number=${pr.number}`}
+                        linkState={REPO_LINK_STATE}
                         avatar={`https://avatars.githubusercontent.com/${pr.name.split('/')[0]}`}
                         avatarBg={getAvatarBg(pr.name)}
                         label={
@@ -564,7 +560,7 @@ const RepositoriesPage: React.FC = () => {
           <TopRepositoriesTable
             repositories={repoStats}
             isLoading={isLoading}
-            onSelectRepository={handleSelectRepository}
+            backLabel="Back to Repositories"
           />
         </Card>
       </Box>

--- a/src/pages/TopMinersPage.tsx
+++ b/src/pages/TopMinersPage.tsx
@@ -1,24 +1,19 @@
 import React, { useMemo } from 'react';
 import { useMediaQuery, Box, Typography, alpha } from '@mui/material';
-import { useNavigate } from 'react-router-dom';
 import { Page } from '../components/layout';
 import { TopMinersTable, LeaderboardSidebar, SEO } from '../components';
 import { useAllMiners } from '../api';
 import { parseNumber } from '../utils';
 import theme from '../theme';
 
-const TopMinersPage: React.FC = () => {
-  const navigate = useNavigate();
+const getMinerHref = (githubId: string) =>
+  `/miners/details?githubId=${encodeURIComponent(githubId)}`;
+const minerLinkState = { backLabel: 'Back to Leaderboard' };
 
+const TopMinersPage: React.FC = () => {
   const allMinerStatsQuery = useAllMiners();
   const allMinersStats = allMinerStatsQuery?.data;
   const isLoadingMinerStats = allMinerStatsQuery?.isLoading;
-
-  const handleSelectMiner = (githubId: string) => {
-    navigate(`/miners/details?githubId=${githubId}`, {
-      state: { backLabel: 'Back to Leaderboard' },
-    });
-  };
 
   // Normalize leaderboard miner data.
   const minerStats = useMemo(() => {
@@ -123,7 +118,8 @@ const TopMinersPage: React.FC = () => {
             <TopMinersTable
               miners={minerStats}
               isLoading={isLoadingMinerStats}
-              onSelectMiner={handleSelectMiner}
+              getMinerHref={getMinerHref}
+              linkState={minerLinkState}
             />
           </Box>
         </Box>
@@ -143,7 +139,8 @@ const TopMinersPage: React.FC = () => {
           {/* Render extracted Sidebar Content here */}
           <LeaderboardSidebar
             miners={minerStats}
-            onSelectMiner={handleSelectMiner}
+            getMinerHref={getMinerHref}
+            linkState={minerLinkState}
           />
         </Box>
       </Box>

--- a/src/pages/search/IssuesTab.tsx
+++ b/src/pages/search/IssuesTab.tsx
@@ -92,7 +92,7 @@ type IssuesTabProps = {
   issueResults: IssueBounty[];
   onPageChange: (newPage: number) => void;
   onRowsPerPageChange: (rowsPerPage: number) => void;
-  onSelectIssue: (id: number) => void;
+  linkState?: unknown;
   page: number;
   paginatedIssueResults: IssueBounty[];
   rowsPerPage: number;
@@ -105,7 +105,7 @@ const IssuesTab: React.FC<IssuesTabProps> = ({
   issueResults,
   onPageChange,
   onRowsPerPageChange,
-  onSelectIssue,
+  linkState,
   page,
   paginatedIssueResults,
   rowsPerPage,
@@ -120,7 +120,8 @@ const IssuesTab: React.FC<IssuesTabProps> = ({
     isLoading={isLoading}
     minWidth={900}
     onPageChange={onPageChange}
-    onRowClick={(issue) => onSelectIssue(issue.id)}
+    getRowHref={(issue) => `/bounties/details?id=${issue.id}`}
+    getRowLinkState={() => linkState}
     onRowsPerPageChange={onRowsPerPageChange}
     page={page}
     rows={paginatedIssueResults}

--- a/src/pages/search/MinerTab.tsx
+++ b/src/pages/search/MinerTab.tsx
@@ -141,7 +141,7 @@ type MinerTabProps = {
   minerResults: MinerSearchData[];
   onPageChange: (newPage: number) => void;
   onRowsPerPageChange: (rowsPerPage: number) => void;
-  onSelectMiner: (githubId: string) => void;
+  linkState?: unknown;
   page: number;
   paginatedMinerResults: MinerSearchData[];
   rowsPerPage: number;
@@ -154,7 +154,7 @@ const MinerTab: React.FC<MinerTabProps> = ({
   minerResults,
   onPageChange,
   onRowsPerPageChange,
-  onSelectMiner,
+  linkState,
   page,
   paginatedMinerResults,
   rowsPerPage,
@@ -169,7 +169,10 @@ const MinerTab: React.FC<MinerTabProps> = ({
     isLoading={isLoading}
     minWidth={980}
     onPageChange={onPageChange}
-    onRowClick={(miner: MinerSearchData) => onSelectMiner(miner.githubId)}
+    getRowHref={(miner: MinerSearchData) =>
+      `/miners/details?githubId=${encodeURIComponent(miner.githubId)}`
+    }
+    getRowLinkState={() => linkState}
     onRowsPerPageChange={onRowsPerPageChange}
     page={page}
     rows={paginatedMinerResults}

--- a/src/pages/search/PullRequestsTab.tsx
+++ b/src/pages/search/PullRequestsTab.tsx
@@ -137,7 +137,7 @@ type PullRequestsTabProps = {
   isLoading: boolean;
   onPageChange: (newPage: number) => void;
   onRowsPerPageChange: (rowsPerPage: number) => void;
-  onSelectPr: (repository: string, pullRequestNumber: number) => void;
+  linkState?: unknown;
   page: number;
   paginatedPrResults: CommitLog[];
   prResults: CommitLog[];
@@ -150,7 +150,7 @@ const PullRequestsTab: React.FC<PullRequestsTabProps> = ({
   isLoading,
   onPageChange,
   onRowsPerPageChange,
-  onSelectPr,
+  linkState,
   page,
   paginatedPrResults,
   prResults,
@@ -166,9 +166,10 @@ const PullRequestsTab: React.FC<PullRequestsTabProps> = ({
     isLoading={isLoading}
     minWidth={960}
     onPageChange={onPageChange}
-    onRowClick={(pr: CommitLog) =>
-      onSelectPr(pr.repository, pr.pullRequestNumber)
+    getRowHref={(pr: CommitLog) =>
+      `/miners/pr?repo=${encodeURIComponent(pr.repository)}&number=${pr.pullRequestNumber}`
     }
+    getRowLinkState={() => linkState}
     onRowsPerPageChange={onRowsPerPageChange}
     page={page}
     rows={paginatedPrResults}

--- a/src/pages/search/RepositoryTab.tsx
+++ b/src/pages/search/RepositoryTab.tsx
@@ -129,7 +129,7 @@ type RepositoryTabProps = {
   isLoading: boolean;
   onPageChange: (newPage: number) => void;
   onRowsPerPageChange: (rowsPerPage: number) => void;
-  onSelectRepository: (fullName: string) => void;
+  linkState?: unknown;
   page: number;
   paginatedRepositoryResults: RepoSearchData[];
   rowsPerPage: number;
@@ -142,7 +142,7 @@ const RepositoryTab: React.FC<RepositoryTabProps> = ({
   isLoading,
   onPageChange,
   onRowsPerPageChange,
-  onSelectRepository,
+  linkState,
   page,
   paginatedRepositoryResults,
   rowsPerPage,
@@ -158,7 +158,10 @@ const RepositoryTab: React.FC<RepositoryTabProps> = ({
     isLoading={isLoading}
     minWidth={1000}
     onPageChange={onPageChange}
-    onRowClick={(repo: RepoSearchData) => onSelectRepository(repo.fullName)}
+    getRowHref={(repo: RepoSearchData) =>
+      `/miners/repository?name=${encodeURIComponent(repo.fullName)}`
+    }
+    getRowLinkState={() => linkState}
     onRowsPerPageChange={onRowsPerPageChange}
     page={page}
     rows={paginatedRepositoryResults}

--- a/src/pages/search/SearchPage.tsx
+++ b/src/pages/search/SearchPage.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Alert, Box, Stack, Tab, Tabs, Typography } from '@mui/material';
-import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
+import { useLocation, useSearchParams } from 'react-router-dom';
 import { BackButton, SEO } from '../../components';
 import { GlobalSearchBar, Page } from '../../components/layout';
 import IssuesTab from './IssuesTab';
@@ -35,7 +35,6 @@ const paginateResults = <T,>(
 
 const SearchPage: React.FC = () => {
   const location = useLocation();
-  const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const query = searchParams.get('q') || '';
   const tabParam = searchParams.get('tab');
@@ -165,33 +164,6 @@ const SearchPage: React.FC = () => {
     backTo: `${location.pathname}${location.search}`,
   };
 
-  const handleSelectMiner = (githubId: string) => {
-    navigate(`/miners/details?githubId=${encodeURIComponent(githubId)}`, {
-      state: searchBackState,
-    });
-  };
-
-  const handleSelectRepository = (fullName: string) => {
-    navigate(`/miners/repository?name=${encodeURIComponent(fullName)}`, {
-      state: searchBackState,
-    });
-  };
-
-  const handleSelectPr = (repository: string, pullRequestNumber: number) => {
-    navigate(
-      `/miners/pr?repo=${encodeURIComponent(repository)}&number=${pullRequestNumber}`,
-      {
-        state: searchBackState,
-      },
-    );
-  };
-
-  const handleSelectIssue = (id: number) => {
-    navigate(`/bounties/details?id=${id}`, {
-      state: searchBackState,
-    });
-  };
-
   return (
     <Page title="Search">
       <SEO
@@ -276,7 +248,7 @@ const SearchPage: React.FC = () => {
                 isLoading={tabState.isLoading}
                 onPageChange={handlePageChange}
                 onRowsPerPageChange={handleRowsPerPageChange}
-                onSelectMiner={handleSelectMiner}
+                linkState={searchBackState}
                 page={page}
                 rowsPerPage={rowsPerPage}
                 rowsPerPageOptions={ROWS_PER_PAGE_OPTIONS}
@@ -291,7 +263,7 @@ const SearchPage: React.FC = () => {
                 isLoading={tabState.isLoading}
                 onPageChange={handlePageChange}
                 onRowsPerPageChange={handleRowsPerPageChange}
-                onSelectRepository={handleSelectRepository}
+                linkState={searchBackState}
                 page={page}
                 rowsPerPage={rowsPerPage}
                 rowsPerPageOptions={ROWS_PER_PAGE_OPTIONS}
@@ -306,7 +278,7 @@ const SearchPage: React.FC = () => {
                 isLoading={tabState.isLoading}
                 onPageChange={handlePageChange}
                 onRowsPerPageChange={handleRowsPerPageChange}
-                onSelectPr={handleSelectPr}
+                linkState={searchBackState}
                 page={page}
                 rowsPerPage={rowsPerPage}
                 rowsPerPageOptions={ROWS_PER_PAGE_OPTIONS}
@@ -321,7 +293,7 @@ const SearchPage: React.FC = () => {
                 isLoading={tabState.isLoading}
                 onPageChange={handlePageChange}
                 onRowsPerPageChange={handleRowsPerPageChange}
-                onSelectIssue={handleSelectIssue}
+                linkState={searchBackState}
                 page={page}
                 rowsPerPage={rowsPerPage}
                 rowsPerPageOptions={ROWS_PER_PAGE_OPTIONS}

--- a/src/pages/search/SearchResultsTable.tsx
+++ b/src/pages/search/SearchResultsTable.tsx
@@ -186,43 +186,43 @@ const SearchResultsTable = <T,>({
                     }
                   : undefined;
                 return (
-                <TableRow
-                  key={getRowKey(item)}
-                  {...linkProps}
-                  onClick={
-                    !href && onRowClick ? () => onRowClick(item) : undefined
-                  }
-                  sx={
-                    href
-                      ? searchLinkRowSx
-                      : onRowClick
-                        ? searchClickableRowSx
-                        : undefined
-                  }
-                >
-                  {columns.map((column) => {
-                    const customCellSx =
-                      typeof column.cellSx === 'function'
-                        ? column.cellSx(item)
-                        : column.cellSx;
+                  <TableRow
+                    key={getRowKey(item)}
+                    {...linkProps}
+                    onClick={
+                      !href && onRowClick ? () => onRowClick(item) : undefined
+                    }
+                    sx={
+                      href
+                        ? searchLinkRowSx
+                        : onRowClick
+                          ? searchClickableRowSx
+                          : undefined
+                    }
+                  >
+                    {columns.map((column) => {
+                      const customCellSx =
+                        typeof column.cellSx === 'function'
+                          ? column.cellSx(item)
+                          : column.cellSx;
 
-                    return (
-                      <TableCell
-                        key={column.key}
-                        align={column.align}
-                        sx={[
-                          searchBodyCellSx,
-                          ...(column.width !== undefined
-                            ? [{ width: column.width }]
-                            : []),
-                          ...(customCellSx ? [customCellSx] : []),
-                        ]}
-                      >
-                        {column.renderCell(item)}
-                      </TableCell>
-                    );
-                  })}
-                </TableRow>
+                      return (
+                        <TableCell
+                          key={column.key}
+                          align={column.align}
+                          sx={[
+                            searchBodyCellSx,
+                            ...(column.width !== undefined
+                              ? [{ width: column.width }]
+                              : []),
+                            ...(customCellSx ? [customCellSx] : []),
+                          ]}
+                        >
+                          {column.renderCell(item)}
+                        </TableCell>
+                      );
+                    })}
+                  </TableRow>
                 );
               })}
             </TableBody>

--- a/src/pages/search/SearchResultsTable.tsx
+++ b/src/pages/search/SearchResultsTable.tsx
@@ -16,6 +16,7 @@ import {
 } from '@mui/material';
 import { type SxProps, type Theme } from '@mui/material/styles';
 import { type SystemStyleObject } from '@mui/system';
+import { Link as RouterLink } from 'react-router-dom';
 
 export type SearchResultsTableColumn<T> = {
   key: string;
@@ -38,6 +39,8 @@ type SearchResultsTableProps<T> = {
   isLoading: boolean;
   minWidth: number;
   onRowClick?: (item: T) => void;
+  getRowHref?: (item: T) => string;
+  getRowLinkState?: (item: T) => unknown;
   onPageChange: (newPage: number) => void;
   onRowsPerPageChange: (rowsPerPage: number) => void;
   page: number;
@@ -63,6 +66,15 @@ const searchBodyCellSx: SxProps<Theme> = (theme) => ({
 
 const searchClickableRowSx: SxProps<Theme> = (theme) => ({
   cursor: 'pointer',
+  '&:hover': {
+    backgroundColor: theme.palette.surface.subtle,
+  },
+});
+
+const searchLinkRowSx: SxProps<Theme> = (theme) => ({
+  cursor: 'pointer',
+  textDecoration: 'none',
+  color: 'inherit',
   '&:hover': {
     backgroundColor: theme.palette.surface.subtle,
   },
@@ -116,6 +128,8 @@ const SearchResultsTable = <T,>({
   isLoading,
   minWidth,
   onRowClick,
+  getRowHref,
+  getRowLinkState,
   onPageChange,
   onRowsPerPageChange,
   page,
@@ -162,11 +176,29 @@ const SearchResultsTable = <T,>({
               </TableRow>
             </TableHead>
             <TableBody>
-              {rows.map((item) => (
+              {rows.map((item) => {
+                const href = getRowHref?.(item);
+                const linkProps = href
+                  ? {
+                      component: RouterLink,
+                      to: href,
+                      state: getRowLinkState?.(item),
+                    }
+                  : undefined;
+                return (
                 <TableRow
                   key={getRowKey(item)}
-                  onClick={onRowClick ? () => onRowClick(item) : undefined}
-                  sx={onRowClick ? searchClickableRowSx : undefined}
+                  {...linkProps}
+                  onClick={
+                    !href && onRowClick ? () => onRowClick(item) : undefined
+                  }
+                  sx={
+                    href
+                      ? searchLinkRowSx
+                      : onRowClick
+                        ? searchClickableRowSx
+                        : undefined
+                  }
                 >
                   {columns.map((column) => {
                     const customCellSx =
@@ -191,7 +223,8 @@ const SearchResultsTable = <T,>({
                     );
                   })}
                 </TableRow>
-              ))}
+                );
+              })}
             </TableBody>
           </Table>
         </TableContainer>


### PR DESCRIPTION
## Summary

Replaces the `onClick` + `useNavigate()` pattern on clickable rows, cards, and header elements throughout the app with real React Router `<Link>` anchors (via MUI's `component={RouterLink}` prop). Because the rendered element is now an actual `<a href>`, the browser handles link semantics natively. Middle-click, Ctrl/Cmd-click, and right-click -> "Open link in new tab" all work as expected, while plain left-click still navigates in-place.

For the GitHub issue rows under a repository (which point to an external URL), the row now renders as `component="a"` with `target="_blank"` instead of a manual `window.open(...)` so the same behaviors apply.

Callback-style components (`TopMinersTable`, `TopPRsTable`, `TopRepositoriesTable`, `MinerCard`, `LeaderboardSidebar`, `IssuesList`, `SearchResultsTable` + its tabs, `HighlightRow`) were refactored from `onSelectX(id)` callbacks to URL-based props (`getMinerHref`, `backLabel`, `linkState`, `getRowHref`) so the leaf component can render the anchor itself.

A couple of nested clickable elements sitting inside a now-anchor row (e.g. the author link inside `IssueSubmissionsTable`, the author and repo chips inside `TopPRsTable`) use `preventDefault()` plus `stopPropagation()` plus a small modifier key shim so Ctrl/Cmd-click still opens a new tab without also triggering the outer anchor.

### Files touched

- Direct navigate rows converted to `<Link>`:  
  `RepositoryPRsTable`, `MinerPRsTable`, `MinerRepositoriesTable`, `RepositoryIssuesTable` (bounty and GitHub issue rows), `RepositoryContributorsTable`, `IssueSubmissionsTable`, dashboard `RepositoriesTable`, `LiveCommitLog`, `PRDetailsCard`, `PRHeader`, `MinerScoreBreakdown`

- Callback style components refactored to URL props:  
  `TopRepositoriesTable`, `TopPRsTable`, `TopMinersTable`, `MinerCard`, `LeaderboardSidebar`, `IssuesList`, `SearchResultsTable` plus `MinerTab`, `RepositoryTab`, `PullRequestsTab`, `IssuesTab`, `HighlightRow`

- Parent pages updated to pass hrefs and back labels instead of select callbacks:  
  `RepositoriesPage`, `TopMinersPage`, `DiscoveriesPage`, `IssuesPage`, `SearchPage`

## Related Issues

Closes #266

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

<!-- Before: right-click on a leaderboard row, no "Open in new tab" -->
<!-- After: right-click on a leaderboard row, context menu now shows "Open link in new tab" -->

## Checklist

- [x] New components are modularized or separated where sensible
- [x] Uses predefined theme, no hardcoded colors
- [x] Responsive and mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [ ] Screenshots included for any UI or visual changes