### PR TITLE
fix: apply themed scrollbars to PR files changed panels

### DIFF
--- a/src/components/prs/PRFilesChanged.tsx
+++ b/src/components/prs/PRFilesChanged.tsx
@@ -44,7 +44,7 @@ import Tooltip from '@mui/material/Tooltip';
 import IconButton from '@mui/material/IconButton';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import Switch from '@mui/material/Switch';
-import { STATUS_COLORS, DIFF_COLORS } from '../../theme';
+import { STATUS_COLORS, DIFF_COLORS, scrollbarSx } from '../../theme';
 
 interface PRFile {
   sha: string;
@@ -1255,6 +1255,7 @@ const PRFileDiffViewer: React.FC<{
               overflowX: 'auto',
               overflowY: 'auto',
               mr: '16px',
+              ...scrollbarSx,
             }}
           >
             {viewMode === 'unified' ? (
@@ -1398,6 +1399,7 @@ const PRFilesChanged: React.FC<PRFilesChangedProps> = ({
             p: 1,
             display: 'flex',
             flexDirection: 'column',
+            ...scrollbarSx,
           }}
         >
           <Box


### PR DESCRIPTION
## Summary

Apply the project’s shared themed scrollbar styling to both scrollable panels in the PR `Files Changed` view:
- the left file tree sidebar
- the right diff content panel

This keeps the PR details experience visually consistent with the rest of the app.

## Related Issues

Closes https://github.com/entrius/gittensor-ui/issues/309

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

| Before | After |
|---|---|
| <img width="1440" height="947" alt="Screenshot 2026-04-15 083131" src="https://github.com/user-attachments/assets/908bf003-d8be-4aea-98fa-197ce2adb731" /> | <img width="1347" height="952" alt="Screenshot 2026-04-15 083147" src="https://github.com/user-attachments/assets/2d45c8f6-831c-412b-a9a8-59bdf2fd1d6c" /> |

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
