### PR TITLE
fix: abort in-flight fetches in repo viewers to prevent stale content

### DIFF
--- a/src/components/repositories/CodeViewer.tsx
+++ b/src/components/repositories/CodeViewer.tsx
@@ -29,6 +29,8 @@ const CodeViewer: React.FC<CodeViewerProps> = ({
     : '';
 
   useEffect(() => {
+    const controller = new AbortController();
+
     const fetchContent = async () => {
       if (!filePath || isImage) {
         // Don't fetch text content for images or if no file selected
@@ -43,19 +45,23 @@ const CodeViewer: React.FC<CodeViewerProps> = ({
         // Use raw.githubusercontent.com
         const response = await axios.get(rawUrl, {
           transformResponse: [(data) => data],
+          signal: controller.signal,
         }); // Force text
+        if (controller.signal.aborted) return;
         setContent(response.data);
       } catch (err) {
+        if (axios.isCancel(err) || controller.signal.aborted) return;
         console.error('Failed to fetch file content', err);
         setError(
           'Could not load file content. It might be binary or too large.',
         );
       } finally {
-        setLoading(false);
+        if (!controller.signal.aborted) setLoading(false);
       }
     };
 
     fetchContent();
+    return () => controller.abort();
   }, [repositoryFullName, filePath, defaultBranch, isImage, rawUrl]);
 
   if (!filePath) {

--- a/src/components/repositories/ContributingViewer.tsx
+++ b/src/components/repositories/ContributingViewer.tsx
@@ -20,6 +20,8 @@ const ContributingViewer: React.FC<ContributingViewerProps> = ({
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
+    const controller = new AbortController();
+
     const fetchContributing = async () => {
       setLoading(true);
       setError(null);
@@ -33,30 +35,34 @@ const ContributingViewer: React.FC<ContributingViewerProps> = ({
 
       for (const branch of branches) {
         for (const path of paths) {
+          if (controller.signal.aborted) return;
           try {
             const response = await axios.get(
               `https://cdn.jsdelivr.net/gh/${repositoryFullName}@${branch}/${path}`,
+              { signal: controller.signal },
             );
+            if (controller.signal.aborted) return;
             if (response.status === 200 && response.data) {
               setContent(response.data);
               setDefaultBranch(branch);
               setLoading(false);
               return;
             }
-          } catch {
+          } catch (err) {
+            if (axios.isCancel(err) || controller.signal.aborted) return;
             // Continue to next combination
           }
         }
       }
 
+      if (controller.signal.aborted) return;
       // If we get here, nothing was found
       setError('No contributing guidelines found for this repository.');
       setLoading(false);
     };
 
-    if (repositoryFullName) {
-      fetchContributing();
-    }
+    if (repositoryFullName) fetchContributing();
+    return () => controller.abort();
   }, [repositoryFullName]);
 
   if (loading) {

--- a/src/components/repositories/ReadmeViewer.tsx
+++ b/src/components/repositories/ReadmeViewer.tsx
@@ -18,6 +18,8 @@ const ReadmeViewer: React.FC<ReadmeViewerProps> = ({ repositoryFullName }) => {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
+    const controller = new AbortController();
+
     const fetchReadme = async () => {
       setLoading(true);
       setError(null);
@@ -26,28 +28,33 @@ const ReadmeViewer: React.FC<ReadmeViewerProps> = ({ repositoryFullName }) => {
         try {
           const response = await axios.get(
             `https://cdn.jsdelivr.net/gh/${repositoryFullName}@main/README.md`,
+            { signal: controller.signal },
           );
+          if (controller.signal.aborted) return;
           setContent(response.data);
           setDefaultBranch('main');
-        } catch {
+        } catch (err) {
+          if (axios.isCancel(err) || controller.signal.aborted) return;
           // Fallback to 'master' branch
           const response = await axios.get(
             `https://cdn.jsdelivr.net/gh/${repositoryFullName}@master/README.md`,
+            { signal: controller.signal },
           );
+          if (controller.signal.aborted) return;
           setContent(response.data);
           setDefaultBranch('master');
         }
       } catch (err) {
+        if (axios.isCancel(err) || controller.signal.aborted) return;
         console.error('Failed to fetch README', err);
         setError('Could not load README.md');
       } finally {
-        setLoading(false);
+        if (!controller.signal.aborted) setLoading(false);
       }
     };
 
-    if (repositoryFullName) {
-      fetchReadme();
-    }
+    if (repositoryFullName) fetchReadme();
+    return () => controller.abort();
   }, [repositoryFullName]);
 
   if (loading) {


### PR DESCRIPTION
## Summary
Closes #297 . Prevents three viewer components on the Repository Details page from displaying stale remote content when the user navigates away mid-fetch.

## Root cause
`ReadmeViewer`, `ContributingViewer`, and `CodeViewer` each have a `useEffect` that calls `axios.get(...)` and writes the response into component state. None of them register a cleanup function to abort the in-flight request when the effect re-runs (e.g. `repositoryFullName` or `filePath` changes) or when the component unmounts. Late responses from superseded navigations still call `setContent`, so the viewer ends up showing content that does not match its current props.

`ContributingViewer` is the most exposed because it sequentially probes up to 6 branch/path combinations - a long in-flight window on slow networks — and writes partial state along the way.

## Fix
Each `useEffect` now creates an `AbortController`, passes `controller.signal` to every `axios.get` call, and calls `controller.abort()` from the cleanup function. `axios.isCancel` / `signal.aborted` checks prevent post-abort state writes. For `ContributingViewer`, the inner loop additionally checks `signal.aborted` before each request to avoid wasting network on an already-cancelled effect.

No changes to UX, markup, or request URLs. Axios has supported `{ signal }` natively since 0.22; the project is on a newer version, so no dependency bump is required.

## Type of Change
- [x] Bug fix (correctness)

## Testing
- [ ] `npm run build`
- [ ] `npm run lint:fix`
- [ ] Manual with DevTools Network throttled to "Slow 3G":
  - Open `/miners/repository?name=opentensor/bittensor`, then quickly navigate to `/miners/repository?name=bitcoin/bitcoin` before the README loads. Confirm the README tab only ever shows `bitcoin/bitcoin`'s README, never flips back to the first.
  - Same test for CONTRIBUTING tab (flip between repos faster than 6 fallback requests complete).
  - Same test for CodeViewer: click File A in the tree, immediately click File B. Confirm only File B's content is ever shown.
- [ ] Console is free of `CanceledError` traces (the catch blocks swallow them correctly).

## Checklist
- [x] No behavior change for legitimate users
- [x] No new dependencies
- [x] Three files touched
- [x] All state-writes guarded against stale responses

## Follow-ups (out of scope)
- The same anti-pattern exists in `RepositoryCheckTab.tsx`, `RepositoryCodeBrowser.tsx`, and `PRFilesChanged.tsx` (binary-file raw fetch). Separate PR.
- Longer-term, consider migrating these viewers to `useQuery` (TanStack Query is already used elsewhere in the codebase). That comes with automatic cancellation, caching, and dedup for free - but it's a rewrite, not a bug fix.

## Video to upload

https://github.com/user-attachments/assets/8296f83a-023a-42d7-a31c-a6a2619fb564

