### PR TITLE
refactor: replace hardcoded colors in issue components with theme tokens

### DIFF
--- a/src/components/issues/BountyProgress.tsx
+++ b/src/components/issues/BountyProgress.tsx
@@ -1,7 +1,13 @@
 import React from 'react';
-import { Box, LinearProgress, Typography } from '@mui/material';
+import {
+  Box,
+  LinearProgress,
+  Typography,
+  alpha,
+  useTheme,
+} from '@mui/material';
 import { formatTokenAmount } from '../../utils/format';
-import { STATUS_COLORS } from '../../theme';
+import { STATUS_COLORS, TEXT_OPACITY } from '../../theme';
 
 interface BountyProgressProps {
   bountyAmount: string;
@@ -12,6 +18,7 @@ const BountyProgress: React.FC<BountyProgressProps> = ({
   bountyAmount,
   targetBounty,
 }) => {
+  const theme = useTheme();
   const current = parseFloat(bountyAmount) || 0;
   const target = parseFloat(targetBounty) || 0;
   const percentage = target > 0 ? Math.min((current / target) * 100, 100) : 0;
@@ -25,7 +32,7 @@ const BountyProgress: React.FC<BountyProgressProps> = ({
         sx={{
           height: 6,
           borderRadius: 3,
-          backgroundColor: 'rgba(255, 255, 255, 0.1)',
+          backgroundColor: 'surface.light',
           '& .MuiLinearProgress-bar': {
             borderRadius: 3,
             backgroundColor: isFunded
@@ -38,7 +45,7 @@ const BountyProgress: React.FC<BountyProgressProps> = ({
         sx={{
           fontFamily: '"JetBrains Mono", monospace',
           fontSize: '0.65rem',
-          color: 'rgba(255, 255, 255, 0.5)',
+          color: alpha(theme.palette.common.white, TEXT_OPACITY.tertiary),
           mt: 0.5,
           textAlign: 'center',
         }}

--- a/src/components/issues/IssueConversation.tsx
+++ b/src/components/issues/IssueConversation.tsx
@@ -1,5 +1,13 @@
 import React from 'react';
-import { Box, Typography, Avatar, Paper, Link, Chip } from '@mui/material';
+import {
+  Box,
+  Typography,
+  Avatar,
+  Paper,
+  Link,
+  Chip,
+  alpha,
+} from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
@@ -111,7 +119,7 @@ const IssueConversation: React.FC<IssueConversationProps> = ({ issue }) => {
                 sx={{
                   width: 40,
                   height: 40,
-                  border: '1px solid rgba(255,255,255,0.1)',
+                  border: `1px solid ${theme.palette.border.light}`,
                   backgroundColor: theme.palette.background.paper, // Avoid transparency issues over the line
                 }}
               />
@@ -226,7 +234,7 @@ const IssueConversation: React.FC<IssueConversationProps> = ({ issue }) => {
                     label="Description"
                     sx={{
                       color: STATUS_COLORS.info,
-                      borderColor: 'rgba(56, 139, 253, 0.4)',
+                      borderColor: alpha(STATUS_COLORS.info, 0.4),
                     }}
                   />
                 )}
@@ -284,7 +292,7 @@ const IssueConversation: React.FC<IssueConversationProps> = ({ issue }) => {
                   padding: '0.2em 0.4em',
                   margin: 0,
                   fontSize: '85%',
-                  backgroundColor: 'rgba(110, 118, 129, 0.4)',
+                  backgroundColor: alpha(STATUS_COLORS.neutral, 0.4),
                   borderRadius: '6px',
                   fontFamily: '"JetBrains Mono", monospace',
                 },

--- a/src/components/issues/IssueHeaderCard.tsx
+++ b/src/components/issues/IssueHeaderCard.tsx
@@ -1,17 +1,27 @@
 import React from 'react';
-import { Box, Card, Typography, Chip, Link, Stack } from '@mui/material';
+import {
+  Box,
+  Card,
+  Typography,
+  Chip,
+  Link,
+  Stack,
+  alpha,
+  useTheme,
+} from '@mui/material';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import { IssueDetails } from '../../api/models/Issues';
 import { useStats } from '../../api';
 import { formatTokenAmount, formatDate } from '../../utils/format';
 import { getIssueStatusMeta } from '../../utils/issueStatus';
-import { STATUS_COLORS } from '../../theme';
+import { STATUS_COLORS, TEXT_OPACITY } from '../../theme';
 
 interface IssueHeaderCardProps {
   issue: IssueDetails;
 }
 
 const IssueHeaderCard: React.FC<IssueHeaderCardProps> = ({ issue }) => {
+  const theme = useTheme();
   const statusBadge = getIssueStatusMeta(issue.status);
   const { data: dashStats } = useStats();
   const taoPrice = dashStats?.prices?.tao?.data?.price ?? 0;
@@ -28,8 +38,8 @@ const IssueHeaderCard: React.FC<IssueHeaderCardProps> = ({ issue }) => {
   return (
     <Card
       sx={{
-        backgroundColor: '#000000',
-        border: '1px solid rgba(255, 255, 255, 0.1)',
+        backgroundColor: 'background.default',
+        border: `1px solid ${theme.palette.border.light}`,
         borderRadius: 3,
         p: 3,
       }}
@@ -87,7 +97,7 @@ const IssueHeaderCard: React.FC<IssueHeaderCardProps> = ({ issue }) => {
                 '-apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif',
               fontSize: '1.5rem',
               fontWeight: 600,
-              color: '#ffffff',
+              color: 'text.primary',
             }}
           >
             {issue.title}
@@ -108,7 +118,7 @@ const IssueHeaderCard: React.FC<IssueHeaderCardProps> = ({ issue }) => {
               sx={{
                 fontFamily: '"JetBrains Mono", monospace',
                 fontSize: '0.7rem',
-                color: 'rgba(255, 255, 255, 0.5)',
+                color: alpha(theme.palette.common.white, TEXT_OPACITY.tertiary),
                 textTransform: 'uppercase',
                 letterSpacing: '0.5px',
                 mb: 0.5,
@@ -138,7 +148,10 @@ const IssueHeaderCard: React.FC<IssueHeaderCardProps> = ({ issue }) => {
                   sx={{
                     fontFamily: '"JetBrains Mono", monospace',
                     fontSize: '0.9rem',
-                    color: 'rgba(255, 255, 255, 0.5)',
+                    color: alpha(
+                      theme.palette.common.white,
+                      TEXT_OPACITY.tertiary,
+                    ),
                   }}
                 >
                   / {formatTokenAmount(issue.targetBounty)} ل
@@ -164,7 +177,7 @@ const IssueHeaderCard: React.FC<IssueHeaderCardProps> = ({ issue }) => {
                   color:
                     issue.status === 'active'
                       ? STATUS_COLORS.merged
-                      : 'rgba(255, 255, 255, 0.6)',
+                      : alpha(theme.palette.common.white, 0.6),
                 }}
               >
                 {formatTokenAmount(issue.targetBounty)} ل
@@ -175,7 +188,7 @@ const IssueHeaderCard: React.FC<IssueHeaderCardProps> = ({ issue }) => {
                 sx={{
                   fontFamily: '"JetBrains Mono", monospace',
                   fontSize: '0.8rem',
-                  color: 'rgba(255, 255, 255, 0.4)',
+                  color: alpha(theme.palette.common.white, TEXT_OPACITY.muted),
                   mt: 0.25,
                 }}
               >
@@ -190,7 +203,10 @@ const IssueHeaderCard: React.FC<IssueHeaderCardProps> = ({ issue }) => {
                 sx={{
                   fontFamily: '"JetBrains Mono", monospace',
                   fontSize: '0.7rem',
-                  color: 'rgba(255, 255, 255, 0.5)',
+                  color: alpha(
+                    theme.palette.common.white,
+                    TEXT_OPACITY.tertiary,
+                  ),
                   textTransform: 'uppercase',
                   letterSpacing: '0.5px',
                   mb: 0.5,
@@ -202,7 +218,7 @@ const IssueHeaderCard: React.FC<IssueHeaderCardProps> = ({ issue }) => {
                 sx={{
                   fontFamily: '"JetBrains Mono", monospace',
                   fontSize: '0.9rem',
-                  color: '#ffffff',
+                  color: 'text.primary',
                 }}
               >
                 {issue.authorLogin}
@@ -215,7 +231,7 @@ const IssueHeaderCard: React.FC<IssueHeaderCardProps> = ({ issue }) => {
               sx={{
                 fontFamily: '"JetBrains Mono", monospace',
                 fontSize: '0.7rem',
-                color: 'rgba(255, 255, 255, 0.5)',
+                color: alpha(theme.palette.common.white, TEXT_OPACITY.tertiary),
                 textTransform: 'uppercase',
                 letterSpacing: '0.5px',
                 mb: 0.5,
@@ -227,7 +243,7 @@ const IssueHeaderCard: React.FC<IssueHeaderCardProps> = ({ issue }) => {
               sx={{
                 fontFamily: '"JetBrains Mono", monospace',
                 fontSize: '0.9rem',
-                color: '#ffffff',
+                color: 'text.primary',
               }}
             >
               {formatDate(issue.createdAt)}
@@ -246,8 +262,8 @@ const IssueHeaderCard: React.FC<IssueHeaderCardProps> = ({ issue }) => {
                 sx={{
                   fontFamily: '"JetBrains Mono", monospace',
                   fontSize: '0.7rem',
-                  backgroundColor: 'rgba(255, 255, 255, 0.1)',
-                  color: '#ffffff',
+                  backgroundColor: alpha(theme.palette.common.white, 0.1),
+                  color: 'text.primary',
                 }}
               />
             ))}

--- a/src/components/issues/IssueStats.tsx
+++ b/src/components/issues/IssueStats.tsx
@@ -41,7 +41,8 @@ const IssueStats: React.FC<IssueStatsProps> = ({
               sx={{
                 p: 2,
                 backgroundColor: 'transparent',
-                border: '1px solid rgba(255, 255, 255, 0.1)',
+                border: '1px solid',
+                borderColor: 'border.light',
                 borderRadius: 3,
               }}
             >

--- a/src/components/issues/IssueSubmissionsTable.tsx
+++ b/src/components/issues/IssueSubmissionsTable.tsx
@@ -13,10 +13,11 @@ import {
   TableHead,
   TableRow,
   useTheme,
+  alpha,
 } from '@mui/material';
 import EmojiEventsIcon from '@mui/icons-material/EmojiEvents';
 import { IssueSubmission } from '../../api/models/Issues';
-import { STATUS_COLORS } from '../../theme';
+import { STATUS_COLORS, TEXT_OPACITY } from '../../theme';
 import { formatDate } from '../../utils/format';
 
 const headerCellSx = {
@@ -25,16 +26,18 @@ const headerCellSx = {
   fontWeight: 600,
   letterSpacing: '0.5px',
   textTransform: 'uppercase' as const,
-  color: 'rgba(255, 255, 255, 0.3)',
-  borderBottom: '1px solid rgba(255, 255, 255, 0.1)',
+  color: 'text.secondary',
+  borderBottom: '1px solid',
+  borderColor: 'border.light',
   py: 1.5,
 };
 
 const bodyCellSx = {
   fontFamily: '"JetBrains Mono", monospace',
   fontSize: '0.85rem',
-  color: '#ffffff',
-  borderBottom: '1px solid rgba(255, 255, 255, 0.05)',
+  color: 'text.primary',
+  borderBottom: '1px solid',
+  borderBottomColor: 'border.subtle',
   py: 1.5,
 };
 
@@ -55,8 +58,8 @@ const IssueSubmissionsTable: React.FC<IssueSubmissionsTableProps> = ({
   return (
     <Card
       sx={{
-        backgroundColor: '#000000',
-        border: '1px solid rgba(255, 255, 255, 0.1)',
+        backgroundColor: 'background.default',
+        border: `1px solid ${theme.palette.border.light}`,
         borderRadius: 3,
         overflow: 'hidden',
       }}
@@ -68,7 +71,7 @@ const IssueSubmissionsTable: React.FC<IssueSubmissionsTableProps> = ({
             fontFamily: '"JetBrains Mono", monospace',
             fontSize: '0.8rem',
             fontWeight: 600,
-            color: 'rgba(255, 255, 255, 0.5)',
+            color: alpha(theme.palette.common.white, TEXT_OPACITY.tertiary),
             textTransform: 'uppercase',
             letterSpacing: '0.5px',
           }}
@@ -85,7 +88,7 @@ const IssueSubmissionsTable: React.FC<IssueSubmissionsTableProps> = ({
         <Box sx={{ p: 4, pt: 2, textAlign: 'center' }}>
           <Typography
             sx={{
-              color: 'rgba(255, 255, 255, 0.5)',
+              color: alpha(theme.palette.common.white, TEXT_OPACITY.tertiary),
               fontSize: '0.9rem',
             }}
           >
@@ -125,7 +128,7 @@ const IssueSubmissionsTable: React.FC<IssueSubmissionsTableProps> = ({
                     cursor: 'pointer',
                     transition: 'background-color 0.2s',
                     '&:hover': {
-                      backgroundColor: 'rgba(255, 255, 255, 0.03)',
+                      backgroundColor: alpha(theme.palette.common.white, 0.03),
                     },
                   }}
                 >
@@ -224,7 +227,7 @@ const IssueSubmissionsTable: React.FC<IssueSubmissionsTableProps> = ({
                         fontFamily: '"JetBrains Mono", monospace',
                         fontSize: '0.85rem',
                         fontWeight: 600,
-                        color: '#ffffff',
+                        color: 'text.primary',
                       }}
                     >
                       {Number(submission.tokenScore).toLocaleString()}
@@ -235,7 +238,7 @@ const IssueSubmissionsTable: React.FC<IssueSubmissionsTableProps> = ({
                       sx={{
                         fontFamily: '"JetBrains Mono", monospace',
                         fontSize: '0.8rem',
-                        color: 'rgba(255, 255, 255, 0.6)',
+                        color: alpha(theme.palette.common.white, 0.6),
                       }}
                     >
                       {formatDate(submission.prCreatedAt)}

--- a/src/components/issues/IssuesList.tsx
+++ b/src/components/issues/IssuesList.tsx
@@ -14,13 +14,15 @@ import {
   Link,
   Tooltip,
   Avatar,
+  alpha,
+  useTheme,
 } from '@mui/material';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import { IssueBounty } from '../../api/models/Issues';
 import { useStats } from '../../api';
 import { formatTokenAmount, formatDate } from '../../utils/format';
 import { getIssueStatusMeta } from '../../utils/issueStatus';
-import { STATUS_COLORS } from '../../theme';
+import { STATUS_COLORS, TEXT_OPACITY } from '../../theme';
 import BountyProgress from './BountyProgress';
 
 type ListType = 'available' | 'pending' | 'history';
@@ -47,6 +49,7 @@ const IssuesList: React.FC<IssuesListProps> = ({
   listType,
   onSelectIssue,
 }) => {
+  const theme = useTheme();
   const { data: dashStats } = useStats();
   const taoPrice = dashStats?.prices?.tao?.data?.price ?? 0;
   const alphaPrice = dashStats?.prices?.alpha?.data?.price ?? 0;
@@ -64,8 +67,9 @@ const IssuesList: React.FC<IssuesListProps> = ({
     fontWeight: 600,
     letterSpacing: '0.5px',
     textTransform: 'uppercase' as const,
-    color: 'rgba(255, 255, 255, 0.3)',
-    borderBottom: '1px solid rgba(255, 255, 255, 0.1)',
+    color: 'text.secondary',
+    borderBottom: '1px solid',
+    borderColor: 'border.light',
     py: 1.5,
   };
 
@@ -73,7 +77,8 @@ const IssuesList: React.FC<IssuesListProps> = ({
     fontFamily: '"JetBrains Mono", monospace',
     fontSize: '0.85rem',
     color: 'text.primary',
-    borderBottom: '1px solid rgba(255, 255, 255, 0.05)',
+    borderBottom: '1px solid',
+    borderBottomColor: 'border.subtle',
     py: 1.5,
   };
 
@@ -82,7 +87,7 @@ const IssuesList: React.FC<IssuesListProps> = ({
       <Card
         sx={{
           backgroundColor: 'background.default',
-          border: '1px solid rgba(255, 255, 255, 0.1)',
+          border: `1px solid ${theme.palette.border.light}`,
           borderRadius: 3,
         }}
         elevation={0}
@@ -112,14 +117,18 @@ const IssuesList: React.FC<IssuesListProps> = ({
       <Card
         sx={{
           backgroundColor: 'background.default',
-          border: '1px solid rgba(255, 255, 255, 0.1)',
+          border: `1px solid ${theme.palette.border.light}`,
           borderRadius: 3,
           p: 4,
           textAlign: 'center',
         }}
         elevation={0}
       >
-        <Typography sx={{ color: 'rgba(255, 255, 255, 0.5)' }}>
+        <Typography
+          sx={{
+            color: alpha(theme.palette.common.white, TEXT_OPACITY.tertiary),
+          }}
+        >
           {emptyMessages[listType]}
         </Typography>
       </Card>
@@ -130,7 +139,7 @@ const IssuesList: React.FC<IssuesListProps> = ({
     <Card
       sx={{
         backgroundColor: 'background.default',
-        border: '1px solid rgba(255, 255, 255, 0.1)',
+        border: `1px solid ${theme.palette.border.light}`,
         borderRadius: 3,
         overflow: 'hidden',
       }}
@@ -222,7 +231,7 @@ const IssuesList: React.FC<IssuesListProps> = ({
                     cursor: onSelectIssue ? 'pointer' : 'default',
                     transition: 'background-color 0.2s',
                     '&:hover': {
-                      backgroundColor: 'rgba(255, 255, 255, 0.03)',
+                      backgroundColor: alpha(theme.palette.common.white, 0.03),
                     },
                   }}
                 >
@@ -232,7 +241,7 @@ const IssuesList: React.FC<IssuesListProps> = ({
                       sx={{
                         fontFamily: '"JetBrains Mono", monospace',
                         fontSize: '0.8rem',
-                        color: 'rgba(255, 255, 255, 0.6)',
+                        color: alpha(theme.palette.common.white, 0.6),
                       }}
                     >
                       #{issue.id}
@@ -292,7 +301,10 @@ const IssuesList: React.FC<IssuesListProps> = ({
                           gap: 0.5,
                           fontFamily: '"JetBrains Mono", monospace',
                           fontSize: '0.75rem',
-                          color: 'rgba(255, 255, 255, 0.5)',
+                          color: alpha(
+                            theme.palette.common.white,
+                            TEXT_OPACITY.tertiary,
+                          ),
                           textDecoration: 'none',
                           '&:hover': {
                             color: STATUS_COLORS.info,
@@ -325,7 +337,7 @@ const IssuesList: React.FC<IssuesListProps> = ({
                             sx={{
                               fontFamily: '"JetBrains Mono", monospace',
                               fontSize: '0.7rem',
-                              color: 'rgba(255, 255, 255, 0.35)',
+                              color: alpha(theme.palette.common.white, 0.35),
                             }}
                           >
                             {toUsd(issue.targetBounty)}
@@ -368,7 +380,7 @@ const IssuesList: React.FC<IssuesListProps> = ({
                             sx={{
                               fontFamily: '"JetBrains Mono", monospace',
                               fontSize: '0.7rem',
-                              color: 'rgba(255, 255, 255, 0.35)',
+                              color: alpha(theme.palette.common.white, 0.35),
                             }}
                           >
                             {toUsd(issue.targetBounty)}
@@ -410,7 +422,10 @@ const IssuesList: React.FC<IssuesListProps> = ({
                             color:
                               issue.status === 'completed'
                                 ? STATUS_COLORS.merged
-                                : 'rgba(255, 255, 255, 0.4)',
+                                : alpha(
+                                    theme.palette.common.white,
+                                    TEXT_OPACITY.muted,
+                                  ),
                           }}
                         >
                           {`${formatTokenAmount(issue.targetBounty)} ل`}
@@ -420,7 +435,7 @@ const IssuesList: React.FC<IssuesListProps> = ({
                             sx={{
                               fontFamily: '"JetBrains Mono", monospace',
                               fontSize: '0.7rem',
-                              color: 'rgba(255, 255, 255, 0.35)',
+                              color: alpha(theme.palette.common.white, 0.35),
                             }}
                           >
                             {toUsd(issue.targetBounty)}
@@ -445,7 +460,10 @@ const IssuesList: React.FC<IssuesListProps> = ({
                           <Typography
                             sx={{
                               fontSize: '0.8rem',
-                              color: 'rgba(255, 255, 255, 0.3)',
+                              color: alpha(
+                                theme.palette.common.white,
+                                TEXT_OPACITY.faint,
+                              ),
                             }}
                           >
                             -
@@ -471,7 +489,7 @@ const IssuesList: React.FC<IssuesListProps> = ({
                           sx={{
                             fontFamily: '"JetBrains Mono", monospace',
                             fontSize: '0.8rem',
-                            color: 'rgba(255, 255, 255, 0.6)',
+                            color: alpha(theme.palette.common.white, 0.6),
                           }}
                         >
                           {formatDate(issue.completedAt || issue.updatedAt)}


### PR DESCRIPTION
## Summary

Replaces all 46 hardcoded `rgba()`/hex color literals in the 6 issue components with centralized MUI theme tokens (`border.light`, `surface.light`, `text.primary`, `background.default`, `STATUS_COLORS`, `TEXT_OPACITY`) and `alpha()` utility.

## Related Issues

Closes #334

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

No visual changes — same colors, just sourced from the theme instead of hardcoded.

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [ ] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes