### PR TITLE
feat: introduce RowLink primitive and migrate leaderboard (#266)

### DIFF
--- a/src/components/common/RowLink.tsx
+++ b/src/components/common/RowLink.tsx
@@ -1,0 +1,56 @@
+import React, { type CSSProperties, type ReactNode } from 'react';
+import { Box, type SxProps, type Theme } from '@mui/material';
+import { useNavigate } from 'react-router-dom';
+
+interface RowLinkProps {
+  href: string;
+  state?: unknown;
+  onClick?: (e: React.MouseEvent<HTMLAnchorElement>) => void;
+  children: ReactNode;
+  sx?: SxProps<Theme>;
+  className?: string;
+  style?: CSSProperties;
+  'aria-label'?: string;
+}
+
+const isModifiedClick = (e: React.MouseEvent) =>
+  e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0;
+
+export const RowLink: React.FC<RowLinkProps> = ({
+  href,
+  state,
+  onClick,
+  children,
+  sx,
+  className,
+  style,
+  'aria-label': ariaLabel,
+}) => {
+  const navigate = useNavigate();
+
+  const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    onClick?.(e);
+    if (e.defaultPrevented || isModifiedClick(e)) return;
+    e.preventDefault();
+    navigate(href, state ? { state } : undefined);
+  };
+
+  return (
+    <Box
+      component="a"
+      href={href}
+      onClick={handleClick}
+      className={className}
+      style={style}
+      aria-label={ariaLabel}
+      sx={{
+        textDecoration: 'none',
+        color: 'inherit',
+        display: 'block',
+        ...sx,
+      }}
+    >
+      {children}
+    </Box>
+  );
+};

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -1,1 +1,2 @@
+export * from './RowLink';
 export * from './SearchInput';

--- a/src/components/leaderboard/MinerCard.tsx
+++ b/src/components/leaderboard/MinerCard.tsx
@@ -5,11 +5,13 @@ import ReactECharts from 'echarts-for-react';
 import { useMinerGithubData, useMinerPRs } from '../../api';
 import { CHART_COLORS, STATUS_COLORS } from '../../theme';
 import { getGithubAvatarSrc } from '../../utils/ExplorerUtils';
+import { RowLink } from '../common';
 import { type MinerStats, type LeaderboardVariant, FONTS } from './types';
 
 interface MinerCardProps {
   miner: MinerStats;
-  onClick: () => void;
+  href: string;
+  linkState?: unknown;
   variant?: LeaderboardVariant;
 }
 
