### PR TITLE
fix: add mergedAt fallback to merged PR detection in stats and utils

### DIFF
--- a/src/components/repositories/RepositoryContributorsTable.tsx
+++ b/src/components/repositories/RepositoryContributorsTable.tsx
@@ -5,6 +5,7 @@ import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
 import { useAllPrs, useAllMiners } from '../../api';
 import { useNavigate } from 'react-router-dom';
 import { STATUS_COLORS } from '../../theme';
+import { isMergedPr } from '../../utils/prStatus';
 
 interface RepositoryContributorsTableProps {
   repositoryFullName: string;
@@ -45,7 +46,7 @@ const RepositoryContributorsTable: React.FC<
       (pr) =>
         pr.repository.toLowerCase() === repositoryFullName.toLowerCase() &&
         pr.githubId &&
-        pr.prState === 'MERGED',
+        isMergedPr(pr),
     );
 
     const contributorsMap = new Map<

--- a/src/components/repositories/RepositoryStats.tsx
+++ b/src/components/repositories/RepositoryStats.tsx
@@ -9,6 +9,7 @@ import {
 } from '../../api';
 import { RANK_COLORS, STATUS_COLORS } from '../../theme';
 import { formatTokenAmount } from '../../utils/format';
+import { isMergedPr } from '../../utils/prStatus';
 
 interface RepositoryStatsProps {
   repositoryFullName: string;
@@ -38,7 +39,7 @@ const RepositoryStats: React.FC<RepositoryStatsProps> = ({
     const repoPRs = allPRs.filter(
       (pr) =>
         pr.repository.toLowerCase() === repositoryFullName.toLowerCase() &&
-        pr.prState === 'MERGED',
+        isMergedPr(pr),
     );
     const totalScore = repoPRs.reduce(
       (acc, pr) => acc + parseFloat(pr.score || '0'),

--- a/src/utils/ExplorerUtils.ts
+++ b/src/utils/ExplorerUtils.ts
@@ -5,6 +5,7 @@ import {
   type Repository,
   type RepositoryPrScoring,
 } from '../api';
+import { isMergedPr } from './prStatus';
 
 export const getGithubAvatarSrc = (username?: string | null) => {
   if (username) {
@@ -225,7 +226,7 @@ export const aggregatePRsByRepository = (
     };
     existing.prs += 1;
     existing.score += parseFloat(pr.score || '0');
-    if (pr.prState === 'MERGED') {
+    if (isMergedPr(pr)) {
       existing.tokenScore += parseFloat(String(pr.tokenScore ?? '0'));
     }
     statsMap.set(pr.repository, existing);


### PR DESCRIPTION
## Problem

`RepositoryStats`, `RepositoryContributorsTable`, and `aggregatePRsByRepository` in `ExplorerUtils` identified merged PRs by checking only `prState === 'MERGED'`. The rest of the codebase (5 other sites) consistently uses the dual guard:

```ts
pr.prState === 'MERGED' || !!pr.mergedAt
```

PRs that arrive with a `mergedAt` timestamp but a missing or inconsistent `prState` field are silently excluded. This causes:

- **Repository stats card** — merged PR count and total score are under-reported
- **Contributors table** — miners who only have PRs with `mergedAt` set (but `prState` not set to `MERGED`) are excluded from the contributor list entirely
- **`aggregatePRsByRepository`** — `tokenScore` totals in the repositories leaderboard are under-counted for the same PRs

## Changes

| File | Line | Change |
|------|------|--------|
| `src/components/repositories/RepositoryStats.tsx` | 40 | `prState === 'MERGED'` → `prState === 'MERGED' \|\| !!mergedAt` |
| `src/components/repositories/RepositoryContributorsTable.tsx` | 48 | same |
| `src/utils/ExplorerUtils.ts` | 196 | same (tokenScore aggregation gate) |

No logic beyond the filter predicate is changed.

## Test plan

- [ ] Open a repository page that has PRs — verify merged PR count and total score are correct
- [ ] Check the contributors table for the same repo — all miners with merged PRs appear
- [ ] Open the Repositories leaderboard — token scores match expected values
- [ ] Confirm no regression on PRs where both `prState === 'MERGED'` and `mergedAt` are set (the OR means no double-counting)