### PR TITLE
fix: show collateral score for open PRs and rename Merged column to Date

### DIFF
--- a/src/components/repositories/RepositoryPRsTable.tsx
+++ b/src/components/repositories/RepositoryPRsTable.tsx
@@ -232,7 +232,7 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
                 </TableCell>
                 <TableCell sx={headerCellStyle}>Status</TableCell>
                 <TableCell align="right" sx={headerCellStyle}>
-                  Merged
+                  Date
                 </TableCell>
               </TableRow>
             </TableHead>
@@ -316,15 +316,34 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
                     </Box>
                   </TableCell>
                   <TableCell align="right" sx={bodyCellStyle}>
-                    <Typography
-                      sx={{
-                        fontFamily: '"JetBrains Mono", monospace',
-                        fontSize: '0.75rem',
-                        fontWeight: 600,
-                      }}
-                    >
-                      {parseFloat(pr.score || '0').toFixed(4)}
-                    </Typography>
+                    {(() => {
+                      const isOpen =
+                        (pr.prState?.toUpperCase() ||
+                          (pr.mergedAt ? 'MERGED' : 'OPEN')) === 'OPEN';
+                      const collateral = parseFloat(pr.collateralScore || '0');
+                      const showCollateral = isOpen && collateral > 0;
+                      return (
+                        <Typography
+                          sx={{
+                            fontFamily: '"JetBrains Mono", monospace',
+                            fontSize: '0.75rem',
+                            fontWeight: 600,
+                            color: showCollateral
+                              ? theme.palette.status.open
+                              : 'text.primary',
+                          }}
+                          title={
+                            showCollateral
+                              ? 'Collateral score applied while this PR is open'
+                              : undefined
+                          }
+                        >
+                          {showCollateral
+                            ? `-${collateral.toFixed(4)}`
+                            : parseFloat(pr.score || '0').toFixed(4)}
+                        </Typography>
+                      );
+                    })()}
                   </TableCell>
                   <TableCell sx={bodyCellStyle}>
                     {(() => {
@@ -355,9 +374,9 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
                     })()}
                   </TableCell>
                   <TableCell align="right" sx={bodyCellStyle}>
-                    {pr.mergedAt
-                      ? new Date(pr.mergedAt).toLocaleDateString()
-                      : '-'}
+                    {new Date(
+                      pr.mergedAt || pr.prCreatedAt,
+                    ).toLocaleDateString()}
                   </TableCell>
                 </TableRow>
               ))}


### PR DESCRIPTION
## Summary
Fixes #288 . Two small corrections to the Repository → Pull Requests table:

1. **Score column on OPEN PRs** now shows the PR's **collateral score** (already on `CommitLog` as `collateralScore`) styled in the open-status color and prefixed with `-` to signal it's a penalty. Open PRs no longer render a uniform `0.0000` column. Merged and closed PRs are unchanged - still show `score`.
2. The **"Merged"** header becomes **"Date"** and the cell now shows `mergedAt` for merged PRs and `prCreatedAt` otherwise. The column is no longer a sea of dashes on *All* / *Open* / *Closed* filters.

## Why
- Open PRs haven't been fully scored yet, so their `score` field is `0`. Showing `0.0000` gave miners and reviewers no actionable information. The collateral score is what's actively being applied to the miner while the PR sits open — it's the meaningful number.
- The Merged column was wasted whitespace for any PR state other than MERGED. Renaming to Date and backfilling with the creation date keeps the column useful across every filter.

## What changed
- `src/components/repositories/RepositoryPRsTable.tsx`:
  - Score cell now branches on `prState`: OPEN + non-zero `collateralScore` → display `-X.XXXX` in `status.open` color with a tooltip; otherwise display `score.toFixed(4)` in primary text color (current behavior).
  - Header cell renamed `Merged` → `Date`.
  - Date cell now uses `pr.mergedAt ?? pr.prCreatedAt`.

No new data fetched, no new dependencies. `CommitLog` already exposes `collateralScore` and `prCreatedAt`.

## Type of Change
- [x] Bug fix / UX correctness

## Testing
- [ ] `npm run build`
- [ ] `npm run lint:fix`
- [ ] Manual on any repository with a mix of PR states:
  - Score column: open PRs show `-{collateral}` in the open-status color with a tooltip; merged / closed rows show the normal score.
  - Open PRs with `collateralScore = 0` (rare edge case) fall back to showing `0.0000` rather than `-0.0000`.
  - Date column: merged rows show merge date; open / closed rows show creation date; no more dashes under normal data.
  - Hovering a negative collateral cell surfaces the tooltip "Collateral score applied while this PR is open".
- [ ] Mobile viewport: column width doesn't change meaningfully.

## Checklist
- [x] No new dependencies
- [x] One file touched
- [x] No API changes
- [x] Behavior unchanged for MERGED rows

## Video to upload

https://github.com/user-attachments/assets/7189d6b0-0989-41a7-9e5b-a9cf17fbe682