@@ -17,7 +19,8 @@ const INACTIVE_OPACITY = 0.24;
 
 export const MinerCard: React.FC<MinerCardProps> = ({
   miner,
-  onClick,
+  href,
+  linkState,
   variant = 'oss',
 }) => {
   const muiTheme = useTheme();
@@ -38,44 +41,44 @@ export const MinerCard: React.FC<MinerCardProps> = ({
   const isEligible = miner.isEligible ?? false;
 
   return (
-    <Card
-      onClick={onClick}
-      sx={(theme) => ({
-        p: 1,
-        backgroundColor: isEligible
-          ? theme.palette.background.default
-          : theme.palette.surface.subtle,
-        backdropFilter: 'blur(12px)',
-        border: '1px solid',
-        borderColor: isEligible
-          ? alpha(theme.palette.status.merged, 0.3)
-          : theme.palette.border.subtle,
-        borderRadius: 2,
-        cursor: 'pointer',
-        transition: 'all 0.2s cubic-bezier(0.4, 0, 0.2, 1)',
-        height: '100%',
-        display: 'flex',
-        flexDirection: 'column',
-        gap: 1,
-        position: 'relative',
-        boxShadow: isEligible
-          ? `0 2px 8px ${alpha(theme.palette.background.default, 0.1)}`
-          : 'none',
-        '&:hover': {
+    <RowLink href={href} state={linkState} sx={{ height: '100%' }}>
+      <Card
+        sx={(theme) => ({
+          p: 1,
           backgroundColor: isEligible
-            ? theme.palette.surface.elevated
-            : theme.palette.surface.light,
+            ? theme.palette.background.default
+            : theme.palette.surface.subtle,
+          backdropFilter: 'blur(12px)',
+          border: '1px solid',
           borderColor: isEligible
-            ? alpha(theme.palette.status.merged, 0.5)
+            ? alpha(theme.palette.status.merged, 0.3)
             : theme.palette.border.subtle,
-          transform: isEligible ? 'translateY(-2px)' : 'none',
+          borderRadius: 2,
+          cursor: 'pointer',
+          transition: 'all 0.2s cubic-bezier(0.4, 0, 0.2, 1)',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 1,
+          position: 'relative',
           boxShadow: isEligible
-            ? `0 8px 24px -6px ${alpha(theme.palette.background.default, 0.6)}`
+            ? `0 2px 8px ${alpha(theme.palette.background.default, 0.1)}`
             : 'none',
-        },
-      })}
-      elevation={0}
-    >
+          '&:hover': {
+            backgroundColor: isEligible
+              ? theme.palette.surface.elevated
+              : theme.palette.surface.light,
+            borderColor: isEligible
+              ? alpha(theme.palette.status.merged, 0.5)
+              : theme.palette.border.subtle,
+            transform: isEligible ? 'translateY(-2px)' : 'none',
+            boxShadow: isEligible
+              ? `0 8px 24px -6px ${alpha(theme.palette.background.default, 0.6)}`
+              : 'none',
+          },
+        })}
+        elevation={0}
+      >
       <Box
         sx={{
           display: 'flex',
@@ -310,12 +313,13 @@ export const MinerCard: React.FC<MinerCardProps> = ({
         </Box>
       </Box>
 
-      <MinerCardFooter
-        miner={miner}
-        variant={variant}
-        isEligible={isEligible}
-      />
-    </Card>
+        <MinerCardFooter
+          miner={miner}
+          variant={variant}
+          isEligible={isEligible}
+        />
+      </Card>
+    </RowLink>
   );
 };
 

--- a/src/components/leaderboard/MinerCard.tsx
+++ b/src/components/leaderboard/MinerCard.tsx
@@ -79,239 +79,244 @@ export const MinerCard: React.FC<MinerCardProps> = ({
         })}
         elevation={0}
       >
-      <Box
-        sx={{
-          display: 'flex',
-          justifyContent: 'space-between',
-          alignItems: 'flex-start',
-        }}
-      >
         <Box
-          sx={{ display: 'flex', alignItems: 'center', gap: 1.5, minWidth: 0 }}
+          sx={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'flex-start',
+          }}
         >
-          <Avatar
-            src={avatarSrc}
-            sx={(theme) => ({
-              width: 36,
-              height: 36,
-              border: '2px solid',
-              borderColor: isEligible
-                ? alpha(theme.palette.status.merged, 0.3)
-                : theme.palette.border.subtle,
-              filter: isEligible ? 'none' : 'grayscale(100%)',
-              opacity: isEligible ? 1 : INACTIVE_OPACITY,
-              flexShrink: 0,
-            })}
-          />
           <Box
             sx={{
-              minWidth: 0,
-              minHeight: 36,
               display: 'flex',
-              flexDirection: 'column',
-              justifyContent: 'space-between',
-              overflow: 'hidden',
+              alignItems: 'center',
+              gap: 1.5,
+              minWidth: 0,
             }}
           >
-            <Typography
+            <Avatar
+              src={avatarSrc}
               sx={(theme) => ({
-                fontFamily: FONTS.mono,
-                fontSize: '1rem',
-                fontWeight: 700,
-                color: isEligible
-                  ? theme.palette.text.primary
-                  : theme.palette.text.tertiary,
+                width: 36,
+                height: 36,
+                border: '2px solid',
+                borderColor: isEligible
+                  ? alpha(theme.palette.status.merged, 0.3)
+                  : theme.palette.border.subtle,
+                filter: isEligible ? 'none' : 'grayscale(100%)',
                 opacity: isEligible ? 1 : INACTIVE_OPACITY,
+                flexShrink: 0,
+              })}
+            />
+            <Box
+              sx={{
+                minWidth: 0,
+                minHeight: 36,
+                display: 'flex',
+                flexDirection: 'column',
+                justifyContent: 'space-between',
                 overflow: 'hidden',
-                textOverflow: 'ellipsis',
-                whiteSpace: 'nowrap',
-              })}
+              }}
             >
-              {username}
-            </Typography>
+              <Typography
+                sx={(theme) => ({
+                  fontFamily: FONTS.mono,
+                  fontSize: '1rem',
+                  fontWeight: 700,
+                  color: isEligible
+                    ? theme.palette.text.primary
+                    : theme.palette.text.tertiary,
+                  opacity: isEligible ? 1 : INACTIVE_OPACITY,
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                })}
+              >
+                {username}
+              </Typography>
+              <Typography
+                sx={(theme) => ({
+                  fontFamily: FONTS.mono,
+                  fontSize: '0.72rem',
+                  fontWeight: 700,
+                  color: isEligible
+                    ? theme.palette.status.merged
+                    : theme.palette.text.tertiary,
+                  opacity: isEligible ? 1 : INACTIVE_OPACITY,
+                  lineHeight: 1,
+                  mt: 0.1,
+                })}
+              >
+                #{miner.rank}
+              </Typography>
+            </Box>
+          </Box>
+          {!isEligible && (
             <Typography
               sx={(theme) => ({
                 fontFamily: FONTS.mono,
-                fontSize: '0.72rem',
+                fontSize: '0.65rem',
                 fontWeight: 700,
-                color: isEligible
-                  ? theme.palette.status.merged
-                  : theme.palette.text.tertiary,
-                opacity: isEligible ? 1 : INACTIVE_OPACITY,
-                lineHeight: 1,
-                mt: 0.1,
+                color: theme.palette.text.secondary,
+                textTransform: 'uppercase',
+                border: `1px solid ${theme.palette.border.subtle}`,
+                borderRadius: 1,
+                px: 0.75,
+                py: 0.25,
+                letterSpacing: '0.06em',
+                flexShrink: 0,
+                backgroundColor: theme.palette.surface.subtle,
               })}
             >
-              #{miner.rank}
+              Ineligible
             </Typography>
-          </Box>
-        </Box>
-        {!isEligible && (
-          <Typography
-            sx={(theme) => ({
-              fontFamily: FONTS.mono,
-              fontSize: '0.65rem',
-              fontWeight: 700,
-              color: theme.palette.text.secondary,
-              textTransform: 'uppercase',
-              border: `1px solid ${theme.palette.border.subtle}`,
-              borderRadius: 1,
-              px: 0.75,
-              py: 0.25,
-              letterSpacing: '0.06em',
-              flexShrink: 0,
-              backgroundColor: theme.palette.surface.subtle,
-            })}
-          >
-            Ineligible
-          </Typography>
-        )}
-      </Box>
-
-      <Box
-        sx={{
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'space-between',
-          gap: 2,
-        }}
-      >
-        <Box>
-          <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 0.5 }}>
-            <Typography
-              sx={(theme) => ({
-                fontFamily: FONTS.mono,
-                fontSize: '1.6rem',
-                fontWeight: 800,
-                color: isEligible
-                  ? theme.palette.status.merged
-                  : theme.palette.text.tertiary,
-                opacity: isEligible ? 1 : INACTIVE_OPACITY,
-                lineHeight: 1,
-              })}
-            >
-              ${Math.round(miner.usdPerDay || 0).toLocaleString()}
-            </Typography>
-            <Typography
-              sx={(theme) => ({
-                fontFamily: FONTS.mono,
-                fontSize: '0.75rem',
-                color: isEligible
-                  ? theme.palette.status.open
-                  : theme.palette.text.tertiary,
-                opacity: isEligible ? 1 : INACTIVE_OPACITY,
-              })}
-            >
-              /day
-            </Typography>
-          </Box>
-          <Typography
-            sx={(theme) => ({
-              fontFamily: FONTS.mono,
-              fontSize: '0.7rem',
-              color: isEligible
-                ? theme.palette.status.merged
-                : theme.palette.text.tertiary,
-              opacity: isEligible ? 0.7 : INACTIVE_OPACITY,
-              mt: 0.2,
-            })}
-          >
-            ~${Math.round((miner.usdPerDay || 0) * 30).toLocaleString()}/mo
-          </Typography>
+          )}
         </Box>
 
         <Box
           sx={{
-            position: 'relative',
-            width: 56,
-            height: 56,
-            flexShrink: 0,
-            opacity: isEligible ? 1 : INACTIVE_OPACITY,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            gap: 2,
           }}
         >
-          <ReactECharts
-            option={{
-              backgroundColor: 'transparent',
-              series: [
-                {
-                  type: 'pie',
-                  radius: ['65%', '90%'],
-                  silent: true,
-                  label: { show: false },
-                  itemStyle: {
-                    borderRadius: 3,
-                    borderWidth: 0,
-                  },
-                  data: [
-                    {
-                      value: miner.totalMergedPrs ?? 0,
-                      itemStyle: {
-                        color: isEligible
-                          ? CHART_COLORS.merged
-                          : alpha(
-                              muiTheme.palette.text.secondary,
-                              (INACTIVE_OPACITY * 2) / 3,
-                            ),
-                      },
-                    },
-                    {
-                      value: miner.totalOpenPrs ?? 0,
-                      itemStyle: {
-                        color: isEligible
-                          ? CHART_COLORS.open
-                          : alpha(
-                              muiTheme.palette.text.secondary,
-                              INACTIVE_OPACITY,
-                            ),
-                      },
-                    },
-                    {
-                      value: miner.totalClosedPrs ?? 0,
-                      itemStyle: {
-                        color: isEligible
-                          ? CHART_COLORS.closed
-                          : alpha(
-                              muiTheme.palette.text.secondary,
-                              INACTIVE_OPACITY / 2,
-                            ),
-                      },
-                    },
-                  ],
-                },
-              ],
-            }}
-            style={{ width: '100%', height: '100%' }}
-            opts={{ renderer: 'svg' }}
-          />
-          <Box
-            sx={{
-              position: 'absolute',
-              top: 0,
-              left: 0,
-              right: 0,
-              bottom: 0,
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-            }}
-          >
+          <Box>
+            <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 0.5 }}>
+              <Typography
+                sx={(theme) => ({
+                  fontFamily: FONTS.mono,
+                  fontSize: '1.6rem',
+                  fontWeight: 800,
+                  color: isEligible
+                    ? theme.palette.status.merged
+                    : theme.palette.text.tertiary,
+                  opacity: isEligible ? 1 : INACTIVE_OPACITY,
+                  lineHeight: 1,
+                })}
+              >
+                ${Math.round(miner.usdPerDay || 0).toLocaleString()}
+              </Typography>
+              <Typography
+                sx={(theme) => ({
+                  fontFamily: FONTS.mono,
+                  fontSize: '0.75rem',
+                  color: isEligible
+                    ? theme.palette.status.open
+                    : theme.palette.text.tertiary,
+                  opacity: isEligible ? 1 : INACTIVE_OPACITY,
+                })}
+              >
+                /day
+              </Typography>
+            </Box>
             <Typography
               sx={(theme) => ({
                 fontFamily: FONTS.mono,
-                fontSize: '0.75rem',
+                fontSize: '0.7rem',
                 color: isEligible
-                  ? credibilityPercent >= 80
-                    ? STATUS_COLORS.merged
-                    : STATUS_COLORS.open
+                  ? theme.palette.status.merged
                   : theme.palette.text.tertiary,
-                fontWeight: 700,
+                opacity: isEligible ? 0.7 : INACTIVE_OPACITY,
+                mt: 0.2,
               })}
             >
