### PR TITLE
refactor: extract formatTimeAgo to shared utils

### DIFF
--- a/src/components/miners/MinerScoreCard.tsx
+++ b/src/components/miners/MinerScoreCard.tsx
@@ -34,23 +34,7 @@ import {
   calculateDynamicOpenPrThreshold,
   parseNumber,
 } from '../../utils/ExplorerUtils';
-import { credibilityColor } from '../../utils/format';
-
-const formatTimeAgo = (date: Date): string => {
-  const now = new Date();
-  const diffMs = now.getTime() - date.getTime();
-  const diffMins = Math.floor(diffMs / (1000 * 60));
-  const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
-  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
-  if (diffMins < 1) return 'just now';
-  if (diffMins < 60) return `${diffMins}m ago`;
-  if (diffHours < 24) {
-    const mins = diffMins % 60;
-    return mins > 0 ? `${diffHours}h ${mins}m ago` : `${diffHours}h ago`;
-  }
-  if (diffDays === 1) return '1 day ago';
-  return `${diffDays} days ago`;
-};
+import { credibilityColor, formatTimeAgo } from '../../utils/format';
 
 const openPrColor = (open: number, threshold: number) => {
   if (open >= threshold) return RISK_COLORS.exceeded;

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -70,3 +70,19 @@ export const credibilityColor = (cred: number): string => {
   if (cred >= 0.3) return CREDIBILITY_COLORS.low;
   return CREDIBILITY_COLORS.poor;
 };
+
+export const formatTimeAgo = (date: Date): string => {
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffMins = Math.floor(diffMs / (1000 * 60));
+  const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+  if (diffMins < 1) return 'just now';
+  if (diffMins < 60) return `${diffMins}m ago`;
+  if (diffHours < 24) {
+    const mins = diffMins % 60;
+    return mins > 0 ? `${diffHours}h ${mins}m ago` : `${diffHours}h ago`;
+  }
+  if (diffDays === 1) return '1 day ago';
+  return `${diffDays} days ago`;
+};


### PR DESCRIPTION
## Summary

- Moves the locally-defined `formatTimeAgo` out of `MinerScoreCard.tsx` into `src/utils/format.ts`
- Updates the import in `MinerScoreCard.tsx` to use the shared utility
- Follows the same pattern as `formatDate` (#214) and `credibilityColor` (#215)

Net: 17 lines removed from component, 13 lines added to shared util.

## Test plan

- [x] `npm run format:check` — passes
- [x] `npm run lint` — passes (0 warnings)
- [x] `npm run build` — clean build, no TS errors
- [x] MinerScoreCard "Updated X ago" chip still renders correctly
