### PR TITLE
refactor(miners): replace hardcoded colors with theme tokens

### DIFF
--- a/src/components/miners/CredibilityChart.tsx
+++ b/src/components/miners/CredibilityChart.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react';
-import { Box, Typography } from '@mui/material';
+import { Box, Typography, alpha, useTheme } from '@mui/material';
 import ReactECharts from 'echarts-for-react';
-import { CHART_COLORS } from '../../theme';
+import { CHART_COLORS, TEXT_OPACITY } from '../../theme';
 
 interface CredibilityChartProps {
   merged: number;
@@ -16,6 +16,8 @@ const CredibilityChart: React.FC<CredibilityChartProps> = ({
   closed,
   credibility,
 }) => {
+  const theme = useTheme();
+
   const chartOption = useMemo(
     () => ({
       backgroundColor: 'transparent',
@@ -25,13 +27,13 @@ const CredibilityChart: React.FC<CredibilityChartProps> = ({
         left: 'center',
         top: '38%',
         textStyle: {
-          color: '#fff',
+          color: theme.palette.text.primary,
           fontSize: 28,
           fontWeight: 'bold',
           fontFamily: '"JetBrains Mono", monospace',
         },
         subtextStyle: {
-          color: 'rgba(255, 255, 255, 0.4)',
+          color: alpha(theme.palette.common.white, TEXT_OPACITY.muted),
           fontSize: 11,
           fontFamily: '"JetBrains Mono", monospace',
           fontWeight: 500,
@@ -40,11 +42,11 @@ const CredibilityChart: React.FC<CredibilityChartProps> = ({
       tooltip: {
         trigger: 'item',
         formatter: '{b}: {c} ({d}%)',
-        backgroundColor: 'rgba(0, 0, 0, 0.9)',
-        borderColor: 'rgba(255, 255, 255, 0.15)',
+        backgroundColor: alpha(theme.palette.common.black, 0.9),
+        borderColor: alpha(theme.palette.common.white, 0.15),
         borderWidth: 1,
         textStyle: {
-          color: '#fff',
+          color: theme.palette.text.primary,
           fontFamily: '"JetBrains Mono", monospace',
         },
       },
@@ -56,7 +58,7 @@ const CredibilityChart: React.FC<CredibilityChartProps> = ({
           avoidLabelOverlap: false,
           itemStyle: {
             borderRadius: 6,
-            borderColor: '#0d1117',
+            borderColor: theme.palette.background.paper,
             borderWidth: 3,
           },
           label: { show: false, position: 'center' },
@@ -82,7 +84,7 @@ const CredibilityChart: React.FC<CredibilityChartProps> = ({
         },
       ],
     }),
-    [merged, open, closed, credibility],
+    [merged, open, closed, credibility, theme],
   );
 
   return (
@@ -96,7 +98,7 @@ const CredibilityChart: React.FC<CredibilityChartProps> = ({
       <Typography
         variant="monoSmall"
         sx={{
-          color: 'rgba(255, 255, 255, 0.4)',
+          color: alpha(theme.palette.common.white, TEXT_OPACITY.muted),
           mb: 0.75,
           textAlign: 'center',
         }}
@@ -133,36 +135,40 @@ const LegendItem: React.FC<{ label: string; value: number; color: string }> = ({
   label,
   value,
   color,
-}) => (
-  <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-    <Box
-      sx={{
-        width: 6,
-        height: 6,
-        borderRadius: '50%',
-        backgroundColor: color,
-      }}
-    />
-    <Typography
-      sx={{
-        color: 'rgba(255, 255, 255, 0.6)',
-        fontSize: '0.65rem',
-        fontFamily: '"JetBrains Mono", monospace',
-      }}
-    >
-      {label}
-    </Typography>
-    <Typography
-      sx={{
-        color,
-        fontSize: '0.75rem',
-        fontFamily: '"JetBrains Mono", monospace',
-        fontWeight: 700,
-      }}
-    >
-      {value}
-    </Typography>
-  </Box>
-);
+}) => {
+  const theme = useTheme();
+
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+      <Box
+        sx={{
+          width: 6,
+          height: 6,
+          borderRadius: '50%',
+          backgroundColor: color,
+        }}
+      />
+      <Typography
+        sx={{
+          color: alpha(theme.palette.common.white, TEXT_OPACITY.secondary),
+          fontSize: '0.65rem',
+          fontFamily: '"JetBrains Mono", monospace',
+        }}
+      >
+        {label}
+      </Typography>
+      <Typography
+        sx={{
+          color,
+          fontSize: '0.75rem',
+          fontFamily: '"JetBrains Mono", monospace',
+          fontWeight: 700,
+        }}
+      >
+        {value}
+      </Typography>
+    </Box>
+  );
+};
 
 export default CredibilityChart;

--- a/src/components/miners/MinerActivity.tsx
+++ b/src/components/miners/MinerActivity.tsx
@@ -1,5 +1,13 @@
 import React, { useMemo } from 'react';
-import { Box, Card, Typography, Grid, CircularProgress } from '@mui/material';
+import {
+  Box,
+  Card,
+  Typography,
+  Grid,
+  CircularProgress,
+  alpha,
+  useTheme,
+} from '@mui/material';
 import { subDays, format } from 'date-fns';
 import ReactECharts from 'echarts-for-react';
 import {
@@ -30,37 +38,41 @@ const LegendItem: React.FC<{ label: string; value: number; color: string }> = ({
   label,
   value,
   color,
-}) => (
-  <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-    <Box
-      sx={{
-        width: 6,
-        height: 6,
-        borderRadius: '50%',
-        backgroundColor: color,
-      }}
-    />
-    <Typography
-      sx={{
-        color: `rgba(255, 255, 255, ${TEXT_OPACITY.tertiary})`,
-        fontSize: '0.65rem',
-        fontFamily: '"JetBrains Mono", monospace',
-      }}
-    >
-      {label}
-    </Typography>
-    <Typography
-      sx={{
-        color,
-        fontSize: '0.75rem',
-        fontFamily: '"JetBrains Mono", monospace',
-        fontWeight: 700,
-      }}
-    >
-      {value}
-    </Typography>
-  </Box>
-);
+}) => {
+  const theme = useTheme();
+
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+      <Box
+        sx={{
+          width: 6,
+          height: 6,
+          borderRadius: '50%',
+          backgroundColor: color,
+        }}
+      />
+      <Typography
+        sx={{
+          color: alpha(theme.palette.common.white, TEXT_OPACITY.tertiary),
+          fontSize: '0.65rem',
+          fontFamily: '"JetBrains Mono", monospace',
+        }}
+      >
+        {label}
+      </Typography>
+      <Typography
+        sx={{
+          color,
+          fontSize: '0.75rem',
+          fontFamily: '"JetBrains Mono", monospace',
+          fontWeight: 700,
+        }}
+      >
+        {value}
+      </Typography>
+    </Box>
+  );
+};
 
 const IssueCredibilityChart: React.FC<{
   solved: number;
@@ -68,6 +80,8 @@ const IssueCredibilityChart: React.FC<{
   closed: number;
   credibility: number;
 }> = ({ solved, open, closed, credibility }) => {
+  const theme = useTheme();
+
   const chartOption = useMemo(
     () => ({
       backgroundColor: 'transparent',
@@ -77,13 +91,13 @@ const IssueCredibilityChart: React.FC<{
         left: 'center',
         top: '38%',
         textStyle: {
-          color: `rgba(255, 255, 255, ${TEXT_OPACITY.primary})`,
+          color: theme.palette.text.primary,
           fontSize: 28,
           fontWeight: 'bold',
           fontFamily: '"JetBrains Mono", monospace',
         },
         subtextStyle: {
-          color: `rgba(255, 255, 255, ${TEXT_OPACITY.muted})`,
+          color: alpha(theme.palette.common.white, TEXT_OPACITY.muted),
           fontSize: 11,
           fontFamily: '"JetBrains Mono", monospace',
           fontWeight: 500,
@@ -92,11 +106,11 @@ const IssueCredibilityChart: React.FC<{
       tooltip: {
         trigger: 'item',
         formatter: '{b}: {c} ({d}%)',
-        backgroundColor: 'rgba(0, 0, 0, 0.9)',
-        borderColor: `rgba(255, 255, 255, ${TEXT_OPACITY.ghost})`,
+        backgroundColor: alpha(theme.palette.common.black, 0.9),
+        borderColor: alpha(theme.palette.common.white, TEXT_OPACITY.ghost),
         borderWidth: 1,
         textStyle: {
-          color: `rgba(255, 255, 255, ${TEXT_OPACITY.primary})`,
+          color: theme.palette.text.primary,
           fontFamily: '"JetBrains Mono", monospace',
         },
       },
@@ -134,7 +148,7 @@ const IssueCredibilityChart: React.FC<{
         },
       ],
     }),
-    [solved, open, closed, credibility],
+    [solved, open, closed, credibility, theme],
   );
 
   return (
@@ -148,7 +162,7 @@ const IssueCredibilityChart: React.FC<{
       <Typography
         variant="monoSmall"
         sx={{
-          color: `rgba(255, 255, 255, ${TEXT_OPACITY.muted})`,
+          color: alpha(theme.palette.common.white, TEXT_OPACITY.muted),
           mb: 0.75,
           textAlign: 'center',
         }}
@@ -187,6 +201,8 @@ const IssuePerformanceRadar: React.FC<{
   volume: number;
   tokenScore: number;
 }> = ({ credibility, solvedRatio, validRatio, volume, tokenScore }) => {
+  const theme = useTheme();
+
   const chartOption = useMemo(
     () => ({
       backgroundColor: 'transparent',
@@ -203,7 +219,7 @@ const IssuePerformanceRadar: React.FC<{
         shape: 'circle',
         splitNumber: 5,
         axisName: {
-          color: `rgba(255, 255, 255, ${TEXT_OPACITY.tertiary})`,
+          color: alpha(theme.palette.common.white, TEXT_OPACITY.tertiary),
           fontFamily: '"JetBrains Mono", monospace',
           fontSize: 9,
           lineHeight: 12,
@@ -211,14 +227,14 @@ const IssuePerformanceRadar: React.FC<{
         splitLine: {
           lineStyle: {
             color: Array(5).fill(
-              `rgba(255, 255, 255, ${TEXT_OPACITY.ghost * 0.25})`,
+              alpha(theme.palette.common.white, TEXT_OPACITY.ghost * 0.25),
             ),
           },
         },
         splitArea: { show: false },
         axisLine: {
           lineStyle: {
-            color: `rgba(255, 255, 255, ${TEXT_OPACITY.ghost * 0.5})`,
+            color: alpha(theme.palette.common.white, TEXT_OPACITY.ghost * 0.5),
           },
         },
       },
@@ -244,7 +260,7 @@ const IssuePerformanceRadar: React.FC<{
         },
       ],
     }),
-    [credibility, solvedRatio, validRatio, volume, tokenScore],
+    [credibility, solvedRatio, validRatio, volume, tokenScore, theme],
   );
 
   return (
@@ -258,7 +274,7 @@ const IssuePerformanceRadar: React.FC<{
       <Typography
         variant="monoSmall"
         sx={{
-          color: `rgba(255, 255, 255, ${TEXT_OPACITY.muted})`,
+          color: alpha(theme.palette.common.white, TEXT_OPACITY.muted),
           mb: 2,
           textAlign: 'center',
         }}

--- a/src/components/miners/PerformanceRadar.tsx
+++ b/src/components/miners/PerformanceRadar.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react';
-import { Box, Typography } from '@mui/material';
+import { Box, Typography, alpha, useTheme } from '@mui/material';
 import ReactECharts from 'echarts-for-react';
-import { STATUS_COLORS } from '../../theme';
+import { STATUS_COLORS, TEXT_OPACITY } from '../../theme';
 
 interface PerformanceRadarProps {
   credibility: number;
@@ -20,6 +20,8 @@ const PerformanceRadar: React.FC<PerformanceRadarProps> = ({
   totalPRs,
   avgRepoWeight,
 }) => {
+  const theme = useTheme();
+
   const chartOption = useMemo(
     () => ({
       backgroundColor: 'transparent',
@@ -37,19 +39,19 @@ const PerformanceRadar: React.FC<PerformanceRadarProps> = ({
         shape: 'circle',
         splitNumber: 5,
         axisName: {
-          color: 'rgba(255, 255, 255, 0.6)',
+          color: alpha(theme.palette.common.white, TEXT_OPACITY.secondary),
           fontFamily: '"JetBrains Mono", monospace',
           fontSize: 9,
           lineHeight: 12,
         },
         splitLine: {
           lineStyle: {
-            color: Array(5).fill('rgba(255, 255, 255, 0.05)'),
+            color: Array(5).fill(alpha(theme.palette.common.white, 0.05)),
           },
         },
         splitArea: { show: false },
         axisLine: {
-          lineStyle: { color: 'rgba(255, 255, 255, 0.1)' },
+          lineStyle: { color: alpha(theme.palette.common.white, 0.1) },
         },
       },
       series: [
@@ -88,6 +90,7 @@ const PerformanceRadar: React.FC<PerformanceRadarProps> = ({
       uniqueRepos,
       totalPRs,
       avgRepoWeight,
+      theme,
     ],
   );
 
@@ -101,7 +104,11 @@ const PerformanceRadar: React.FC<PerformanceRadarProps> = ({
     >
       <Typography
         variant="monoSmall"
-        sx={{ color: 'rgba(255, 255, 255, 0.4)', mb: 2, textAlign: 'center' }}
+        sx={{
+          color: alpha(theme.palette.common.white, TEXT_OPACITY.muted),
+          mb: 2,
+          textAlign: 'center',
+        }}
       >
         Performance Profile
       </Typography>

--- a/src/components/miners/TrustBadge.tsx
+++ b/src/components/miners/TrustBadge.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo } from 'react';
 import { Chip } from '@mui/material';
+import { alpha } from '@mui/material/styles';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import WarningAmberIcon from '@mui/icons-material/WarningAmber';
 import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
@@ -68,9 +69,9 @@ export const getRiskAssessment = (
   if (credibility >= 0.5) {
     return {
       level: 'medium',
-      color: '#9ca3af',
-      bgColor: 'rgba(156, 163, 175, 0.1)',
-      border: '1px solid rgba(156, 163, 175, 0.25)',
+      color: STATUS_COLORS.neutral,
+      bgColor: alpha(STATUS_COLORS.neutral, 0.1),
+      border: `1px solid ${alpha(STATUS_COLORS.neutral, 0.25)}`,
       icon: <WarningAmberIcon sx={ICON_SIZE} />,
       message: 'Moderate Trust - Standard Code Review',
     };


### PR DESCRIPTION
## Summary

As the continuous work of refactoring to get rid of all hard coded color value usages in this [PR](https://github.com/entrius/gittensor-ui/pull/252)

- Refactors miner UI components to remove hardcoded color literals and use centralized theme tokens.
- Replaces direct color strings with theme.palette, alpha(...), and shared constants (e.g. TEXT_OPACITY, STATUS_COLORS, CHART_COLORS).
- Keeps existing visual behavior while improving consistency and maintainability.

## Scope

- src/components/miners/CredibilityChart.tsx
- src/components/miners/MinerActivity.tsx
- src/components/miners/PerformanceRadar.tsx
- src/components/miners/TrustBadge.tsx


## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

<!-- Include before/after screenshots for every UI/visual change. Remove this section if not applicable. -->

## Checklist

- [ ] New components are modularized/separated where sensible
- [ ] Uses predefined theme (e.g. no hardcoded colors)
- [ ] Responsive/mobile checked
- [ ] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [ ] Screenshots included for any UI/visual changes