-              {credibilityPercent.toFixed(0)}%
+              ~${Math.round((miner.usdPerDay || 0) * 30).toLocaleString()}/mo
             </Typography>
           </Box>
+
+          <Box
+            sx={{
+              position: 'relative',
+              width: 56,
+              height: 56,
+              flexShrink: 0,
+              opacity: isEligible ? 1 : INACTIVE_OPACITY,
+            }}
+          >
+            <ReactECharts
+              option={{
+                backgroundColor: 'transparent',
+                series: [
+                  {
+                    type: 'pie',
+                    radius: ['65%', '90%'],
+                    silent: true,
+                    label: { show: false },
+                    itemStyle: {
+                      borderRadius: 3,
+                      borderWidth: 0,
+                    },
+                    data: [
+                      {
+                        value: miner.totalMergedPrs ?? 0,
+                        itemStyle: {
+                          color: isEligible
+                            ? CHART_COLORS.merged
+                            : alpha(
+                                muiTheme.palette.text.secondary,
+                                (INACTIVE_OPACITY * 2) / 3,
+                              ),
+                        },
+                      },
+                      {
+                        value: miner.totalOpenPrs ?? 0,
+                        itemStyle: {
+                          color: isEligible
+                            ? CHART_COLORS.open
+                            : alpha(
+                                muiTheme.palette.text.secondary,
+                                INACTIVE_OPACITY,
+                              ),
+                        },
+                      },
+                      {
+                        value: miner.totalClosedPrs ?? 0,
+                        itemStyle: {
+                          color: isEligible
+                            ? CHART_COLORS.closed
+                            : alpha(
+                                muiTheme.palette.text.secondary,
+                                INACTIVE_OPACITY / 2,
+                              ),
+                        },
+                      },
+                    ],
+                  },
+                ],
+              }}
+              style={{ width: '100%', height: '100%' }}
+              opts={{ renderer: 'svg' }}
+            />
+            <Box
+              sx={{
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                right: 0,
+                bottom: 0,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+              }}
+            >
+              <Typography
+                sx={(theme) => ({
+                  fontFamily: FONTS.mono,
+                  fontSize: '0.75rem',
+                  color: isEligible
+                    ? credibilityPercent >= 80
+                      ? STATUS_COLORS.merged
+                      : STATUS_COLORS.open
+                    : theme.palette.text.tertiary,
+                  fontWeight: 700,
+                })}
+              >
+                {credibilityPercent.toFixed(0)}%
+              </Typography>
+            </Box>
+          </Box>
         </Box>
