### PR TITLE
refactor: extract getPrStateColor to shared prStatus utils

### DIFF
--- a/src/components/prs/PRDetailsCard.tsx
+++ b/src/components/prs/PRDetailsCard.tsx
@@ -13,6 +13,7 @@ import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import { usePullRequestDetails } from '../../api';
 import { useNavigate } from 'react-router-dom';
 import theme, { RANK_COLORS, STATUS_COLORS } from '../../theme';
+import { getPrStateColor } from '../../utils';
 
 interface PRDetailsCardProps {
   repository: string;
@@ -213,12 +214,10 @@ const PRDetailsCard: React.FC<PRDetailsCardProps> = ({
                 #{pullRequestNumber}
               </Typography>
               {(() => {
-                const statusColor =
-                  prDetails.prState === 'CLOSED'
-                    ? theme.palette.status.closed
-                    : prDetails.prState === 'MERGED'
-                      ? theme.palette.status.merged
-                      : theme.palette.status.open;
+                const statusColor = getPrStateColor(
+                  prDetails.prState,
+                  theme.palette.status,
+                );
                 return (
                   <Box
                     sx={{

--- a/src/components/prs/PRHeader.tsx
+++ b/src/components/prs/PRHeader.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Box, Typography, Avatar, Tooltip, alpha } from '@mui/material';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import { useNavigate } from 'react-router-dom';
-import { formatUsdEstimate } from '../../utils';
+import { formatUsdEstimate, getPrStateColor } from '../../utils';
 import { type PullRequestDetails } from '../../api/models/Dashboard';
 import { STATUS_COLORS } from '../../theme';
 import { getRepositoryOwnerAvatarBackground } from '../leaderboard/types';
@@ -26,12 +26,7 @@ const PRHeader: React.FC<PRHeaderProps> = ({
   const earnedScore = parseFloat(prDetails.earnedScore || '0');
   const predictedUsdPerDay = prDetails.predictedUsdPerDay;
   const ownerAvatarBackground = getRepositoryOwnerAvatarBackground(owner);
-  const statusColor =
-    prDetails.prState === 'CLOSED'
-      ? STATUS_COLORS.closed
-      : prDetails.prState === 'MERGED'
-        ? STATUS_COLORS.merged
-        : STATUS_COLORS.open;
+  const statusColor = getPrStateColor(prDetails.prState, STATUS_COLORS);
 
   return (
     <Box sx={{ mb: 3, display: 'flex', alignItems: 'flex-start', gap: 2 }}>

--- a/src/utils/prStatus.ts
+++ b/src/utils/prStatus.ts
@@ -18,3 +18,13 @@ export const getPrStatusCounts = <T extends PrStatusLike>(prs: T[]) => ({
   merged: prs.filter(isMergedPr).length,
   closed: prs.filter(isClosedUnmergedPr).length,
 });
+
+export const getPrStateColor = (
+  prState: string | null | undefined,
+  statusPalette: { closed: string; merged: string; open: string },
+): string =>
+  prState === 'CLOSED'
+    ? statusPalette.closed
+    : prState === 'MERGED'
+      ? statusPalette.merged
+      : statusPalette.open;


### PR DESCRIPTION
## Summary

- Adds `getPrStateColor(prState, statusPalette)` to `src/utils/prStatus.ts`, alongside the existing `isOpenPr`, `isMergedPr`, etc.
- Replaces the identical `CLOSED/MERGED/else` ternary duplicated verbatim in `PRHeader.tsx` and `PRDetailsCard.tsx`
- Follows the same pattern as `getPrStatusCounts` already in `prStatus.ts`

## Test plan

- [x] `npm run format:check` - passes
- [x] `npm run lint` - passes (0 warnings)
- [x] `npm run build` - clean build, no TS errors
- [x] PR status badge color renders correctly (OPEN/MERGED/CLOSED) in both PR header and PR details card
