### PR TITLE
fix(api): normalize list query responses to arrays

### DIFF
--- a/src/api/ApiUtils.ts
+++ b/src/api/ApiUtils.ts
@@ -1,6 +1,9 @@
 import { useQuery } from '@tanstack/react-query';
 import axios, { type AxiosError } from 'axios';
 
+export const ensureArray = <T>(value: unknown): T[] =>
+  Array.isArray(value) ? value : [];
+
 export const useApiQuery = <TResponse = void, TSelect = TResponse>(
   queryName: string,
   url: string,
@@ -16,6 +19,28 @@ export const useApiQuery = <TResponse = void, TSelect = TResponse>(
       const requestUrl = baseUrl ? `${baseUrl}${url}` : url;
       const { data } = await axios.get(requestUrl, { params: queryParams });
       return data;
+    },
+    retry: false,
+    enabled: enabled ?? true,
+    refetchInterval,
+  });
+};
+
+export const useArrayApiQuery = <TItem = void>(
+  queryName: string,
+  url: string,
+  refetchInterval?: number,
+  queryParams?: Record<string, string | number | undefined>,
+  enabled?: boolean,
+) => {
+  const baseUrl = import.meta.env.VITE_REACT_APP_BASE_URL;
+
+  return useQuery<TItem[], AxiosError, TItem[]>({
+    queryKey: [queryName, url, queryParams],
+    queryFn: async () => {
+      const requestUrl = baseUrl ? `${baseUrl}${url}` : url;
+      const { data } = await axios.get(requestUrl, { params: queryParams });
+      return ensureArray<TItem>(data);
     },
     retry: false,
     enabled: enabled ?? true,

--- a/src/api/DashboardApi.ts
+++ b/src/api/DashboardApi.ts
@@ -1,4 +1,4 @@
-import { useApiQuery } from './ApiUtils';
+import { useApiQuery, useArrayApiQuery, ensureArray } from './ApiUtils';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import axios from 'axios';
 import {
@@ -25,13 +25,31 @@ export const useDashboardQuery = <TResponse = void, TSelect = TResponse>(
     enabled,
   );
 
+export const useDashboardArrayQuery = <TItem = void>(
+  queryName: string,
+  url: string,
+  refetchInterval?: number,
+  queryParams?: Record<string, string | number | undefined>,
+  enabled?: boolean,
+) =>
+  useArrayApiQuery<TItem>(
+    queryName,
+    `/dash${url}`,
+    refetchInterval,
+    queryParams,
+    enabled,
+  );
+
 export const useStats = () => useDashboardQuery<Stats>('useStats', '/stats');
 
 export const useHistoricalTrend = () =>
-  useDashboardQuery<CommitsTrend[]>('useHistoricalTrend', '/lines/hist-trend');
+  useDashboardArrayQuery<CommitsTrend>(
+    'useHistoricalTrend',
+    '/lines/hist-trend',
+  );
 
 export const useRepoChanges = (options?: { refetchInterval?: number }) =>
-  useDashboardQuery<RepoChanges[]>(
+  useDashboardArrayQuery<RepoChanges>(
     'useRepoChanges',
     '/repos/commits',
     options?.refetchInterval,
@@ -42,17 +60,20 @@ export const getReposQueryKey = () =>
   ['useReposAndWeights', '/dash/repos', undefined] as const;
 
 export const useReposAndWeights = () =>
-  useDashboardQuery<Repository[]>('useReposAndWeights', '/repos');
+  useDashboardArrayQuery<Repository>('useReposAndWeights', '/repos');
 
 export const useLanguagesAndWeights = () =>
-  useDashboardQuery<LanguageWeight[]>('useLanguagesAndWeights', '/languages');
+  useDashboardArrayQuery<LanguageWeight>(
+    'useLanguagesAndWeights',
+    '/languages',
+  );
 
 export const useCommitLog = (
   options?: { refetchInterval?: number },
   page?: number,
   limit?: number,
 ) =>
-  useDashboardQuery<CommitLog[]>(
+  useDashboardArrayQuery<CommitLog>(
     'useCommitLog',
     '/commits',
     options?.refetchInterval,
@@ -73,7 +94,7 @@ export const useInfiniteCommitLog = (options?: {
       const { data } = await axios.get<CommitLog[]>(requestUrl, {
         params: { page: pageParam, limit },
       });
-      return data;
+      return ensureArray<CommitLog>(data);
     },
     getNextPageParam: (lastPage: CommitLog[], allPages: CommitLog[][]) => {
       // If the last page has fewer items than the limit, we've reached the end

--- a/src/api/IssuesApi.ts
+++ b/src/api/IssuesApi.ts
@@ -1,7 +1,7 @@
 /**
  * Issues API - For issue bounties.
  */
-import { useApiQuery } from './ApiUtils';
+import { useApiQuery, useArrayApiQuery } from './ApiUtils';
 import {
   IssueBounty,
   IssueDetails,
@@ -17,7 +17,7 @@ export const useIssues = (status?: string, repository?: string) => {
   const params: Record<string, string> = {};
   if (status) params.status = status;
   if (repository) params.repository = repository;
-  return useApiQuery<IssueBounty[]>(
+  return useArrayApiQuery<IssueBounty>(
     'useIssues',
     '/issues',
     undefined,
@@ -37,7 +37,7 @@ export const getIssuesQueryKey = (status?: string, repository?: string) =>
  * Fetch all bounties for a specific repository.
  */
 export const useRepoIssues = (repoFullName: string) =>
-  useApiQuery<IssueBounty[]>(
+  useArrayApiQuery<IssueBounty>(
     'useRepoIssues',
     '/issues',
     undefined,
@@ -79,7 +79,7 @@ export const useIssueDetails = (id: number) =>
  * Fetch PR submissions for an issue.
  */
 export const useIssueSubmissions = (id: number) =>
-  useApiQuery<IssueSubmission[]>(
+  useArrayApiQuery<IssueSubmission>(
     'useIssueSubmissions',
     `/issues/${id}/submissions`,
     undefined,

--- a/src/api/MinerApi.ts
+++ b/src/api/MinerApi.ts
@@ -1,5 +1,5 @@
 // Miner API hooks - uses /miners endpoints
-import { useApiQuery } from './ApiUtils';
+import { useApiQuery, useArrayApiQuery } from './ApiUtils';
 import {
   type GithubMinerData,
   type MinerEvaluation,
@@ -24,13 +24,28 @@ const useMinersQuery = <TResponse = void, TSelect = TResponse>(
     enabled,
   );
 
+const useMinersArrayQuery = <TItem = void>(
+  queryName: string,
+  url: string,
+  refetchInterval?: number,
+  queryParams?: Record<string, string | number | undefined>,
+  enabled?: boolean,
+) =>
+  useArrayApiQuery<TItem>(
+    queryName,
+    `/miners${url}`,
+    refetchInterval,
+    queryParams,
+    enabled,
+  );
+
 /**
  * Get all active miners with their pre-computed stats
  * Only includes miners currently registered on the subnet (in current_miners table)
  * Ideal for leaderboards
  */
 export const useAllMiners = () =>
-  useMinersQuery<MinerEvaluation[]>('useAllMiners', '');
+  useMinersArrayQuery<MinerEvaluation>('useAllMiners', '');
 
 // Shared cache key for the miners dataset.
 export const getAllMinersQueryKey = () =>
@@ -49,7 +64,7 @@ export const useMinerStats = (githubId: string) =>
  * @param enabled - Optional flag to enable/disable the query
  */
 export const useMinerPRs = (githubId: string, enabled?: boolean) =>
-  useMinersQuery<CommitLog[]>(
+  useMinersArrayQuery<CommitLog>(
     'useMinerPRs',
     `/${githubId}/prs`,
     undefined,

--- a/src/api/PrsApi.ts
+++ b/src/api/PrsApi.ts
@@ -1,5 +1,5 @@
 // Pull Request API hooks - uses /prs endpoints
-import { useApiQuery } from './ApiUtils';
+import { useApiQuery, useArrayApiQuery } from './ApiUtils';
 import {
   type CommitLog,
   type PullRequestComment,
@@ -24,11 +24,26 @@ const usePrsQuery = <TResponse = void, TSelect = TResponse>(
     enabled,
   );
 
+const usePrsArrayQuery = <TItem = void>(
+  queryName: string,
+  url: string,
+  refetchInterval?: number,
+  queryParams?: Record<string, string | number | undefined>,
+  enabled?: boolean,
+) =>
+  useArrayApiQuery<TItem>(
+    queryName,
+    `/prs${url}`,
+    refetchInterval,
+    queryParams,
+    enabled,
+  );
+
 /**
  * Get all pull requests across the network
  * Returns all PRs regardless of miner registration status
  */
-export const useAllPrs = () => usePrsQuery<CommitLog[]>('useAllPrs', '');
+export const useAllPrs = () => usePrsArrayQuery<CommitLog>('useAllPrs', '');
 
 // Shared cache key for the pull requests dataset.
 export const getAllPrsQueryKey = () =>
@@ -58,7 +73,7 @@ export const usePullRequestDetails = (
  * @param number - Pull request number
  */
 export const usePullRequestComments = (repo: string, number: number) =>
-  usePrsQuery<PullRequestComment[]>(
+  usePrsArrayQuery<PullRequestComment>(
     'usePullRequestComments',
     '/comments',
     undefined,

--- a/src/api/ReposApi.ts
+++ b/src/api/ReposApi.ts
@@ -1,5 +1,5 @@
 // Repository API hooks - uses /repos endpoints
-import { useApiQuery } from './ApiUtils';
+import { useApiQuery, useArrayApiQuery } from './ApiUtils';
 import { type RepositoryMaintainer, type RepositoryIssue } from './models';
 import { type CommitLog, type Repository } from './models/Dashboard';
 
@@ -13,6 +13,19 @@ const useReposQuery = <TResponse = void, TSelect = TResponse>(
   queryParams?: Record<string, string | number | undefined>,
 ) =>
   useApiQuery<TResponse, TSelect>(
+    queryName,
+    `/repos${url}`,
+    refetchInterval,
+    queryParams,
+  );
+
+const useReposArrayQuery = <TItem = void>(
+  queryName: string,
+  url: string,
+  refetchInterval?: number,
+  queryParams?: Record<string, string | number | undefined>,
+) =>
+  useArrayApiQuery<TItem>(
     queryName,
     `/repos${url}`,
     refetchInterval,
@@ -34,7 +47,7 @@ export const useRepositoryConfig = (repo: string) =>
  * @param repo - Full repository name (e.g., "opentensor/btcli")
  */
 export const useRepositoryMaintainers = (repo: string) =>
-  useReposQuery<RepositoryMaintainer[]>(
+  useReposArrayQuery<RepositoryMaintainer>(
     'useRepositoryMaintainers',
     `/${encodeURIComponent(repo)}/maintainers`,
   );
@@ -44,7 +57,7 @@ export const useRepositoryMaintainers = (repo: string) =>
  * @param repo - Full repository name (e.g., "opentensor/btcli")
  */
 export const useRepositoryIssues = (repo: string) =>
-  useReposQuery<RepositoryIssue[]>(
+  useReposArrayQuery<RepositoryIssue>(
     'useRepositoryIssues',
     `/${encodeURIComponent(repo)}/issues`,
   );
@@ -55,7 +68,7 @@ export const useRepositoryIssues = (repo: string) =>
  * @param state - Optional filter: "open", "closed", "merged"
  */
 export const useRepositoryPRs = (repo: string, state?: string) =>
-  useReposQuery<CommitLog[]>(
+  useReposArrayQuery<CommitLog>(
     'useRepositoryPRs',
     `/${encodeURIComponent(repo)}/prs`,
     undefined,

--- a/src/api/SearchApi.ts
+++ b/src/api/SearchApi.ts
@@ -28,6 +28,8 @@ type SearchDatasets = {
   issues: DatasetState<IssueBounty>;
 };
 
+const asArray = <T>(value: unknown): T[] => (Array.isArray(value) ? value : []);
+
 const isDatasetLoading = <T>(
   shouldFetch: boolean,
   cachedData: T[] | undefined,
@@ -48,11 +50,18 @@ const useCachedSearchDataset = <T>(
     shouldFetch && cachedData === undefined,
   );
 
+  const normalizedCachedData = asArray<T>(cachedData);
+  const normalizedQueryData = asArray<T>(datasetQuery.data);
+
   return {
-    data: datasetQuery.data ?? cachedData ?? [],
+    data:
+      normalizedQueryData.length > 0 ||
+      (datasetQuery.data !== undefined && Array.isArray(datasetQuery.data))
+        ? normalizedQueryData
+        : normalizedCachedData,
     isLoading: isDatasetLoading(
       shouldFetch,
-      cachedData,
+      normalizedCachedData.length > 0 ? normalizedCachedData : undefined,
       datasetQuery.isLoading,
     ),
     isError: datasetQuery.isError,


### PR DESCRIPTION
## Summary

- normalize list-style API query responses to arrays before exposing them to UI consumers
- harden shared list query hooks used by search, dashboard, repositories, miners, and issues views
- prevent render-time crashes when the test API returns a non-array payload for list endpoints

## Related Issues

Follow-up to the page-only theme token refactor PR (#263).
Addresses runtime crashes such as:
- `miners.map is not a function`
- `allPRs.forEach is not a function`

## Type of Change

- [x] Bug fix
- [ ] Refactor
- [ ] New feature
- [ ] Documentation
- [ ] Other (describe below)

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Responsive/mobile checked where relevant
- [x] `npm run format:check` has been run
- [x] `npm run lint` has been run
- [x] `npm run build` passes
