### PR TITLE
refactor: replace inline FilterButton in TopMinersTable with shared component

### DIFF
--- a/src/components/leaderboard/TopMinersTable.tsx
+++ b/src/components/leaderboard/TopMinersTable.tsx
@@ -1,10 +1,11 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Box, Typography, CircularProgress, Grid } from '@mui/material';
-import { alpha, type Theme } from '@mui/material/styles';
+import { alpha, useTheme, type Theme } from '@mui/material/styles';
 import { useSearchParams } from 'react-router-dom';
 import { SectionCard } from './SectionCard';
 import { MinerCard } from './MinerCard';
 import { SearchInput } from '../common/SearchInput';
+import FilterButton from '../FilterButton';
 import { STATUS_COLORS } from '../../theme';
 import {
   type MinerStats,
@@ -52,6 +53,7 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
   linkState,
   variant = 'oss',
 }) => {
+  const theme = useTheme();
   const [searchParams, setSearchParams] = useSearchParams();
   const [searchQuery, setSearchQuery] = useState('');
   const sortParamValue = searchParams.get(SORT_QUERY_PARAM);
@@ -193,6 +195,7 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
               label="Eligible"
               isActive={showEligibleOnly}
               onClick={handleToggleEligible}
+              color={theme.palette.status.merged}
             />
           </Box>
         }
@@ -355,55 +358,6 @@ const SortButtons: React.FC<SortButtonsProps> = ({
         </Typography>
       </Box>
     ))}
-  </Box>
-);
-
-interface FilterButtonProps {
-  label: string;
-  isActive: boolean;
-  onClick: () => void;
-}
-
-const FilterButton: React.FC<FilterButtonProps> = ({
-  label,
-  isActive,
-  onClick,
-}) => (
-  <Box
-    onClick={onClick}
-    sx={(theme) => ({
-      px: 1.5,
-      height: 32,
-      display: 'flex',
-      alignItems: 'center',
-      borderRadius: 2,
-      cursor: 'pointer',
-      backgroundColor: isActive
-        ? alpha(theme.palette.status.merged, 0.16)
-        : 'transparent',
-      color: isActive ? theme.palette.text.primary : STATUS_COLORS.open,
-      border: '1px solid',
-      borderColor: isActive
-        ? alpha(theme.palette.status.merged, 0.4)
-        : 'transparent',
-      transition: 'all 0.2s',
-      '&:hover': {
-        backgroundColor: isActive
-          ? alpha(theme.palette.status.merged, 0.2)
-          : theme.palette.surface.light,
-        color: theme.palette.text.primary,
-      },
-    })}
-  >
-    <Typography
-      sx={{
-        fontFamily: FONTS.mono,
-        fontSize: '0.75rem',
-        fontWeight: 600,
-      }}
-    >
-      {label}
-    </Typography>
   </Box>
 );
 


### PR DESCRIPTION
## Summary

`TopMinersTable` defined its own inline `FilterButton` component (50 lines) at module scope instead of using the shared `src/components/FilterButton.tsx` that `TopPRsTable`, `RepositoryPRsTable`, and `RepositoryIssuesTable` already use.

This PR removes the local definition and switches to the shared component, making all four table components consistent.

## Changes

- Remove local `FilterButtonProps` interface and `FilterButton` component from `TopMinersTable.tsx` (−49 lines)
- Import shared `FilterButton` from `'../FilterButton'`
- Add `useTheme` to resolve `theme.palette.status.merged` for the required `color` prop
- Pass `color={theme.palette.status.merged}` to match the previous active-border colour

## Test plan

- [ ] Open the Miners leaderboard page
- [ ] Click the **Eligible** toggle — verify it activates/deactivates correctly with the correct border colour
- [ ] Verify the button hover state works as expected
- [ ] Confirm no visual regression on the sort buttons or the rest of the table