### PR TITLE
refactor: Replace hardcoded colors in repository components with theme tokens

### DIFF
--- a/src/components/repositories/RepositoryCheckTab.tsx
+++ b/src/components/repositories/RepositoryCheckTab.tsx
@@ -7,6 +7,8 @@ import {
   Divider,
   Card,
   CircularProgress,
+  alpha,
+  useTheme,
 } from '@mui/material';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import CancelIcon from '@mui/icons-material/Cancel';
@@ -31,6 +33,7 @@ interface HealthCheck {
 const RepositoryCheckTab: React.FC<RepositoryCheckTabProps> = ({
   repositoryFullName,
 }) => {
+  const theme = useTheme();
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [repoData, setRepoData] = useState<any>(null);
@@ -188,7 +191,7 @@ const RepositoryCheckTab: React.FC<RepositoryCheckTabProps> = ({
       <Box sx={{ mb: 3 }}>
         <Typography
           variant="h6"
-          sx={{ color: '#fff', mb: 0.5, fontWeight: 600 }}
+          sx={{ color: 'text.primary', mb: 0.5, fontWeight: 600 }}
         >
           Repository Health Check & Feasibility
         </Typography>
@@ -213,8 +216,8 @@ const RepositoryCheckTab: React.FC<RepositoryCheckTabProps> = ({
             <Card
               sx={{
                 p: 3,
-                backgroundColor: '#000000',
-                border: '1px solid rgba(255, 255, 255, 0.1)',
+                backgroundColor: 'background.default',
+                border: `1px solid ${theme.palette.border.light}`,
                 borderRadius: 2,
                 display: 'flex',
                 flexDirection: 'column',
@@ -238,10 +241,10 @@ const RepositoryCheckTab: React.FC<RepositoryCheckTabProps> = ({
                   sx={{
                     color:
                       score > 80
-                        ? '#238636'
+                        ? STATUS_COLORS.success
                         : score > 50
-                          ? '#e3b341'
-                          : '#da3633',
+                          ? STATUS_COLORS.warning
+                          : STATUS_COLORS.error,
                   }}
                 />
                 <Box
@@ -259,7 +262,7 @@ const RepositoryCheckTab: React.FC<RepositoryCheckTabProps> = ({
                   <Typography
                     component="div"
                     sx={{
-                      color: '#fff',
+                      color: 'text.primary',
                       fontWeight: 700,
                       fontSize: '32px',
                       fontFamily: '"JetBrains Mono", monospace',
@@ -271,7 +274,7 @@ const RepositoryCheckTab: React.FC<RepositoryCheckTabProps> = ({
               </Box>
               <Typography
                 variant="h6"
-                sx={{ color: '#fff', mb: 0.5, fontSize: '16px' }}
+                sx={{ color: 'text.primary', mb: 0.5, fontSize: '16px' }}
               >
                 Health Score
               </Typography>
@@ -291,8 +294,8 @@ const RepositoryCheckTab: React.FC<RepositoryCheckTabProps> = ({
             <Card
               sx={{
                 p: 3,
-                backgroundColor: '#000000',
-                border: '1px solid rgba(255, 255, 255, 0.1)',
+                backgroundColor: 'background.default',
+                border: `1px solid ${theme.palette.border.light}`,
                 borderRadius: 2,
                 flex: 1, // Fill remaining space
               }}
@@ -300,7 +303,7 @@ const RepositoryCheckTab: React.FC<RepositoryCheckTabProps> = ({
               <Typography
                 variant="h6"
                 sx={{
-                  color: '#fff',
+                  color: 'text.primary',
                   mb: 2,
                   fontSize: '14px',
                   fontWeight: 600,
@@ -322,7 +325,7 @@ const RepositoryCheckTab: React.FC<RepositoryCheckTabProps> = ({
                   <Typography
                     variant="body2"
                     sx={{
-                      color: '#c9d1d9',
+                      color: 'text.primary',
                       fontSize: '13px',
                       fontFamily: '"JetBrains Mono", monospace',
                     }}
@@ -340,7 +343,7 @@ const RepositoryCheckTab: React.FC<RepositoryCheckTabProps> = ({
                   <Typography
                     variant="body2"
                     sx={{
-                      color: '#c9d1d9',
+                      color: 'text.primary',
                       fontSize: '13px',
                       fontFamily: '"JetBrains Mono", monospace',
                     }}
@@ -364,12 +367,12 @@ const RepositoryCheckTab: React.FC<RepositoryCheckTabProps> = ({
                       bgcolor: repoData.archived
                         ? 'error.dark'
                         : 'success.dark',
-                      color: '#fff',
+                      color: 'text.primary',
                     }}
                   />
                 </Box>
               </Box>
-              <Divider sx={{ my: 2, borderColor: 'rgba(255,255,255,0.1)' }} />
+              <Divider sx={{ my: 2, borderColor: 'border.light' }} />
               <Typography
                 variant="body2"
                 sx={{
@@ -400,8 +403,8 @@ const RepositoryCheckTab: React.FC<RepositoryCheckTabProps> = ({
             <Card
               sx={{
                 p: 3,
-                backgroundColor: '#000000',
-                border: '1px solid rgba(255, 255, 255, 0.1)',
+                backgroundColor: 'background.default',
+                border: `1px solid ${theme.palette.border.light}`,
                 borderRadius: 2,
               }}
             >
@@ -409,7 +412,7 @@ const RepositoryCheckTab: React.FC<RepositoryCheckTabProps> = ({
                 <Typography
                   variant="h6"
                   sx={{
-                    color: '#fff',
+                    color: 'text.primary',
                     fontSize: '14px',
                     fontWeight: 600,
                     display: 'flex',
@@ -428,8 +431,8 @@ const RepositoryCheckTab: React.FC<RepositoryCheckTabProps> = ({
                     sx={{
                       p: 2,
                       borderRadius: 1,
-                      bgcolor: 'rgba(255,255,255,0.03)',
-                      border: '1px solid rgba(255,255,255,0.05)',
+                      bgcolor: alpha(theme.palette.common.white, 0.03),
+                      border: `1px solid ${alpha(theme.palette.common.white, 0.05)}`,
                       height: '100%',
                       display: 'flex',
                       flexDirection: 'column',
@@ -439,7 +442,7 @@ const RepositoryCheckTab: React.FC<RepositoryCheckTabProps> = ({
                     <Typography
                       variant="h4"
                       sx={{
-                        color: '#fff',
+                        color: 'text.primary',
                         fontFamily: '"JetBrains Mono", monospace',
                         fontSize: '24px',
                         mb: 0.5,
@@ -464,8 +467,8 @@ const RepositoryCheckTab: React.FC<RepositoryCheckTabProps> = ({
                     sx={{
                       p: 2,
                       borderRadius: 1,
-                      bgcolor: 'rgba(255,255,255,0.03)',
-                      border: '1px solid rgba(255,255,255,0.05)',
+                      bgcolor: alpha(theme.palette.common.white, 0.03),
+                      border: `1px solid ${alpha(theme.palette.common.white, 0.05)}`,
                       height: '100%',
                       display: 'flex',
                       flexDirection: 'column',
@@ -475,7 +478,7 @@ const RepositoryCheckTab: React.FC<RepositoryCheckTabProps> = ({
                     <Typography
                       variant="h4"
                       sx={{
-                        color: '#fff',
+                        color: 'text.primary',
                         fontFamily: '"JetBrains Mono", monospace',
                         fontSize: '24px',
                         mb: 0.5,
@@ -502,8 +505,8 @@ const RepositoryCheckTab: React.FC<RepositoryCheckTabProps> = ({
                     sx={{
                       p: 2,
                       borderRadius: 1,
-                      bgcolor: 'rgba(255,255,255,0.03)',
-                      border: '1px solid rgba(255,255,255,0.05)',
+                      bgcolor: alpha(theme.palette.common.white, 0.03),
+                      border: `1px solid ${alpha(theme.palette.common.white, 0.05)}`,
                       height: '100%',
                       minWidth: 0,
                       display: 'flex',
@@ -515,8 +518,8 @@ const RepositoryCheckTab: React.FC<RepositoryCheckTabProps> = ({
                       boxSizing: 'border-box',
                       transition: 'all 0.2s',
                       '&:hover': {
-                        bgcolor: 'rgba(255,255,255,0.08)',
-                        border: '1px solid rgba(255,255,255,0.1)',
+                        bgcolor: alpha(theme.palette.common.white, 0.08),
+                        border: `1px solid ${theme.palette.border.light}`,
                         transform: 'translateY(-2px)',
                       },
                     }}
@@ -535,7 +538,7 @@ const RepositoryCheckTab: React.FC<RepositoryCheckTabProps> = ({
                         <Typography
                           variant="h4"
                           sx={{
-                            color: '#fff',
+                            color: 'text.primary',
                             fontFamily: '"JetBrains Mono", monospace',
                             fontSize: '24px',
                             mb: 0.5,
@@ -568,7 +571,7 @@ const RepositoryCheckTab: React.FC<RepositoryCheckTabProps> = ({
                     </Box>
                     <Typography
                       variant="caption"
-                      sx={{ color: '#6e7681', fontSize: '11px' }}
+                      sx={{ color: 'text.secondary', fontSize: '11px' }}
                     >
                       Perfect for beginners
                     </Typography>
@@ -585,8 +588,8 @@ const RepositoryCheckTab: React.FC<RepositoryCheckTabProps> = ({
                     sx={{
                       p: 2,
                       borderRadius: 1,
-                      bgcolor: 'rgba(255,255,255,0.03)',
-                      border: '1px solid rgba(255,255,255,0.05)',
+                      bgcolor: alpha(theme.palette.common.white, 0.03),
+                      border: `1px solid ${alpha(theme.palette.common.white, 0.05)}`,
                       height: '100%',
                       minWidth: 0,
                       display: 'flex',
@@ -598,8 +601,8 @@ const RepositoryCheckTab: React.FC<RepositoryCheckTabProps> = ({
                       boxSizing: 'border-box',
                       transition: 'all 0.2s',
                       '&:hover': {
-                        bgcolor: 'rgba(255,255,255,0.08)',
-                        border: '1px solid rgba(255,255,255,0.1)',
+                        bgcolor: alpha(theme.palette.common.white, 0.08),
+                        border: `1px solid ${theme.palette.border.light}`,
                         transform: 'translateY(-2px)',
                       },
                     }}
@@ -618,7 +621,7 @@ const RepositoryCheckTab: React.FC<RepositoryCheckTabProps> = ({
                         <Typography
                           variant="h4"
                           sx={{
-                            color: '#fff',
+                            color: 'text.primary',
                             fontFamily: '"JetBrains Mono", monospace',
                             fontSize: '24px',
                             mb: 0.5,
@@ -649,7 +652,7 @@ const RepositoryCheckTab: React.FC<RepositoryCheckTabProps> = ({
                     </Box>
                     <Typography
                       variant="caption"
-                      sx={{ color: '#6e7681', fontSize: '11px' }}
+                      sx={{ color: 'text.secondary', fontSize: '11px' }}
                     >
                       General contributions
                     </Typography>
@@ -662,8 +665,8 @@ const RepositoryCheckTab: React.FC<RepositoryCheckTabProps> = ({
             <Card
               sx={{
                 p: 0,
-                backgroundColor: '#000000',
-                border: '1px solid rgba(255, 255, 255, 0.1)',
+                backgroundColor: 'background.default',
+                border: `1px solid ${theme.palette.border.light}`,
                 borderRadius: 2,
                 flex: 1,
                 overflow: 'hidden',
@@ -672,14 +675,14 @@ const RepositoryCheckTab: React.FC<RepositoryCheckTabProps> = ({
               <Box
                 sx={{
                   p: 2,
-                  borderBottom: '1px solid rgba(255, 255, 255, 0.1)',
-                  backgroundColor: 'rgba(255,255,255,0.03)',
+                  borderBottom: `1px solid ${theme.palette.border.light}`,
+                  backgroundColor: alpha(theme.palette.common.white, 0.03),
                 }}
               >
                 <Typography
                   variant="subtitle1"
                   sx={{
-                    color: '#fff',
+                    color: 'text.primary',
                     fontWeight: 600,
                     fontSize: '14px',
                     display: 'flex',
@@ -699,33 +702,36 @@ const RepositoryCheckTab: React.FC<RepositoryCheckTabProps> = ({
                         sx={{
                           p: 2,
                           borderRadius: 1,
-                          bgcolor: 'rgba(255,255,255,0.02)',
-                          border: '1px solid rgba(255,255,255,0.05)',
+                          bgcolor: 'surface.subtle',
+                          border: `1px solid ${alpha(theme.palette.common.white, 0.05)}`,
                           display: 'flex',
                           alignItems: 'flex-start',
                           gap: 2,
                           height: '100%',
                           transition: 'background-color 0.2s',
                           '&:hover': {
-                            bgcolor: 'rgba(255,255,255,0.04)',
+                            bgcolor: alpha(theme.palette.common.white, 0.04),
                           },
                         }}
                       >
                         <Box sx={{ mt: 0.5 }}>
                           {check.passed ? (
                             <CheckCircleIcon
-                              sx={{ color: '#238636', fontSize: 22 }}
+                              sx={{
+                                color: STATUS_COLORS.success,
+                                fontSize: 22,
+                              }}
                             />
                           ) : (
                             <CancelIcon
-                              sx={{ color: '#da3633', fontSize: 22 }}
+                              sx={{ color: STATUS_COLORS.error, fontSize: 22 }}
                             />
                           )}
                         </Box>
                         <Box>
                           <Typography
                             sx={{
-                              color: '#c9d1d9',
+                              color: 'text.primary',
                               fontWeight: 600,
                               fontSize: '14px',
                               mb: 0.5,

--- a/src/components/repositories/RepositoryContributorsTable.tsx
+++ b/src/components/repositories/RepositoryContributorsTable.tsx
@@ -1,5 +1,12 @@
 import React, { useMemo, useState } from 'react';
-import { Box, Typography, CircularProgress, Avatar } from '@mui/material';
+import {
+  Box,
+  Typography,
+  CircularProgress,
+  Avatar,
+  alpha,
+  useTheme,
+} from '@mui/material';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
 import { useAllPrs, useAllMiners } from '../../api';
@@ -13,6 +20,7 @@ interface RepositoryContributorsTableProps {
 const RepositoryContributorsTable: React.FC<
   RepositoryContributorsTableProps
 > = ({ repositoryFullName }) => {
+  const theme = useTheme();
   const navigate = useNavigate();
   const { data: allPRs, isLoading } = useAllPrs();
   const { data: allMinersStats } = useAllMiners();
@@ -136,7 +144,7 @@ const RepositoryContributorsTable: React.FC<
           alignItems: 'center',
           px: 1.5,
           py: 1,
-          borderBottom: '1px solid rgba(255,255,255,0.1)',
+          borderBottom: `1px solid ${theme.palette.border.light}`,
         }}
       >
         <Typography sx={{ fontSize: '11px', color: 'text.secondary' }}>
@@ -185,12 +193,12 @@ const RepositoryContributorsTable: React.FC<
                 rowGap: 0,
                 px: 1.5,
                 py: 1,
-                borderBottom: '1px solid rgba(255,255,255,0.05)',
+                borderBottom: `1px solid ${alpha(theme.palette.common.white, 0.05)}`,
                 alignItems: 'center',
                 minWidth: 0,
                 opacity: isInactive ? 0.5 : 1,
                 '&:hover': {
-                  backgroundColor: 'rgba(255,255,255,0.04)',
+                  backgroundColor: alpha(theme.palette.common.white, 0.04),
                   opacity: 1,
                 },
                 transition: 'all 0.1s',
@@ -201,7 +209,7 @@ const RepositoryContributorsTable: React.FC<
                 sx={{
                   fontFamily: '"JetBrains Mono", monospace',
                   fontSize: '12px',
-                  color: index < 3 ? '#fff' : STATUS_COLORS.open,
+                  color: index < 3 ? 'text.primary' : STATUS_COLORS.open,
                   fontWeight: index < 3 ? 600 : 400,
                 }}
               >
@@ -232,7 +240,7 @@ const RepositoryContributorsTable: React.FC<
                   sx={{
                     width: 20,
                     height: 20,
-                    border: '1px solid rgba(255,255,255,0.1)',
+                    border: `1px solid ${theme.palette.border.light}`,
                   }}
                 />
                 <Box
@@ -247,7 +255,7 @@ const RepositoryContributorsTable: React.FC<
                     sx={{
                       fontSize: '13px',
                       fontWeight: 500,
-                      color: '#c9d1d9',
+                      color: 'text.primary',
                       fontFamily:
                         '-apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif',
                       whiteSpace: 'nowrap',
@@ -280,7 +288,7 @@ const RepositoryContributorsTable: React.FC<
                 sx={{
                   textAlign: 'right',
                   fontSize: '12px',
-                  color: '#c9d1d9',
+                  color: 'text.primary',
                   fontFamily: '"JetBrains Mono", monospace',
                   fontVariantNumeric: 'tabular-nums',
                   minWidth: 0,
@@ -294,7 +302,7 @@ const RepositoryContributorsTable: React.FC<
                 sx={{
                   textAlign: 'right',
                   fontSize: '12px',
-                  color: '#c9d1d9',
+                  color: 'text.primary',
                   fontFamily: '"JetBrains Mono", monospace',
                   fontVariantNumeric: 'tabular-nums',
                   minWidth: 0,
@@ -320,8 +328,8 @@ const RepositoryContributorsTable: React.FC<
               color: STATUS_COLORS.open,
               fontSize: '12px',
               '&:hover': {
-                color: '#fff',
-                backgroundColor: 'rgba(255,255,255,0.02)',
+                color: 'text.primary',
+                backgroundColor: 'surface.subtle',
               },
               transition: 'all 0.1s',
             }}

--- a/src/components/repositories/RepositoryIssuesTable.tsx
+++ b/src/components/repositories/RepositoryIssuesTable.tsx
@@ -13,6 +13,8 @@ import {
   CircularProgress,
   Chip,
   Stack,
+  alpha,
+  useTheme,
 } from '@mui/material';
 import { useRepositoryIssues, useRepoIssues } from '../../api';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
@@ -20,7 +22,7 @@ import RadioButtonUncheckedIcon from '@mui/icons-material/RadioButtonUnchecked';
 
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
 import { formatTokenAmount } from '../../utils/format';
-import { STATUS_COLORS, scrollbarSx } from '../../theme';
+import { STATUS_COLORS, TEXT_OPACITY, scrollbarSx } from '../../theme';
 import FilterButton from '../FilterButton';
 
 interface RepositoryIssuesTableProps {
@@ -30,6 +32,7 @@ interface RepositoryIssuesTableProps {
 const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
   repositoryFullName,
 }) => {
+  const theme = useTheme();
   const navigate = useNavigate();
   const { data: issues, isLoading } = useRepositoryIssues(repositoryFullName);
   const { data: bounties } = useRepoIssues(repositoryFullName);
@@ -68,7 +71,7 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
       <Card
         sx={{
           borderRadius: 3,
-          border: '1px solid rgba(255, 255, 255, 0.1)',
+          border: `1px solid ${theme.palette.border.light}`,
           backgroundColor: 'transparent',
           p: 4,
           textAlign: 'center',
@@ -101,32 +104,32 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
             switch (status) {
               case 'active':
                 return {
-                  bg: 'rgba(88, 166, 255, 0.15)',
-                  border: 'rgba(88, 166, 255, 0.4)',
+                  bg: alpha(STATUS_COLORS.info, 0.15),
+                  border: alpha(STATUS_COLORS.info, 0.4),
                   text: STATUS_COLORS.info,
                 };
               case 'completed':
                 return {
-                  bg: 'rgba(63, 185, 80, 0.15)',
-                  border: 'rgba(63, 185, 80, 0.4)',
+                  bg: alpha(STATUS_COLORS.merged, 0.15),
+                  border: alpha(STATUS_COLORS.merged, 0.4),
                   text: STATUS_COLORS.merged,
                 };
               case 'registered':
                 return {
-                  bg: 'rgba(245, 158, 11, 0.15)',
-                  border: 'rgba(245, 158, 11, 0.4)',
+                  bg: alpha(STATUS_COLORS.warning, 0.15),
+                  border: alpha(STATUS_COLORS.warning, 0.4),
                   text: STATUS_COLORS.warning,
                 };
               case 'cancelled':
                 return {
-                  bg: 'rgba(239, 68, 68, 0.15)',
-                  border: 'rgba(239, 68, 68, 0.4)',
+                  bg: alpha(STATUS_COLORS.error, 0.15),
+                  border: alpha(STATUS_COLORS.error, 0.4),
                   text: STATUS_COLORS.error,
                 };
               default:
                 return {
-                  bg: 'rgba(139, 148, 158, 0.15)',
-                  border: 'rgba(139, 148, 158, 0.4)',
+                  bg: alpha(STATUS_COLORS.neutral, 0.15),
+                  border: alpha(STATUS_COLORS.neutral, 0.4),
                   text: STATUS_COLORS.open,
                 };
             }
@@ -154,16 +157,16 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
               case 'completed':
                 return STATUS_COLORS.merged;
               case 'cancelled':
-                return 'rgba(255, 255, 255, 0.4)';
+                return alpha(theme.palette.common.white, TEXT_OPACITY.muted);
               default:
-                return 'rgba(255, 255, 255, 0.6)';
+                return alpha(theme.palette.common.white, 0.6);
             }
           };
           return (
             <Card
               sx={{
                 borderRadius: 3,
-                border: '1px solid rgba(255, 255, 255, 0.1)',
+                border: `1px solid ${theme.palette.border.light}`,
                 backgroundColor: 'transparent',
                 p: 0,
                 overflow: 'hidden',
@@ -173,7 +176,7 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
               <Box
                 sx={{
                   p: 3,
-                  borderBottom: '1px solid rgba(255, 255, 255, 0.1)',
+                  borderBottom: `1px solid ${theme.palette.border.light}`,
                   display: 'flex',
                   alignItems: 'center',
                   justifyContent: 'space-between',
@@ -210,13 +213,13 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
                         justifyContent: 'space-between',
                         p: 2,
                         borderRadius: 2,
-                        border: '1px solid rgba(255, 255, 255, 0.06)',
-                        backgroundColor: 'rgba(255, 255, 255, 0.02)',
+                        border: `1px solid ${alpha(theme.palette.common.white, 0.06)}`,
+                        backgroundColor: 'surface.subtle',
                         cursor: 'pointer',
                         transition: 'all 0.2s ease',
                         '&:hover': {
-                          backgroundColor: 'rgba(255, 255, 255, 0.05)',
-                          borderColor: 'rgba(255, 255, 255, 0.15)',
+                          backgroundColor: 'surface.light',
+                          borderColor: alpha(theme.palette.common.white, 0.15),
                           transform: 'translateX(2px)',
                         },
                       }}
@@ -255,7 +258,7 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
                         </Typography>
                         <Typography
                           sx={{
-                            color: 'rgba(255, 255, 255, 0.85)',
+                            color: 'text.primary',
                             fontFamily: '"JetBrains Mono", monospace',
                             fontSize: '0.85rem',
                             overflow: 'hidden',
@@ -292,7 +295,10 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
                         </Typography>
                         <ArrowForwardIcon
                           sx={{
-                            color: 'rgba(255, 255, 255, 0.2)',
+                            color: alpha(
+                              theme.palette.common.white,
+                              TEXT_OPACITY.ghost,
+                            ),
                             fontSize: 16,
                           }}
                         />
@@ -309,7 +315,7 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
       <Card
         sx={{
           borderRadius: 3,
-          border: '1px solid rgba(255, 255, 255, 0.1)',
+          border: `1px solid ${theme.palette.border.light}`,
           backgroundColor: 'transparent',
           p: 0,
           display: 'flex',
@@ -321,7 +327,7 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
         <Box
           sx={{
             p: 3,
-            borderBottom: '1px solid rgba(255, 255, 255, 0.1)',
+            borderBottom: `1px solid ${theme.palette.border.light}`,
             display: 'flex',
             justifyContent: 'space-between',
             alignItems: 'center',
@@ -373,7 +379,7 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
           <Box sx={{ p: 4, textAlign: 'center' }}>
             <Typography
               sx={{
-                color: 'rgba(255, 255, 255, 0.5)',
+                color: alpha(theme.palette.common.white, TEXT_OPACITY.tertiary),
                 fontFamily: '"JetBrains Mono", monospace',
                 fontSize: '0.9rem',
               }}
@@ -413,7 +419,7 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
                       sx={{
                         cursor: 'pointer',
                         '&:hover': {
-                          backgroundColor: 'rgba(255, 255, 255, 0.05)',
+                          backgroundColor: 'surface.light',
                         },
                         transition: 'background-color 0.2s',
                       }}
@@ -489,7 +495,14 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
                             #{issue.prNumber}
                           </a>
                         ) : (
-                          <span style={{ color: 'rgba(255, 255, 255, 0.3)' }}>
+                          <span
+                            style={{
+                              color: alpha(
+                                theme.palette.common.white,
+                                TEXT_OPACITY.faint,
+                              ),
+                            }}
+                          >
                             -
                           </span>
                         )}
@@ -517,13 +530,14 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
 };
 
 const headerCellStyle = {
-  backgroundColor: 'rgba(18, 18, 20, 0.95)',
+  backgroundColor: 'surface.tooltip',
   backdropFilter: 'blur(8px)',
-  color: 'rgba(255, 255, 255, 0.7)',
+  color: 'text.secondary',
   fontFamily: '"JetBrains Mono", monospace',
   fontWeight: 500,
   fontSize: '0.75rem',
-  borderBottom: '1px solid rgba(255, 255, 255, 0.1)',
+  borderBottom: '1px solid',
+  borderColor: 'border.light',
   textTransform: 'uppercase' as const,
   letterSpacing: '0.5px',
 };
@@ -531,7 +545,8 @@ const headerCellStyle = {
 const bodyCellStyle = {
   color: 'text.primary',
   fontFamily: '"JetBrains Mono", monospace',
-  borderBottom: '1px solid rgba(255, 255, 255, 0.1)',
+  borderBottom: '1px solid',
+  borderColor: 'border.light',
   fontSize: '0.85rem',
 };
 

--- a/src/components/repositories/RepositoryPRsTable.tsx
+++ b/src/components/repositories/RepositoryPRsTable.tsx
@@ -14,6 +14,8 @@ import {
   Avatar,
   Chip,
   Stack,
+  alpha,
+  useTheme,
 } from '@mui/material';
 
 type PrSortField =
@@ -28,7 +30,7 @@ type PrSortField =
 type SortOrder = 'asc' | 'desc';
 import { useAllPrs } from '../../api';
 import { useNavigate } from 'react-router-dom';
-import theme, { scrollbarSx } from '../../theme';
+import { TEXT_OPACITY, scrollbarSx } from '../../theme';
 import {
   getPrStatusCounts,
   isClosedUnmergedPr,
@@ -46,6 +48,7 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
   repositoryFullName,
   state = 'all',
 }) => {
+  const theme = useTheme();
   const navigate = useNavigate();
   const [filter, setFilter] = useState<'all' | 'open' | 'closed' | 'merged'>(
     state,
@@ -134,7 +137,7 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
       <Card
         sx={{
           borderRadius: 3,
-          border: '1px solid rgba(255, 255, 255, 0.1)',
+          border: `1px solid ${theme.palette.border.light}`,
           backgroundColor: 'transparent',
           p: 4,
           textAlign: 'center',
@@ -144,7 +147,10 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
         <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 3 }}>
           <Typography
             variant="h6"
-            sx={{ color: '#fff', fontFamily: '"JetBrains Mono", monospace' }}
+            sx={{
+              color: 'text.primary',
+              fontFamily: '"JetBrains Mono", monospace',
+            }}
           >
             Pull Requests
           </Typography>
@@ -188,7 +194,7 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
     <Card
       sx={{
         borderRadius: 3,
-        border: '1px solid rgba(255, 255, 255, 0.1)',
+        border: `1px solid ${theme.palette.border.light}`,
         backgroundColor: 'transparent',
         p: 0,
         display: 'flex',
@@ -200,7 +206,7 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
       <Box
         sx={{
           p: 3,
-          borderBottom: '1px solid rgba(255, 255, 255, 0.1)',
+          borderBottom: `1px solid ${theme.palette.border.light}`,
           display: 'flex',
           justifyContent: 'space-between',
           alignItems: 'center',
@@ -211,7 +217,7 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
         <Typography
           variant="h6"
           sx={{
-            color: '#ffffff',
+            color: 'text.primary',
             fontFamily: '"JetBrains Mono", monospace',
             fontSize: '1.1rem',
             fontWeight: 500,
@@ -256,7 +262,7 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
         <Box sx={{ p: 4, textAlign: 'center' }}>
           <Typography
             sx={{
-              color: 'rgba(255, 255, 255, 0.5)',
+              color: alpha(theme.palette.common.white, TEXT_OPACITY.tertiary),
               fontFamily: '"JetBrains Mono", monospace',
               fontSize: '0.9rem',
             }}
@@ -366,7 +372,7 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
                   sx={{
                     cursor: 'pointer',
                     '&:hover': {
-                      backgroundColor: 'rgba(255, 255, 255, 0.05)',
+                      backgroundColor: 'surface.light',
                     },
                     transition: 'background-color 0.2s',
                   }}
@@ -377,7 +383,7 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
                       target="_blank"
                       rel="noopener noreferrer"
                       style={{
-                        color: '#ffffff',
+                        color: theme.palette.text.primary,
                         textDecoration: 'none',
                         fontWeight: 500,
                       }}
@@ -487,21 +493,23 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
 };
 
 const headerCellStyle = {
-  backgroundColor: 'rgba(18, 18, 20, 0.95)',
+  backgroundColor: 'surface.tooltip',
   backdropFilter: 'blur(8px)',
-  color: 'rgba(255, 255, 255, 0.7)',
+  color: 'text.secondary',
   fontFamily: '"JetBrains Mono", monospace',
   fontWeight: 500,
   fontSize: '0.75rem',
-  borderBottom: '1px solid rgba(255, 255, 255, 0.1)',
+  borderBottom: '1px solid',
+  borderColor: 'border.light',
   textTransform: 'uppercase' as const,
   letterSpacing: '0.5px',
 };
 
 const bodyCellStyle = {
-  color: '#ffffff',
+  color: 'text.primary',
   fontFamily: '"JetBrains Mono", monospace',
-  borderBottom: '1px solid rgba(255, 255, 255, 0.1)',
+  borderBottom: '1px solid',
+  borderColor: 'border.light',
   fontSize: '0.85rem',
 };
 

--- a/src/components/repositories/RepositoryScoreCard.tsx
+++ b/src/components/repositories/RepositoryScoreCard.tsx
@@ -7,9 +7,15 @@ import {
   CircularProgress,
   Avatar,
   alpha,
+  useTheme,
 } from '@mui/material';
 import { useAllPrs } from '../../api';
-import { RANK_COLORS, STATUS_COLORS } from '../../theme';
+import {
+  RANK_COLORS,
+  REPO_OWNER_AVATAR_BACKGROUNDS,
+  STATUS_COLORS,
+  TEXT_OPACITY,
+} from '../../theme';
 
 interface RepositoryScoreCardProps {
   repositoryFullName: string;
@@ -18,6 +24,7 @@ interface RepositoryScoreCardProps {
 const RepositoryScoreCard: React.FC<RepositoryScoreCardProps> = ({
   repositoryFullName,
 }) => {
+  const theme = useTheme();
   const { data: allPRs, isLoading } = useAllPrs();
 
   const repoStats = useMemo(() => {
@@ -147,7 +154,7 @@ const RepositoryScoreCard: React.FC<RepositoryScoreCardProps> = ({
         sx={{
           backgroundColor: 'transparent',
           borderRadius: '8px',
-          border: '1px solid rgba(255, 255, 255, 0.1)',
+          border: `1px solid ${theme.palette.border.light}`,
           p: 4,
           textAlign: 'center',
         }}
@@ -162,7 +169,7 @@ const RepositoryScoreCard: React.FC<RepositoryScoreCardProps> = ({
     return (
       <Card
         sx={{
-          backgroundColor: 'rgba(255, 255, 255, 0.02)',
+          backgroundColor: 'surface.subtle',
           borderRadius: '8px',
           border: '1px solid',
           borderColor: 'border.subtle',
@@ -217,7 +224,7 @@ const RepositoryScoreCard: React.FC<RepositoryScoreCardProps> = ({
     <Card
       sx={{
         borderRadius: 3,
-        border: '1px solid rgba(255, 255, 255, 0.1)',
+        border: `1px solid ${theme.palette.border.light}`,
         backgroundColor: 'transparent',
         p: 3,
       }}
@@ -230,20 +237,18 @@ const RepositoryScoreCard: React.FC<RepositoryScoreCardProps> = ({
           sx={{
             width: 64,
             height: 64,
-            border: '2px solid rgba(255, 255, 255, 0.2)',
+            border: `2px solid ${theme.palette.border.medium}`,
             backgroundColor:
-              owner === 'opentensor'
-                ? '#ffffff'
-                : owner === 'bitcoin'
-                  ? '#F7931A'
-                  : 'transparent',
+              REPO_OWNER_AVATAR_BACKGROUNDS[
+                owner as keyof typeof REPO_OWNER_AVATAR_BACKGROUNDS
+              ] ?? 'transparent',
           }}
         />
         <Box>
           <Typography
             variant="h5"
             sx={{
-              color: '#ffffff',
+              color: 'text.primary',
               fontFamily: '"JetBrains Mono", monospace',
               mb: 0.5,
               fontSize: '1.3rem',
@@ -254,7 +259,7 @@ const RepositoryScoreCard: React.FC<RepositoryScoreCardProps> = ({
           </Typography>
           <Typography
             sx={{
-              color: 'rgba(255, 255, 255, 0.5)',
+              color: alpha(theme.palette.common.white, TEXT_OPACITY.tertiary),
               fontFamily: '"JetBrains Mono", monospace',
               fontSize: '0.85rem',
             }}
@@ -271,7 +276,7 @@ const RepositoryScoreCard: React.FC<RepositoryScoreCardProps> = ({
               sx={{
                 backgroundColor: 'transparent',
                 borderRadius: 3,
-                border: '1px solid rgba(255, 255, 255, 0.1)',
+                border: `1px solid ${theme.palette.border.light}`,
                 p: 2.5,
                 height: '100%',
                 display: 'flex',
@@ -289,7 +294,10 @@ const RepositoryScoreCard: React.FC<RepositoryScoreCardProps> = ({
               >
                 <Typography
                   sx={{
-                    color: 'rgba(255, 255, 255, 0.5)',
+                    color: alpha(
+                      theme.palette.common.white,
+                      TEXT_OPACITY.tertiary,
+                    ),
                     fontFamily: '"JetBrains Mono", monospace',
                     fontSize: '0.7rem',
                     textTransform: 'uppercase',
@@ -302,7 +310,7 @@ const RepositoryScoreCard: React.FC<RepositoryScoreCardProps> = ({
                 {item.rank && (
                   <Box
                     sx={{
-                      backgroundColor: '#000000',
+                      backgroundColor: 'background.default',
                       borderRadius: '2px',
                       width: '20px',
                       height: '20px',
@@ -318,7 +326,7 @@ const RepositoryScoreCard: React.FC<RepositoryScoreCardProps> = ({
                             ? alpha(RANK_COLORS.second, 0.4)
                             : item.rank === 3
                               ? alpha(RANK_COLORS.third, 0.4)
-                              : 'rgba(255, 255, 255, 0.15)',
+                              : alpha(theme.palette.common.white, 0.15),
                       boxShadow:
                         item.rank === 1
                           ? `0 0 12px ${alpha(RANK_COLORS.first, 0.4)}, 0 0 4px ${alpha(RANK_COLORS.first, 0.2)}`
@@ -339,7 +347,7 @@ const RepositoryScoreCard: React.FC<RepositoryScoreCardProps> = ({
                               ? RANK_COLORS.second
                               : item.rank === 3
                                 ? RANK_COLORS.third
-                                : 'rgba(255, 255, 255, 0.6)',
+                                : alpha(theme.palette.common.white, 0.6),
                         fontFamily: '"JetBrains Mono", monospace',
                         fontSize: '0.6rem',
                         fontWeight: 600,
@@ -356,7 +364,7 @@ const RepositoryScoreCard: React.FC<RepositoryScoreCardProps> = ({
               </Box>
               <Typography
                 sx={{
-                  color: '#ffffff',
+                  color: 'text.primary',
                   fontFamily: '"JetBrains Mono", monospace',
                   fontSize: '1.5rem',
                   fontWeight: 600,

--- a/src/components/repositories/RepositoryStats.tsx
+++ b/src/components/repositories/RepositoryStats.tsx
@@ -1,5 +1,12 @@
 import React, { useMemo } from 'react';
-import { Box, Typography, Skeleton, Divider, Chip } from '@mui/material';
+import {
+  Box,
+  Typography,
+  Skeleton,
+  Divider,
+  Chip,
+  useTheme,
+} from '@mui/material';
 import {
   useReposAndWeights,
   useAllPrs,
@@ -17,6 +24,7 @@ interface RepositoryStatsProps {
 const RepositoryStats: React.FC<RepositoryStatsProps> = ({
   repositoryFullName,
 }) => {
+  const theme = useTheme();
   const { data: repos, isLoading: isLoadingRepos } = useReposAndWeights();
   const { data: allPRs, isLoading: isLoadingPRs } = useAllPrs();
   const { data: issues, isLoading: isLoadingIssues } =
@@ -65,14 +73,19 @@ const RepositoryStats: React.FC<RepositoryStatsProps> = ({
       <Box sx={{ mb: 4 }}>
         <Typography
           variant="subtitle2"
-          sx={{ color: '#fff', fontWeight: 600, mb: 2, fontSize: '14px' }}
+          sx={{
+            color: 'text.primary',
+            fontWeight: 600,
+            mb: 2,
+            fontSize: '14px',
+          }}
         >
           Repository Stats
         </Typography>
         <Skeleton
           variant="rectangular"
           height={160}
-          sx={{ bgcolor: 'rgba(255,255,255,0.05)', borderRadius: 2 }}
+          sx={{ bgcolor: 'surface.light', borderRadius: 2 }}
         />
       </Box>
     );
@@ -86,7 +99,7 @@ const RepositoryStats: React.FC<RepositoryStatsProps> = ({
     <Box sx={{ mb: 4 }}>
       <Typography
         variant="subtitle2"
-        sx={{ color: '#fff', fontWeight: 600, mb: 2, fontSize: '14px' }}
+        sx={{ color: 'text.primary', fontWeight: 600, mb: 2, fontSize: '14px' }}
       >
         Repository Stats
       </Typography>
@@ -109,7 +122,7 @@ const RepositoryStats: React.FC<RepositoryStatsProps> = ({
           <Typography
             variant="body2"
             sx={{
-              color: '#fff',
+              color: 'text.primary',
               fontFamily: '"JetBrains Mono", monospace',
               fontSize: '13px',
             }}
@@ -118,7 +131,7 @@ const RepositoryStats: React.FC<RepositoryStatsProps> = ({
           </Typography>
         </Box>
 
-        <Divider sx={{ borderColor: 'rgba(255,255,255,0.1)', my: 0.5 }} />
+        <Divider sx={{ borderColor: 'border.light', my: 0.5 }} />
 
         {/* Total Score */}
         <Box
@@ -137,7 +150,7 @@ const RepositoryStats: React.FC<RepositoryStatsProps> = ({
           <Typography
             variant="body2"
             sx={{
-              color: '#fff',
+              color: 'text.primary',
               fontFamily: '"JetBrains Mono", monospace',
               fontSize: '13px',
             }}
@@ -165,7 +178,7 @@ const RepositoryStats: React.FC<RepositoryStatsProps> = ({
           <Typography
             variant="body2"
             sx={{
-              color: '#fff',
+              color: 'text.primary',
               fontFamily: '"JetBrains Mono", monospace',
               fontSize: '13px',
             }}
@@ -191,7 +204,7 @@ const RepositoryStats: React.FC<RepositoryStatsProps> = ({
           <Typography
             variant="body2"
             sx={{
-              color: '#fff',
+              color: 'text.primary',
               fontFamily: '"JetBrains Mono", monospace',
               fontSize: '13px',
             }}
@@ -203,7 +216,7 @@ const RepositoryStats: React.FC<RepositoryStatsProps> = ({
         {/* Bounties */}
         {bountySummary && bountySummary.totalBounties > 0 && (
           <>
-            <Divider sx={{ borderColor: 'rgba(255,255,255,0.1)', my: 0.5 }} />
+            <Divider sx={{ borderColor: 'border.light', my: 0.5 }} />
 
             {/* Total Bounties */}
             <Box
@@ -250,7 +263,7 @@ const RepositoryStats: React.FC<RepositoryStatsProps> = ({
                 <Typography
                   variant="body2"
                   sx={{
-                    color: '#fff',
+                    color: 'text.primary',
                     fontFamily: '"JetBrains Mono", monospace',
                     fontSize: '13px',
                   }}
@@ -295,7 +308,7 @@ const RepositoryStats: React.FC<RepositoryStatsProps> = ({
         {repoConfig?.additionalAcceptableBranches &&
           repoConfig.additionalAcceptableBranches.length > 0 && (
             <>
-              <Divider sx={{ borderColor: 'rgba(255,255,255,0.1)', my: 0.5 }} />
+              <Divider sx={{ borderColor: 'border.light', my: 0.5 }} />
               <Typography
                 variant="body2"
                 sx={{ fontSize: '13px', color: STATUS_COLORS.open }}
@@ -318,9 +331,9 @@ const RepositoryStats: React.FC<RepositoryStatsProps> = ({
                       fontFamily: '"JetBrains Mono", monospace',
                       fontSize: '12px',
                       height: '24px',
-                      bgcolor: 'rgba(255,255,255,0.06)',
-                      color: '#fff',
-                      border: '1px solid rgba(255,255,255,0.1)',
+                      bgcolor: 'surface.light',
+                      color: 'text.primary',
+                      border: `1px solid ${theme.palette.border.light}`,
                     }}
                   />
                 ))}

--- a/src/components/repositories/RepositoryWeightsTable.tsx
+++ b/src/components/repositories/RepositoryWeightsTable.tsx
@@ -1,5 +1,10 @@
 import React, { useState, useMemo, useRef, useEffect } from 'react';
-import { scrollbarSx } from '../../theme';
+import {
+  REPO_OWNER_AVATAR_BACKGROUNDS,
+  STATUS_COLORS,
+  TEXT_OPACITY,
+  scrollbarSx,
+} from '../../theme';
 import {
   Box,
   Table,
@@ -18,6 +23,7 @@ import {
   useMediaQuery,
   useTheme,
   CircularProgress,
+  alpha,
   Tooltip,
   Select,
   MenuItem,
@@ -59,7 +65,7 @@ const AnimatedWeightBar = ({
       sx={{
         width: '100%',
         height: '4px',
-        backgroundColor: 'rgba(255, 255, 255, 0.1)',
+        backgroundColor: 'surface.light',
         borderRadius: '2px',
         overflow: 'hidden',
       }}
@@ -68,8 +74,7 @@ const AnimatedWeightBar = ({
         sx={{
           width: `${width}%`,
           height: '100%',
-          background:
-            'linear-gradient(90deg, rgba(139, 148, 158, 0.8), rgba(100, 108, 118, 0.4))',
+          background: `linear-gradient(90deg, ${alpha(STATUS_COLORS.neutral, 0.8)}, ${alpha(STATUS_COLORS.neutral, 0.4)})`,
           borderRadius: '2px',
           transition: 'width 1s cubic-bezier(0.4, 0, 0.2, 1)',
         }}
@@ -184,7 +189,7 @@ const RepositoryWeightsTable: React.FC = () => {
 
     const minWeight = weights.length > 0 ? Math.min(...weights) : 0;
 
-    const textColor = 'rgba(255, 255, 255, 0.85)';
+    const textColor = theme.palette.text.primary;
     const gridColor = theme.palette.border.subtle;
 
     const xAxisData = chartData.map((item) => item.name);
@@ -202,8 +207,8 @@ const RepositoryWeightsTable: React.FC = () => {
           x2: 0,
           y2: 1,
           colorStops: [
-            { offset: 0, color: 'rgba(139, 148, 158, 0.8)' },
-            { offset: 1, color: 'rgba(100, 108, 118, 0.4)' },
+            { offset: 0, color: alpha(STATUS_COLORS.neutral, 0.8) },
+            { offset: 1, color: alpha(STATUS_COLORS.neutral, 0.4) },
           ],
         },
         borderRadius: [4, 4, 0, 0],
@@ -218,13 +223,13 @@ const RepositoryWeightsTable: React.FC = () => {
         left: 'center',
         top: 20,
         textStyle: {
-          color: '#ffffff',
+          color: theme.palette.text.primary,
           fontFamily: 'JetBrains Mono',
           fontSize: 18,
           fontWeight: 600,
         },
         subtextStyle: {
-          color: 'rgba(255, 255, 255, 0.5)',
+          color: alpha(theme.palette.common.white, TEXT_OPACITY.tertiary),
           fontFamily: 'JetBrains Mono',
           fontSize: 12,
         },
@@ -232,10 +237,13 @@ const RepositoryWeightsTable: React.FC = () => {
       tooltip: {
         trigger: 'axis',
         axisPointer: { type: 'shadow' },
-        backgroundColor: 'rgba(15, 15, 18, 0.95)',
-        borderColor: 'rgba(255, 255, 255, 0.15)',
+        backgroundColor: alpha(theme.palette.background.paper, 0.95),
+        borderColor: alpha(theme.palette.common.white, 0.15),
         borderWidth: 1,
-        textStyle: { color: '#fff', fontFamily: 'JetBrains Mono' },
+        textStyle: {
+          color: theme.palette.text.primary,
+          fontFamily: 'JetBrains Mono',
+        },
         formatter: (params: any) => {
           const data = params[0]?.data;
           if (!data) return '';
@@ -244,7 +252,7 @@ const RepositoryWeightsTable: React.FC = () => {
               <div style="display: flex; align-items: center; gap: 8px; margin-bottom: 8px;">
                 <img
                   src="https://avatars.githubusercontent.com/${data.owner}"
-                  style="width: 20px; height: 20px; border-radius: 50%; border: 1px solid rgba(255,255,255,0.2); background-color: ${data.owner === 'opentensor' ? '#ffffff' : data.owner === 'bitcoin' ? '#F7931A' : 'transparent'};"
+                  style="width: 20px; height: 20px; border-radius: 50%; border: 1px solid ${theme.palette.border.medium}; background-color: ${data.owner === 'opentensor' ? REPO_OWNER_AVATAR_BACKGROUNDS.opentensor : data.owner === 'bitcoin' ? REPO_OWNER_AVATAR_BACKGROUNDS.bitcoin : 'transparent'};"
                 />
                 <div style="font-weight: 600;">${data.fullName}</div>
               </div>
@@ -340,13 +348,15 @@ const RepositoryWeightsTable: React.FC = () => {
                 onClick={() => setShowChart(!showChart)}
                 size="small"
                 sx={{
-                  color: showChart ? '#ffffff' : 'rgba(255, 255, 255, 0.5)',
-                  border: '1px solid rgba(255, 255, 255, 0.1)',
+                  color: showChart
+                    ? 'text.primary'
+                    : alpha(theme.palette.common.white, TEXT_OPACITY.tertiary),
+                  border: `1px solid ${theme.palette.border.light}`,
                   borderRadius: 2,
                   padding: '6px',
                   '&:hover': {
-                    backgroundColor: 'rgba(255, 255, 255, 0.05)',
-                    borderColor: 'rgba(255, 255, 255, 0.2)',
+                    backgroundColor: 'surface.light',
+                    borderColor: 'border.medium',
                   },
                 }}
               >
@@ -363,7 +373,10 @@ const RepositoryWeightsTable: React.FC = () => {
                 <Typography
                   variant="body2"
                   sx={{
-                    color: 'rgba(255, 255, 255, 0.7)',
+                    color: alpha(
+                      theme.palette.common.white,
+                      TEXT_OPACITY.secondary,
+                    ),
                     fontFamily: '"JetBrains Mono", monospace',
                     fontSize: '0.8rem',
                   }}
@@ -377,16 +390,16 @@ const RepositoryWeightsTable: React.FC = () => {
                     setPage(0);
                   }}
                   sx={{
-                    color: '#ffffff',
+                    color: 'text.primary',
                     fontFamily: '"JetBrains Mono", monospace',
-                    backgroundColor: 'rgba(0, 0, 0, 0.4)',
+                    backgroundColor: alpha(theme.palette.common.black, 0.4),
                     fontSize: '0.8rem',
                     height: '36px',
                     borderRadius: 2,
                     minWidth: '80px',
-                    '& fieldset': { borderColor: 'rgba(255, 255, 255, 0.1)' },
+                    '& fieldset': { borderColor: theme.palette.border.light },
                     '&:hover fieldset': {
-                      borderColor: 'rgba(255, 255, 255, 0.2)',
+                      borderColor: theme.palette.border.medium,
                     },
                     '&.Mui-focused fieldset': { borderColor: 'primary.main' },
                     '& .MuiSelect-select': {
@@ -411,7 +424,10 @@ const RepositoryWeightsTable: React.FC = () => {
                   <InputAdornment position="start">
                     <Search
                       sx={{
-                        color: 'rgba(255, 255, 255, 0.5)',
+                        color: alpha(
+                          theme.palette.common.white,
+                          TEXT_OPACITY.tertiary,
+                        ),
                         fontSize: '1rem',
                       }}
                     />
@@ -421,15 +437,15 @@ const RepositoryWeightsTable: React.FC = () => {
               sx={{
                 width: '200px',
                 '& .MuiOutlinedInput-root': {
-                  color: '#ffffff',
+                  color: 'text.primary',
                   fontFamily: '"JetBrains Mono", monospace',
-                  backgroundColor: 'rgba(0, 0, 0, 0.4)',
+                  backgroundColor: alpha(theme.palette.common.black, 0.4),
                   fontSize: '0.8rem',
                   height: '36px',
                   borderRadius: 2,
-                  '& fieldset': { borderColor: 'rgba(255, 255, 255, 0.1)' },
+                  '& fieldset': { borderColor: theme.palette.border.light },
                   '&:hover fieldset': {
-                    borderColor: 'rgba(255, 255, 255, 0.2)',
+                    borderColor: theme.palette.border.medium,
                   },
                   '&.Mui-focused fieldset': { borderColor: 'primary.main' },
                 },
@@ -443,9 +459,9 @@ const RepositoryWeightsTable: React.FC = () => {
         <Box
           sx={{
             p: 2,
-            borderBottom: '1px solid rgba(255, 255, 255, 0.1)',
+            borderBottom: `1px solid ${theme.palette.border.light}`,
             height: '500px',
-            backgroundColor: 'rgba(0,0,0,0.2)',
+            backgroundColor: alpha(theme.palette.common.black, 0.2),
           }}
         >
           {showChart && filteredAndSortedRepos.length > 0 && (
@@ -479,9 +495,12 @@ const RepositoryWeightsTable: React.FC = () => {
                 {!isMobile && (
                   <TableCell
                     sx={{
-                      backgroundColor: 'rgba(18, 18, 20, 0.95)',
+                      backgroundColor: alpha(
+                        theme.palette.background.paper,
+                        0.95,
+                      ),
                       backdropFilter: 'blur(8px)',
-                      borderBottom: '1px solid rgba(255, 255, 255, 0.1)',
+                      borderBottom: `1px solid ${theme.palette.border.light}`,
                       height: '56px',
                       py: 1.5,
                       boxSizing: 'border-box',
@@ -507,9 +526,12 @@ const RepositoryWeightsTable: React.FC = () => {
                 )}
                 <TableCell
                   sx={{
-                    backgroundColor: 'rgba(18, 18, 20, 0.95)',
+                    backgroundColor: alpha(
+                      theme.palette.background.paper,
+                      0.95,
+                    ),
                     backdropFilter: 'blur(8px)',
-                    borderBottom: '1px solid rgba(255, 255, 255, 0.1)',
+                    borderBottom: `1px solid ${theme.palette.border.light}`,
                     height: '56px',
                     py: 1.5,
                     boxSizing: 'border-box',
@@ -535,9 +557,12 @@ const RepositoryWeightsTable: React.FC = () => {
                 <TableCell
                   align="right"
                   sx={{
-                    backgroundColor: 'rgba(18, 18, 20, 0.95)',
+                    backgroundColor: alpha(
+                      theme.palette.background.paper,
+                      0.95,
+                    ),
                     backdropFilter: 'blur(8px)',
-                    borderBottom: '1px solid rgba(255, 255, 255, 0.1)',
+                    borderBottom: `1px solid ${theme.palette.border.light}`,
                     height: '56px',
                     py: 1.5,
                     boxSizing: 'border-box',
@@ -582,11 +607,11 @@ const RepositoryWeightsTable: React.FC = () => {
                       hover
                       sx={{
                         backgroundColor: isInactive
-                          ? 'rgba(211, 47, 47, 0.08)'
+                          ? alpha(theme.palette.error.main, 0.08)
                           : 'inherit',
                         '&:hover': {
                           backgroundColor: isInactive
-                            ? 'rgba(211, 47, 47, 0.12)'
+                            ? alpha(theme.palette.error.main, 0.12)
                             : undefined,
                         },
                       }}
@@ -621,13 +646,11 @@ const RepositoryWeightsTable: React.FC = () => {
                                 sx={{
                                   width: 24,
                                   height: 24,
-                                  border: '1px solid rgba(255, 255, 255, 0.2)',
+                                  border: `1px solid ${theme.palette.border.medium}`,
                                   backgroundColor:
-                                    repo.owner === 'opentensor'
-                                      ? '#ffffff'
-                                      : repo.owner === 'bitcoin'
-                                        ? '#F7931A'
-                                        : 'transparent',
+                                    REPO_OWNER_AVATAR_BACKGROUNDS[
+                                      repo.owner as keyof typeof REPO_OWNER_AVATAR_BACKGROUNDS
+                                    ] ?? 'transparent',
                                   transition: 'transform 0.2s',
                                   '&:hover': {
                                     transform: 'scale(1.2)',
@@ -681,13 +704,11 @@ const RepositoryWeightsTable: React.FC = () => {
                                 sx={{
                                   width: 24,
                                   height: 24,
-                                  border: '1px solid rgba(255, 255, 255, 0.2)',
+                                  border: `1px solid ${theme.palette.border.medium}`,
                                   backgroundColor:
-                                    repo.owner === 'opentensor'
-                                      ? '#ffffff'
-                                      : repo.owner === 'bitcoin'
-                                        ? '#F7931A'
-                                        : 'transparent',
+                                    REPO_OWNER_AVATAR_BACKGROUNDS[
+                                      repo.owner as keyof typeof REPO_OWNER_AVATAR_BACKGROUNDS
+                                    ] ?? 'transparent',
                                   transition: 'transform 0.2s',
                                   '&:hover': {
                                     transform: 'scale(1.2)',
@@ -733,7 +754,7 @@ const RepositoryWeightsTable: React.FC = () => {
                                 variant="body2"
                                 sx={{
                                   color: isInactive
-                                    ? 'rgba(211, 47, 47, 0.7)'
+                                    ? alpha(theme.palette.error.main, 0.7)
                                     : 'text.secondary',
                                   textDecoration: 'none',
                                   '&:hover': { textDecoration: 'underline' },


### PR DESCRIPTION
## Summary

Swaps all hardcoded hex/rgba color values in the 7 repository components with existing theme tokens (`border.light`, `surface.light`, `text.primary`, `STATUS_COLORS`, `TEXT_OPACITY`, `REPO_OWNER_AVATAR_BACKGROUNDS`, etc.) using `useTheme()` and `alpha()` from MUI. No layout or behavior changes.

## Related Issues

Closes #323

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

No visual changes — same colors, just sourced from the theme instead of hardcoded.

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [ ] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes