### PR TITLE
fix: back button and scroll-to-top issues on tabbed pages

### DIFF
--- a/src/components/miners/MinerPRsTable.tsx
+++ b/src/components/miners/MinerPRsTable.tsx
@@ -101,7 +101,7 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
         if (next === 0) p.delete('prPage');
         else p.set('prPage', String(next));
         return p;
-      });
+      }, { replace: true });
     },
     [page, setSearchParams],
   );

--- a/src/components/miners/MinerPRsTable.tsx
+++ b/src/components/miners/MinerPRsTable.tsx
@@ -96,12 +96,15 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
   const setPage = useCallback(
     (updater: number | ((prev: number) => number)) => {
       const next = typeof updater === 'function' ? updater(page) : updater;
-      setSearchParams((prev) => {
-        const p = new URLSearchParams(prev);
-        if (next === 0) p.delete('prPage');
-        else p.set('prPage', String(next));
-        return p;
-      }, { replace: true });
+      setSearchParams(
+        (prev) => {
+          const p = new URLSearchParams(prev);
+          if (next === 0) p.delete('prPage');
+          else p.set('prPage', String(next));
+          return p;
+        },
+        { replace: true },
+      );
     },
     [page, setSearchParams],
   );

--- a/src/components/miners/MinerScoreBreakdown.tsx
+++ b/src/components/miners/MinerScoreBreakdown.tsx
@@ -728,7 +728,7 @@ const PrBreakdownView: React.FC<{ githubId: string }> = ({ githubId }) => {
         if (next === 0) p.delete('scorePage');
         else p.set('scorePage', String(next));
         return p;
-      });
+      }, { replace: true });
     },
     [page, setSearchParams],
   );

--- a/src/components/miners/MinerScoreBreakdown.tsx
+++ b/src/components/miners/MinerScoreBreakdown.tsx
@@ -723,12 +723,15 @@ const PrBreakdownView: React.FC<{ githubId: string }> = ({ githubId }) => {
   const setPage = useCallback(
     (updater: number | ((prev: number) => number)) => {
       const next = typeof updater === 'function' ? updater(page) : updater;
-      setSearchParams((prev) => {
-        const p = new URLSearchParams(prev);
-        if (next === 0) p.delete('scorePage');
-        else p.set('scorePage', String(next));
-        return p;
-      }, { replace: true });
+      setSearchParams(
+        (prev) => {
+          const p = new URLSearchParams(prev);
+          if (next === 0) p.delete('scorePage');
+          else p.set('scorePage', String(next));
+          return p;
+        },
+        { replace: true },
+      );
     },
     [page, setSearchParams],
   );

--- a/src/hooks/useOnNavigate.ts
+++ b/src/hooks/useOnNavigate.ts
@@ -1,11 +1,14 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useLocation } from 'react-router-dom';
 
 export const useOnNavigate = (callback: () => void) => {
   const { pathname } = useLocation();
+  const callbackRef = useRef(callback);
+  callbackRef.current = callback;
+
   useEffect(() => {
-    callback();
-  }, [callback, pathname]);
+    callbackRef.current();
+  }, [pathname]);
 };
 
 export default useOnNavigate;

--- a/src/pages/MinerDetailsPage.tsx
+++ b/src/pages/MinerDetailsPage.tsx
@@ -54,7 +54,7 @@ const MinerDetailsPage: React.FC = () => {
     const p = new URLSearchParams(searchParams);
     p.set('mode', mode);
     p.set('tab', 'overview');
-    setSearchParams(p);
+    setSearchParams(p, { replace: true });
   };
 
   const handleTabChange = (
@@ -63,7 +63,7 @@ const MinerDetailsPage: React.FC = () => {
   ) => {
     const p = new URLSearchParams(searchParams);
     p.set('tab', newValue);
-    setSearchParams(p);
+    setSearchParams(p, { replace: true });
   };
 
   if (!githubId) {

--- a/src/pages/OnboardPage.tsx
+++ b/src/pages/OnboardPage.tsx
@@ -41,7 +41,7 @@ const OnboardPage: React.FC = () => {
   const handleTabChange = (_event: React.SyntheticEvent, newValue: number) => {
     const newParams = new URLSearchParams(searchParams);
     newParams.set('tab', indexToTabName[newValue]);
-    setSearchParams(newParams);
+    setSearchParams(newParams, { replace: true });
   };
 
   return (


### PR DESCRIPTION
## Summary

- Fix back button requiring multiple clicks on Miner Details page by using `{ replace: true }` on all `setSearchParams` calls for tabs, filters, and pagination
- Fix scroll jumping to top when switching tabs by stabilising the `useOnNavigate` callback with `useRef` so it only fires on actual pathname changes
- Add `{ replace: true }` to OnboardPage tab navigation for consistency

## Related Issues

Fixes #311

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Videos
Bug:
https://github.com/user-attachments/assets/fe526026-1fa6-4a10-96b7-a041f0ada75c
Fix:
https://github.com/user-attachments/assets/c6292bc5-9015-4770-b3a8-64bfb525acd7

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [ ] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
