### PR TITLE
refactor: replace hardcoded colors with theme tokens in PRDetailsCard, AboutPage, Scoring, AppLayout

### DIFF
--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -6,6 +6,7 @@ import {
   IconButton,
   AppBar,
   Toolbar,
+  alpha,
 } from '@mui/material';
 import { Outlet, useLocation } from 'react-router-dom';
 import MenuIcon from '@mui/icons-material/Menu';
@@ -69,8 +70,7 @@ const AppLayout: React.FC = () => {
               style={{
                 height: '40px',
                 width: 'auto',
-                filter:
-                  'brightness(0) invert(1) drop-shadow(0 0 6px rgba(255, 255, 255, 0.8))',
+                filter: `brightness(0) invert(1) drop-shadow(0 0 6px ${alpha(theme.palette.common.white, 0.8)})`,
               }}
             />
           </Toolbar>
@@ -91,13 +91,12 @@ const AppLayout: React.FC = () => {
             '& .MuiDrawer-paper': {
               boxSizing: 'border-box',
               width: 280,
-              backgroundColor: '#000000',
-              backgroundImage:
-                'linear-gradient(rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0.05))',
-              borderRight: '1px solid rgba(255, 255, 255, 0.1)',
+              backgroundColor: 'background.default',
+              backgroundImage: `linear-gradient(${alpha(theme.palette.common.white, 0.05)}, ${alpha(theme.palette.common.white, 0.05)})`,
+              borderRight: `1px solid ${theme.palette.border.light}`,
             },
             '& .MuiBackdrop-root': {
-              backgroundColor: 'rgba(0, 0, 0, 0.7)',
+              backgroundColor: alpha(theme.palette.common.black, 0.7),
             },
           }}
         >
@@ -112,7 +111,7 @@ const AppLayout: React.FC = () => {
             flexShrink: 0,
             width: '240px',
             minWidth: '240px',
-            borderRight: '1px solid rgba(255, 255, 255, 0.1)',
+            borderRight: `1px solid ${theme.palette.border.light}`,
           }}
         >
           <Sidebar />

--- a/src/components/onboard/Scoring.tsx
+++ b/src/components/onboard/Scoring.tsx
@@ -1,5 +1,14 @@
 import React, { useState } from 'react';
-import { Box, Typography, Button, Grid, Tabs, Tab } from '@mui/material';
+import {
+  Box,
+  Typography,
+  Button,
+  Grid,
+  Tabs,
+  Tab,
+  alpha,
+  useTheme,
+} from '@mui/material';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 
 type ScoringCategory = 'oss' | 'discovery';
