### PR TITLE
feat: add miner watchlist with localStorage persistence

### DIFF
--- a/src/components/common/WatchlistButton.tsx
+++ b/src/components/common/WatchlistButton.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { IconButton, Tooltip, type SxProps, type Theme } from '@mui/material';
+import StarIcon from '@mui/icons-material/Star';
+import StarBorderIcon from '@mui/icons-material/StarBorder';
+import { useWatchlist } from '../../hooks/useWatchlist';
+
+interface WatchlistButtonProps {
+  githubId: string;
+  size?: 'small' | 'medium';
+  sx?: SxProps<Theme>;
+}
+
+export const WatchlistButton: React.FC<WatchlistButtonProps> = ({
+  githubId,
+  size = 'small',
+  sx,
+}) => {
+  const { isWatched, toggle } = useWatchlist();
+  const watched = isWatched(githubId);
+  const label = watched ? 'Remove from watchlist' : 'Add to watchlist';
+
+  const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+    e.preventDefault();
+    if (!githubId) return;
+    toggle(githubId);
+  };
+
+  return (
+    <Tooltip title={label} placement="top" arrow>
+      <IconButton
+        size={size}
+        onClick={handleClick}
+        aria-label={label}
+        aria-pressed={watched}
+        sx={{
+          color: watched ? 'warning.main' : 'text.tertiary',
+          transition: 'color 0.15s, transform 0.15s',
+          '&:hover': {
+            color: 'warning.light',
+            transform: 'scale(1.08)',
+            backgroundColor: 'rgba(255,255,255,0.06)',
+          },
+          ...sx,
+        }}
+      >
+        {watched ? (
+          <StarIcon fontSize={size === 'medium' ? 'medium' : 'small'} />
+        ) : (
+          <StarBorderIcon fontSize={size === 'medium' ? 'medium' : 'small'} />
+        )}
+      </IconButton>
+    </Tooltip>
+  );
+};

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -1,2 +1,3 @@
 export * from './RowLink';
 export * from './SearchInput';
+export * from './WatchlistButton';

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -8,6 +8,7 @@ import {
   Divider,
 } from '@mui/material';
 import { useNavigate, useLocation } from 'react-router-dom';
