### PR TITLE
feat: add Issue Discoveries status charts and unify miner status labels on dashboard

### DIFF
--- a/src/components/dashboard/GlobalActivity.tsx
+++ b/src/components/dashboard/GlobalActivity.tsx
@@ -310,14 +310,22 @@ const GlobalActivity: React.FC = () => {
                   title="Eligible"
                   subtitle="Paid"
                   variant="primary"
-                  statLabels={{ merged: 'Solved', open: 'Open', closed: 'Closed' }}
+                  statLabels={{
+                    merged: 'Solved',
+                    open: 'Open',
+                    closed: 'Closed',
+                  }}
                 />
                 <PRStatusChart
                   stats={inactiveDiscoveryStats}
                   title="Ineligible"
                   subtitle="Unpaid"
                   variant="secondary"
-                  statLabels={{ merged: 'Solved', open: 'Open', closed: 'Closed' }}
+                  statLabels={{
+                    merged: 'Solved',
+                    open: 'Open',
+                    closed: 'Closed',
+                  }}
                 />
               </Box>
             </Card>

--- a/src/components/dashboard/GlobalActivity.tsx
+++ b/src/components/dashboard/GlobalActivity.tsx
@@ -268,13 +268,13 @@ const GlobalActivity: React.FC = () => {
               >
                 <PRStatusChart
                   stats={activeStats}
-                  title="Active"
+                  title="Eligible"
                   subtitle="Paid"
                   variant="primary"
                 />
                 <PRStatusChart
                   stats={inactiveStats}
-                  title="Unranked"
+                  title="Ineligible"
                   subtitle="Unpaid"
                   variant="secondary"
                 />

--- a/src/components/dashboard/GlobalActivity.tsx
+++ b/src/components/dashboard/GlobalActivity.tsx
@@ -131,6 +131,45 @@ const GlobalActivity: React.FC = () => {
     };
   }, [allMinerStats]);
 
