### PR TITLE
feat: make Repository Pull Requests table columns sortable

### DIFF
--- a/src/components/repositories/RepositoryPRsTable.tsx
+++ b/src/components/repositories/RepositoryPRsTable.tsx
@@ -124,10 +124,7 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
           );
         case 'score':
         default:
-          return cmpNum(
-            parseFloat(a.score || '0'),
-            parseFloat(b.score || '0'),
-          );
+          return cmpNum(parseFloat(a.score || '0'), parseFloat(b.score || '0'));
       }
     });
   }, [filteredPRs, sortField, sortOrder]);

--- a/src/components/repositories/RepositoryPRsTable.tsx
+++ b/src/components/repositories/RepositoryPRsTable.tsx
@@ -9,11 +9,23 @@ import {
   TableContainer,
   TableHead,
   TableRow,
+  TableSortLabel,
   CircularProgress,
   Avatar,
   Chip,
   Stack,
 } from '@mui/material';
+
+type PrSortField =
+  | 'pullRequestNumber'
+  | 'pullRequestTitle'
+  | 'author'
+  | 'commitCount'
+  | 'lines'
+  | 'score'
+  | 'status'
+  | 'mergedAt';
+type SortOrder = 'asc' | 'desc';
 import { useAllPrs } from '../../api';
 import { useNavigate } from 'react-router-dom';
 import theme, { scrollbarSx } from '../../theme';
@@ -38,6 +50,19 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
   const [filter, setFilter] = useState<'all' | 'open' | 'closed' | 'merged'>(
     state,
   );
+  const [sortField, setSortField] = useState<PrSortField>('score');
+  const [sortOrder, setSortOrder] = useState<SortOrder>('desc');
+
+  const handleSort = (field: PrSortField) => {
+    if (sortField === field) {
+      setSortOrder((o) => (o === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setSortField(field);
+      setSortOrder(
+        field === 'pullRequestTitle' || field === 'author' ? 'asc' : 'desc',
+      );
+    }
+  };
 
   // Fetch ALL PRs at once to enable client-side filtering and accurate counts
   // This avoids server roundtrips on filter change and provides instant UI feedback
@@ -64,13 +89,48 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
     return allPRs;
   }, [allPRs, filter]);
 
