### PR TITLE
Show percentage in dashboard overview donut center

### DIFF
--- a/src/pages/dashboard/dashboardData.ts
+++ b/src/pages/dashboard/dashboardData.ts
@@ -41,7 +41,7 @@ export interface DashboardOverviewSection {
     label: string;
     value: number;
   }>;
-  chartTotal: string;
+  chartCenterLabel: string;
 }
 
 export interface DashboardKpi {
@@ -368,6 +368,11 @@ const getIssueOverviewMetrics = (
   };
 };
 
+const formatCenterPercent = (resolved: number, total: number) => {
+  if (total <= 0) return '0%';
+  return `${((resolved / total) * 100).toFixed(1)}%`;
+};
+
 export const buildDashboardOverview = (
   prs: CommitLog[],
   issues: IssueBounty[],
@@ -398,7 +403,10 @@ export const buildDashboardOverview = (
         { label: 'Open', value: currentPrMetrics.open },
         { label: 'Closed', value: currentPrMetrics.closed },
       ],
-      chartTotal: currentPrMetrics.total.toLocaleString(),
+      chartCenterLabel: formatCenterPercent(
+        currentPrMetrics.merged,
+        currentPrMetrics.total,
+      ),
       metrics: [
         {
           label: 'Total',
@@ -438,7 +446,10 @@ export const buildDashboardOverview = (
         { label: 'Open', value: currentIssueMetrics.open },
         { label: 'Closed', value: currentIssueMetrics.closed },
       ],
-      chartTotal: currentIssueMetrics.total.toLocaleString(),
+      chartCenterLabel: formatCenterPercent(
+        currentIssueMetrics.solved,
+        currentIssueMetrics.total,
+      ),
       metrics: [
         {
           label: 'Total',

--- a/src/pages/dashboard/views/DashboardOverview.tsx
+++ b/src/pages/dashboard/views/DashboardOverview.tsx
@@ -40,7 +40,7 @@ const getDeltaColor = (theme: Theme, delta: string): string => {
 
 const buildStatusChartOption = (
   theme: Theme,
-  total: string,
+  centerLabel: string,
   segments: DashboardOverviewSection['chartSegments'],
 ): Record<string, unknown> => {
   const totalValue = segments.reduce((sum, segment) => sum + segment.value, 0);
@@ -49,7 +49,7 @@ const buildStatusChartOption = (
   return {
     backgroundColor: 'transparent',
     title: {
-      text: total,
+      text: centerLabel,
       left: 'center',
       top: '34%',
       textStyle: {
@@ -270,7 +270,7 @@ const DashboardOverview: React.FC<DashboardOverviewProps> = ({
                           <ReactECharts
                             option={buildStatusChartOption(
                               theme,
-                              section.chartTotal,
+                              section.chartCenterLabel,
                               section.chartSegments,
                             )}
                             style={{ width: '100%', height: '100%' }}


### PR DESCRIPTION
## Summary

Updates the dashboard Overview donut charts to show a percentage in the center instead of a raw total count.

Mango requested this change so the Overview donuts communicate the key ratio directly, rather than showing a total that was less useful in the chart center.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

<img width="1476" height="718" alt="image" src="https://github.com/user-attachments/assets/3948148c-1bd9-4729-a88c-23fedababa5e" />

## Checklist

- [ ] New components are modularized/separated where sensible
- [ ] Uses predefined theme (e.g. no hardcoded colors)
- [ ] Responsive/mobile checked
- [ ] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
