### PR TITLE
fix: use parseFloat instead of Number() to prevent NaN in PR score display

### DIFF
--- a/src/pages/search/PullRequestsTab.tsx
+++ b/src/pages/search/PullRequestsTab.tsx
@@ -14,7 +14,7 @@ const formatPrScore = (pr: CommitLog) => {
   if (pr.prState === 'CLOSED' && !pr.mergedAt) return '-';
   if (!pr.score) return '-';
 
-  return Number(pr.score).toFixed(4);
+  return parseFloat(pr.score).toFixed(4);
 };
 
 const formatPrDateOrStatus = (pr: CommitLog) => {


### PR DESCRIPTION
`Number()` coerces non-numeric strings to `NaN`, causing `.toFixed(4)` to render `"NaN"` in the search results table. `parseFloat` is consistent with the rest of the codebase and safely handles invalid score strings.