-  const sortedPRs = useMemo(
-    () =>
-      [...filteredPRs].sort(
-        (a, b) => parseFloat(b.score || '0') - parseFloat(a.score || '0'),
-      ),
-    [filteredPRs],
-  );
+  const sortedPRs = useMemo(() => {
+    const dir = sortOrder === 'asc' ? 1 : -1;
+    const cmpStr = (a = '', b = '') => a.localeCompare(b) * dir;
+    const cmpNum = (a = 0, b = 0) => (a - b) * dir;
+    const stateRank = (pr: (typeof filteredPRs)[number]) => {
+      const s = pr.prState?.toUpperCase() || (pr.mergedAt ? 'MERGED' : 'OPEN');
+      return (
+        ({ OPEN: 0, MERGED: 1, CLOSED: 2 } as Record<string, number>)[s] ?? 3
+      );
+    };
+
+    return [...filteredPRs].sort((a, b) => {
+      switch (sortField) {
+        case 'pullRequestNumber':
+          return cmpNum(a.pullRequestNumber, b.pullRequestNumber);
+        case 'pullRequestTitle':
+          return cmpStr(a.pullRequestTitle, b.pullRequestTitle);
+        case 'author':
+          return cmpStr(a.author, b.author);
+        case 'commitCount':
+          return cmpNum(a.commitCount, b.commitCount);
+        case 'lines':
+          return cmpNum(
+            (a.additions ?? 0) + (a.deletions ?? 0),
+            (b.additions ?? 0) + (b.deletions ?? 0),
+          );
+        case 'status':
+          return (stateRank(a) - stateRank(b)) * dir;
+        case 'mergedAt':
+          return cmpNum(
+            a.mergedAt ? new Date(a.mergedAt).getTime() : 0,
+            b.mergedAt ? new Date(b.mergedAt).getTime() : 0,
+          );
+        case 'score':
+        default:
+          return cmpNum(
+            parseFloat(a.score || '0'),
+            parseFloat(b.score || '0'),
+          );
+      }
+    });
+  }, [filteredPRs, sortField, sortOrder]);
 
   if (isLoading) {
     return (
@@ -218,21 +278,81 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
           <Table stickyHeader>
             <TableHead>
               <TableRow>
-                <TableCell sx={headerCellStyle}>PR #</TableCell>
-                <TableCell sx={headerCellStyle}>Title</TableCell>
-                <TableCell sx={headerCellStyle}>Author</TableCell>
-                <TableCell align="right" sx={headerCellStyle}>
-                  Commits
+                <TableCell sx={headerCellStyle}>
+                  <TableSortLabel
+                    active={sortField === 'pullRequestNumber'}
+                    direction={
+                      sortField === 'pullRequestNumber' ? sortOrder : 'desc'
+                    }
+                    onClick={() => handleSort('pullRequestNumber')}
+                  >
+                    PR #
+                  </TableSortLabel>
+                </TableCell>
+                <TableCell sx={headerCellStyle}>
+                  <TableSortLabel
+                    active={sortField === 'pullRequestTitle'}
+                    direction={
+                      sortField === 'pullRequestTitle' ? sortOrder : 'asc'
+                    }
+                    onClick={() => handleSort('pullRequestTitle')}
+                  >
+                    Title
+                  </TableSortLabel>
+                </TableCell>
+                <TableCell sx={headerCellStyle}>
+                  <TableSortLabel
+                    active={sortField === 'author'}
+                    direction={sortField === 'author' ? sortOrder : 'asc'}
+                    onClick={() => handleSort('author')}
+                  >
+                    Author
+                  </TableSortLabel>
                 </TableCell>
                 <TableCell align="right" sx={headerCellStyle}>
-                  +/-
+                  <TableSortLabel
+                    active={sortField === 'commitCount'}
+                    direction={sortField === 'commitCount' ? sortOrder : 'desc'}
+                    onClick={() => handleSort('commitCount')}
+                  >
+                    Commits
+                  </TableSortLabel>
                 </TableCell>
                 <TableCell align="right" sx={headerCellStyle}>
-                  Score
+                  <TableSortLabel
+                    active={sortField === 'lines'}
+                    direction={sortField === 'lines' ? sortOrder : 'desc'}
+                    onClick={() => handleSort('lines')}
+                  >
+                    +/-
+                  </TableSortLabel>
                 </TableCell>
-                <TableCell sx={headerCellStyle}>Status</TableCell>
                 <TableCell align="right" sx={headerCellStyle}>
-                  Merged
+                  <TableSortLabel
+                    active={sortField === 'score'}
+                    direction={sortField === 'score' ? sortOrder : 'desc'}
+                    onClick={() => handleSort('score')}
+                  >
+                    Score
+                  </TableSortLabel>
+                </TableCell>
+                <TableCell sx={headerCellStyle}>
+                  <TableSortLabel
+                    active={sortField === 'status'}
+                    direction={sortField === 'status' ? sortOrder : 'asc'}
+                    onClick={() => handleSort('status')}
+                  >
+                    Status
+                  </TableSortLabel>
+                </TableCell>
+                <TableCell align="right" sx={headerCellStyle}>
+                  <TableSortLabel
+                    active={sortField === 'mergedAt'}
+                    direction={sortField === 'mergedAt' ? sortOrder : 'desc'}
+                    onClick={() => handleSort('mergedAt')}
+                  >
+                    Merged
+                  </TableSortLabel>
                 </TableCell>
               </TableRow>
             </TableHead>


### PR DESCRIPTION
## Summary
On the Repository page's Pull Requests tab, the table columns are now clickable and sortable (PR #, Title, Author, Commits, +/-, Score, Status, Merged). Default sort remains **Score desc** so the current UX is preserved. Matches the `TableSortLabel`-based sort pattern already used in `RepositoryWeightsTable` and `LanguageWeightsTable`.

## What changed
- Added `sortField` / `sortOrder` state with a `handleSort` toggle that flips asc ↔ desc on the active column and jumps to a sensible default when switching columns (strings default to asc, numbers/dates default to desc).
- Replaced the hardcoded score-only sort in `sortedPRs` with a dynamic comparator that handles:
  - numeric fields (`pullRequestNumber`, `commitCount`, `score`, total `lines` = additions + deletions)
  - string fields (`pullRequestTitle`, `author`) via `localeCompare`
  - `mergedAt` via `new Date().getTime()` with unmerged PRs sorting to 0
  - `status` via a stable rank order (OPEN → MERGED → CLOSED)
- Wrapped every header cell in `<TableSortLabel>` so users see MUI's standard arrow indicator on the active column.

No behavior change on initial render (default is still score desc). No new API calls; all sorting is client-side on the already-fetched PR list.

## Type of Change
- [x] Enhancement / UX

## Testing
Manual on any repo Pull Requests tab:
  - Default render shows score descending (arrow on Score header)
  - Click a column → rows re-sort, arrow moves to that column
  - Click the same column again → asc/desc flips
  - String columns (Title, Author) default to asc on first click; numeric / date columns default to desc
  - Merged column sorts PRs with `mergedAt` above the dashed placeholders
  - Status column groups OPEN / MERGED / CLOSED consistently
  - Filter chips (All/Open/Merged/Closed) still work alongside sort

## Checklist
- [x] No new dependencies
- [x] One file touched
- [x] Follows the `TableSortLabel` pattern already used elsewhere in the repo
- [x] Default sort unchanged (score desc)

## Media to upload

https://github.com/user-attachments/assets/1e116dc8-5a46-4f42-b41c-2f32b38651cb

Fixes #282 