### PR TITLE
refactor: replace inline scrollbar styles with shared scrollbarSx

### DIFF
--- a/src/components/dashboard/LiveCommitLog.tsx
+++ b/src/components/dashboard/LiveCommitLog.tsx
@@ -12,7 +12,7 @@ import {
   Chip,
 } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
-import theme, { REPO_OWNER_AVATAR_BACKGROUNDS } from '../../theme';
+import theme, { REPO_OWNER_AVATAR_BACKGROUNDS, scrollbarSx } from '../../theme';
 import { useInfiniteCommitLog, usePullRequestDetails } from '../../api';
 
 const MONTH_SHORT = [
@@ -448,13 +448,7 @@ const LiveCommitLog: React.FC = () => {
               overflowY: 'auto',
               overflowX: 'hidden',
               pr: 1,
-              '&::-webkit-scrollbar': { width: '6px' },
-              '&::-webkit-scrollbar-track': { backgroundColor: 'transparent' },
-              '&::-webkit-scrollbar-thumb': {
-                backgroundColor: theme.palette.border.light,
-                borderRadius: '3px',
-                '&:hover': { backgroundColor: theme.palette.border.medium },
-              },
+              ...scrollbarSx,
             }}
           >
             <Stack spacing={isMobile ? 1 : isTablet ? 1.25 : 1}>

--- a/src/components/layout/GlobalSearchBar.tsx
+++ b/src/components/layout/GlobalSearchBar.tsx
@@ -18,6 +18,7 @@ import {
 } from '@mui/material';
 import { type Theme } from '@mui/material/styles';
 import SearchIcon from '@mui/icons-material/Search';
+import { scrollbarSx } from '../../theme';
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
 import CloseIcon from '@mui/icons-material/Close';
 import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
@@ -612,16 +613,7 @@ const GlobalSearchBar: React.FC = () => {
             backgroundColor: theme.palette.background.default,
             maxHeight: 'min(420px, calc(100vh - 96px))',
             overflowY: 'auto',
-            '&::-webkit-scrollbar': {
-              width: '8px',
-            },
-            '&::-webkit-scrollbar-track': {
-              backgroundColor: 'transparent',
-            },
-            '&::-webkit-scrollbar-thumb': {
-              backgroundColor: theme.palette.border.light,
-              borderRadius: 1,
-            },
+            ...scrollbarSx,
           })}
         >
           {isLoading && (

--- a/src/components/miners/MinerPRsTable.tsx
+++ b/src/components/miners/MinerPRsTable.tsx
@@ -26,6 +26,7 @@ import {
   NavigateNext as NextIcon,
 } from '@mui/icons-material';
 import { useMinerPRs, type CommitLog } from '../../api';
+import { scrollbarSx } from '../../theme';
 import {
   getPrStatusCounts,
   isClosedUnmergedPr,
@@ -376,16 +377,7 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
             sx={{
               overflowY: 'auto',
               overflowX: 'auto',
-              '&::-webkit-scrollbar': {
-                width: { xs: '6px', sm: '8px' },
-                height: { xs: '6px', sm: '8px' },
-              },
-              '&::-webkit-scrollbar-track': { backgroundColor: 'transparent' },
-              '&::-webkit-scrollbar-thumb': {
-                backgroundColor: 'border.light',
-                borderRadius: '4px',
-                '&:hover': { backgroundColor: 'border.medium' },
-              },
+              ...scrollbarSx,
             }}
           >
             <Table

--- a/src/pages/search/SearchResultsTable.tsx
+++ b/src/pages/search/SearchResultsTable.tsx
@@ -16,6 +16,7 @@ import {
 } from '@mui/material';
 import { type SxProps, type Theme } from '@mui/material/styles';
 import { type SystemStyleObject } from '@mui/system';
+import { scrollbarSx } from '../../theme';
 
 export type SearchResultsTableColumn<T> = {
   key: string;
@@ -75,19 +76,10 @@ const searchTableCardSx = (theme: Theme) => ({
   overflow: 'hidden',
 });
 
-const searchTableContainerSx = (theme: Theme) => ({
+const searchTableContainerSx = {
   overflowX: 'auto',
-  '&::-webkit-scrollbar': {
-    height: 8,
-  },
-  '&::-webkit-scrollbar-track': {
-    backgroundColor: theme.palette.surface.subtle,
-  },
-  '&::-webkit-scrollbar-thumb': {
-    backgroundColor: theme.palette.border.light,
-    borderRadius: 1,
-  },
-});
+  ...scrollbarSx,
+};
 
 const searchTableSx = {
   tableLayout: 'fixed',


### PR DESCRIPTION
## Summary

- Replaces raw `&::-webkit-scrollbar` CSS blocks in 4 files with the shared `scrollbarSx` constant from `src/theme.ts`
- Follows the same pattern established by #249, which unified scrollbar styles across the rest of the codebase
- No functional changes — purely cosmetic/consistency cleanup

Files updated:
- `src/pages/search/SearchResultsTable.tsx`
- `src/components/layout/GlobalSearchBar.tsx`
- `src/components/miners/MinerPRsTable.tsx`
- `src/components/dashboard/LiveCommitLog.tsx`

Net: 10 insertions, 40 deletions across 4 files.

## Test plan

- [x] `npm run format:check` — passes
- [x] `npm run lint` — passes (0 warnings)
- [x] `npm run build` — clean build, no TS errors
- [x] Scrollbars render correctly in Search results, Global search dropdown, Miner PRs table, and Live commit log
