### PR TITLE
fix: show collateral on open PRs and unify the Merged column into Date

### DIFF
--- a/src/components/repositories/RepositoryPRsTable.tsx
+++ b/src/components/repositories/RepositoryPRsTable.tsx
@@ -9,10 +9,12 @@ import {
   TableContainer,
   TableHead,
   TableRow,
+  TableSortLabel,
   CircularProgress,
   Avatar,
   Chip,
   Stack,
+  Tooltip,
 } from '@mui/material';
 import { useAllPrs } from '../../api';
 import { useNavigate } from 'react-router-dom';
@@ -24,11 +26,22 @@ import {
   isOpenPr,
 } from '../../utils';
 import FilterButton from '../FilterButton';
+import type { CommitLog } from '../../api/models/Dashboard';
 
 interface RepositoryPRsTableProps {
   repositoryFullName: string;
   state?: 'open' | 'closed' | 'merged' | 'all';
 }
+
+type SortKey = 'pr' | 'commits' | 'changes' | 'score' | 'collateral' | 'date';
+type SortDir = 'asc' | 'desc';
+
+const num = (s?: string | null) => parseFloat(s || '0') || 0;
+
+const effectiveDateMs = (pr: CommitLog) => {
+  const iso = pr.mergedAt || pr.prCreatedAt;
+  return iso ? new Date(iso).getTime() : 0;
+};
 
 const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
   repositoryFullName,
@@ -38,6 +51,8 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
   const [filter, setFilter] = useState<'all' | 'open' | 'closed' | 'merged'>(
     state,
   );
+  const [sortKey, setSortKey] = useState<SortKey>('score');
+  const [sortDir, setSortDir] = useState<SortDir>('desc');
 
   // Fetch ALL PRs at once to enable client-side filtering and accurate counts
   // This avoids server roundtrips on filter change and provides instant UI feedback
@@ -64,12 +79,75 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
     return allPRs;
   }, [allPRs, filter]);
 
-  const sortedPRs = useMemo(
-    () =>
-      [...filteredPRs].sort(
-        (a, b) => parseFloat(b.score || '0') - parseFloat(a.score || '0'),
-      ),
-    [filteredPRs],
+  const sortedPRs = useMemo(() => {
+    const dir = sortDir === 'asc' ? 1 : -1;
+    const cmp = (a: CommitLog, b: CommitLog): number => {
+      switch (sortKey) {
+        case 'pr':
+          return (a.pullRequestNumber - b.pullRequestNumber) * dir;
+        case 'commits':
+          return (a.commitCount - b.commitCount) * dir;
+        case 'changes':
+          return (
+            (a.additions + a.deletions - (b.additions + b.deletions)) * dir
+          );
+        case 'collateral':
+          return (num(a.collateralScore) - num(b.collateralScore)) * dir;
+        case 'date':
+          return (effectiveDateMs(a) - effectiveDateMs(b)) * dir;
+        case 'score':
+        default: {
+          const primary = (num(a.score) - num(b.score)) * dir;
+          if (primary !== 0) return primary;
+          // Tie-break on collateral so the most-penalized open PRs surface
+          // first when score ties at 0 (addresses issue #288 directly).
+          return (num(a.collateralScore) - num(b.collateralScore)) * dir;
+        }
+      }
+    };
+    return [...filteredPRs].sort(cmp);
+  }, [filteredPRs, sortKey, sortDir]);
+
+  const handleSort = (key: SortKey) => {
+    if (sortKey === key) {
+      setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setSortKey(key);
+      setSortDir('desc');
+    }
+  };
+
+  const renderFilters = () => (
+    <Stack direction="row" spacing={1}>
+      <FilterButton
+        label="All"
+        isActive={filter === 'all'}
+        onClick={() => setFilter('all')}
+        count={counts.all}
+        color={theme.palette.status.neutral}
+      />
+      <FilterButton
+        label="Open"
+        isActive={filter === 'open'}
+        onClick={() => setFilter('open')}
+        count={counts.open}
+        color={theme.palette.status.open}
+      />
+      <FilterButton
+        label="Merged"
+        isActive={filter === 'merged'}
+        onClick={() => setFilter('merged')}
+        count={counts.merged}
+        color={theme.palette.status.merged}
+      />
+      <FilterButton
+        label="Closed"
+        isActive={filter === 'closed'}
+        onClick={() => setFilter('closed')}
+        count={counts.closed}
+        color={theme.palette.status.closed}
+      />
+    </Stack>
   );
 
   if (isLoading) {
@@ -91,41 +169,55 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
           >
             Pull Requests
           </Typography>
-          <Stack direction="row" spacing={1}>
-            <FilterButton
-              label="All"
-              isActive={filter === 'all'}
-              onClick={() => setFilter('all')}
-              count={counts.all}
-              color={theme.palette.status.neutral}
-            />
-            <FilterButton
-              label="Open"
-              isActive={filter === 'open'}
-              onClick={() => setFilter('open')}
-              count={counts.open}
-              color={theme.palette.status.open}
-            />
-            <FilterButton
-              label="Merged"
-              isActive={filter === 'merged'}
-              onClick={() => setFilter('merged')}
-              count={counts.merged}
-              color={theme.palette.status.merged}
-            />
-            <FilterButton
-              label="Closed"
-              isActive={filter === 'closed'}
-              onClick={() => setFilter('closed')}
-              count={counts.closed}
-              color={theme.palette.status.closed}
-            />
-          </Stack>
+          {renderFilters()}
         </Box>
         <CircularProgress size={40} sx={{ color: 'primary.main' }} />
       </Card>
     );
   }
+
+  // Aggregate stats for the current filter — surfaces total collateral
+  // exposure across open PRs in this repo, which is the actionable number
+  // the issue reporter is implicitly asking for.
+  const totalCollateral = filteredPRs.reduce(
+    (sum, pr) => (isOpenPr(pr) ? sum + num(pr.collateralScore) : sum),
+    0,
+  );
+
+  const sortableHeader = (
+    key: SortKey,
+    label: React.ReactNode,
+    align: 'left' | 'right' = 'left',
+    tooltip?: string,
+  ) => {
+    const inner = (
+      <TableSortLabel
+        active={sortKey === key}
+        direction={sortKey === key ? sortDir : 'desc'}
+        onClick={() => handleSort(key)}
+        sx={{
+          color: 'inherit !important',
+          '& .MuiTableSortLabel-icon': {
+            color: 'inherit !important',
+            opacity: sortKey === key ? 1 : 0.4,
+          },
+        }}
+      >
+        {label}
+      </TableSortLabel>
+    );
+    return (
+      <TableCell align={align} sx={headerCellStyle}>
+        {tooltip ? (
+          <Tooltip title={tooltip} arrow>
+            <Box component="span">{inner}</Box>
+          </Tooltip>
+        ) : (
+          inner
+        )}
+      </TableCell>
+    );
+  };
 
   return (
     <Card
@@ -151,48 +243,40 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
           gap: 2,
         }}
       >
-        <Typography
-          variant="h6"
-          sx={{
-            color: '#ffffff',
-            fontFamily: '"JetBrains Mono", monospace',
-            fontSize: '1.1rem',
-            fontWeight: 500,
-          }}
-        >
-          Pull Requests ({sortedPRs.length})
-        </Typography>
+        <Box>
+          <Typography
+            variant="h6"
+            sx={{
+              color: '#ffffff',
+              fontFamily: '"JetBrains Mono", monospace',
+              fontSize: '1.1rem',
+              fontWeight: 500,
+            }}
+          >
+            Pull Requests ({sortedPRs.length})
+          </Typography>
+          {totalCollateral > 0 && (
+            <Tooltip
+              title="Sum of collateral penalties currently applied across all open PRs in this repository."
+              arrow
+            >
+              <Typography
+                sx={{
+                  mt: 0.5,
+                  color: theme.palette.status.open,
+                  fontFamily: '"JetBrains Mono", monospace',
+                  fontSize: '0.7rem',
+                  letterSpacing: '0.5px',
+                  cursor: 'help',
+                }}
+              >
+                Open collateral exposure: −{totalCollateral.toFixed(4)}
+              </Typography>
+            </Tooltip>
+          )}
+        </Box>
 