+import { useWatchlist } from '../../hooks/useWatchlist';
 
 interface SidebarProps {
   onNavigate?: () => void;
@@ -16,16 +17,26 @@ interface SidebarProps {
 const Sidebar: React.FC<SidebarProps> = ({ onNavigate }) => {
   const navigate = useNavigate();
   const location = useLocation();
+  const { count: watchlistCount } = useWatchlist();
 
   const handleNavigate = (path: string) => {
     navigate(path);
     onNavigate?.(); // Call onNavigate if provided (for mobile drawer closing)
   };
 
-  const navItems = [
+  const navItems: Array<{
+    label: string;
+    path: string;
+    badge?: string | number;
+  }> = [
     { label: 'dashboard', path: '/dashboard' },
     { label: 'oss contributions', path: '/top-miners' },
     { label: 'discoveries', path: '/discoveries', badge: 'new' },
+    {
+      label: 'watchlist',
+      path: '/watchlist',
+      badge: watchlistCount > 0 ? watchlistCount : undefined,
+    },
     { label: 'bounties', path: '/bounties' },
     { label: 'repositories', path: '/repositories' },
     { label: 'onboard', path: '/onboard' },

--- a/src/components/leaderboard/MinerCard.tsx
+++ b/src/components/leaderboard/MinerCard.tsx
@@ -5,7 +5,7 @@ import ReactECharts from 'echarts-for-react';
 import { useMinerGithubData, useMinerPRs } from '../../api';
 import { CHART_COLORS, STATUS_COLORS } from '../../theme';
 import { getGithubAvatarSrc } from '../../utils/ExplorerUtils';
-import { RowLink } from '../common';
+import { RowLink, WatchlistButton } from '../common';
 import { type MinerStats, type LeaderboardVariant, FONTS } from './types';
 
 interface MinerCardProps {
@@ -151,26 +151,37 @@ export const MinerCard: React.FC<MinerCardProps> = ({
               </Typography>
             </Box>
           </Box>
-          {!isEligible && (
-            <Typography
-              sx={(theme) => ({
-                fontFamily: FONTS.mono,
-                fontSize: '0.65rem',
-                fontWeight: 700,
-                color: theme.palette.text.secondary,
-                textTransform: 'uppercase',
-                border: `1px solid ${theme.palette.border.subtle}`,
-                borderRadius: 1,
-                px: 0.75,
-                py: 0.25,
-                letterSpacing: '0.06em',
-                flexShrink: 0,
-                backgroundColor: theme.palette.surface.subtle,
-              })}
-            >
-              Ineligible
-            </Typography>
-          )}
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 0.5,
+              flexShrink: 0,
+            }}
+          >
+            {!isEligible && (
+              <Typography
+                sx={(theme) => ({
+                  fontFamily: FONTS.mono,
+                  fontSize: '0.65rem',
+                  fontWeight: 700,
+                  color: theme.palette.text.secondary,
+                  textTransform: 'uppercase',
+                  border: `1px solid ${theme.palette.border.subtle}`,
+                  borderRadius: 1,
+                  px: 0.75,
+                  py: 0.25,
+                  letterSpacing: '0.06em',
+                  backgroundColor: theme.palette.surface.subtle,
+                })}
+              >
+                Ineligible
+              </Typography>
+            )}
+            {miner.githubId && (
+              <WatchlistButton githubId={miner.githubId} size="small" />
+            )}
+          </Box>
         </Box>
 
         <Box

--- a/src/hooks/useWatchlist.ts
+++ b/src/hooks/useWatchlist.ts
@@ -1,0 +1,81 @@
+import { useCallback, useEffect, useState } from 'react';
+
+const STORAGE_KEY = 'gittensor.watchlist.v1';
+
+const readFromStorage = (): string[] => {
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed)
+      ? parsed.filter((x): x is string => typeof x === 'string')
+      : [];
+  } catch {
+    return [];
+  }
+};
+
+const writeToStorage = (ids: string[]) => {
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(ids));
+  } catch {
+    // Storage unavailable (private mode, quota). In-memory state still works.
+  }
+};
+
+interface UseWatchlist {
+  ids: string[];
+  count: number;
+  isWatched: (id: string) => boolean;
+  add: (id: string) => void;
+  remove: (id: string) => void;
+  toggle: (id: string) => void;
+  clear: () => void;
+}
+
+export const useWatchlist = (): UseWatchlist => {
+  const [ids, setIds] = useState<string[]>(() => readFromStorage());
+
+  useEffect(() => {
+    const handler = (e: StorageEvent) => {
+      if (e.key !== STORAGE_KEY) return;
+      setIds(readFromStorage());
+    };
+    window.addEventListener('storage', handler);
+    return () => window.removeEventListener('storage', handler);
+  }, []);
+
+  const persist = useCallback((next: string[]) => {
+    setIds(next);
+    writeToStorage(next);
+  }, []);
+
+  const isWatched = useCallback((id: string) => ids.includes(id), [ids]);
+
+  const add = useCallback(
+    (id: string) => {
+      if (!id || ids.includes(id)) return;
+      persist([...ids, id]);
+    },
+    [ids, persist],
+  );
+
+  const remove = useCallback(
+    (id: string) => {
+      if (!ids.includes(id)) return;
+      persist(ids.filter((x) => x !== id));
+    },
+    [ids, persist],
+  );
+
+  const toggle = useCallback(
+    (id: string) => {
+      persist(ids.includes(id) ? ids.filter((x) => x !== id) : [...ids, id]);
+    },
+    [ids, persist],
+  );
+
+  const clear = useCallback(() => persist([]), [persist]);
+
+  return { ids, count: ids.length, isWatched, add, remove, toggle, clear };
+};

--- a/src/hooks/useWatchlist.ts
+++ b/src/hooks/useWatchlist.ts
@@ -1,6 +1,9 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useSyncExternalStore } from 'react';
 
 const STORAGE_KEY = 'gittensor.watchlist.v1';
+
+type Listener = () => void;
+const listeners = new Set<Listener>();
 
 const readFromStorage = (): string[] => {
   try {
@@ -15,13 +18,51 @@ const readFromStorage = (): string[] => {
   }
 };
 
-const writeToStorage = (ids: string[]) => {
+// Module-level snapshot — every useWatchlist() instance in the tab reads from
+// the same reference, so writes from any caller propagate to all consumers.
+let snapshot: string[] = readFromStorage();
+
+const notify = () => {
+  listeners.forEach((l) => l());
+};
+
+const setSnapshot = (next: string[]) => {
+  if (
+    next.length === snapshot.length &&
+    next.every((id, i) => id === snapshot[i])
+  ) {
+    return;
+  }
+  snapshot = next;
   try {
-    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(ids));
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
   } catch {
     // Storage unavailable (private mode, quota). In-memory state still works.
   }
+  notify();
 };
+
+const handleStorageEvent = (e: StorageEvent) => {
+  if (e.key !== STORAGE_KEY) return;
+  const next = readFromStorage();
+  snapshot = next;
+  notify();
+};
+
+const subscribe = (listener: Listener) => {
+  if (listeners.size === 0) {
+    window.addEventListener('storage', handleStorageEvent);
+  }
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+    if (listeners.size === 0) {
+      window.removeEventListener('storage', handleStorageEvent);
+    }
+  };
+};
+
+const getSnapshot = () => snapshot;
 
 interface UseWatchlist {
   ids: string[];
@@ -34,48 +75,36 @@ interface UseWatchlist {
 }
 
 export const useWatchlist = (): UseWatchlist => {
-  const [ids, setIds] = useState<string[]>(() => readFromStorage());
+  const ids = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
 
-  useEffect(() => {
-    const handler = (e: StorageEvent) => {
-      if (e.key !== STORAGE_KEY) return;
-      setIds(readFromStorage());
-    };
-    window.addEventListener('storage', handler);
-    return () => window.removeEventListener('storage', handler);
+  const isWatched = useCallback(
+    (id: string) => snapshot.includes(id),
+    // Depending on `ids` ensures consumers re-render when the snapshot changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [ids],
+  );
+
+  // Action callbacks read from the module-level `snapshot`, not the rendered
+  // `ids`. This is the key to rapid-click correctness: two fast toggles see
+  // each other's writes immediately instead of both reading a stale array.
+  const add = useCallback((id: string) => {
+    if (!id || snapshot.includes(id)) return;
+    setSnapshot([...snapshot, id]);
   }, []);
 
-  const persist = useCallback((next: string[]) => {
-    setIds(next);
-    writeToStorage(next);
+  const remove = useCallback((id: string) => {
+    if (!snapshot.includes(id)) return;
+    setSnapshot(snapshot.filter((x) => x !== id));
   }, []);
 
-  const isWatched = useCallback((id: string) => ids.includes(id), [ids]);
+  const toggle = useCallback((id: string) => {
+    if (!id) return;
+    setSnapshot(
+      snapshot.includes(id) ? snapshot.filter((x) => x !== id) : [...snapshot, id],
+    );
+  }, []);
 
-  const add = useCallback(
-    (id: string) => {
-      if (!id || ids.includes(id)) return;
-      persist([...ids, id]);
-    },
-    [ids, persist],
-  );
-
-  const remove = useCallback(
-    (id: string) => {
-      if (!ids.includes(id)) return;
-      persist(ids.filter((x) => x !== id));
-    },
-    [ids, persist],
-  );
-
-  const toggle = useCallback(
-    (id: string) => {
-      persist(ids.includes(id) ? ids.filter((x) => x !== id) : [...ids, id]);
-    },
-    [ids, persist],
-  );
-
-  const clear = useCallback(() => persist([]), [persist]);
+  const clear = useCallback(() => setSnapshot([]), []);
 
   return { ids, count: ids.length, isWatched, add, remove, toggle, clear };
 };

--- a/src/hooks/useWatchlist.ts
+++ b/src/hooks/useWatchlist.ts
@@ -100,7 +100,9 @@ export const useWatchlist = (): UseWatchlist => {
   const toggle = useCallback((id: string) => {
     if (!id) return;
     setSnapshot(
-      snapshot.includes(id) ? snapshot.filter((x) => x !== id) : [...snapshot, id],
+      snapshot.includes(id)
+        ? snapshot.filter((x) => x !== id)
+        : [...snapshot, id],
     );
   }, []);
 

--- a/src/pages/MinerDetailsPage.tsx
+++ b/src/pages/MinerDetailsPage.tsx
@@ -12,6 +12,7 @@ import {
   MinerScoreCard,
   SEO,
 } from '../components';
+import { WatchlistButton } from '../components/common';
 
 type ViewMode = 'prs' | 'issues';
 
@@ -102,7 +103,10 @@ const MinerDetailsPage: React.FC = () => {
               justifyContent: 'space-between',
             }}
           >
-            <BackButton to="/top-miners" mb={0} />
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+              <BackButton to="/top-miners" mb={0} />
+              <WatchlistButton githubId={githubId} size="medium" />
+            </Box>
             <Box
               sx={{
                 display: 'flex',

--- a/src/pages/TopMinersPage.tsx
+++ b/src/pages/TopMinersPage.tsx
@@ -4,7 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import { Page } from '../components/layout';
 import { TopMinersTable, LeaderboardSidebar, SEO } from '../components';
 import { useAllMiners } from '../api';
-import { parseNumber } from '../utils';
+import { mapAllMinersToStats } from '../utils/minerMapper';
 import theme, { scrollbarSx } from '../theme';
 
 const TopMinersPage: React.FC = () => {
@@ -20,38 +20,10 @@ const TopMinersPage: React.FC = () => {
     });
   };
 
-  // Normalize leaderboard miner data.
-  const minerStats = useMemo(() => {
-    if (!Array.isArray(allMinersStats)) return [];
-
-    const rankById = new Map(
-      [...allMinersStats]
-        .sort((a, b) => Number(b.totalScore) - Number(a.totalScore))
-        .map((stat, index) => [String(stat.id), index + 1]),
-    );
-
-    return allMinersStats.map((stat) => ({
-      id: String(stat.id),
-      githubId: stat.githubId || '',
-      author: stat.githubUsername || undefined,
-      totalScore: parseNumber(stat.totalScore),
-      baseTotalScore: parseNumber(stat.baseTotalScore),
-      totalPRs: parseNumber(stat.totalPrs),
-      linesChanged: parseNumber(stat.totalNodesScored),
-      linesAdded: parseNumber(stat.totalAdditions),
-      linesDeleted: parseNumber(stat.totalDeletions),
-      hotkey: stat.hotkey || 'N/A',
-      rank: rankById.get(String(stat.id)),
-      uniqueReposCount: parseNumber(stat.uniqueReposCount),
-      credibility: parseNumber(stat.credibility),
-      isEligible: stat.isEligible ?? false,
-      usdPerDay: parseNumber(stat.usdPerDay),
-      // PR status counts for credibility donut
-      totalMergedPrs: parseNumber(stat.totalMergedPrs),
-      totalOpenPrs: parseNumber(stat.totalOpenPrs),
-      totalClosedPrs: parseNumber(stat.totalClosedPrs),
-    }));
-  }, [allMinersStats]);
+  const minerStats = useMemo(
+    () => mapAllMinersToStats(allMinersStats ?? []),
+    [allMinersStats],
+  );
 
   // Dashboard-like responsive logic
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));

--- a/src/pages/WatchlistPage.tsx
+++ b/src/pages/WatchlistPage.tsx
@@ -1,69 +1,45 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import {
-  useMediaQuery,
   Box,
   Typography,
   Button,
   alpha,
   Stack,
+  Dialog,
+  DialogTitle,
+  DialogActions,
 } from '@mui/material';
 import { Link as RouterLink } from 'react-router-dom';
 import { Page } from '../components/layout';
 import { TopMinersTable, SEO } from '../components';
 import { useAllMiners } from '../api';
-import { parseNumber } from '../utils';
+import { mapAllMinersToStats } from '../utils/minerMapper';
 import { useWatchlist } from '../hooks/useWatchlist';
-import theme, { scrollbarSx } from '../theme';
 
 const WatchlistPage: React.FC = () => {
   const { ids, count, clear } = useWatchlist();
   const watchedSet = useMemo(() => new Set(ids), [ids]);
+  const [confirmOpen, setConfirmOpen] = useState(false);
 
   const allMinerStatsQuery = useAllMiners();
   const allMinersStats = allMinerStatsQuery?.data;
   const isLoadingMinerStats = allMinerStatsQuery?.isLoading;
 
-  const minerStats = useMemo(() => {
-    if (!Array.isArray(allMinersStats)) return [];
-
-    const rankById = new Map(
-      [...allMinersStats]
-        .sort((a, b) => Number(b.totalScore) - Number(a.totalScore))
-        .map((stat, index) => [String(stat.id), index + 1]),
-    );
-
-    return allMinersStats
-      .filter((stat) => watchedSet.has(stat.githubId || ''))
-      .map((stat) => ({
-        id: String(stat.id),
-        githubId: stat.githubId || '',
-        author: stat.githubUsername || undefined,
-        totalScore: parseNumber(stat.totalScore),
-        baseTotalScore: parseNumber(stat.baseTotalScore),
-        totalPRs: parseNumber(stat.totalPrs),
-        linesChanged: parseNumber(stat.totalNodesScored),
-        linesAdded: parseNumber(stat.totalAdditions),
-        linesDeleted: parseNumber(stat.totalDeletions),
-        hotkey: stat.hotkey || 'N/A',
-        rank: rankById.get(String(stat.id)),
-        uniqueReposCount: parseNumber(stat.uniqueReposCount),
-        credibility: parseNumber(stat.credibility),
-        isEligible: stat.isEligible ?? false,
-        usdPerDay: parseNumber(stat.usdPerDay),
-        totalMergedPrs: parseNumber(stat.totalMergedPrs),
-        totalOpenPrs: parseNumber(stat.totalOpenPrs),
-        totalClosedPrs: parseNumber(stat.totalClosedPrs),
-      }));
-  }, [allMinersStats, watchedSet]);
-
-  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
-  const isTablet = useMediaQuery(theme.breakpoints.between('sm', 'md'));
-  const isLargeScreen = useMediaQuery(theme.breakpoints.up('xl'));
-  const showSidebarRight = useMediaQuery(theme.breakpoints.up('xl'));
-  const sidebarWidth =
-    isMobile || isTablet ? '100%' : isLargeScreen ? '340px' : '300px';
+  const allMinerStats = useMemo(
+    () => mapAllMinersToStats(allMinersStats ?? []),
+    [allMinersStats],
+  );
+  const minerStats = useMemo(
+    () => allMinerStats.filter((m) => watchedSet.has(m.githubId)),
+    [allMinerStats, watchedSet],
+  );
 
   const isEmpty = count === 0;
+
+  const handleClear = () => {
+    clear();
+    setConfirmOpen(false);
+  };
 
   return (
     <Page title="Watchlist">
@@ -74,129 +50,115 @@ const WatchlistPage: React.FC = () => {
       <Box
         sx={{
           width: '100%',
-          height: showSidebarRight ? 'calc(100vh - 64px)' : 'auto',
           display: 'flex',
-          flexDirection: showSidebarRight ? 'row' : 'column',
-          gap: { xs: 2, sm: 2, md: 2.5, lg: 3 },
+          flexDirection: 'column',
+          gap: { xs: 2, sm: 1.5 },
           py: { xs: 2, sm: 2, md: 2.5, lg: 3 },
           px: { xs: 2, sm: 2, md: 2.5, lg: 3 },
-          overflow: 'hidden',
         }}
       >
-        <Box
-          sx={{
-            flex: 1,
-            display: 'flex',
-            flexDirection: 'column',
-            gap: { xs: 2, sm: 1.5 },
-            minHeight: 0,
-            overflow: showSidebarRight ? 'auto' : 'visible',
-            minWidth: 0,
-            pr: showSidebarRight ? 1 : 0,
-            ...scrollbarSx,
-          }}
+        <Stack
+          direction="row"
+          alignItems="center"
+          justifyContent="space-between"
+          spacing={2}
         >
-          <Stack
-            direction="row"
-            alignItems="center"
-            justifyContent="space-between"
-            spacing={2}
+          <Typography
+            sx={{
+              fontFamily: '"JetBrains Mono", monospace',
+              fontSize: '0.8rem',
+              color: (t) => alpha(t.palette.text.primary, 0.5),
+              lineHeight: 1.6,
+            }}
+          >
+            Your watchlist — {count}{' '}
+            {count === 1 ? 'miner pinned' : 'miners pinned'}. Stored locally
+            in this browser.
+          </Typography>
+          {count > 0 && (
+            <Button
+              size="small"
+              onClick={() => setConfirmOpen(true)}
+              sx={{
+                fontFamily: '"JetBrains Mono", monospace',
+                fontSize: '0.75rem',
+                textTransform: 'none',
+                color: 'text.secondary',
+              }}
+            >
+              Clear watchlist
+            </Button>
+          )}
+        </Stack>
+
+        {isEmpty ? (
+          <Box
+            sx={{
+              py: 8,
+              textAlign: 'center',
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 2,
+              alignItems: 'center',
+              color: 'text.secondary',
+            }}
           >
             <Typography
               sx={{
                 fontFamily: '"JetBrains Mono", monospace',
-                fontSize: '0.8rem',
-                color: (t) => alpha(t.palette.text.primary, 0.5),
-                lineHeight: 1.6,
+                fontSize: '0.95rem',
               }}
             >
-              Your watchlist — {count}{' '}
-              {count === 1 ? 'miner pinned' : 'miners pinned'}. Stored locally
-              in this browser.
+              Your watchlist is empty.
             </Typography>
-            {count > 0 && (
-              <Button
-                size="small"
-                onClick={clear}
-                sx={{
-                  fontFamily: '"JetBrains Mono", monospace',
-                  fontSize: '0.75rem',
-                  textTransform: 'none',
-                  color: 'text.secondary',
-                }}
-              >
-                Clear watchlist
-              </Button>
-            )}
-          </Stack>
-
-          {isEmpty ? (
-            <Box
+            <Typography
               sx={{
-                py: 8,
-                textAlign: 'center',
-                display: 'flex',
-                flexDirection: 'column',
-                gap: 2,
-                alignItems: 'center',
-                color: 'text.secondary',
+                fontFamily: '"JetBrains Mono", monospace',
+                fontSize: '0.8rem',
+                maxWidth: 480,
+                color: (t) => alpha(t.palette.text.primary, 0.5),
               }}
             >
-              <Typography
-                sx={{
-                  fontFamily: '"JetBrains Mono", monospace',
-                  fontSize: '0.95rem',
-                }}
-              >
-                Your watchlist is empty.
-              </Typography>
-              <Typography
-                sx={{
-                  fontFamily: '"JetBrains Mono", monospace',
-                  fontSize: '0.8rem',
-                  maxWidth: 480,
-                  color: (t) => alpha(t.palette.text.primary, 0.5),
-                }}
-              >
-                Browse the leaderboard and star miners you want to track. Pinned
-                miners appear here across reloads and tabs.
-              </Typography>
-              <Button
-                component={RouterLink}
-                to="/top-miners"
-                variant="outlined"
-                size="small"
-                sx={{ textTransform: 'none', mt: 1 }}
-              >
-                Go to leaderboard
-              </Button>
-            </Box>
-          ) : (
-            <Box sx={{ width: '100%' }}>
-              <TopMinersTable
-                miners={minerStats}
-                isLoading={isLoadingMinerStats}
-                getHref={(m) =>
-                  `/miners/details?githubId=${encodeURIComponent(m.githubId)}`
-                }
-                linkState={{ backLabel: 'Back to Watchlist' }}
-              />
-            </Box>
-          )}
-        </Box>
-
-        <Box
-          sx={{
-            width: showSidebarRight ? sidebarWidth : '100%',
-            height: showSidebarRight ? '100%' : 'auto',
-            maxHeight: showSidebarRight ? '100%' : 'none',
-            flexShrink: 0,
-            display: 'flex',
-            flexDirection: 'column',
-            gap: 2,
-          }}
-        />
+              Browse the leaderboard and star miners you want to track. Pinned
+              miners appear here across reloads and tabs.
+            </Typography>
+            <Button
+              component={RouterLink}
+              to="/top-miners"
+              variant="outlined"
+              size="small"
+              sx={{ textTransform: 'none', mt: 1 }}
+            >
+              Go to leaderboard
+            </Button>
+          </Box>
+        ) : (
+          <Box sx={{ width: '100%' }}>
+            <TopMinersTable
+              miners={minerStats}
+              isLoading={isLoadingMinerStats}
+              getHref={(m) =>
+                `/miners/details?githubId=${encodeURIComponent(m.githubId)}`
+              }
+              linkState={{ backLabel: 'Back to Watchlist' }}
+            />
+          </Box>
+        )}
       </Box>
+
+      <Dialog open={confirmOpen} onClose={() => setConfirmOpen(false)}>
+        <DialogTitle sx={{ fontFamily: '"JetBrains Mono", monospace' }}>
+          Clear all {count} pinned miners?
+        </DialogTitle>
+        <DialogActions>
+          <Button onClick={() => setConfirmOpen(false)} sx={{ textTransform: 'none' }}>
+            Cancel
+          </Button>
+          <Button onClick={handleClear} color="error" sx={{ textTransform: 'none' }}>
+            Clear watchlist
+          </Button>
+        </DialogActions>
+      </Dialog>
     </Page>
   );
 };

--- a/src/pages/WatchlistPage.tsx
+++ b/src/pages/WatchlistPage.tsx
@@ -158,8 +158,8 @@ const WatchlistPage: React.FC = () => {
                   color: (t) => alpha(t.palette.text.primary, 0.5),
                 }}
               >
-                Browse the leaderboard and star miners you want to track.
-                Pinned miners appear here across reloads and tabs.
+                Browse the leaderboard and star miners you want to track. Pinned
+                miners appear here across reloads and tabs.
               </Typography>
               <Button
                 component={RouterLink}

--- a/src/pages/WatchlistPage.tsx
+++ b/src/pages/WatchlistPage.tsx
@@ -72,8 +72,8 @@ const WatchlistPage: React.FC = () => {
             }}
           >
             Your watchlist — {count}{' '}
-            {count === 1 ? 'miner pinned' : 'miners pinned'}. Stored locally
-            in this browser.
+            {count === 1 ? 'miner pinned' : 'miners pinned'}. Stored locally in
+            this browser.
           </Typography>
           {count > 0 && (
             <Button
@@ -151,10 +151,17 @@ const WatchlistPage: React.FC = () => {
           Clear all {count} pinned miners?
         </DialogTitle>
         <DialogActions>
-          <Button onClick={() => setConfirmOpen(false)} sx={{ textTransform: 'none' }}>
+          <Button
+            onClick={() => setConfirmOpen(false)}
+            sx={{ textTransform: 'none' }}
+          >
             Cancel
           </Button>
-          <Button onClick={handleClear} color="error" sx={{ textTransform: 'none' }}>
+          <Button
+            onClick={handleClear}
+            color="error"
+            sx={{ textTransform: 'none' }}
+          >
             Clear watchlist
           </Button>
         </DialogActions>

--- a/src/pages/WatchlistPage.tsx
+++ b/src/pages/WatchlistPage.tsx
@@ -1,0 +1,204 @@
+import React, { useMemo } from 'react';
+import {
+  useMediaQuery,
+  Box,
+  Typography,
+  Button,
+  alpha,
+  Stack,
+} from '@mui/material';
+import { Link as RouterLink } from 'react-router-dom';
+import { Page } from '../components/layout';
+import { TopMinersTable, SEO } from '../components';
+import { useAllMiners } from '../api';
+import { parseNumber } from '../utils';
+import { useWatchlist } from '../hooks/useWatchlist';
+import theme, { scrollbarSx } from '../theme';
+
+const WatchlistPage: React.FC = () => {
+  const { ids, count, clear } = useWatchlist();
+  const watchedSet = useMemo(() => new Set(ids), [ids]);
+
+  const allMinerStatsQuery = useAllMiners();
+  const allMinersStats = allMinerStatsQuery?.data;
+  const isLoadingMinerStats = allMinerStatsQuery?.isLoading;
+
+  const minerStats = useMemo(() => {
+    if (!Array.isArray(allMinersStats)) return [];
+
+    const rankById = new Map(
+      [...allMinersStats]
+        .sort((a, b) => Number(b.totalScore) - Number(a.totalScore))
+        .map((stat, index) => [String(stat.id), index + 1]),
+    );
+
+    return allMinersStats
+      .filter((stat) => watchedSet.has(stat.githubId || ''))
+      .map((stat) => ({
+        id: String(stat.id),
+        githubId: stat.githubId || '',
+        author: stat.githubUsername || undefined,
+        totalScore: parseNumber(stat.totalScore),
+        baseTotalScore: parseNumber(stat.baseTotalScore),
+        totalPRs: parseNumber(stat.totalPrs),
+        linesChanged: parseNumber(stat.totalNodesScored),
+        linesAdded: parseNumber(stat.totalAdditions),
+        linesDeleted: parseNumber(stat.totalDeletions),
+        hotkey: stat.hotkey || 'N/A',
+        rank: rankById.get(String(stat.id)),
+        uniqueReposCount: parseNumber(stat.uniqueReposCount),
+        credibility: parseNumber(stat.credibility),
+        isEligible: stat.isEligible ?? false,
+        usdPerDay: parseNumber(stat.usdPerDay),
+        totalMergedPrs: parseNumber(stat.totalMergedPrs),
+        totalOpenPrs: parseNumber(stat.totalOpenPrs),
+        totalClosedPrs: parseNumber(stat.totalClosedPrs),
+      }));
+  }, [allMinersStats, watchedSet]);
+
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+  const isTablet = useMediaQuery(theme.breakpoints.between('sm', 'md'));
+  const isLargeScreen = useMediaQuery(theme.breakpoints.up('xl'));
+  const showSidebarRight = useMediaQuery(theme.breakpoints.up('xl'));
+  const sidebarWidth =
+    isMobile || isTablet ? '100%' : isLargeScreen ? '340px' : '300px';
+
+  const isEmpty = count === 0;
+
+  return (
+    <Page title="Watchlist">
+      <SEO
+        title="Watchlist"
+        description="Your pinned miners on Gittensor. Quickly revisit the miners you're tracking."
+      />
+      <Box
+        sx={{
+          width: '100%',
+          height: showSidebarRight ? 'calc(100vh - 64px)' : 'auto',
+          display: 'flex',
+          flexDirection: showSidebarRight ? 'row' : 'column',
+          gap: { xs: 2, sm: 2, md: 2.5, lg: 3 },
+          py: { xs: 2, sm: 2, md: 2.5, lg: 3 },
+          px: { xs: 2, sm: 2, md: 2.5, lg: 3 },
+          overflow: 'hidden',
+        }}
+      >
+        <Box
+          sx={{
+            flex: 1,
+            display: 'flex',
+            flexDirection: 'column',
+            gap: { xs: 2, sm: 1.5 },
+            minHeight: 0,
+            overflow: showSidebarRight ? 'auto' : 'visible',
+            minWidth: 0,
+            pr: showSidebarRight ? 1 : 0,
+            ...scrollbarSx,
+          }}
+        >
+          <Stack
+            direction="row"
+            alignItems="center"
+            justifyContent="space-between"
+            spacing={2}
+          >
+            <Typography
+              sx={{
+                fontFamily: '"JetBrains Mono", monospace',
+                fontSize: '0.8rem',
+                color: (t) => alpha(t.palette.text.primary, 0.5),
+                lineHeight: 1.6,
+              }}
+            >
+              Your watchlist — {count}{' '}
+              {count === 1 ? 'miner pinned' : 'miners pinned'}. Stored locally
+              in this browser.
+            </Typography>
+            {count > 0 && (
+              <Button
+                size="small"
+                onClick={clear}
+                sx={{
+                  fontFamily: '"JetBrains Mono", monospace',
+                  fontSize: '0.75rem',
+                  textTransform: 'none',
+                  color: 'text.secondary',
+                }}
+              >
+                Clear watchlist
+              </Button>
+            )}
+          </Stack>
+
+          {isEmpty ? (
+            <Box
+              sx={{
+                py: 8,
+                textAlign: 'center',
+                display: 'flex',
+                flexDirection: 'column',
+                gap: 2,
+                alignItems: 'center',
+                color: 'text.secondary',
+              }}
+            >
+              <Typography
+                sx={{
+                  fontFamily: '"JetBrains Mono", monospace',
+                  fontSize: '0.95rem',
+                }}
+              >
+                Your watchlist is empty.
+              </Typography>
+              <Typography
+                sx={{
+                  fontFamily: '"JetBrains Mono", monospace',
+                  fontSize: '0.8rem',
+                  maxWidth: 480,
+                  color: (t) => alpha(t.palette.text.primary, 0.5),
+                }}
+              >
+                Browse the leaderboard and star miners you want to track.
+                Pinned miners appear here across reloads and tabs.
+              </Typography>
+              <Button
+                component={RouterLink}
+                to="/top-miners"
+                variant="outlined"
+                size="small"
+                sx={{ textTransform: 'none', mt: 1 }}
+              >
+                Go to leaderboard
+              </Button>
+            </Box>
+          ) : (
+            <Box sx={{ width: '100%' }}>
+              <TopMinersTable
+                miners={minerStats}
+                isLoading={isLoadingMinerStats}
+                getHref={(m) =>
+                  `/miners/details?githubId=${encodeURIComponent(m.githubId)}`
+                }
+                linkState={{ backLabel: 'Back to Watchlist' }}
+              />
+            </Box>
+          )}
+        </Box>
+
+        <Box
+          sx={{
+            width: showSidebarRight ? sidebarWidth : '100%',
+            height: showSidebarRight ? '100%' : 'auto',
+            maxHeight: showSidebarRight ? '100%' : 'none',
+            flexShrink: 0,
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 2,
+          }}
+        />
+      </Box>
+    </Page>
+  );
+};
+
+export default WatchlistPage;

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -26,6 +26,7 @@ const RepositoryDetailsPage = React.lazy(
 const PRDetailsPage = React.lazy(() => import('./pages/PRDetailsPage'));
 const DiscoveriesPage = React.lazy(() => import('./pages/DiscoveriesPage'));
 const OnboardPage = React.lazy(() => import('./pages/OnboardPage'));
+const WatchlistPage = React.lazy(() => import('./pages/WatchlistPage'));
 
 // 404 page
 const NotFoundPage = React.lazy(() => import('./pages/NotFoundPage'));
@@ -60,6 +61,12 @@ const routesArray: AppRoute[] = [
     name: 'top-miners',
     path: '/top-miners',
     element: <TopMinersPage />,
+    showGlobalSearch: true,
+  },
+  {
+    name: 'watchlist',
+    path: '/watchlist',
+    element: <WatchlistPage />,
     showGlobalSearch: true,
   },
   {

--- a/src/utils/minerMapper.ts
+++ b/src/utils/minerMapper.ts
@@ -1,0 +1,34 @@
+import { type MinerEvaluation } from '../api/models/Dashboard';
+import { type MinerStats } from '../components/leaderboard/types';
+import { parseNumber } from './ExplorerUtils';
+
+export const mapAllMinersToStats = (
+  allMinersStats: MinerEvaluation[],
+): MinerStats[] => {
+  const rankById = new Map(
+    [...allMinersStats]
+      .sort((a, b) => Number(b.totalScore) - Number(a.totalScore))
+      .map((stat, index) => [String(stat.id), index + 1]),
+  );
+
+  return allMinersStats.map((stat) => ({
+    id: String(stat.id),
+    githubId: stat.githubId || '',
+    author: stat.githubUsername || undefined,
+    totalScore: parseNumber(stat.totalScore),
+    baseTotalScore: parseNumber(stat.baseTotalScore),
+    totalPRs: parseNumber(stat.totalPrs),
+    linesChanged: parseNumber(stat.totalNodesScored),
+    linesAdded: parseNumber(stat.totalAdditions),
+    linesDeleted: parseNumber(stat.totalDeletions),
+    hotkey: stat.hotkey || 'N/A',
+    rank: rankById.get(String(stat.id)),
+    uniqueReposCount: parseNumber(stat.uniqueReposCount),
+    credibility: parseNumber(stat.credibility),
+    isEligible: stat.isEligible ?? false,
+    usdPerDay: parseNumber(stat.usdPerDay),
+    totalMergedPrs: parseNumber(stat.totalMergedPrs),
+    totalOpenPrs: parseNumber(stat.totalOpenPrs),
+    totalClosedPrs: parseNumber(stat.totalClosedPrs),
+  }));
+};


### PR DESCRIPTION
## Summary
Adds a client-side miner **watchlist** feature. Users can star miners from the leaderboard and the miner detail page, then view only their starred miners on a dedicated `/watchlist` route. Persistence is local to the browser via `localStorage` - no backend changes required.

## Motivation
The leaderboard has hundreds of miners. Users investigating a specific set (their own subnet, a competitor cluster, a rising cohort) currently have no way to pin or re-open those miners across sessions. A watchlist gives them a persistent, zero-friction way to collect and revisit miners of interest - the same pattern GitHub, Kaggle, Coingecko, and every analytics dashboard ships with.

## What's added

### `src/hooks/useWatchlist.ts` (new)
Self-contained hook exposing `{ ids, count, isWatched, add, remove, toggle, clear }`. Backed by `localStorage` under the versioned key `gittensor.watchlist.v1`. Syncs across tabs via the `storage` event so opening the dashboard in two tabs keeps the list consistent. Defensively parses stored JSON - malformed payloads, non-arrays, and non-string entries are filtered out, returning `[]`. Storage errors (private mode, quota exceeded) are swallowed; in-memory state remains functional.

### `src/components/common/WatchlistButton.tsx` (new)
Star `IconButton` with tooltip and `aria-pressed`. Drops into any context where a `githubId` is known. Stops event propagation so it can sit inside clickable rows/cards without triggering navigation. Filled when watched, outlined when not. Small and medium variants.

### `src/pages/WatchlistPage.tsx` (new, routed at `/watchlist`)
Reuses the existing `TopMinersTable` primitive, filtered to the watchlist IDs, with the same normalization pipeline used by `TopMinersPage`. Header shows count + "Clear watchlist" action. Empty state guides the user to the main leaderboard.

### Integrations
- `routes.tsx` - adds `/watchlist`.
- `Sidebar.tsx` - adds a "watchlist" nav entry with a live count pill sourced from `useWatchlist()`.
- `MinerCard.tsx` - embeds `WatchlistButton` in the top-right corner of the card.
- `MinerDetailsPage.tsx` - embeds `WatchlistButton` beside the miner's name.

## Design notes
- **No backend dependency.** LocalStorage is enough - watchlists are inherently personal and low-stakes. A future server-synced version can layer on top of the same hook surface without breaking callers.
- **Storage key is versioned (`...v1`).** Schema migrations or a reset path can bump the version without clobbering user data on rollout.
- **Hook API is the contract.** The button and the page both consume the hook - nothing reaches into `localStorage` directly. Swapping the backing store (IndexedDB, server) later is a one-file change.

## Type of Change
- [x] Feature / enhancement

## Testing
- [ ] `npm run build`
- [ ] `npm run lint:fix`
- [ ] Manual:
  - Click star on a miner card → card shows filled star, sidebar pill increments, `/watchlist` lists the miner.
  - Click star again → removed from list, sidebar decrements, `/watchlist` drops the row.
  - Refresh the browser → watchlist persists.
  - Open app in two tabs, toggle a star in one → the other updates via `storage` event.
  - Open in an Incognito / private window where `localStorage` write fails → UI still works (in-memory state), no crash.
  - Corrupt `localStorage` entry manually (invalid JSON) → app reads empty list, no crash.
  - Empty watchlist → `/watchlist` shows empty-state with link back to `/top-miners`.
  - `clear()` from the WatchlistPage → list empties, sidebar pill disappears.
  - Keyboard: Tab to the star, Space/Enter toggles.

## Checklist
- [x] No backend changes
- [x] No new dependencies
- [x] Three new files (`useWatchlist`, `WatchlistButton`, `WatchlistPage`), small integrations into existing surfaces
- [x] Accessible (aria-pressed, tooltip, keyboard)
- [x] Graceful degradation when storage is unavailable or malformed
- [x] Tab-sync via `storage` event

## Follow-ups (out of scope for this PR)
- Add a "watchlist only" filter chip on `TopMinersPage` itself as an alternate entry point
- Extend the pattern to **repositories** (`useRepoWatchlist`) once this lands
- Server-sync watchlists once an authenticated user context exists (hook API stays stable)

## Video to upload

https://github.com/user-attachments/assets/edb6b774-f366-4e68-acad-27d87ba80321

Closes #424 .