### PR TITLE
fix: cancel stale repo viewer fetches so content matches current props

### DIFF
--- a/src/components/repositories/CodeViewer.tsx
+++ b/src/components/repositories/CodeViewer.tsx
@@ -1,10 +1,14 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { scrollbarSx } from '../../theme';
 import { Box, Typography, CircularProgress, Alert } from '@mui/material';
 import axios from 'axios';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { vscDarkPlus } from 'react-syntax-highlighter/dist/esm/styles/prism';
 import ReactMarkdown from 'react-markdown';
+import {
+  isAbortError,
+  useAbortableEffect,
+} from '../../hooks/useAbortableEffect';
 
 interface CodeViewerProps {
   repositoryFullName: string;
@@ -29,8 +33,8 @@ const CodeViewer: React.FC<CodeViewerProps> = ({
     ? `https://cdn.jsdelivr.net/gh/${repositoryFullName}@${defaultBranch}/${filePath}`
     : '';
 
-  useEffect(() => {
-    const fetchContent = async () => {
+  useAbortableEffect(
+    async (signal) => {
       if (!filePath || isImage) {
         // Don't fetch text content for images or if no file selected
         setContent(null);
@@ -41,23 +45,24 @@ const CodeViewer: React.FC<CodeViewerProps> = ({
       setLoading(true);
       setError(null);
       try {
-        // Use raw.githubusercontent.com
-        const response = await axios.get(rawUrl, {
-          transformResponse: [(data) => data],
-        }); // Force text
+        const response = await axios.get<string>(rawUrl, {
+          transformResponse: [(data) => data], // Force text
+          signal,
+        });
+        if (signal.aborted) return;
         setContent(response.data);
       } catch (err) {
+        if (isAbortError(err)) return;
         console.error('Failed to fetch file content', err);
         setError(
           'Could not load file content. It might be binary or too large.',
         );
       } finally {
-        setLoading(false);
+        if (!signal.aborted) setLoading(false);
       }
-    };
-
-    fetchContent();
-  }, [repositoryFullName, filePath, defaultBranch, isImage, rawUrl]);
+    },
+    [filePath, isImage, rawUrl],
+  );
 
   if (!filePath) {
     return (

--- a/src/components/repositories/ContributingViewer.tsx
+++ b/src/components/repositories/ContributingViewer.tsx
@@ -1,11 +1,12 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { Box, Paper, CircularProgress, Alert } from '@mui/material';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import rehypeRaw from 'rehype-raw';
-import axios from 'axios';
 import { STATUS_COLORS } from '../../theme';
 import { resolveRelativeUrl } from './MarkdownRenderers';
+import { useAbortableEffect } from '../../hooks/useAbortableEffect';
+import { fetchFirstMarkdown } from './jsdelivrFetch';
 
 interface ContributingViewerProps {
   repositoryFullName: string; // e.g., "opentensor/bittensor"
@@ -19,45 +20,28 @@ const ContributingViewer: React.FC<ContributingViewerProps> = ({
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    const fetchContributing = async () => {
+  useAbortableEffect(
+    async (signal) => {
+      if (!repositoryFullName) return;
       setLoading(true);
       setError(null);
-
-      const branches = ['main', 'master'];
-      const paths = [
-        'CONTRIBUTING.md',
-        '.github/CONTRIBUTING.md',
-        'docs/CONTRIBUTING.md',
-      ];
-
-      for (const branch of branches) {
-        for (const path of paths) {
-          try {
-            const response = await axios.get(
-              `https://cdn.jsdelivr.net/gh/${repositoryFullName}@${branch}/${path}`,
-            );
-            if (response.status === 200 && response.data) {
-              setContent(response.data);
-              setDefaultBranch(branch);
-              setLoading(false);
-              return;
-            }
-          } catch {
-            // Continue to next combination
-          }
-        }
+      const result = await fetchFirstMarkdown(
+        repositoryFullName,
+        ['main', 'master'],
+        ['CONTRIBUTING.md', '.github/CONTRIBUTING.md', 'docs/CONTRIBUTING.md'],
+        signal,
+      );
+      if (signal.aborted) return;
+      if (result) {
+        setContent(result.content);
+        setDefaultBranch(result.branch);
+      } else {
+        setError('No contributing guidelines found for this repository.');
       }
-
-      // If we get here, nothing was found
-      setError('No contributing guidelines found for this repository.');
       setLoading(false);
-    };
-
-    if (repositoryFullName) {
-      fetchContributing();
-    }
-  }, [repositoryFullName]);
+    },
+    [repositoryFullName],
+  );
 
   if (loading) {
     return (

--- a/src/components/repositories/ReadmeViewer.tsx
+++ b/src/components/repositories/ReadmeViewer.tsx
@@ -1,11 +1,12 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { Box, CircularProgress, Alert, Paper } from '@mui/material';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import rehypeRaw from 'rehype-raw';
-import axios from 'axios';
 import { STATUS_COLORS } from '../../theme';
 import { resolveRelativeUrl } from './MarkdownRenderers';
+import { useAbortableEffect } from '../../hooks/useAbortableEffect';
+import { fetchFirstMarkdown } from './jsdelivrFetch';
 
 interface ReadmeViewerProps {
   repositoryFullName: string; // e.g., "opentensor/bittensor"
@@ -17,38 +18,28 @@ const ReadmeViewer: React.FC<ReadmeViewerProps> = ({ repositoryFullName }) => {
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    const fetchReadme = async () => {
+  useAbortableEffect(
+    async (signal) => {
+      if (!repositoryFullName) return;
       setLoading(true);
       setError(null);
-      try {
-        // Try 'main' branch first
-        try {
-          const response = await axios.get(
-            `https://cdn.jsdelivr.net/gh/${repositoryFullName}@main/README.md`,
-          );
-          setContent(response.data);
-          setDefaultBranch('main');
-        } catch {
-          // Fallback to 'master' branch
-          const response = await axios.get(
-            `https://cdn.jsdelivr.net/gh/${repositoryFullName}@master/README.md`,
-          );
-          setContent(response.data);
-          setDefaultBranch('master');
-        }
-      } catch (err) {
-        console.error('Failed to fetch README', err);
+      const result = await fetchFirstMarkdown(
+        repositoryFullName,
+        ['main', 'master'],
+        ['README.md'],
+        signal,
+      );
+      if (signal.aborted) return;
+      if (result) {
+        setContent(result.content);
+        setDefaultBranch(result.branch);
+      } else {
         setError('Could not load README.md');
-      } finally {
-        setLoading(false);
       }
-    };
-
-    if (repositoryFullName) {
-      fetchReadme();
-    }
-  }, [repositoryFullName]);
+      setLoading(false);
+    },
+    [repositoryFullName],
+  );
 
   if (loading) {
     return (

--- a/src/components/repositories/jsdelivrFetch.ts
+++ b/src/components/repositories/jsdelivrFetch.ts
@@ -1,0 +1,45 @@
+import axios from 'axios';
+import { isAbortError } from '../../hooks/useAbortableEffect';
+
+/** Build a jsDelivr raw-file URL for a file at a given branch of a GitHub repo. */
+export const jsdelivrUrl = (
+  repositoryFullName: string,
+  branch: string,
+  path: string,
+): string =>
+  `https://cdn.jsdelivr.net/gh/${repositoryFullName}@${branch}/${path}`;
+
+export interface MarkdownProbeResult {
+  content: string;
+  branch: string;
+}
+
+/**
+ * Probe jsDelivr for the first branch/path combination that returns a non-empty
+ * file. Returns null when nothing was found or the signal was aborted.
+ * Aborts are propagated by re-throwing so callers can distinguish them from
+ * "not found".
+ */
+export async function fetchFirstMarkdown(
+  repositoryFullName: string,
+  branches: readonly string[],
+  paths: readonly string[],
+  signal: AbortSignal,
+): Promise<MarkdownProbeResult | null> {
+  for (const branch of branches) {
+    for (const path of paths) {
+      if (signal.aborted) return null;
+      try {
+        const { status, data } = await axios.get<string>(
+          jsdelivrUrl(repositoryFullName, branch, path),
+          { signal },
+        );
+        if (status === 200 && data) return { content: data, branch };
+      } catch (err) {
+        if (isAbortError(err)) return null;
+        // 404 or other failure — try the next combination.
+      }
+    }
+  }
+  return null;
+}

--- a/src/hooks/useAbortableEffect.ts
+++ b/src/hooks/useAbortableEffect.ts
@@ -1,0 +1,22 @@
+import { DependencyList, useEffect } from 'react';
+import axios from 'axios';
+
+/** True when an error came from an aborted request (axios CanceledError). */
+export const isAbortError = (err: unknown): boolean => axios.isCancel(err);
+
+/**
+ * Like useEffect, but passes an AbortSignal to the effect and aborts it when
+ * deps change or the component unmounts. Use the signal to cancel in-flight
+ * requests so late responses cannot overwrite state from the current render.
+ */
+export function useAbortableEffect(
+  effect: (signal: AbortSignal) => void | Promise<void>,
+  deps: DependencyList,
+): void {
+  useEffect(() => {
+    const controller = new AbortController();
+    void effect(controller.signal);
+    return () => controller.abort();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, deps);
+}


### PR DESCRIPTION
## Summary

Three viewers on the Repository Details page (`ReadmeViewer`, `ContributingViewer`, `CodeViewer`) fetched content in `useEffect` with no cleanup. On slow networks, switching repos or files before a request resolved let the old response land and overwrite the new view with stale content.
`ContributingViewer` was the worst offender since it probes up to six branch/path combinations per load.

## Approach

The same cancellation pattern would repeat in every viewer, so the fix adds two small shared primitives instead of inlining the same boilerplate three times:

- **`src/hooks/useAbortableEffect.ts`** owns the `AbortController` lifecycle and hands the effect a signal. Cleanup is automatic, so it cannot be forgotten in future viewers.
- **`src/components/repositories/jsdelivrFetch.ts`** exposes `fetchFirstMarkdown`, collapsing the branch/path probe loop that
  `ReadmeViewer` and `ContributingViewer` were each open coding. It is abort aware and returns `null` on cancellation.

Each viewer now passes the signal to `axios.get` and guards state writes with `signal.aborted`. URLs, fallback order, loading states, and error messages are unchanged.

## Related Issues

Fixes #297

## Type of Change

- [x] Bug fix
- [x] Refactor

## Screenshots

N/A, no visual change.

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [ ] Screenshots included for any UI/visual changes