### PR TITLE
refactor: extract duplicated cell styles from leaderboard tables into shared constants

### DIFF
--- a/src/components/leaderboard/TopPRsTable.tsx
+++ b/src/components/leaderboard/TopPRsTable.tsx
@@ -32,7 +32,11 @@ import BarChartIcon from '@mui/icons-material/BarChart';
 import TableChartIcon from '@mui/icons-material/TableChart';
 import ReactECharts from 'echarts-for-react';
 import { type CommitLog } from '../../api/models/Dashboard';
-import { getRepositoryOwnerAvatarBackground } from './types';
+import {
+  getRepositoryOwnerAvatarBackground,
+  headerCellStyle,
+  bodyCellStyle,
+} from './types';
 import {
   formatUsdEstimate,
   getPrStatusCounts,
@@ -928,31 +932,6 @@ const TopPRsTable: React.FC<TopPRsTableProps> = ({
       />
     </Card>
   );
-};
-
-const headerCellStyle = {
-  backgroundColor: 'surface.tooltip',
-  backdropFilter: 'blur(8px)',
-  color: 'text.primary',
-  fontFamily: '"JetBrains Mono", monospace',
-  fontWeight: 500,
-  fontSize: '0.75rem',
-  borderBottom: '1px solid',
-  borderColor: 'border.light',
-  height: '48px',
-  py: 1,
-  boxSizing: 'border-box' as const,
-};
-
-const bodyCellStyle = {
-  color: 'text.primary',
-  fontFamily: '"JetBrains Mono", monospace',
-  borderBottom: '1px solid',
-  borderColor: 'border.light',
-  fontSize: '0.75rem',
-  py: 0.75,
-  height: '52px',
-  boxSizing: 'border-box' as const,
 };
 
 export default TopPRsTable;

--- a/src/components/leaderboard/TopRepositoriesTable.tsx
+++ b/src/components/leaderboard/TopRepositoriesTable.tsx
@@ -40,7 +40,11 @@ import ReactECharts from 'echarts-for-react';
 import { useSearchParams } from 'react-router-dom';
 import { truncateText } from '../../utils';
 import { RankIcon } from './RankIcon';
-import { getRepositoryOwnerAvatarBackground } from './types';
+import {
+  getRepositoryOwnerAvatarBackground,
+  headerCellStyle,
+  bodyCellStyle,
+} from './types';
 import {
   CHART_COLORS,
   STATUS_COLORS,
@@ -926,31 +930,6 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
       />
     </Card>
   );
-};
-
-const headerCellStyle = {
-  backgroundColor: 'surface.tooltip',
-  backdropFilter: 'blur(8px)',
-  color: 'text.primary',
-  fontFamily: '"JetBrains Mono", monospace',
-  fontWeight: 500,
-  fontSize: '0.75rem',
-  borderBottom: '1px solid',
-  borderColor: 'border.light',
-  height: '48px',
-  py: 1,
-  boxSizing: 'border-box' as const,
-};
-
-const bodyCellStyle = {
-  color: 'text.primary',
-  fontFamily: '"JetBrains Mono", monospace',
-  borderBottom: '1px solid',
-  borderColor: 'border.light',
-  fontSize: '0.75rem',
-  py: 0.75,
-  height: '52px',
-  boxSizing: 'border-box' as const,
 };
 
 export default TopRepositoriesTable;

--- a/src/components/leaderboard/index.ts
+++ b/src/components/leaderboard/index.ts
@@ -9,4 +9,4 @@ export { SectionCard } from './SectionCard';
 
 // Types and utilities
 export type { MinerStats, SortOption } from './types';
-export { FONTS, getRankColors } from './types';
+export { FONTS, getRankColors, headerCellStyle, bodyCellStyle } from './types';

--- a/src/components/leaderboard/types.ts
+++ b/src/components/leaderboard/types.ts
@@ -50,3 +50,28 @@ export const getRepositoryOwnerAvatarBackground = (owner: string) => {
   if (owner === 'bitcoin') return '#F7931A';
   return 'transparent';
 };
+
+export const headerCellStyle = {
+  backgroundColor: 'surface.tooltip',
+  backdropFilter: 'blur(8px)',
+  color: 'text.primary',
+  fontFamily: FONTS.mono,
+  fontWeight: 500,
+  fontSize: '0.75rem',
+  borderBottom: '1px solid',
+  borderColor: 'border.light',
+  height: '48px',
+  py: 1,
+  boxSizing: 'border-box' as const,
+};
+
+export const bodyCellStyle = {
+  color: 'text.primary',
+  fontFamily: FONTS.mono,
+  borderBottom: '1px solid',
+  borderColor: 'border.light',
+  fontSize: '0.75rem',
+  py: 0.75,
+  height: '52px',
+  boxSizing: 'border-box' as const,
+};


### PR DESCRIPTION
## Summary

[TopPRsTable.tsx](cci:7://file:///root/mkdev11/gold/gittensor-ui/src/components/leaderboard/TopPRsTable.tsx:0:0-0:0) and [TopRepositoriesTable.tsx](cci:7://file:///root/mkdev11/gold/gittensor-ui/src/components/leaderboard/TopRepositoriesTable.tsx:0:0-0:0) each define identical `headerCellStyle` and `bodyCellStyle` constants (~22 lines duplicated). Moved both to [types.ts](cci:7://file:///root/mkdev11/gold/gittensor-ui/src/components/leaderboard/types.ts:0:0-0:0) — which already holds shared leaderboard constants (`FONTS`, [getRankColors](cci:1://file:///root/mkdev11/gold/gittensor-ui/src/components/leaderboard/types.ts:40:0-45:2)) — and updated both tables to import them.

Bonus: the shared definitions now use the existing `FONTS.mono` constant instead of a hardcoded font string.

## Related Issues

Partial fix for #210

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes

No visual changes — logic-only refactor.