### PR TITLE
fix(security): prevent XSS by disabling raw HTML in markdown renderers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,6 @@
         "react-router-dom": "^6.25.1",
         "react-syntax-highlighter": "^16.1.0",
         "react-tooltip": "^5.30.0",
-        "rehype-raw": "^7.0.0",
         "remark-gfm": "^4.0.1"
       },
       "devDependencies": {
@@ -2961,18 +2960,6 @@
         "react": "^15.0.0 || >=16.0.0"
       }
     },
-    "node_modules/entities": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
-      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
     "node_modules/error-ex": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
@@ -3745,26 +3732,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/hast-util-from-parse5": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
-      "integrity": "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "@types/unist": "^3.0.0",
-        "devlop": "^1.0.0",
-        "hastscript": "^9.0.0",
-        "property-information": "^7.0.0",
-        "vfile": "^6.0.0",
-        "vfile-location": "^5.0.0",
-        "web-namespaces": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/hast-util-parse-selector": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
@@ -3772,31 +3739,6 @@
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hast-util-raw": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-9.1.0.tgz",
-      "integrity": "sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "@types/unist": "^3.0.0",
-        "@ungap/structured-clone": "^1.0.0",
-        "hast-util-from-parse5": "^8.0.0",
-        "hast-util-to-parse5": "^8.0.0",
-        "html-void-elements": "^3.0.0",
-        "mdast-util-to-hast": "^13.0.0",
-        "parse5": "^7.0.0",
-        "unist-util-position": "^5.0.0",
-        "unist-util-visit": "^5.0.0",
-        "vfile": "^6.0.0",
-        "web-namespaces": "^2.0.0",
-        "zwitch": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -3824,25 +3766,6 @@
         "style-to-js": "^1.0.0",
         "unist-util-position": "^5.0.0",
         "vfile-message": "^4.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hast-util-to-parse5": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-8.0.1.tgz",
-      "integrity": "sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "comma-separated-tokens": "^2.0.0",
-        "devlop": "^1.0.0",
-        "property-information": "^7.0.0",
-        "space-separated-tokens": "^2.0.0",
-        "web-namespaces": "^2.0.0",
-        "zwitch": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -3917,16 +3840,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/html-void-elements": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
-      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/ignore": {
@@ -5347,18 +5260,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/parse5": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
-      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
-      "license": "MIT",
-      "dependencies": {
-        "entities": "^6.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/inikulin/parse5?sponsor=1"
-      }
-    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -5760,21 +5661,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/rehype-raw": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/rehype-raw/-/rehype-raw-7.0.0.tgz",
-      "integrity": "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "hast-util-raw": "^9.0.0",
-        "vfile": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/remark-gfm": {
@@ -6406,20 +6292,6 @@
       "dependencies": {
         "@types/unist": "^3.0.0",
         "vfile-message": "^4.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/vfile-location": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz",
-      "integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0",
-        "vfile": "^6.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -7111,34 +6983,6 @@
         "yaml": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vitest/node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
-    },
-    "node_modules/web-namespaces": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
-      "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "react-router-dom": "^6.25.1",
     "react-syntax-highlighter": "^16.1.0",
     "react-tooltip": "^5.30.0",