+  // Calculate Active/Inactive Discovery Stats
+  const { activeDiscoveryStats, inactiveDiscoveryStats } = useMemo(() => {
+    const defaultStats = { merged: 0, open: 0, closed: 0 };
+
+    if (!Array.isArray(allMinerStats)) {
+      return {
+        activeDiscoveryStats: { ...defaultStats, credibility: 0 },
+        inactiveDiscoveryStats: { ...defaultStats, credibility: 0 },
+      };
+    }
+
+    const active = { ...defaultStats };
+    const inactive = { ...defaultStats };
+
+    allMinerStats.forEach((m) => {
+      const target = m.isIssueEligible ? active : inactive;
+      target.merged += m.totalSolvedIssues || 0;
+      target.open += m.totalOpenIssues || 0;
+      target.closed += m.totalClosedIssues || 0;
+    });
+
+    return {
+      activeDiscoveryStats: {
+        ...active,
+        credibility:
+          active.merged + active.closed > 0
+            ? active.merged / (active.merged + active.closed)
+            : 0,
+      },
+      inactiveDiscoveryStats: {
+        ...inactive,
+        credibility:
+          inactive.merged + inactive.closed > 0
+            ? inactive.merged / (inactive.merged + inactive.closed)
+            : 0,
+      },
+    };
+  }, [allMinerStats]);
+
   if (isLoadingPRs || isLoadingStats) {
     return (
       <Card sx={{ p: 4, display: 'flex', justifyContent: 'center' }}>
@@ -238,6 +277,47 @@ const GlobalActivity: React.FC = () => {
                   title="Unranked"
                   subtitle="Unpaid"
                   variant="secondary"
+                />
+              </Box>
+            </Card>
+          </Grid>
+
+          {/* Issue Discoveries Stats */}
+          <Grid item xs={12}>
+            <Card
+              sx={{
+                p: { xs: 1.5, sm: 3 },
+                display: 'flex',
+                flexDirection: 'column',
+                overflow: 'visible',
+              }}
+            >
+              <Typography
+                variant="sectionTitle"
+                sx={{ mb: 2, fontSize: '0.95rem' }}
+              >
+                Issue Discoveries
+              </Typography>
+              <Box
+                sx={{
+                  display: 'flex',
+                  flexDirection: 'row',
+                  gap: { xs: 1, sm: 3, lg: 1.5, xl: 3 },
+                }}
+              >
+                <PRStatusChart
+                  stats={activeDiscoveryStats}
+                  title="Eligible"
+                  subtitle="Paid"
+                  variant="primary"
+                  statLabels={{ merged: 'Solved', open: 'Open', closed: 'Closed' }}
+                />
+                <PRStatusChart
+                  stats={inactiveDiscoveryStats}
+                  title="Ineligible"
+                  subtitle="Unpaid"
+                  variant="secondary"
+                  statLabels={{ merged: 'Solved', open: 'Open', closed: 'Closed' }}
                 />
               </Box>
             </Card>

--- a/src/components/dashboard/PRStatusChart.tsx
+++ b/src/components/dashboard/PRStatusChart.tsx
@@ -15,6 +15,7 @@ interface PRStatusChartProps {
   title: string;
   subtitle?: string;
   variant?: 'primary' | 'secondary';
+  statLabels?: { merged: string; open: string; closed: string };
 }
 
 const PRStatusChart: React.FC<PRStatusChartProps> = ({
@@ -22,6 +23,7 @@ const PRStatusChart: React.FC<PRStatusChartProps> = ({
   title,
   subtitle,
   variant = 'primary',
+  statLabels = { merged: 'Merged', open: 'Open', closed: 'Closed' },
 }) => {
   const theme = useTheme();
   const { merged, open, closed, credibility } = stats;
@@ -74,7 +76,7 @@ const PRStatusChart: React.FC<PRStatusChartProps> = ({
           data: [
             {
               value: merged,
-              name: 'Merged',
+              name: statLabels.merged,
               itemStyle: {
                 color: CHART_COLORS.merged,
                 opacity: isPrimary ? 1 : 0.7,
@@ -82,7 +84,7 @@ const PRStatusChart: React.FC<PRStatusChartProps> = ({
             },
             {
               value: open,
-              name: 'Open',
+              name: statLabels.open,
               itemStyle: {
                 color: CHART_COLORS.open,
                 opacity: isPrimary ? 1 : 0.7,
@@ -90,7 +92,7 @@ const PRStatusChart: React.FC<PRStatusChartProps> = ({
             },
             {
               value: closed,
-              name: 'Closed',
+              name: statLabels.closed,
               itemStyle: {
                 color: CHART_COLORS.closed,
                 opacity: isPrimary ? 1 : 0.7,
@@ -100,7 +102,7 @@ const PRStatusChart: React.FC<PRStatusChartProps> = ({
         },
       ],
     }),
-    [merged, open, closed, credibilityPercent, isPrimary, theme],
+    [merged, open, closed, credibilityPercent, isPrimary, theme, statLabels],
   );
 
   return (
@@ -170,9 +172,9 @@ const PRStatusChart: React.FC<PRStatusChartProps> = ({
           justifyContent: 'center',
         }}
       >
-        <StatItem label="Merged" value={merged} />
-        <StatItem label="Open" value={open} />
-        <StatItem label="Closed" value={closed} />
+        <StatItem label={statLabels.merged} value={merged} />
+        <StatItem label={statLabels.open} value={open} />
+        <StatItem label={statLabels.closed} value={closed} />
       </Box>
     </Box>
   );


### PR DESCRIPTION
## Summary

- Added **Issue Discoveries** status section to the Global Developer Activity dashboard, displaying two donut charts — **Eligible (Paid)** and **Ineligible (Unpaid)** — aggregating solved, open, and closed issue counts across all miners split by `isIssueEligible`
- Renamed OSS contribution charts from **Active/Unranked** to **Eligible/Ineligible** to be consistent with the miner status terminology used across the rest of the app
- Extended `PRStatusChart` with an optional `statLabels` prop to support custom stat labels (e.g. "Solved" instead of "Merged"), keeping existing usage fully backward-compatible

## Changes

- `src/components/dashboard/PRStatusChart.tsx` — added optional `statLabels` prop with default `{ merged: 'Merged', open: 'Open', closed: 'Closed' }`
- `src/components/dashboard/GlobalActivity.tsx` — renamed OSS chart titles to Eligible/Ineligible, added discovery stats `useMemo` and a new full-width "Issue Discoveries" card

## Test plan

- [ ] Navigate to the Dashboard page and confirm the "Issue Discoveries" section appears below the heatmap and PR charts
- [ ] Verify OSS charts now display **Eligible (Paid)** and **Ineligible (Unpaid)** labels
- [ ] Verify **Eligible (Paid)** discovery chart shows counts from miners where `isIssueEligible === true`
- [ ] Verify **Ineligible (Unpaid)** discovery chart shows counts from miners where `isIssueEligible === false`
- [ ] Confirm discovery stat labels read **Solved / Open / Closed**
- [ ] Confirm OSS stat labels still read **Merged / Open / Closed**

## Closes: #315 

## Screenshot

https://github.com/user-attachments/assets/9155a489-3e98-4033-ad03-7872abd05f32