@@ -56,6 +65,7 @@ const CATEGORIES: {
 ];
 
 export const Scoring: React.FC = () => {
+  const theme = useTheme();
   const [category, setCategory] = useState<ScoringCategory>('oss');
   const activeCategory =
     CATEGORIES.find((c) => c.value === category) ?? CATEGORIES[0];
@@ -69,7 +79,7 @@ export const Scoring: React.FC = () => {
         sx={{
           mb: 4,
           fontFamily: '"JetBrains Mono", monospace',
-          color: '#fff',
+          color: 'text.primary',
           textAlign: 'center',
         }}
       >
@@ -79,7 +89,7 @@ export const Scoring: React.FC = () => {
       <Box
         sx={{
           mb: 4,
-          borderBottom: '1px solid rgba(255, 255, 255, 0.1)',
+          borderBottom: `1px solid ${theme.palette.border.light}`,
           display: 'flex',
           justifyContent: 'center',
         }}
@@ -92,10 +102,12 @@ export const Scoring: React.FC = () => {
               textTransform: 'none',
               fontFamily: '"JetBrains Mono", monospace',
               fontSize: '0.9rem',
-              color: 'rgba(255, 255, 255, 0.55)',
-              '&.Mui-selected': { color: '#fff' },
+              color: alpha(theme.palette.common.white, 0.55),
+              '&.Mui-selected': { color: 'text.primary' },
             },
-            '& .MuiTabs-indicator': { backgroundColor: '#fff' },
+            '& .MuiTabs-indicator': {
+              backgroundColor: theme.palette.common.white,
+            },
           }}
         >
           {CATEGORIES.map((c) => (
@@ -113,7 +125,7 @@ export const Scoring: React.FC = () => {
                 p: 3,
                 borderRadius: 4,
                 cursor: 'default',
-                background: 'rgba(255, 255, 255, 0.02)',
+                background: alpha(theme.palette.common.white, 0.02),
                 border: '1px solid',
                 borderColor: 'border.subtle',
               }}
@@ -122,7 +134,7 @@ export const Scoring: React.FC = () => {
                 variant="h6"
                 sx={{
                   fontWeight: 'bold',
-                  color: '#fff',
+                  color: 'text.primary',
                   mb: 2,
                   fontSize: '1.1rem',
                 }}
@@ -148,8 +160,7 @@ export const Scoring: React.FC = () => {
           textAlign: 'center',
           p: 6,
           borderRadius: 4,
-          background:
-            'linear-gradient(180deg, rgba(0,0,0,0) 0%, rgba(255,255,255,0.02) 100%)',
+          background: `linear-gradient(180deg, transparent 0%, ${alpha(theme.palette.common.white, 0.02)} 100%)`,
           border: '1px solid',
           borderColor: 'border.subtle',
         }}
@@ -157,7 +168,7 @@ export const Scoring: React.FC = () => {
         <Typography
           variant="h5"
           fontWeight="bold"
-          sx={{ mb: 2, color: '#fff' }}
+          sx={{ mb: 2, color: 'text.primary' }}
         >
           Dive Deeper
         </Typography>
@@ -183,7 +194,7 @@ export const Scoring: React.FC = () => {
             fontSize: '1rem',
             fontWeight: 'bold',
             borderRadius: '50px',
-            boxShadow: '0 0 20px rgba(0, 0, 0, 0.2)',
+            boxShadow: `0 0 20px ${alpha(theme.palette.common.black, 0.2)}`,
             textTransform: 'none',
           }}
         >

--- a/src/components/prs/PRDetailsCard.tsx
+++ b/src/components/prs/PRDetailsCard.tsx
@@ -12,7 +12,7 @@ import {
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import { usePullRequestDetails } from '../../api';
 import { useNavigate } from 'react-router-dom';
-import theme, { RANK_COLORS, STATUS_COLORS } from '../../theme';
+import theme, { RANK_COLORS, STATUS_COLORS, TEXT_OPACITY } from '../../theme';
 
 interface PRDetailsCardProps {
   repository: string;
@@ -34,7 +34,7 @@ const PRDetailsCard: React.FC<PRDetailsCardProps> = ({
     return (
       <Card
         sx={{
-          backgroundColor: 'rgba(255, 255, 255, 0.02)',
+          backgroundColor: alpha(theme.palette.common.white, 0.02),
           borderRadius: '8px',
           border: '1px solid',
           borderColor: 'border.subtle',
@@ -52,7 +52,7 @@ const PRDetailsCard: React.FC<PRDetailsCardProps> = ({
     return (
       <Card
         sx={{
-          backgroundColor: 'rgba(255, 255, 255, 0.02)',
+          backgroundColor: alpha(theme.palette.common.white, 0.02),
           borderRadius: '8px',
           border: '1px solid',
           borderColor: 'border.subtle',
@@ -82,7 +82,7 @@ const PRDetailsCard: React.FC<PRDetailsCardProps> = ({
       label: 'Base Score',
       value: parseFloat(prDetails.baseScore ?? '0').toFixed(2),
       rank: null,
-      color: 'rgba(255, 255, 255, 0.7)',
+      color: alpha(theme.palette.common.white, TEXT_OPACITY.secondary),
     },
     {
       label: 'Tokens Scored',
@@ -157,7 +157,7 @@ const PRDetailsCard: React.FC<PRDetailsCardProps> = ({
     <Card
       sx={{
         borderRadius: 3,
-        border: '1px solid rgba(255, 255, 255, 0.1)',
+        border: `1px solid ${theme.palette.border.light}`,
         backgroundColor: 'transparent',
         p: 3,
       }}
@@ -187,10 +187,10 @@ const PRDetailsCard: React.FC<PRDetailsCardProps> = ({
               sx={{
                 width: 64,
                 height: 64,
-                border: '2px solid rgba(255, 255, 255, 0.2)',
+                border: `2px solid ${alpha(theme.palette.common.white, 0.2)}`,
                 backgroundColor:
                   owner === 'opentensor'
-                    ? '#ffffff'
+                    ? theme.palette.common.white
                     : owner === 'bitcoin'
                       ? '#F7931A'
                       : 'transparent',
@@ -204,7 +204,7 @@ const PRDetailsCard: React.FC<PRDetailsCardProps> = ({
               <Typography
                 variant="h5"
                 sx={{
-                  color: '#ffffff',
+                  color: 'text.primary',
                   fontFamily: '"JetBrains Mono", monospace',
                   fontSize: '1.3rem',
                   fontWeight: 500,
@@ -247,7 +247,7 @@ const PRDetailsCard: React.FC<PRDetailsCardProps> = ({
             </Box>
             <Typography
               sx={{
-                color: '#ffffff',
+                color: 'text.primary',
                 fontSize: '1rem',
                 fontWeight: 400,
                 mb: 0.5,
@@ -266,7 +266,10 @@ const PRDetailsCard: React.FC<PRDetailsCardProps> = ({
                   )
                 }
                 sx={{
-                  color: 'rgba(255, 255, 255, 0.5)',
+                  color: alpha(
+                    theme.palette.common.white,
+                    TEXT_OPACITY.tertiary,
+                  ),
                   fontFamily: '"JetBrains Mono", monospace',
                   fontSize: '0.85rem',
                   cursor: 'pointer',
@@ -292,7 +295,7 @@ const PRDetailsCard: React.FC<PRDetailsCardProps> = ({
               sx={{
                 backgroundColor: 'transparent',
                 borderRadius: 3,
-                border: '1px solid rgba(255, 255, 255, 0.1)',
+                border: `1px solid ${theme.palette.border.light}`,
                 p: 2.5,
                 height: '100%',
                 display: 'flex',
@@ -310,7 +313,10 @@ const PRDetailsCard: React.FC<PRDetailsCardProps> = ({
               >
                 <Typography
                   sx={{
-                    color: 'rgba(255, 255, 255, 0.5)',
+                    color: alpha(
+                      theme.palette.common.white,
+                      TEXT_OPACITY.tertiary,
+                    ),
                     fontFamily: '"JetBrains Mono", monospace',
                     fontSize: '0.7rem',
                     textTransform: 'uppercase',
@@ -323,7 +329,7 @@ const PRDetailsCard: React.FC<PRDetailsCardProps> = ({
                 {item.rank && (
                   <Box
                     sx={{
-                      backgroundColor: '#000000',
+                      backgroundColor: 'background.default',
                       borderRadius: '2px',
                       width: '20px',
                       height: '20px',
@@ -339,7 +345,7 @@ const PRDetailsCard: React.FC<PRDetailsCardProps> = ({
                             ? alpha(RANK_COLORS.second, 0.4)
                             : item.rank === 3
                               ? alpha(RANK_COLORS.third, 0.4)
-                              : 'rgba(255, 255, 255, 0.15)',
+                              : alpha(theme.palette.common.white, 0.15),
                       boxShadow:
                         item.rank === 1
                           ? `0 0 12px ${alpha(RANK_COLORS.first, 0.4)}, 0 0 4px ${alpha(RANK_COLORS.first, 0.2)}`
@@ -360,7 +366,7 @@ const PRDetailsCard: React.FC<PRDetailsCardProps> = ({
                               ? RANK_COLORS.second
                               : item.rank === 3
                                 ? RANK_COLORS.third
-                                : 'rgba(255, 255, 255, 0.6)',
+                                : alpha(theme.palette.common.white, 0.6),
                         fontFamily: '"JetBrains Mono", monospace',
                         fontSize: '0.6rem',
                         fontWeight: 600,
@@ -391,7 +397,10 @@ const PRDetailsCard: React.FC<PRDetailsCardProps> = ({
                   <Typography
                     component="span"
                     sx={{
-                      color: 'rgba(255, 255, 255, 0.4)',
+                      color: alpha(
+                        theme.palette.common.white,
+                        TEXT_OPACITY.muted,
+                      ),
                       fontFamily: '"JetBrains Mono", monospace',
                       fontSize: '1.5rem',
                       fontWeight: 400,
@@ -414,7 +423,7 @@ const PRDetailsCard: React.FC<PRDetailsCardProps> = ({
               ) : (
                 <Typography
                   sx={{
-                    color: item.color || '#ffffff',
+                    color: item.color || theme.palette.text.primary,
                     fontFamily: '"JetBrains Mono", monospace',
                     fontSize: '1.5rem',
                     fontWeight: 600,
@@ -433,7 +442,7 @@ const PRDetailsCard: React.FC<PRDetailsCardProps> = ({
       <Box sx={{ mb: 3 }}>
         <Typography
           sx={{
-            color: 'rgba(255, 255, 255, 0.7)',
+            color: alpha(theme.palette.common.white, TEXT_OPACITY.secondary),
             fontFamily: '"JetBrains Mono", monospace',
             fontSize: '0.8rem',
             textTransform: 'uppercase',
@@ -451,9 +460,9 @@ const PRDetailsCard: React.FC<PRDetailsCardProps> = ({
             const content = (
               <Box
                 sx={{
-                  backgroundColor: 'rgba(255, 255, 255, 0.03)',
+                  backgroundColor: alpha(theme.palette.common.white, 0.03),
                   borderRadius: 2,
-                  border: '1px solid rgba(255, 255, 255, 0.05)',
+                  border: `1px solid ${alpha(theme.palette.common.white, 0.05)}`,
                   p: 2,
                   display: 'flex',
                   flexDirection: 'column',
@@ -465,7 +474,10 @@ const PRDetailsCard: React.FC<PRDetailsCardProps> = ({
               >
                 <Typography
                   sx={{
-                    color: 'rgba(255, 255, 255, 0.5)',
+                    color: alpha(
+                      theme.palette.common.white,
+                      TEXT_OPACITY.tertiary,
+                    ),
                     fontSize: '0.7rem',
                     mb: 0.5,
                     display: 'flex',
@@ -480,7 +492,7 @@ const PRDetailsCard: React.FC<PRDetailsCardProps> = ({
                 </Typography>
                 <Typography
                   sx={{
-                    color: '#ffffff',
+                    color: 'text.primary',
                     fontFamily: '"JetBrains Mono", monospace',
                     fontSize: '1.1rem',
                     fontWeight: 600,
@@ -505,7 +517,7 @@ const PRDetailsCard: React.FC<PRDetailsCardProps> = ({
                         <Typography
                           sx={{
                             fontSize: '0.7rem',
-                            color: 'rgba(255, 255, 255, 0.9)',
+                            color: alpha(theme.palette.common.white, 0.9),
                           }}
                         >
                           This multiplier is based on your PR success rate,
@@ -518,15 +530,15 @@ const PRDetailsCard: React.FC<PRDetailsCardProps> = ({
                     slotProps={{
                       tooltip: {
                         sx: {
-                          backgroundColor: 'rgba(20, 20, 20, 0.98)',
-                          border: '1px solid rgba(255, 255, 255, 0.15)',
+                          backgroundColor: 'surface.tooltip',
+                          border: `1px solid ${alpha(theme.palette.common.white, 0.15)}`,
                           borderRadius: '8px',
                           maxWidth: 280,
                         },
                       },
                       arrow: {
                         sx: {
-                          color: 'rgba(20, 20, 20, 0.98)',
+                          color: 'surface.tooltip',
                         },
                       },
                     }}
@@ -550,14 +562,14 @@ const PRDetailsCard: React.FC<PRDetailsCardProps> = ({
             sx={{
               backgroundColor: 'transparent',
               borderRadius: 3,
-              border: '1px solid rgba(255, 255, 255, 0.1)',
+              border: `1px solid ${theme.palette.border.light}`,
               p: 2.5,
               height: '100%',
             }}
           >
             <Typography
               sx={{
-                color: 'rgba(255, 255, 255, 0.5)',
+                color: alpha(theme.palette.common.white, TEXT_OPACITY.tertiary),
                 fontFamily: '"JetBrains Mono", monospace',
                 fontSize: '0.7rem',
                 textTransform: 'uppercase',
@@ -595,7 +607,7 @@ const PRDetailsCard: React.FC<PRDetailsCardProps> = ({
               />
               <Typography
                 sx={{
-                  color: '#ffffff',
+                  color: 'text.primary',
                   fontFamily: '"JetBrains Mono", monospace',
                   fontSize: '0.95rem',
                   fontWeight: 500,
@@ -614,14 +626,14 @@ const PRDetailsCard: React.FC<PRDetailsCardProps> = ({
             sx={{
               backgroundColor: 'transparent',
               borderRadius: 3,
-              border: '1px solid rgba(255, 255, 255, 0.1)',
+              border: `1px solid ${theme.palette.border.light}`,
               p: 2.5,
               height: '100%',
             }}
           >
             <Typography
               sx={{
-                color: 'rgba(255, 255, 255, 0.5)',
+                color: alpha(theme.palette.common.white, TEXT_OPACITY.tertiary),
                 fontFamily: '"JetBrains Mono", monospace',
                 fontSize: '0.7rem',
                 textTransform: 'uppercase',
@@ -634,7 +646,7 @@ const PRDetailsCard: React.FC<PRDetailsCardProps> = ({
             </Typography>
             <Typography
               sx={{
-                color: '#ffffff',
+                color: 'text.primary',
                 fontFamily: '"JetBrains Mono", monospace',
                 fontSize: '0.95rem',
                 fontWeight: 500,
@@ -658,13 +670,16 @@ const PRDetailsCard: React.FC<PRDetailsCardProps> = ({
               sx={{
                 backgroundColor: 'transparent',
                 borderRadius: 3,
-                border: '1px solid rgba(255, 255, 255, 0.1)',
+                border: `1px solid ${theme.palette.border.light}`,
                 p: 2.5,
               }}
             >
               <Typography
                 sx={{
-                  color: 'rgba(255, 255, 255, 0.5)',
+                  color: alpha(
+                    theme.palette.common.white,
+                    TEXT_OPACITY.tertiary,
+                  ),
                   fontFamily: '"JetBrains Mono", monospace',
                   fontSize: '0.7rem',
                   textTransform: 'uppercase',
@@ -694,7 +709,7 @@ const PRDetailsCard: React.FC<PRDetailsCardProps> = ({
             sx={{
               backgroundColor: 'transparent',
               borderRadius: 3,
-              border: '1px solid rgba(255, 255, 255, 0.1)',
+              border: `1px solid ${theme.palette.border.light}`,
               p: 2.5,
               display: 'flex',
               alignItems: 'center',
@@ -703,7 +718,10 @@ const PRDetailsCard: React.FC<PRDetailsCardProps> = ({
           >
             <Typography
               sx={{
-                color: 'rgba(255, 255, 255, 0.7)',
+                color: alpha(
+                  theme.palette.common.white,
+                  TEXT_OPACITY.secondary,
+                ),
                 fontFamily: '"JetBrains Mono", monospace',
                 fontSize: '0.85rem',
               }}

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -1,5 +1,13 @@
 import React from 'react';
-import { Box, Typography, Grid, Button, Stack } from '@mui/material';
+import {
+  Box,
+  Typography,
+  Grid,
+  Button,
+  Stack,
+  alpha,
+  useTheme,
+} from '@mui/material';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import CodeIcon from '@mui/icons-material/Code';
 import MonetizationOnIcon from '@mui/icons-material/MonetizationOn';
@@ -9,6 +17,7 @@ import { SEO } from '../components';
 import { useMonthlyRewards } from '../hooks/useMonthlyRewards';
 
 export const AboutContent: React.FC = () => {
+  const theme = useTheme();
   const monthlyRewards = useMonthlyRewards();
 
   return (
@@ -35,7 +44,7 @@ export const AboutContent: React.FC = () => {
             sx={{
               mb: 3,
               fontFamily: '"JetBrains Mono", monospace',
-              color: '#fff',
+              color: 'text.primary',
             }}
           >
             The Marketplace for Open Source
@@ -45,7 +54,7 @@ export const AboutContent: React.FC = () => {
               <Typography
                 variant="body1"
                 sx={{
-                  color: 'rgba(255, 255, 255, 0.8)',
+                  color: alpha(theme.palette.common.white, 0.8),
                   lineHeight: 1.8,
                   fontSize: '1.05rem',
                   mb: 2,
@@ -59,7 +68,7 @@ export const AboutContent: React.FC = () => {
               <Typography
                 variant="body1"
                 sx={{
-                  color: 'rgba(255, 255, 255, 0.8)',
+                  color: alpha(theme.palette.common.white, 0.8),
                   lineHeight: 1.8,
                   fontSize: '1.05rem',
                 }}
@@ -67,7 +76,9 @@ export const AboutContent: React.FC = () => {
                 Submit Pull Requests to whitelisted repositories and earn when
                 they merge. Discover open issues that others later solve and
                 earn from a separate pool. Two ways to earn, one network:{' '}
-                <strong style={{ color: 'white' }}>Code, Merge, Earn.</strong>
+                <strong style={{ color: theme.palette.text.primary }}>
+                  Code, Merge, Earn.
+                </strong>
               </Typography>
             </Grid>
             <Grid item xs={12} md={6}>
@@ -75,9 +86,8 @@ export const AboutContent: React.FC = () => {
                 sx={{
                   p: 3,
                   borderRadius: 4,
-                  background:
-                    'linear-gradient(135deg, rgba(255,255,255,0.05) 0%, rgba(255,255,255,0.02) 100%)',
-                  border: '1px solid rgba(255, 255, 255, 0.1)',
+                  background: `linear-gradient(135deg, ${alpha(theme.palette.common.white, 0.05)} 0%, ${alpha(theme.palette.common.white, 0.02)} 100%)`,
+                  border: `1px solid ${theme.palette.border.light}`,
                 }}
               >
                 <Typography
@@ -173,7 +183,7 @@ export const AboutContent: React.FC = () => {
                     p: 4,
                     height: '100%',
                     borderRadius: 4,
-                    background: 'rgba(255, 255, 255, 0.02)',
+                    background: alpha(theme.palette.common.white, 0.02),
                     border: '1px solid',
                     borderColor: 'border.subtle',
                   }}
@@ -183,7 +193,7 @@ export const AboutContent: React.FC = () => {
                     variant="h6"
                     fontWeight="bold"
                     gutterBottom
-                    sx={{ color: '#fff' }}
+                    sx={{ color: 'text.primary' }}
                   >
                     {card.title}
                   </Typography>
@@ -206,9 +216,8 @@ export const AboutContent: React.FC = () => {
             textAlign: 'center',
             p: 6,
             borderRadius: 4,
-            background:
-              'linear-gradient(180deg, rgba(0,0,0,0) 0%, rgba(255,255,255,0.03) 100%)',
-            border: '1px solid rgba(255, 255, 255, 0.1)',
+            background: `linear-gradient(180deg, transparent 0%, ${alpha(theme.palette.common.white, 0.03)} 100%)`,
+            border: `1px solid ${theme.palette.border.light}`,
             mb: 8,
           }}
         >
@@ -237,7 +246,7 @@ export const AboutContent: React.FC = () => {
               fontSize: '1.1rem',
               fontWeight: 'bold',
               borderRadius: '50px',
-              boxShadow: '0 0 20px rgba(0, 0, 0, 0.3)',
+              boxShadow: `0 0 20px ${alpha(theme.palette.common.black, 0.3)}`,
               textTransform: 'none',
             }}
           >
@@ -251,8 +260,8 @@ export const AboutContent: React.FC = () => {
             mt: { xs: 4, sm: 5, md: 6 },
             p: { xs: 3, sm: 4 },
             borderRadius: 3,
-            backgroundColor: 'rgba(0, 0, 0, 0.3)',
-            border: '1px solid rgba(255, 255, 255, 0.1)',
+            backgroundColor: alpha(theme.palette.common.black, 0.3),
+            border: `1px solid ${theme.palette.border.light}`,
             position: 'relative',
             overflow: 'hidden',
             width: '100%',
@@ -265,7 +274,7 @@ export const AboutContent: React.FC = () => {
             sx={{
               mb: 2.5,
               fontSize: { xs: '1.2rem', sm: '1.3rem' },
-              color: '#ffffff',
+              color: 'text.primary',
               fontFamily: '"JetBrains Mono", monospace',
               letterSpacing: '0.02em',
             }}
@@ -275,7 +284,7 @@ export const AboutContent: React.FC = () => {
           <Typography
             variant="body1"
             lineHeight={1.8}
-            color="rgba(255, 255, 255, 0.9)"
+            color={alpha(theme.palette.common.white, 0.9)}
             fontSize={{ xs: '0.95rem', sm: '1rem' }}
             sx={{ mb: 2 }}
           >
@@ -301,7 +310,7 @@ export const AboutContent: React.FC = () => {
           <Typography
             variant="body1"
             lineHeight={1.8}
-            color="rgba(255, 255, 255, 0.9)"
+            color={alpha(theme.palette.common.white, 0.9)}
             fontSize={{ xs: '0.95rem', sm: '1rem' }}
           >
             Review our codebase and get started mining by checking out the


### PR DESCRIPTION
## Summary

Replace 66 hardcoded `rgba()`/hex color literals across 4 components with centralized MUI theme tokens and `alpha()` utility.

- **PRDetailsCard** (35 hits): borders → `border.light`, text → `text.primary`/`TEXT_OPACITY`, backgrounds → `background.default`/`surface.tooltip`, rank fallbacks → `alpha()`
- **AboutPage** (15 hits): gradients → template literals with `alpha()`, borders → `border.light`, community section → `alpha(common.black, 0.3)`
- **Scoring** (10 hits): tab indicator → `common.white`, card backgrounds → `alpha()`, gradient → template literal
- **AppLayout** (6 hits): drawer → `background.default` + gradient, borders → `border.light`, backdrop → `alpha(common.black, 0.7)`, logo filter → `alpha()`

## Related Issues

Closes #338

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

No visual changes — only swaps raw color literals for equivalent theme token references.

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [ ] Screenshots included for any UI/visual changes