### PR TITLE
feat: make Discoveries miner card show issue-only stats

### DIFF
--- a/src/components/leaderboard/MinerCard.tsx
+++ b/src/components/leaderboard/MinerCard.tsx
@@ -331,11 +331,7 @@ const MinerCardFooter: React.FC<MinerCardFooterProps> = ({
       p: 1,
     })}
   >
-    <PrimaryStatsRow
-      miner={miner}
-      isEligible={isEligible}
-      variant={variant}
-    />
+    <PrimaryStatsRow miner={miner} isEligible={isEligible} variant={variant} />
   </Box>
 );
 
@@ -477,4 +473,3 @@ const PrimaryStatsRow: React.FC<PrimaryStatsRowProps> = ({
     </Box>
   );
 };
-

--- a/src/components/leaderboard/MinerCard.tsx
+++ b/src/components/leaderboard/MinerCard.tsx
@@ -37,6 +37,19 @@ export const MinerCard: React.FC<MinerCardProps> = ({
   const credibilityPercent = (miner.credibility ?? 0) * 100;
   const isEligible = miner.isEligible ?? false;
 
+  const donutSegments =
+    variant === 'discoveries'
+      ? [
+          { value: miner.totalSolvedIssues ?? 0, color: CHART_COLORS.merged },
+          { value: miner.totalOpenIssues ?? 0, color: CHART_COLORS.open },
+          { value: miner.totalClosedIssues ?? 0, color: CHART_COLORS.closed },
+        ]
+      : [
+          { value: miner.totalMergedPrs ?? 0, color: CHART_COLORS.merged },
+          { value: miner.totalOpenPrs ?? 0, color: CHART_COLORS.open },
+          { value: miner.totalClosedPrs ?? 0, color: CHART_COLORS.closed },
+        ];
+
   return (
     <Card
       onClick={onClick}
@@ -239,41 +252,17 @@ export const MinerCard: React.FC<MinerCardProps> = ({
                     borderRadius: 3,
                     borderWidth: 0,
                   },
-                  data: [
-                    {
-                      value: miner.totalMergedPrs ?? 0,
-                      itemStyle: {
-                        color: isEligible
-                          ? CHART_COLORS.merged
-                          : alpha(
-                              muiTheme.palette.text.secondary,
-                              (INACTIVE_OPACITY * 2) / 3,
-                            ),
-                      },
+                  data: donutSegments.map((seg) => ({
+                    value: seg.value,
+                    itemStyle: {
+                      color: isEligible
+                        ? seg.color
+                        : alpha(
+                            muiTheme.palette.text.secondary,
+                            (INACTIVE_OPACITY * 2) / 3,
+                          ),
                     },
-                    {
-                      value: miner.totalOpenPrs ?? 0,
-                      itemStyle: {
-                        color: isEligible
-                          ? CHART_COLORS.open
-                          : alpha(
-                              muiTheme.palette.text.secondary,
-                              INACTIVE_OPACITY,
-                            ),
-                      },
-                    },
-                    {
-                      value: miner.totalClosedPrs ?? 0,
-                      itemStyle: {
-                        color: isEligible
-                          ? CHART_COLORS.closed
-                          : alpha(
-                              muiTheme.palette.text.secondary,
-                              INACTIVE_OPACITY / 2,
-                            ),
-                      },
-                    },
-                  ],
+                  })),
                 },
               ],
             }}
@@ -329,45 +318,88 @@ const MinerCardFooter: React.FC<MinerCardFooterProps> = ({
   miner,
   variant,
   isEligible,
-}) => {
-  const muiTheme = useTheme();
-
-  return (
-    <Box
-      sx={(theme) => ({
-        display: 'flex',
-        flexDirection: 'column',
-        gap: variant === 'discoveries' ? 0.75 : 0,
-        backgroundColor: isEligible
-          ? alpha(theme.palette.background.default, 0.2)
-          : theme.palette.surface.subtle,
-        opacity: isEligible ? 1 : 0.62,
-        borderRadius: 1.5,
-        p: 1,
-      })}
-    >
-      <PrimaryStatsRow miner={miner} isEligible={isEligible} />
-      {variant === 'discoveries' && (
-        <IssueStatsSection
-          miner={miner}
-          isEligible={isEligible}
-          textColor={alpha(muiTheme.palette.text.tertiary, INACTIVE_OPACITY)}
-        />
-      )}
-    </Box>
-  );
-};
+}) => (
+  <Box
+    sx={(theme) => ({
+      display: 'flex',
+      flexDirection: 'column',
+      backgroundColor: isEligible
+        ? alpha(theme.palette.background.default, 0.2)
+        : theme.palette.surface.subtle,
+      opacity: isEligible ? 1 : 0.62,
+      borderRadius: 1.5,
+      p: 1,
+    })}
+  >
+    <PrimaryStatsRow
+      miner={miner}
+      isEligible={isEligible}
+      variant={variant}
+    />
+  </Box>
+);
 
 interface PrimaryStatsRowProps {
   miner: MinerStats;
   isEligible: boolean;
+  variant: LeaderboardVariant;
 }
 
 const PrimaryStatsRow: React.FC<PrimaryStatsRowProps> = ({
   miner,
   isEligible,
+  variant,
 }) => {
   const muiTheme = useTheme();
+
+  const stats =
+    variant === 'discoveries'
+      ? [
+          {
+            label: 'Solved',
+            value: miner.totalSolvedIssues ?? 0,
+            color: isEligible
+              ? STATUS_COLORS.merged
+              : alpha(muiTheme.palette.text.tertiary, INACTIVE_OPACITY),
+          },
+          {
+            label: 'Open',
+            value: miner.totalOpenIssues ?? 0,
+            color: isEligible
+              ? alpha(muiTheme.palette.text.primary, 0.84)
+              : alpha(muiTheme.palette.text.tertiary, INACTIVE_OPACITY),
+          },
+          {
+            label: 'Closed',
+            value: miner.totalClosedIssues ?? 0,
+            color: isEligible
+              ? muiTheme.palette.status.closed
+              : alpha(muiTheme.palette.text.tertiary, INACTIVE_OPACITY),
+          },
+        ]
+      : [
+          {
+            label: 'Merged',
+            value: miner.totalMergedPrs ?? 0,
+            color: isEligible
+              ? STATUS_COLORS.merged
+              : alpha(muiTheme.palette.text.tertiary, INACTIVE_OPACITY),
+          },
+          {
+            label: 'Open',
+            value: miner.totalOpenPrs ?? 0,
+            color: isEligible
+              ? alpha(muiTheme.palette.text.primary, 0.84)
+              : alpha(muiTheme.palette.text.tertiary, INACTIVE_OPACITY),
+          },
+          {
+            label: 'Closed',
+            value: miner.totalClosedPrs ?? 0,
+            color: isEligible
+              ? muiTheme.palette.status.closed
+              : alpha(muiTheme.palette.text.tertiary, INACTIVE_OPACITY),
+          },
+        ];
 
   return (
     <Box
@@ -378,29 +410,7 @@ const PrimaryStatsRow: React.FC<PrimaryStatsRowProps> = ({
         alignItems: 'center',
       }}
     >
-      {[
-        {
-          label: 'Merged',
-          value: miner.totalMergedPrs ?? 0,
-          color: isEligible
-            ? STATUS_COLORS.merged
-            : alpha(muiTheme.palette.text.tertiary, INACTIVE_OPACITY),
-        },
-        {
-          label: 'Open',
-          value: miner.totalOpenPrs ?? 0,
-          color: isEligible
-            ? alpha(muiTheme.palette.text.primary, 0.84)
-            : alpha(muiTheme.palette.text.tertiary, INACTIVE_OPACITY),
-        },
-        {
-          label: 'Closed',
-          value: miner.totalClosedPrs ?? 0,
-          color: isEligible
-            ? muiTheme.palette.status.closed
-            : alpha(muiTheme.palette.text.tertiary, INACTIVE_OPACITY),
-        },
-      ].map(({ label, value, color }) => (
+      {stats.map(({ label, value, color }) => (
         <Box key={label}>
           <Typography
             sx={(theme) => ({
@@ -468,131 +478,3 @@ const PrimaryStatsRow: React.FC<PrimaryStatsRowProps> = ({
   );
 };
 
-interface IssueStatsSectionProps {
-  miner: MinerStats;
-  isEligible: boolean;
-  textColor: string;
-}
-
-const IssueStatsSection: React.FC<IssueStatsSectionProps> = ({
-  miner,
-  isEligible,
-  textColor,
-}) => {
-  const muiTheme = useTheme();
-
-  return (
-    <Box
-      sx={(theme) => ({
-        pt: 0.35,
-        borderTop: `1px solid ${theme.palette.border.light}`,
-      })}
-    >
-      <Typography
-        sx={{
-          fontFamily: FONTS.mono,
-          fontSize: '0.7rem',
-          fontWeight: 700,
-          color: muiTheme.palette.status.open,
-          minWidth: 28,
-          textTransform: 'uppercase',
-          mb: 0.35,
-          letterSpacing: '0.04em',
-        }}
-      >
-        Issues
-      </Typography>
-      <Box
-        sx={{
-          display: 'grid',
-          gridTemplateColumns: '1fr 1fr 1fr auto',
-          gap: 1,
-          alignItems: 'center',
-        }}
-      >
-        {[
-          {
-            label: 'Solved',
-            value: miner.totalSolvedIssues ?? 0,
-            color: isEligible ? STATUS_COLORS.merged : textColor,
-          },
-          {
-            label: 'Open',
-            value: miner.totalOpenIssues ?? 0,
-            color: isEligible
-              ? alpha(muiTheme.palette.text.primary, 0.84)
-              : textColor,
-          },
-          {
-            label: 'Closed',
-            value: miner.totalClosedIssues ?? 0,
-            color: isEligible ? muiTheme.palette.status.closed : textColor,
-          },
-        ].map(({ label, value, color }) => (
-          <Box key={label}>
-            <Typography
-              sx={(theme) => ({
-                fontFamily: FONTS.mono,
-                fontSize: '0.6rem',
-                color: isEligible
-                  ? theme.palette.status.open
-                  : alpha(muiTheme.palette.text.tertiary, INACTIVE_OPACITY),
-                textTransform: 'uppercase',
-                mb: 0.2,
-              })}
-            >
-              {label}
-            </Typography>
-            <Typography
-              sx={{
-                fontFamily: FONTS.mono,
-                fontSize: '0.85rem',
-                color,
-                fontWeight: 600,
-              }}
-            >
-              {value}
-            </Typography>
-          </Box>
-        ))}
-        <Box
-          sx={(theme) => ({
-            textAlign: 'right',
-            borderLeft: `1px solid ${
-              isEligible
-                ? theme.palette.border.light
-                : theme.palette.border.subtle
-            }`,
-            pl: 1.5,
-          })}
-        >
-          <Typography
-            sx={(theme) => ({
-              fontFamily: FONTS.mono,
-              fontSize: '0.6rem',
-              color: isEligible
-                ? theme.palette.status.open
-                : alpha(muiTheme.palette.text.tertiary, INACTIVE_OPACITY),
-              textTransform: 'uppercase',
-              mb: 0.2,
-            })}
-          >
-            Issues
-          </Typography>
-          <Typography
-            sx={{
-              fontFamily: FONTS.mono,
-              fontSize: '0.9rem',
-              color: isEligible ? muiTheme.palette.text.primary : textColor,
-              fontWeight: 700,
-            }}
-          >
-            {(miner.totalSolvedIssues ?? 0) +
-              (miner.totalOpenIssues ?? 0) +
-              (miner.totalClosedIssues ?? 0)}
-          </Typography>
-        </Box>
-      </Box>
-    </Box>
-  );
-};


### PR DESCRIPTION
Fixes #277

## Summary
On the Discoveries page (`/discoveries`), each miner card showed two stat rows - one for pull-request activity and one for issue-discovery activity. Since the page is scoped to issue discovery, the PR row is noise. This PR makes the card fully variant-aware: on the Discoveries page it shows only issue counts (Solved / Open / Closed) plus the discovery score, while the OSS Contributions page is unchanged.

Also fixes a visual inconsistency where the circular indicator's donut segments came from PR counts even though the overlaid percentage was issue credibility. Donut and percentage now agree.

## What changed
- `PrimaryStatsRow` in `MinerCard.tsx` now takes a `variant` prop and picks between PR stats (Merged / Open / Closed + Score) and Issue stats (Solved / Open / Closed + discovery score).
- The pie chart's dataset now branches on `variant`: discoveries → issue state counts; oss → PR state counts.
- `MinerCardFooter` no longer appends a separate `IssueStatsSection` on discoveries - a single row via `PrimaryStatsRow` covers both views.
- Deleted the now-unused `IssueStatsSection` component (~120 lines of duplicated styling gone).

## Type of Change
- [x] Enhancement / UX correctness

## Testing
- [ ] `npm run build`
- [ ] `npm run lint:fix`
- [ ] Manual on `/top-miners` (OSS Contributions view): cards show Merged / Open / Closed PRs + Score, donut matches PR merged/open/closed. Unchanged from today.
- [ ] Manual on `/discoveries`: cards show Solved / Open / Closed issues + discovery score, donut segments match those issue counts, percent in the middle (issue credibility) no longer disagrees with the donut.
- [ ] Ineligible miners still render greyed-out correctly on both variants.

## Checklist
- [x] No new dependencies
- [x] One file touched (`src/components/leaderboard/MinerCard.tsx`)
- [x] No data/API changes — uses fields already present on `MinerStats`
- [x] OSS view unchanged
- [x] Net line reduction (duplicated section removed)


## Screenshot to upload

<img width="1618" height="797" alt="image" src="https://github.com/user-attachments/assets/aaf0a003-445b-43c2-934d-515005a9845a" />
