### PR TITLE
fix: persist Top Miners filters in URL

### DIFF
--- a/src/components/leaderboard/TopMinersTable.tsx
+++ b/src/components/leaderboard/TopMinersTable.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Box, Typography, CircularProgress, Grid } from '@mui/material';
 import { alpha, type Theme } from '@mui/material/styles';
 import { useSearchParams } from 'react-router-dom';
@@ -54,43 +54,51 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
 }) => {
   const [searchParams, setSearchParams] = useSearchParams();
   const [searchQuery, setSearchQuery] = useState('');
-  const [sortOption, setSortOption] = useState<SortOption>(() =>
-    getSortOptionFromQuery(searchParams.get(SORT_QUERY_PARAM), variant),
+  const sortOption = useMemo(
+    () => getSortOptionFromQuery(searchParams.get(SORT_QUERY_PARAM), variant),
+    [searchParams, variant],
   );
-  const [showEligibleOnly, setShowEligibleOnly] = useState(
-    () => searchParams.get(ELIGIBLE_QUERY_PARAM) === 'true',
-  );
+  const showEligibleOnly = searchParams.get(ELIGIBLE_QUERY_PARAM) === 'true';
   const [visibleCount, setVisibleCount] = useState(MINERS_PAGE_SIZE);
 
   useEffect(() => {
-    const sortFromQuery = getSortOptionFromQuery(
-      searchParams.get(SORT_QUERY_PARAM),
-      variant,
-    );
-    const eligibleFromQuery =
-      searchParams.get(ELIGIBLE_QUERY_PARAM) === 'true';
+    const rawSort = searchParams.get(SORT_QUERY_PARAM);
+    const rawEligible = searchParams.get(ELIGIBLE_QUERY_PARAM);
+    const allowedSortOptions = getAllowedSortOptions(variant);
 
-    setSortOption((prev) => (prev === sortFromQuery ? prev : sortFromQuery));
-    setShowEligibleOnly((prev) =>
-      prev === eligibleFromQuery ? prev : eligibleFromQuery,
+    const hasInvalidSort =
+      rawSort != null && !allowedSortOptions.includes(rawSort as SortOption);
+    const hasInvalidEligible =
+      rawEligible != null && rawEligible !== 'true';
+
+    if (!hasInvalidSort && !hasInvalidEligible) {
+      return;
+    }
+
+    setSearchParams(
+      (previousParams) => {
+        const nextSearchParams = new URLSearchParams(previousParams);
+        if (hasInvalidSort) {
+          nextSearchParams.delete(SORT_QUERY_PARAM);
+        }
+        if (hasInvalidEligible) {
+          nextSearchParams.delete(ELIGIBLE_QUERY_PARAM);
+        }
+        return nextSearchParams;
+      },
+      { replace: true },
     );
   }, [searchParams, variant]);
 
-  useEffect(() => {
+  const handleSortChange = useCallback((nextSortOption: SortOption) => {
     setSearchParams(
       (previousParams) => {
         const nextSearchParams = new URLSearchParams(previousParams);
 
-        if (sortOption === 'totalScore') {
+        if (nextSortOption === 'totalScore') {
           nextSearchParams.delete(SORT_QUERY_PARAM);
         } else {
-          nextSearchParams.set(SORT_QUERY_PARAM, sortOption);
-        }
-
-        if (showEligibleOnly) {
-          nextSearchParams.set(ELIGIBLE_QUERY_PARAM, 'true');
-        } else {
-          nextSearchParams.delete(ELIGIBLE_QUERY_PARAM);
+          nextSearchParams.set(SORT_QUERY_PARAM, nextSortOption);
         }
 
         return nextSearchParams.toString() === previousParams.toString()
@@ -99,7 +107,28 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
       },
       { replace: true },
     );
-  }, [setSearchParams, showEligibleOnly, sortOption]);
+  }, [setSearchParams]);
+
+  const handleToggleEligible = useCallback(() => {
+    setSearchParams(
+      (previousParams) => {
+        const nextSearchParams = new URLSearchParams(previousParams);
+        const isEligibleEnabled =
+          nextSearchParams.get(ELIGIBLE_QUERY_PARAM) === 'true';
+
+        if (isEligibleEnabled) {
+          nextSearchParams.delete(ELIGIBLE_QUERY_PARAM);
+        } else {
+          nextSearchParams.set(ELIGIBLE_QUERY_PARAM, 'true');
+        }
+
+        return nextSearchParams.toString() === previousParams.toString()
+          ? previousParams
+          : nextSearchParams;
+      },
+      { replace: true },
+    );
+  }, [setSearchParams]);
 
   // Helper to sort a list of miners
   const sortMinersList = (list: MinerStats[], option: SortOption) =>
@@ -182,13 +211,13 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
           >
             <SortButtons
               sortOption={sortOption}
-              onSortChange={setSortOption}
+              onSortChange={handleSortChange}
               variant={variant}
             />
             <FilterButton
               label="Eligible"
               isActive={showEligibleOnly}
-              onClick={() => setShowEligibleOnly((prev) => !prev)}
+              onClick={handleToggleEligible}
             />
           </Box>
         }

--- a/src/components/leaderboard/TopMinersTable.tsx
+++ b/src/components/leaderboard/TopMinersTable.tsx
@@ -54,40 +54,13 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
 }) => {
   const [searchParams, setSearchParams] = useSearchParams();
   const [searchQuery, setSearchQuery] = useState('');
+  const sortParamValue = searchParams.get(SORT_QUERY_PARAM);
   const sortOption = useMemo(
-    () => getSortOptionFromQuery(searchParams.get(SORT_QUERY_PARAM), variant),
-    [searchParams, variant],
+    () => getSortOptionFromQuery(sortParamValue, variant),
+    [sortParamValue, variant],
   );
   const showEligibleOnly = searchParams.get(ELIGIBLE_QUERY_PARAM) === 'true';
   const [visibleCount, setVisibleCount] = useState(MINERS_PAGE_SIZE);
-
-  useEffect(() => {
-    const rawSort = searchParams.get(SORT_QUERY_PARAM);
-    const rawEligible = searchParams.get(ELIGIBLE_QUERY_PARAM);
-    const allowedSortOptions = getAllowedSortOptions(variant);
-
-    const hasInvalidSort =
-      rawSort != null && !allowedSortOptions.includes(rawSort as SortOption);
-    const hasInvalidEligible = rawEligible != null && rawEligible !== 'true';
-
-    if (!hasInvalidSort && !hasInvalidEligible) {
-      return;
-    }
-
-    setSearchParams(
-      (previousParams) => {
-        const nextSearchParams = new URLSearchParams(previousParams);
-        if (hasInvalidSort) {
-          nextSearchParams.delete(SORT_QUERY_PARAM);
-        }
-        if (hasInvalidEligible) {
-          nextSearchParams.delete(ELIGIBLE_QUERY_PARAM);
-        }
-        return nextSearchParams;
-      },
-      { replace: true },
-    );
-  }, [searchParams, setSearchParams, variant]);
 
   const handleSortChange = useCallback(
     (nextSortOption: SortOption) => {

--- a/src/components/leaderboard/TopMinersTable.tsx
+++ b/src/components/leaderboard/TopMinersTable.tsx
@@ -68,8 +68,7 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
 
     const hasInvalidSort =
       rawSort != null && !allowedSortOptions.includes(rawSort as SortOption);
-    const hasInvalidEligible =
-      rawEligible != null && rawEligible !== 'true';
+    const hasInvalidEligible = rawEligible != null && rawEligible !== 'true';
 
     if (!hasInvalidSort && !hasInvalidEligible) {
       return;
@@ -90,24 +89,27 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
     );
   }, [searchParams, variant]);
 
-  const handleSortChange = useCallback((nextSortOption: SortOption) => {
-    setSearchParams(
-      (previousParams) => {
-        const nextSearchParams = new URLSearchParams(previousParams);
+  const handleSortChange = useCallback(
+    (nextSortOption: SortOption) => {
+      setSearchParams(
+        (previousParams) => {
+          const nextSearchParams = new URLSearchParams(previousParams);
 
-        if (nextSortOption === 'totalScore') {
-          nextSearchParams.delete(SORT_QUERY_PARAM);
-        } else {
-          nextSearchParams.set(SORT_QUERY_PARAM, nextSortOption);
-        }
+          if (nextSortOption === 'totalScore') {
+            nextSearchParams.delete(SORT_QUERY_PARAM);
+          } else {
+            nextSearchParams.set(SORT_QUERY_PARAM, nextSortOption);
+          }
 
-        return nextSearchParams.toString() === previousParams.toString()
-          ? previousParams
-          : nextSearchParams;
-      },
-      { replace: true },
-    );
-  }, [setSearchParams]);
+          return nextSearchParams.toString() === previousParams.toString()
+            ? previousParams
+            : nextSearchParams;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
+  );
 
   const handleToggleEligible = useCallback(() => {
     setSearchParams(

--- a/src/components/leaderboard/TopMinersTable.tsx
+++ b/src/components/leaderboard/TopMinersTable.tsx
@@ -87,7 +87,7 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
       },
       { replace: true },
     );
-  }, [searchParams, variant]);
+  }, [searchParams, setSearchParams, variant]);
 
   const handleSortChange = useCallback(
     (nextSortOption: SortOption) => {

--- a/src/components/leaderboard/TopMinersTable.tsx
+++ b/src/components/leaderboard/TopMinersTable.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { Box, Typography, CircularProgress, Grid } from '@mui/material';
 import { alpha, type Theme } from '@mui/material/styles';
+import { useSearchParams } from 'react-router-dom';
 import { SectionCard } from './SectionCard';
 import { MinerCard } from './MinerCard';
 import { SearchInput } from '../common/SearchInput';
@@ -16,6 +17,8 @@ import {
 export type { MinerStats } from './types';
 
 const MINERS_PAGE_SIZE = 60;
+const SORT_QUERY_PARAM = 'sort';
+const ELIGIBLE_QUERY_PARAM = 'eligible';
 
 interface TopMinersTableProps {
   miners: MinerStats[];
@@ -25,6 +28,23 @@ interface TopMinersTableProps {
   variant?: LeaderboardVariant;
 }
 
+const getAllowedSortOptions = (variant: LeaderboardVariant): SortOption[] =>
+  variant === 'discoveries'
+    ? ['totalScore', 'usdPerDay', 'totalPRs', 'totalIssues', 'credibility']
+    : ['totalScore', 'usdPerDay', 'totalPRs', 'credibility'];
+
+const getSortOptionFromQuery = (
+  value: string | null,
+  variant: LeaderboardVariant,
+): SortOption => {
+  if (!value) return 'totalScore';
+
+  const allowedOptions = getAllowedSortOptions(variant);
+  return allowedOptions.includes(value as SortOption)
+    ? (value as SortOption)
+    : 'totalScore';
+};
+
 const TopMinersTable: React.FC<TopMinersTableProps> = ({
   miners,
   isLoading,
@@ -32,10 +52,54 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
   linkState,
   variant = 'oss',
 }) => {
+  const [searchParams, setSearchParams] = useSearchParams();
   const [searchQuery, setSearchQuery] = useState('');
-  const [sortOption, setSortOption] = useState<SortOption>('totalScore');
-  const [showEligibleOnly, setShowEligibleOnly] = useState(false);
+  const [sortOption, setSortOption] = useState<SortOption>(() =>
+    getSortOptionFromQuery(searchParams.get(SORT_QUERY_PARAM), variant),
+  );
+  const [showEligibleOnly, setShowEligibleOnly] = useState(
+    () => searchParams.get(ELIGIBLE_QUERY_PARAM) === 'true',
+  );
   const [visibleCount, setVisibleCount] = useState(MINERS_PAGE_SIZE);
+
+  useEffect(() => {
+    const sortFromQuery = getSortOptionFromQuery(
+      searchParams.get(SORT_QUERY_PARAM),
+      variant,
+    );
+    const eligibleFromQuery =
+      searchParams.get(ELIGIBLE_QUERY_PARAM) === 'true';
+
+    setSortOption((prev) => (prev === sortFromQuery ? prev : sortFromQuery));
+    setShowEligibleOnly((prev) =>
+      prev === eligibleFromQuery ? prev : eligibleFromQuery,
+    );
+  }, [searchParams, variant]);
+
+  useEffect(() => {
+    setSearchParams(
+      (previousParams) => {
+        const nextSearchParams = new URLSearchParams(previousParams);
+
+        if (sortOption === 'totalScore') {
+          nextSearchParams.delete(SORT_QUERY_PARAM);
+        } else {
+          nextSearchParams.set(SORT_QUERY_PARAM, sortOption);
+        }
+
+        if (showEligibleOnly) {
+          nextSearchParams.set(ELIGIBLE_QUERY_PARAM, 'true');
+        } else {
+          nextSearchParams.delete(ELIGIBLE_QUERY_PARAM);
+        }
+
+        return nextSearchParams.toString() === previousParams.toString()
+          ? previousParams
+          : nextSearchParams;
+      },
+      { replace: true },
+    );
+  }, [setSearchParams, showEligibleOnly, sortOption]);
 
   // Helper to sort a list of miners
   const sortMinersList = (list: MinerStats[], option: SortOption) =>


### PR DESCRIPTION
## Summary

### Motivation
Filter choices on Top Miners were lost on refresh and couldn’t be shared via URL, creating a frustrating user experience and making filtered views non-reproducible. This change makes filters persistent and shareable while fixing the flicker caused by URL/state sync conflicts.

This PR makes Top Miners filters URL-persistent and stable.

- Adds query-param sync for Top Miners filters (sort, eligible) in src/components/leaderboard/TopMinersTable.tsx.
- Restores selected filter state from the URL on load/refresh so filter choices are not lost.
- Keeps default URL clean by removing params when filters are at defaults.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

<img width="1361" height="353" alt="image" src="https://github.com/user-attachments/assets/dde5f948-12b7-491c-92b3-c334b01d06b6" />
<img width="1395" height="331" alt="image" src="https://github.com/user-attachments/assets/8f7e555a-0ef2-4956-9c4e-987f68db1a70" />

## Checklist

- [ ] New components are modularized/separated where sensible
- [ ] Uses predefined theme (e.g. no hardcoded colors)
- [ ] Responsive/mobile checked
- [ ] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
