### PR TITLE
fix: hide default webkit scrollbar button artifact in repo weights table

### DIFF
--- a/src/components/repositories/RepositoryWeightsTable.tsx
+++ b/src/components/repositories/RepositoryWeightsTable.tsx
@@ -486,6 +486,14 @@ const RepositoryWeightsTable: React.FC = () => {
                 backgroundColor: 'rgba(255, 255, 255, 0.2)',
               },
             },
+            '&::-webkit-scrollbar-button': {
+              display: 'none',
+              height: 0,
+              width: 0,
+            },
+            '&::-webkit-scrollbar-corner': {
+              backgroundColor: 'transparent',
+            },
           }}
         >
           <Table stickyHeader>

--- a/src/components/repositories/RepositoryWeightsTable.tsx
+++ b/src/components/repositories/RepositoryWeightsTable.tsx
@@ -315,11 +315,7 @@ const RepositoryWeightsTable: React.FC = () => {
 
   return (
     <Box ref={containerRef}>
-      <Box
-        sx={{
-          borderBottom: '1px solid rgba(255, 255, 255, 0.1)',
-        }}
-      >
+      <Box sx={{ mb: 3 }}>
         <Box sx={{ p: 2, pb: 1 }}>
           <Typography variant="body2" color="text.secondary">
             Contribute to any of these projects to gain score and earn emissions
@@ -485,14 +481,6 @@ const RepositoryWeightsTable: React.FC = () => {
               '&:hover': {
                 backgroundColor: 'rgba(255, 255, 255, 0.2)',
               },
-            },
-            '&::-webkit-scrollbar-button': {
-              display: 'none',
-              height: 0,
-              width: 0,
-            },
-            '&::-webkit-scrollbar-corner': {
-              backgroundColor: 'transparent',
             },
           }}
         >


### PR DESCRIPTION
Fixes #280 
## Summary
Fixes a visual artifact on the Onboard → Repositories tab: when the table is scrollable (e.g. Rows ≥ 25), a thin line appears above the vertical scrollbar in the top-right corner.

## Root cause
In `src/components/repositories/RepositoryWeightsTable.tsx`, the `<Box>` wrapping the description + controls has a `borderBottom: '1px solid rgba(255,255,255,0.1)'`. That wrapper spans the full component width. The `TableContainer` beneath it is `overflow: auto`, so when the scrollbar appears it narrows the scrollable area by ~8px — but the border above doesn't shrink with it, leaving ~8px of border hanging over the top of the scrollbar track. That's the "dash" in the issue.

The sibling `LanguageWeightsTable` doesn't have this bug because it separates its controls from its table with `mb: 3` spacing instead of a full-width border, and the sticky header cells supply their own per-cell `borderBottom` that naturally stops where the scrollbar starts.

## Fix
Match the pattern used by `LanguageWeightsTable`:

- Remove `borderBottom: '1px solid rgba(255,255,255,0.1)'` from the outer header wrapper in `RepositoryWeightsTable.tsx`.
- Replace it with `mb: 3` for breathing room.

The sticky-header `borderBottom` on each `TableCell` already provides the visible separator between controls and rows, and it correctly shrinks with the scrollable area.

## Type of Change
- [x] Bug fix (visual)

## Testing
- [ ] `npm run build`
- [ ] `npm run lint:fix`
- [ ] Manual on `/onboard?tab=repositories`: set Rows to 25 → scrollbar appears → no dash above it.
- [ ] Manual on `/onboard?tab=languages`: unchanged (verifies the fix just aligns the two tabs).

## Checklist
- [x] No behavior change
- [x] No new dependencies
- [x] One file touched
- [x] Matches the pattern already used by `LanguageWeightsTable`

## Screenshots
<img width="1649" height="771" alt="image" src="https://github.com/user-attachments/assets/7ed1332e-7f60-4335-9056-548381e1e5f4" />