-        <Stack direction="row" spacing={1}>
-          <FilterButton
-            label="All"
-            isActive={filter === 'all'}
-            onClick={() => setFilter('all')}
-            count={counts.all}
-            color={theme.palette.status.neutral}
-          />
-          <FilterButton
-            label="Open"
-            isActive={filter === 'open'}
-            onClick={() => setFilter('open')}
-            count={counts.open}
-            color={theme.palette.status.open}
-          />
-          <FilterButton
-            label="Merged"
-            isActive={filter === 'merged'}
-            onClick={() => setFilter('merged')}
-            count={counts.merged}
-            color={theme.palette.status.merged}
-          />
-          <FilterButton
-            label="Closed"
-            isActive={filter === 'closed'}
-            onClick={() => setFilter('closed')}
-            count={counts.closed}
-            color={theme.palette.status.closed}
-          />
-        </Stack>
+        {renderFilters()}
       </Box>
 
       {sortedPRs.length === 0 ? (
@@ -218,149 +302,250 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
           <Table stickyHeader>
             <TableHead>
               <TableRow>
-                <TableCell sx={headerCellStyle}>PR #</TableCell>
+                {sortableHeader('pr', 'PR #')}
                 <TableCell sx={headerCellStyle}>Title</TableCell>
                 <TableCell sx={headerCellStyle}>Author</TableCell>
-                <TableCell align="right" sx={headerCellStyle}>
-                  Commits
-                </TableCell>
-                <TableCell align="right" sx={headerCellStyle}>
-                  +/-
-                </TableCell>
-                <TableCell align="right" sx={headerCellStyle}>
-                  Score
-                </TableCell>
+                {sortableHeader('commits', 'Commits', 'right')}
+                {sortableHeader('changes', '+/-', 'right')}
+                {sortableHeader(
+                  'score',
+                  'Score',
+                  'right',
+                  'Final score for merged/closed PRs. For open PRs, shows the negative collateral penalty currently being applied. Click again to flip direction.',
+                )}
+                {sortableHeader(
+                  'collateral',
+                  'Collateral',
+                  'right',
+                  'Collateral penalty currently applied (only open PRs accrue collateral).',
+                )}
                 <TableCell sx={headerCellStyle}>Status</TableCell>
-                <TableCell align="right" sx={headerCellStyle}>
-                  Merged
-                </TableCell>
+                {sortableHeader(
+                  'date',
+                  'Date',
+                  'right',
+                  'Merge date for merged PRs, otherwise creation date.',
+                )}
               </TableRow>
             </TableHead>
             <TableBody>
-              {sortedPRs.map((pr) => (
-                <TableRow
-                  key={`${pr.repository}-${pr.pullRequestNumber}`}
-                  onClick={() => {
-                    navigate(
-                      `/miners/pr?repo=${encodeURIComponent(pr.repository)}&number=${pr.pullRequestNumber}`,
-                      { state: { backLabel: `Back to ${repositoryFullName}` } },
-                    );
-                  }}
-                  sx={{
-                    cursor: 'pointer',
-                    '&:hover': {
-                      backgroundColor: 'rgba(255, 255, 255, 0.05)',
-                    },
-                    transition: 'background-color 0.2s',
-                  }}
-                >
-                  <TableCell sx={bodyCellStyle}>
-                    <a
-                      href={`https://github.com/${pr.repository}/pull/${pr.pullRequestNumber}`}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      style={{
-                        color: '#ffffff',
-                        textDecoration: 'none',
-                        fontWeight: 500,
-                      }}
-                      onClick={(e) => e.stopPropagation()}
-                    >
-                      #{pr.pullRequestNumber}
-                    </a>
-                  </TableCell>
-                  <TableCell sx={bodyCellStyle}>
-                    <Box
-                      sx={{
-                        maxWidth: '300px',
-                        overflow: 'hidden',
-                        textOverflow: 'ellipsis',
-                        whiteSpace: 'nowrap',
-                      }}
-                    >
-                      {pr.pullRequestTitle}
-                    </Box>
-                  </TableCell>
+              {sortedPRs.map((pr) => {
+                const isOpen = isOpenPr(pr);
+                const collateral = num(pr.collateralScore);
+                const showCollateral = isOpen && collateral > 0;
+                const scoreVal = num(pr.score);
+                const scoreColor = showCollateral
+                  ? theme.palette.status.open
+                  : scoreVal > 0
+                    ? theme.palette.diff.additions
+                    : scoreVal < 0
+                      ? theme.palette.diff.deletions
+                      : 'rgba(255, 255, 255, 0.6)';
+                const scoreDisplay = showCollateral
+                  ? `−${collateral.toFixed(4)}`
+                  : scoreVal.toFixed(4);
+                const scoreTooltip = showCollateral
+                  ? `Open PR collateral penalty: −${collateral.toFixed(4)}. This will be replaced by the earned score once the PR is merged or closed.`
+                  : `Final score: ${scoreVal.toFixed(4)}.`;
 
-                  <TableCell sx={bodyCellStyle}>
-                    <Box
-                      sx={{
-                        display: 'flex',
-                        alignItems: 'center',
-                        gap: 1,
-                      }}
-                    >
-                      <Avatar
-                        src={`https://avatars.githubusercontent.com/${pr.author}`}
-                        alt={pr.author}
-                        sx={{ width: 20, height: 20 }}
-                      />
-                      {pr.author}
-                    </Box>
-                  </TableCell>
-                  <TableCell align="right" sx={bodyCellStyle}>
-                    {pr.commitCount}
-                  </TableCell>
-                  <TableCell align="right" sx={bodyCellStyle}>
-                    <Box
-                      component="span"
-                      sx={{ color: theme.palette.diff.additions, mr: 1 }}
-                    >
-                      +{pr.additions}
-                    </Box>
-                    <Box
-                      component="span"
-                      sx={{ color: theme.palette.diff.deletions }}
-                    >
-                      -{pr.deletions}
-                    </Box>
-                  </TableCell>
-                  <TableCell align="right" sx={bodyCellStyle}>
-                    <Typography
-                      sx={{
-                        fontFamily: '"JetBrains Mono", monospace',
-                        fontSize: '0.75rem',
-                        fontWeight: 600,
-                      }}
-                    >
-                      {parseFloat(pr.score || '0').toFixed(4)}
-                    </Typography>
-                  </TableCell>
-                  <TableCell sx={bodyCellStyle}>
-                    {(() => {
-                      const state =
-                        pr.prState?.toUpperCase() ||
-                        (pr.mergedAt ? 'MERGED' : 'OPEN');
-                      let color = theme.palette.status.neutral;
-                      const label = state;
+                const isMergedRow = !!pr.mergedAt;
+                const dateIso = isMergedRow ? pr.mergedAt! : pr.prCreatedAt;
+                const dateObj = dateIso ? new Date(dateIso) : null;
+                const dateLabel = isMergedRow ? 'merged' : 'created';
 
-                      if (state === 'MERGED') {
-                        color = theme.palette.status.merged;
-                      } else if (state === 'OPEN') {
-                        color = theme.palette.status.open;
-                      } else if (state === 'CLOSED') {
-                        color = theme.palette.status.closed;
-                      }
-
-                      return (
-                        <Chip
-                          variant="status"
-                          label={label}
-                          sx={{
-                            color,
-                            borderColor: color,
-                          }}
-                        />
+                return (
+                  <TableRow
+                    key={`${pr.repository}-${pr.pullRequestNumber}`}
+                    onClick={() => {
+                      navigate(
+                        `/miners/pr?repo=${encodeURIComponent(pr.repository)}&number=${pr.pullRequestNumber}`,
+                        {
+                          state: {
+                            backLabel: `Back to ${repositoryFullName}`,
+                          },
+                        },
                       );
-                    })()}
-                  </TableCell>
-                  <TableCell align="right" sx={bodyCellStyle}>
-                    {pr.mergedAt
-                      ? new Date(pr.mergedAt).toLocaleDateString()
-                      : '-'}
-                  </TableCell>
-                </TableRow>
-              ))}
+                    }}
+                    sx={{
+                      cursor: 'pointer',
+                      '&:hover': {
+                        backgroundColor: 'rgba(255, 255, 255, 0.05)',
+                      },
+                      transition: 'background-color 0.2s',
+                    }}
+                  >
+                    <TableCell sx={bodyCellStyle}>
+                      <a
+                        href={`https://github.com/${pr.repository}/pull/${pr.pullRequestNumber}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        style={{
+                          color: '#ffffff',
+                          textDecoration: 'none',
+                          fontWeight: 500,
+                        }}
+                        onClick={(e) => e.stopPropagation()}
+                      >
+                        #{pr.pullRequestNumber}
+                      </a>
+                    </TableCell>
+                    <TableCell sx={bodyCellStyle}>
+                      <Box
+                        sx={{
+                          maxWidth: '300px',
+                          overflow: 'hidden',
+                          textOverflow: 'ellipsis',
+                          whiteSpace: 'nowrap',
+                        }}
+                      >
+                        {pr.pullRequestTitle}
+                      </Box>
+                    </TableCell>
+
+                    <TableCell sx={bodyCellStyle}>
+                      <Box
+                        sx={{
+                          display: 'flex',
+                          alignItems: 'center',
+                          gap: 1,
+                        }}
+                      >
+                        <Avatar
+                          src={`https://avatars.githubusercontent.com/${pr.author}`}
+                          alt={pr.author}
+                          sx={{ width: 20, height: 20 }}
+                        />
+                        {pr.author}
+                      </Box>
+                    </TableCell>
+                    <TableCell align="right" sx={bodyCellStyle}>
+                      {pr.commitCount}
+                    </TableCell>
+                    <TableCell align="right" sx={bodyCellStyle}>
+                      <Box
+                        component="span"
+                        sx={{ color: theme.palette.diff.additions, mr: 1 }}
+                      >
+                        +{pr.additions}
+                      </Box>
+                      <Box
+                        component="span"
+                        sx={{ color: theme.palette.diff.deletions }}
+                      >
+                        -{pr.deletions}
+                      </Box>
+                    </TableCell>
+                    <TableCell align="right" sx={bodyCellStyle}>
+                      <Tooltip title={scoreTooltip} arrow placement="left">
+                        <Typography
+                          sx={{
+                            fontFamily: '"JetBrains Mono", monospace',
+                            fontSize: '0.75rem',
+                            fontWeight: 600,
+                            color: scoreColor,
+                            cursor: 'help',
+                          }}
+                        >
+                          {scoreDisplay}
+                        </Typography>
+                      </Tooltip>
+                    </TableCell>
+                    <TableCell align="right" sx={bodyCellStyle}>
+                      {collateral > 0 ? (
+                        <Tooltip
+                          title={
+                            isOpen
+                              ? 'Active collateral penalty while this PR remains open.'
+                              : 'Collateral penalty recorded for this PR.'
+                          }
+                          arrow
+                          placement="left"
+                        >
+                          <Typography
+                            sx={{
+                              fontFamily: '"JetBrains Mono", monospace',
+                              fontSize: '0.75rem',
+                              fontWeight: 500,
+                              color: isOpen
+                                ? theme.palette.status.open
+                                : 'rgba(255, 255, 255, 0.6)',
+                              cursor: 'help',
+                            }}
+                          >
+                            −{collateral.toFixed(4)}
+                          </Typography>
+                        </Tooltip>
+                      ) : (
+                        <Box
+                          component="span"
+                          sx={{ color: 'rgba(255, 255, 255, 0.3)' }}
+                        >
+                          —
+                        </Box>
+                      )}
+                    </TableCell>
+                    <TableCell sx={bodyCellStyle}>
+                      {(() => {
+                        const st =
+                          pr.prState?.toUpperCase() ||
+                          (pr.mergedAt ? 'MERGED' : 'OPEN');
+                        let color = theme.palette.status.neutral;
+                        if (st === 'MERGED')
+                          color = theme.palette.status.merged;
+                        else if (st === 'OPEN')
+                          color = theme.palette.status.open;
+                        else if (st === 'CLOSED')
+                          color = theme.palette.status.closed;
+                        return (
+                          <Chip
+                            variant="status"
+                            label={st}
+                            sx={{ color, borderColor: color }}
+                          />
+                        );
+                      })()}
+                    </TableCell>
+                    <TableCell align="right" sx={bodyCellStyle}>
+                      {dateObj ? (
+                        <Tooltip
+                          title={`${isMergedRow ? 'Merged' : 'Created'} on ${dateObj.toLocaleString()}`}
+                          arrow
+                          placement="left"
+                        >
+                          <Box
+                            sx={{
+                              display: 'inline-flex',
+                              flexDirection: 'column',
+                              alignItems: 'flex-end',
+                              cursor: 'help',
+                            }}
+                          >
+                            <Box component="span">
+                              {dateObj.toLocaleDateString()}
+                            </Box>
+                            <Box
+                              component="span"
+                              sx={{
+                                fontSize: '0.6rem',
+                                color: isMergedRow
+                                  ? theme.palette.status.merged
+                                  : theme.palette.status.open,
+                                textTransform: 'uppercase',
+                                letterSpacing: '0.5px',
+                                fontWeight: 600,
+                              }}
+                            >
+                              {dateLabel}
+                            </Box>
+                          </Box>
+                        </Tooltip>
+                      ) : (
+                        '-'
+                      )}
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
             </TableBody>
           </Table>
         </TableContainer>


### PR DESCRIPTION
## Summary

Closes #288

The Pull Requests table on a repository page had two gaps that hid useful information:

1. Open PRs always showed a Score of `0.0000`, even when a collateral penalty was actively being applied.
2. The Merged column was empty for every non-merged PR, leaving Open and Closed rows with a lonely dash.

This change reworks the table so both columns stay informative across every PR state, and adds a few small affordances that make the penalty data actually usable.

## Changes

* **Score column for open PRs**: when an open PR has a non-zero collateral score, the cell now renders `−X.XXXX` in the open-status color with a tooltip explaining that the value is a penalty and will be replaced by the earned score once the PR is merged or closed.
* **Score color coding**: positive final scores render in the additions green, negative ones in the deletions red, zero in muted white. Makes scanning a long table much faster.
* **New Collateral column**: dedicated, sortable column so the penalty can be inspected and ranked on its own without conflating it with final score. Non-applicable rows show an em dash.
* **Renamed Merged to Date**: shows `mergedAt` for merged PRs and `prCreatedAt` for everything else, with a small `MERGED` / `CREATED` sub-label (color matched to the status palette) and a tooltip with the full timestamp.
* **Sortable headers**: PR #, Commits, +/-, Score, Collateral, and Date are all sortable via `TableSortLabel`. Score sort tie-breaks on collateral so the most-penalized open PRs still rise to the top within a score = 0 group.
* **Open collateral exposure summary**: small subtitle under "Pull Requests (N)" that totals the active collateral across all open PRs in the current filter, so the repo-wide cost is visible at a glance.
* **Header tooltips** on Score, Collateral, and Date so the dual meaning of each column is self-documenting.

## Files touched

* `src/components/repositories/RepositoryPRsTable.tsx`

No new data fetching, no new dependencies. `collateralScore` and `prCreatedAt` were already present on `CommitLog`.

[result-screen.webm](https://github.com/user-attachments/assets/490a822d-133d-43c8-a8b6-a16afa105ae9)