-      </Box>
 
         <MinerCardFooter
           miner={miner}

--- a/src/components/leaderboard/TopMinersTable.tsx
+++ b/src/components/leaderboard/TopMinersTable.tsx
@@ -20,14 +20,16 @@ const MINERS_PAGE_SIZE = 60;
 interface TopMinersTableProps {
   miners: MinerStats[];
   isLoading?: boolean;
-  onSelectMiner: (githubId: string) => void;
+  getHref: (miner: MinerStats) => string;
+  linkState?: unknown;
   variant?: LeaderboardVariant;
 }
 
 const TopMinersTable: React.FC<TopMinersTableProps> = ({
   miners,
   isLoading,
-  onSelectMiner,
+  getHref,
+  linkState,
   variant = 'oss',
 }) => {
   const [searchQuery, setSearchQuery] = useState('');
@@ -151,7 +153,8 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
                 <MinerCard
                   miner={miner}
                   variant={variant}
-                  onClick={() => onSelectMiner(miner.githubId)}
+                  href={getHref(miner)}
+                  linkState={linkState}
                 />
               </Grid>
             ))}

--- a/src/pages/DiscoveriesPage.tsx
+++ b/src/pages/DiscoveriesPage.tsx
@@ -125,7 +125,10 @@ const DiscoveriesPage: React.FC = () => {
             <TopMinersTable
               miners={sortedMinerStats}
               isLoading={isLoadingMinerStats}
-              onSelectMiner={handleSelectMiner}
+              getHref={(m) =>
+                `/miners/details?githubId=${encodeURIComponent(m.githubId)}&mode=issues`
+              }
+              linkState={{ backLabel: 'Back to Discoveries' }}
               variant="discoveries"
             />
           </Box>

--- a/src/pages/TopMinersPage.tsx
+++ b/src/pages/TopMinersPage.tsx
@@ -123,7 +123,10 @@ const TopMinersPage: React.FC = () => {
             <TopMinersTable
               miners={minerStats}
               isLoading={isLoadingMinerStats}
-              onSelectMiner={handleSelectMiner}
+              getHref={(m) =>
+                `/miners/details?githubId=${encodeURIComponent(m.githubId)}`
+              }
+              linkState={{ backLabel: 'Back to Leaderboard' }}
             />
           </Box>
         </Box>


### PR DESCRIPTION
## Summary
Introduces a shared `RowLink` primitive that renders clickable list rows as real `<a href>` elements, and migrates the Leaderboard surface (`TopMinersTable` rows + `MinerCard`) to use it. Middle-click, Cmd/Ctrl-click, and right-click "Open link in new tab" now all work on the Top Miners and Discoveries pages.

## What changed

### New primitive — `src/components/common/RowLink.tsx`
A thin `<a href>` wrapper that:
- On **plain left-click**: calls `preventDefault()` and `navigate(href, { state })` so React Router handles the transition (no full page reload, back-stack preserved, same UX as today)
- On **modifier-click / middle-click / right-click**: lets the browser handle it — native "new tab", native context menu, native drag-to-bookmark, etc.
- Respects `defaultPrevented` so nested clickable elements (copy buttons, inline links) keep working when they `e.stopPropagation()`

### Migrations
- `MinerCard`: replaced `onClick: () => void` prop with `href` + `linkState`. Wraps the card body in `<RowLink>`.
- `TopMinersTable`: replaced `onSelectMiner` with a `getHref(miner)` prop and optional `linkState`. Every row (desktop + mobile card) is now a `RowLink`.
- `TopMinersPage` and `DiscoveriesPage`: drop their `handleSelectMiner` callbacks; pass a URL builder and `backLabel` in `linkState` instead.

### Unchanged
- Plain left-click behavior on every migrated row — same target URL, same React Router transition, same back-button state. No visual changes, no animation changes.

## Motivation (from #266)
Rows built with `onClick + useNavigate()` silently break every browser-native navigation idiom users expect from a list of links: middle-click, Cmd-click, right-click "Open in new tab", drag-to-bookmark. Fixing this with custom `onAuxClick` + modifier handlers only covers middle- and Cmd-click — the right-click context menu only surfaces "Open link in new tab" when the element is a real `<a>`. So the primitive is the right abstraction.

## Scope
Intentionally limited to the Leaderboard surface for this PR. The other ~14 surfaces called out in #266 (Dashboard, Repositories page, Repository detail tabs, Miner detail tabs, PR detail header, Bounties, Search) will follow as individual PRs using the same primitive — each small and independently reviewable.

## Type of Change
- [x] Feature / enhancement

## Testing
- [ ] `npm run build`
- [ ] `npm run lint:fix`
- [ ] Manual on `/top-miners`:
  - Plain click on a miner row → navigates to detail page, back label is `Back to Leaderboard` ✓
  - **Middle-click** on a row → opens detail page in new tab ✓
  - **Cmd-click / Ctrl-click** on a row → opens in new tab ✓
  - **Right-click** → context menu shows "Open link in new tab" ✓
  - Hover shows the destination URL in the browser's status bar ✓
- [ ] Manual on `/top-miners?mode=discovery` and `/discoveries` — same four behaviors; detail page opens with `mode=issues`, back label is `Back to Discoveries`.
- [ ] Any internal clickable element inside a row (e.g. hotkey copy, sort chip) still works and does **not** navigate to the row's detail URL (guarded by `e.stopPropagation()`).
- [ ] Keyboard: Tab focuses the row; Enter activates the link.

## Checklist
- [x] No behavior change for plain left-click
- [x] No new dependencies
- [x] New primitive is framework-generic — reusable in follow-up PRs
- [x] URL construction moved into leaf components (closes the `getMinerHref` / `linkState` part of the issue)

## Follow-ups (out of scope)
One PR per surface:
- [ ] Dashboard — Live Activity + Repositories table
- [ ] Repositories page — trending, most collateral, recent PRs, main table
- [ ] Repository detail — PRs, bounties, GitHub issues, contributors
- [ ] Miner detail — PRs, repositories, score breakdown
- [ ] PR detail header — repo avatar / name / author
- [ ] Bounties — available, pending, history, issue submissions
- [ ] Search — miners, repositories, PRs, issues
- [ ] `LeaderboardSidebar` (discoveries sidebar on XL viewports)

## Media to upload

https://github.com/user-attachments/assets/f01c69eb-080a-4672-a71e-a33156f0e939


Fixes #266 