-    "rehype-raw": "^7.0.0",
     "remark-gfm": "^4.0.1"
   },
   "devDependencies": {

--- a/src/components/issues/IssueConversation.tsx
+++ b/src/components/issues/IssueConversation.tsx
@@ -3,7 +3,6 @@ import { Box, Typography, Avatar, Paper, Link, Chip } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import rehypeRaw from 'rehype-raw';
 import { type IssueDetails } from '../../api/models/Issues';
 import { STATUS_COLORS } from '../../theme';
 
@@ -339,7 +338,6 @@ const IssueConversation: React.FC<IssueConversationProps> = ({ issue }) => {
               <div className="markdown-body" style={{ fontSize: '14px' }}>
                 <ReactMarkdown
                   remarkPlugins={[remarkGfm]}
-                  rehypePlugins={[rehypeRaw]}
                 >
                   {item.body}
                 </ReactMarkdown>

--- a/src/components/issues/IssueConversation.tsx
+++ b/src/components/issues/IssueConversation.tsx
@@ -336,9 +336,7 @@ const IssueConversation: React.FC<IssueConversationProps> = ({ issue }) => {
               }}
             >
               <div className="markdown-body" style={{ fontSize: '14px' }}>
-                <ReactMarkdown
-                  remarkPlugins={[remarkGfm]}
-                >
+                <ReactMarkdown remarkPlugins={[remarkGfm]}>
                   {item.body}
                 </ReactMarkdown>
               </div>

--- a/src/components/prs/PRComments.tsx
+++ b/src/components/prs/PRComments.tsx
@@ -10,7 +10,6 @@ import {
 } from '@mui/material';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import rehypeRaw from 'rehype-raw';
 import { usePullRequestComments } from '../../api';
 import {
   type PullRequestComment,
@@ -375,7 +374,6 @@ const PRComments: React.FC<PRCommentsProps> = ({
               <div className="markdown-body" style={{ fontSize: '14px' }}>
                 <ReactMarkdown
                   remarkPlugins={[remarkGfm]}
-                  rehypePlugins={[rehypeRaw]}
                 >
                   {item.body}
                 </ReactMarkdown>

--- a/src/components/prs/PRComments.tsx
+++ b/src/components/prs/PRComments.tsx
@@ -372,9 +372,7 @@ const PRComments: React.FC<PRCommentsProps> = ({
               }}
             >
               <div className="markdown-body" style={{ fontSize: '14px' }}>
-                <ReactMarkdown
-                  remarkPlugins={[remarkGfm]}
-                >
+                <ReactMarkdown remarkPlugins={[remarkGfm]}>
                   {item.body}
                 </ReactMarkdown>
               </div>

--- a/src/components/repositories/ContributingViewer.tsx
+++ b/src/components/repositories/ContributingViewer.tsx
@@ -2,7 +2,6 @@ import React, { useState, useEffect } from 'react';
 import { Box, Paper, CircularProgress, Alert } from '@mui/material';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import rehypeRaw from 'rehype-raw';
 import axios from 'axios';
 import { STATUS_COLORS } from '../../theme';
 import { resolveRelativeUrl } from './MarkdownRenderers';
@@ -175,7 +174,6 @@ const ContributingViewer: React.FC<ContributingViewerProps> = ({
     >
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
-        rehypePlugins={[rehypeRaw]}
         components={{
           a: ({
             href,

--- a/src/components/repositories/ReadmeViewer.tsx
+++ b/src/components/repositories/ReadmeViewer.tsx
@@ -2,7 +2,6 @@ import React, { useState, useEffect } from 'react';
 import { Box, CircularProgress, Alert, Paper } from '@mui/material';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import rehypeRaw from 'rehype-raw';
 import axios from 'axios';
 import { STATUS_COLORS } from '../../theme';
 import { resolveRelativeUrl } from './MarkdownRenderers';
@@ -177,7 +176,6 @@ const ReadmeViewer: React.FC<ReadmeViewerProps> = ({ repositoryFullName }) => {
     >
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
-        rehypePlugins={[rehypeRaw]}
         components={{
           a: ({
             href,


### PR DESCRIPTION
## Summary

This PR addresses a cross-site scripting (XSS) risk in markdown rendering across the UI.
Previously, several components used react-markdown with rehype-raw, which allows raw HTML from markdown input to be parsed into live DOM elements. Because these markdown sources come from external/untrusted content (GitHub repository docs and user-generated issue/PR text), this created a client-side injection path.

Why this was vulnerable

- rehype-raw explicitly enables raw HTML passthrough in markdown.
- External markdown (README / CONTRIBUTING / comments) can contain crafted HTML payloads.
- Rendering those payloads in-app can lead to script execution or malicious UI injection depending on browser behavior and payload structure.
- This is especially sensitive in issue/PR conversations where content is user-authored and high-volume.

## Behavioral impact

- Markdown is still rendered with remark-gfm, so standard GitHub-style markdown remains intact.
- Raw embedded HTML in markdown is now treated as plain text / not interpreted as active DOM.
- Existing safe behavior for external links (target="_blank" + rel="noopener noreferrer") remains unchanged.

## Security outcome

- Eliminates the direct raw-HTML rendering vector in the app’s markdown surfaces.
- Reduces attack surface in both repository document viewers and user-comment timelines.
- Improves defense-in-depth by removing the unneeded parser dependency entirely.


## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

<!-- Include before/after screenshots for every UI/visual change. Remove this section if not applicable. -->

## Checklist

- [ ] New components are modularized/separated where sensible
- [ ] Uses predefined theme (e.g. no hardcoded colors)
- [ ] Responsive/mobile checked
- [ ] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [ ] Screenshots included for any UI/visual changes
