### PR TITLE
fix(miners): Score sort matches displayed value and Repository is sortable

### DIFF
--- a/src/components/miners/MinerPRsTable.tsx
+++ b/src/components/miners/MinerPRsTable.tsx
@@ -36,10 +36,31 @@ import { useNavigate, useSearchParams } from 'react-router-dom';
 import ExplorerFilterButton from './ExplorerFilterButton';
 import { type MinerStatusFilter } from '../../utils/ExplorerUtils';
 
-type PrSortField = 'number' | 'score' | 'lines' | 'date';
+type PrSortField = 'number' | 'repository' | 'score' | 'lines' | 'date';
 type SortDir = 'asc' | 'desc';
 
 const PAGE_SIZE = 20;
+
+// Direction applied when a user first clicks a column header — string
+// columns feel natural ascending, numeric/date columns descending.
+const DEFAULT_SORT_DIR: Record<PrSortField, SortDir> = {
+  number: 'desc',
+  repository: 'asc',
+  score: 'desc',
+  lines: 'desc',
+  date: 'desc',
+};
+
+// Mirrors the Score cell's render logic so clicking the Score header
+// sorts by what users actually see: merged → score, open → collateral,
+// closed-unmerged → treated as zero.
+const getEffectiveScore = (pr: CommitLog): number => {
+  if (pr.prState === 'CLOSED' && !pr.mergedAt) return 0;
+  if (!pr.mergedAt && pr.collateralScore) {
+    return parseFloat(pr.collateralScore || '0');
+  }
+  return parseFloat(pr.score || '0');
+};
 
 const tooltipSlotProps = {
   tooltip: {
@@ -112,7 +133,7 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
         setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
       } else {
         setSortField(field);
-        setSortDir('desc');
+        setSortDir(DEFAULT_SORT_DIR[field]);
       }
       setPage(0);
     },
@@ -149,8 +170,12 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
         case 'number':
           cmp = a.pullRequestNumber - b.pullRequestNumber;
           break;
+        case 'repository':
+          cmp = a.repository.localeCompare(b.repository);
+          if (cmp === 0) cmp = a.pullRequestNumber - b.pullRequestNumber;
+          break;
         case 'score':
-          cmp = parseFloat(a.score || '0') - parseFloat(b.score || '0');
+          cmp = getEffectiveScore(a) - getEffectiveScore(b);
           break;
         case 'lines':
           cmp = a.additions + a.deletions - (b.additions + b.deletions);
@@ -408,7 +433,18 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
                     Title
                   </TableCell>
                   <TableCell sx={{ ...headerCellStyle, width: '25%' }}>
-                    Repository
+                    <TableSortLabel
+                      active={sortField === 'repository'}
+                      direction={
+                        sortField === 'repository'
+                          ? sortDir
+                          : DEFAULT_SORT_DIR.repository
+                      }
+                      onClick={() => handleSort('repository')}
+                      sx={sortLabelSx}
+                    >
+                      Repository
+                    </TableSortLabel>
                   </TableCell>
                   <TableCell
                     align="right"


### PR DESCRIPTION
## Summary

On the Miner Details page's PR table (`/miners/details?githubId=<id>&tab=pull-requests`):

- **Score column sort was broken for open PRs.** The comparator read `pr.score` unconditionally while the cell's render fallback shows `collateralScore` for open PRs, `score` for merged PRs, and `-` for closed-unmerged. Every open PR collapsed to sort key `0` and clicking Score never reordered them. Verified against miner `42954461`: 17 open PRs, all `pr.score = "0.000000"`, `collateralScore` ranging from `0.001` to `0.370` → old comparator had 1 distinct sort key, new comparator has 17.
- **Repository column was not sortable.** The header was a plain `<TableCell>Repository</TableCell>` with no click target, even though the other five columns are sortable.

### Changes — `src/components/miners/MinerPRsTable.tsx`

1. **`getEffectiveScore(pr)` helper** mirrors the Score cell's render fallback exactly (`CLOSED && !mergedAt → 0`, `!mergedAt && collateralScore → parseFloat(collateralScore)`, else `parseFloat(score)`). Used in the `'score'` sort case so the sort key matches the displayed value.
2. **`'repository'` added to `PrSortField`** with `a.repository.localeCompare(b.repository)` and a `pullRequestNumber` tiebreaker. Within a single repo, rows get a deterministic order that flips with the primary sort direction.
3. **`DEFAULT_SORT_DIR: Record<PrSortField, SortDir>` map** centralizes each column's natural idle direction (string columns ascending, numeric/date descending). `handleSort` reads from it instead of branching on the field name, so adding Title/Author sort in the future is a one-line map entry.
4. **Repository header wrapped in `<TableSortLabel>`** consistent with PR #, +/-, Score, Date. Idle-state direction pulled from `DEFAULT_SORT_DIR.repository`.

Diff stat: **1 file, +40 / −4**.

## Related Issues

Closes #276

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

**Before:** 

https://github.com/user-attachments/assets/49bceb35-5d15-4e45-be55-096c3185fa98

Clicking Score on miner `42954461` leaves the open-PR rows (marked "Collateral") in API order. Repository header is static.

**After:** 

https://github.com/user-attachments/assets/b26870e1-8835-4233-bdbe-61b91bf6b6bf

Same miner, same clicks. Score now reorders open-PR rows by their displayed collateral value (highest-first, then lowest-first on toggle). Repository is a sortable header that groups rows by `owner/repo` with a `pullRequestNumber` tiebreaker.

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes