### PR TITLE
fix: remove N+1 PR details requests from LiveCommitLog

### DIFF
--- a/src/pages/dashboard/views/LiveCommitLog.tsx
+++ b/src/pages/dashboard/views/LiveCommitLog.tsx
@@ -12,7 +12,7 @@ import {
   Chip,
 } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
-import { useInfiniteCommitLog, usePullRequestDetails } from '../../../api';
+import { useInfiniteCommitLog } from '../../../api';
 import theme, { REPO_OWNER_AVATAR_BACKGROUNDS } from '../../../theme';
 
 const MONTH_SHORT = [
@@ -73,13 +73,8 @@ const CommitLogItem: React.FC<{
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
   const isTablet = useMediaQuery(theme.breakpoints.between('sm', 'md'));
 
-  const { data: details } = usePullRequestDetails(
-    entry.repository,
-    entry.pullRequestNumber,
-  );
-
-  const isMerged = !!(details?.mergedAt || entry.mergedAt);
-  const isClosed = details?.prState === 'CLOSED' || entry.prState === 'CLOSED';
+  const isMerged = !!entry.mergedAt;
+  const isClosed = entry.prState === 'CLOSED' && !entry.mergedAt;
 
   let status = { label: 'OPEN', color: theme.palette.status.neutral };
   if (isMerged)
@@ -87,11 +82,7 @@ const CommitLogItem: React.FC<{
   else if (isClosed)
     status = { label: 'CLOSED', color: theme.palette.status.closed };
 
-  const timestampRaw =
-    details?.mergedAt ||
-    details?.prCreatedAt ||
-    entry.mergedAt ||
-    entry.prCreatedAt;
+  const timestampRaw = entry.mergedAt || entry.prCreatedAt;
   const timestamp = timestampRaw
     ? formatUtcTimestamp(timestampRaw)
     : 'Loading...';

--- a/src/pages/dashboard/views/LiveCommitLog.tsx
+++ b/src/pages/dashboard/views/LiveCommitLog.tsx
@@ -129,16 +129,7 @@ const CommitLogItem: React.FC<{
     status = { label: 'MERGED', color: theme.palette.status.merged };
   else if (isClosed)
     status = { label: 'CLOSED', color: theme.palette.status.closed };
-<<<<<<< HEAD
-
   const timestampRaw = entry.mergedAt || entry.prCreatedAt;
-=======
-  const timestampRaw =
-    details?.mergedAt ||
-    details?.prCreatedAt ||
-    entry.mergedAt ||
-    entry.prCreatedAt;
->>>>>>> test
   const timestamp = timestampRaw
     ? formatUtcTimestamp(timestampRaw)
     : 'Loading...';


### PR DESCRIPTION
## Summary
Removes the unnecessary per-entry `usePullRequestDetails` fetch from the Dashboard live activity feed. Eliminates N simultaneous `GET /prs/details` requests on initial load (15 with the default page size) and every 10-second auto-refresh, with no change to what the user sees.

## Root cause
`CommitLogItem` is rendered once per entry in the live feed. Inside its body it unconditionally called:

```tsx
const { data: details } = usePullRequestDetails(
  entry.repository,
  entry.pullRequestNumber,
);
