### PR TITLE
fix: live commit log animation, timer leak, and related bugs

### DIFF
--- a/src/api/DashboardApi.ts
+++ b/src/api/DashboardApi.ts
@@ -64,12 +64,12 @@ export const useInfiniteCommitLog = (options?: {
 }) => {
   const baseUrl = import.meta.env.VITE_REACT_APP_BASE_URL;
   const limit = 15;
+  const url = '/dash/commits';
+  const requestUrl = baseUrl ? `${baseUrl}${url}` : url;
 
   return useInfiniteQuery({
-    queryKey: ['useInfiniteCommitLog'],
+    queryKey: ['useInfiniteCommitLog', requestUrl, limit],
     queryFn: async ({ pageParam }: { pageParam: number }) => {
-      const url = '/dash/commits';
-      const requestUrl = baseUrl ? `${baseUrl}${url}` : url;
       const { data } = await axios.get<CommitLog[]>(requestUrl, {
         params: { page: pageParam, limit },
       });

--- a/src/components/dashboard/LiveCommitLog.tsx
+++ b/src/components/dashboard/LiveCommitLog.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef } from 'react';
 import {
   Card,
   CardContent,
@@ -14,6 +14,7 @@ import {
 import { useNavigate } from 'react-router-dom';
 import theme from '../../theme';
 import { useInfiniteCommitLog, usePullRequestDetails } from '../../api';
+import { useCommitLogStream } from './useCommitLogStream';
 
 const MONTH_SHORT = [
   'Jan',
@@ -282,9 +283,6 @@ const LiveCommitLog: React.FC = () => {
   const { data, isLoading, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useInfiniteCommitLog({ refetchInterval: 10000 }); // Poll every 10 seconds
 
-  const [logEntries, setLogEntries] = useState<CommitLogEntry[]>([]);
-  const [_seenEntryIds, setSeenEntryIds] = useState<Set<string>>(new Set());
-  const [newEntryIds, setNewEntryIds] = useState<Set<string>>(new Set());
   const logContainerRef = useRef<HTMLDivElement>(null);
   const loadMoreRef = useRef<HTMLDivElement>(null);
 
@@ -294,56 +292,12 @@ const LiveCommitLog: React.FC = () => {
     [data],
   );
 
-  useEffect(() => {
-    if (apiCommits.length === 0) return;
-
-    const getCommitId = (c: CommitLogEntry) =>
-      `${c.pullRequestNumber}-${c.mergedAt || c.prCreatedAt || c.prState || 'OPEN'}`;
-
-    setSeenEntryIds((prevSeen) => {
-      const newSeen = new Set(prevSeen);
-      const novelItems: CommitLogEntry[] = [];
-
-      apiCommits.forEach((c) => {
-        const id = getCommitId(c);
-        if (!newSeen.has(id)) {
-          novelItems.push(c);
-          newSeen.add(id);
-        }
-      });
-
-      if (novelItems.length === 0) return prevSeen;
-
-      // Check if we should prepend or append
-      // If the *first* item in the incoming API list was one of the novel items, assume it's new data (Prepend)
-      // Otherwise append.
-      const firstApiId = getCommitId(apiCommits[0]);
-      const isHeadUpdate = novelItems.some(
-        (c) => getCommitId(c) === firstApiId,
-      );
-
-      setLogEntries((prevLog) => {
-        if (prevLog.length === 0) return apiCommits; // Initial fill
-
-        if (isHeadUpdate) {
-          // Newest items first
-          // Mark for animation
-          const ids = new Set(novelItems.map(getCommitId));
-          setNewEntryIds(ids);
-          setTimeout(() => setNewEntryIds(new Set()), 2000);
-          return [...novelItems, ...prevLog];
-        } else {
-          return [...prevLog, ...novelItems];
-        }
-      });
-
-      return newSeen;
-    });
-  }, [apiCommits]);
+  const { logEntries, newEntryIds } = useCommitLogStream(apiCommits);
 
   // Intersection observer for infinite scroll
   useEffect(() => {
-    if (!loadMoreRef.current) return;
+    const node = loadMoreRef.current;
+    if (!node) return;
 
     const observer = new IntersectionObserver(
       (entries) => {
@@ -354,10 +308,10 @@ const LiveCommitLog: React.FC = () => {
       { threshold: 0.1 },
     );
 
-    observer.observe(loadMoreRef.current);
+    observer.observe(node);
 
     return () => observer.disconnect();
-  }, [hasNextPage, isFetchingNextPage, fetchNextPage, logEntries.length]);
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
 
   return (
     <Card

--- a/src/components/dashboard/useCommitLogStream.ts
+++ b/src/components/dashboard/useCommitLogStream.ts
@@ -1,0 +1,104 @@
+import { useEffect, useRef, useState } from 'react';
+
+interface CommitLike {
+  pullRequestNumber: number;
+  mergedAt: string | null;
+  prCreatedAt: string;
+  prState?: string;
+}
+
+const ANIMATION_DURATION_MS = 2000;
+// Bound the seen-IDs set so a long-lived dashboard doesn't leak memory across hours of polling.
+const MAX_SEEN_IDS = 5000;
+
+const getCommitId = (c: CommitLike) =>
+  `${c.pullRequestNumber}-${c.mergedAt || c.prCreatedAt || c.prState || 'OPEN'}`;
+
+const getCommitTime = (c: CommitLike) => {
+  const t = new Date(c.mergedAt || c.prCreatedAt).getTime();
+  return Number.isFinite(t) ? t : 0;
+};
+
+const trimSet = (set: Set<string>, max: number) => {
+  const overflow = set.size - max;
+  if (overflow <= 0) return;
+  let removed = 0;
+  for (const id of set) {
+    if (removed >= overflow) break;
+    set.delete(id);
+    removed++;
+  }
+};
+
+/**
+ * Tracks an append-only commit log fed by a polling/paginating API.
+ *
+ * - Prepends commits whose timestamp is newer than anything previously seen (head update),
+ *   appends everything else (paginated history).
+ * - Returns the IDs of the most recent head update so the caller can animate them
+ *   for ANIMATION_DURATION_MS.
+ * - Skips animation on the very first fill so initial commits don't all pulse at once.
+ */
+export const useCommitLogStream = <T extends CommitLike>(apiCommits: T[]) => {
+  const [logEntries, setLogEntries] = useState<T[]>([]);
+  const [newEntryIds, setNewEntryIds] = useState<Set<string>>(new Set());
+  const seenIdsRef = useRef<Set<string>>(new Set());
+  const newestTimestampRef = useRef<number>(0);
+  const hasPopulatedRef = useRef<boolean>(false);
+  const animationTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(
+    () => () => {
+      if (animationTimerRef.current) clearTimeout(animationTimerRef.current);
+    },
+    [],
+  );
+
+  useEffect(() => {
+    if (apiCommits.length === 0) return;
+
+    const seen = seenIdsRef.current;
+    const novelItems: T[] = [];
+    for (const c of apiCommits) {
+      const id = getCommitId(c);
+      if (!seen.has(id)) {
+        novelItems.push(c);
+        seen.add(id);
+      }
+    }
+    if (novelItems.length === 0) return;
+
+    trimSet(seen, MAX_SEEN_IDS);
+
+    const incomingMax = novelItems.reduce(
+      (max, c) => Math.max(max, getCommitTime(c)),
+      0,
+    );
+    const isHeadUpdate =
+      hasPopulatedRef.current && incomingMax > newestTimestampRef.current;
+    newestTimestampRef.current = Math.max(
+      newestTimestampRef.current,
+      incomingMax,
+    );
+
+    setLogEntries((prev) =>
+      prev.length === 0
+        ? [...apiCommits]
+        : isHeadUpdate
+          ? [...novelItems, ...prev]
+          : [...prev, ...novelItems],
+    );
+    hasPopulatedRef.current = true;
+
+    if (isHeadUpdate) {
+      setNewEntryIds(new Set(novelItems.map(getCommitId)));
+      if (animationTimerRef.current) clearTimeout(animationTimerRef.current);
+      animationTimerRef.current = setTimeout(() => {
+        setNewEntryIds(new Set());
+        animationTimerRef.current = null;
+      }, ANIMATION_DURATION_MS);
+    }
+  }, [apiCommits]);
+
+  return { logEntries, newEntryIds };
+};

--- a/src/pages/PRDetailsPage.tsx
+++ b/src/pages/PRDetailsPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useSearchParams, useNavigate } from 'react-router-dom';
+import { Navigate, useSearchParams } from 'react-router-dom';
 import { Box, Tabs, Tab, CircularProgress, Typography } from '@mui/material';
 import { Page } from '../components/layout';
 import {
@@ -18,24 +18,19 @@ import ChatBubbleOutlineIcon from '@mui/icons-material/ChatBubbleOutline';
 
 const PRDetailsPage: React.FC = () => {
   const [searchParams] = useSearchParams();
-  const navigate = useNavigate();
   const repository = searchParams.get('repo');
   const pullRequestNumber = searchParams.get('number');
+  const hasParams = !!repository && !!pullRequestNumber;
   const [tabValue, setTabValue] = useState(0);
 
-  // Call hook unconditionally (React rules of hooks)
+  // Call hook unconditionally (React rules of hooks); skip the request when params are missing.
   const { data: prDetails, isLoading } = usePullRequestDetails(
-    repository || '',
-    pullRequestNumber ? parseInt(pullRequestNumber) : 0,
+    repository ?? '',
+    pullRequestNumber ? parseInt(pullRequestNumber, 10) : 0,
+    hasParams,
   );
 
-  // If no repo or PR number is provided, redirect to miners page
-  if (!repository || !pullRequestNumber) {
-    if (typeof window !== 'undefined') {
-      navigate('/miners?tab=prs');
-    }
-    return null;
-  }
+  if (!hasParams) return <Navigate to="/miners?tab=prs" replace />;
 
   const handleTabChange = (_event: React.SyntheticEvent, newValue: number) => {
     setTabValue(newValue);

--- a/src/pages/RepositoriesPage.tsx
+++ b/src/pages/RepositoriesPage.tsx
@@ -282,32 +282,29 @@ const RepositoriesPage: React.FC = () => {
     const today = new Date();
     today.setHours(0, 0, 0, 0);
 
+    const repoWeight = (repository: string) =>
+      parseFloat(String(repoMap.get(repository.toLowerCase())?.weight || '0'));
+
     return allPRs
       .filter(
-        (pr) =>
-          pr.repository &&
-          pr.mergedAt &&
+        (pr): pr is CommitLog & { repository: string; mergedAt: string } =>
+          !!pr.repository &&
+          !!pr.mergedAt &&
           repoMap.has(pr.repository.toLowerCase()) &&
           new Date(pr.mergedAt) >= today,
       )
       .sort((a, b) => {
-        const scoreA = parseFloat(a.score || '0');
-        const scoreB = parseFloat(b.score || '0');
-        if (scoreB !== scoreA) return scoreB - scoreA;
-        // Tiebreak by repo weight
-        const weightA = parseFloat(
-          String(repoMap.get(a.repository?.toLowerCase() ?? '')?.weight || '0'),
-        );
-        const weightB = parseFloat(
-          String(repoMap.get(b.repository?.toLowerCase() ?? '')?.weight || '0'),
-        );
-        return weightB - weightA;
+        const scoreDelta =
+          parseFloat(b.score || '0') - parseFloat(a.score || '0');
+        return scoreDelta !== 0
+          ? scoreDelta
+          : repoWeight(b.repository) - repoWeight(a.repository);
       })
       .slice(0, 5)
       .map((pr) => ({
         name: pr.repository,
         title: pr.pullRequestTitle,
-        createdAt: new Date(pr.mergedAt || new Date()),
+        createdAt: new Date(pr.mergedAt),
         number: pr.pullRequestNumber,
       }));
   }, [allPRs, reposWithWeights]);


### PR DESCRIPTION
## Summary

Fixes a handful of correctness issues in the dashboard and PR details flow:

- **LiveCommitLog**: extracted the stream-tracking logic into `useCommitLogStream`. The new hook uses an explicit first-fill guard (so initial rows no longer all pulse), tracks the animation timer in a ref with cleanup on unmount, classifies head updates by timestamp instead of list position, and caps the seen-IDs set so a long-lived dashboard cannot leak memory. Also dropped `logEntries.length` from the IntersectionObserver deps so the observer is no longer rebuilt on every poll.
- **PRDetailsPage**: replaced the `navigate()`-during-render with `<Navigate replace />`, and passed `enabled={hasParams}` to `usePullRequestDetails` so the request does not fire with empty params.
- **RepositoriesPage**: replaced `new Date(pr.mergedAt || new Date())` with a type predicate on the `.filter()` so `mergedAt` is narrowed to `string` and the fallback is no longer needed. Pulled the duplicated weight lookup into a small `repoWeight` helper.
- **DashboardApi**: included the resolved `requestUrl` and `limit` in the `useInfiniteCommitLog` query key so the cache stays correct across env changes.

## Related Issues

Closes #293

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

Not applicable; no visual changes.

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [ ] Screenshots included for any UI/visual changes
