### PR TITLE
refactor: extract useAbortableFetch hook for repo viewers (#336)

### DIFF
--- a/src/components/repositories/CodeViewer.tsx
+++ b/src/components/repositories/CodeViewer.tsx
@@ -1,10 +1,11 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { scrollbarSx } from '../../theme';
 import { Box, Typography, CircularProgress, Alert } from '@mui/material';
 import axios from 'axios';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { vscDarkPlus } from 'react-syntax-highlighter/dist/esm/styles/prism';
 import ReactMarkdown from 'react-markdown';
+import { useAbortableFetch } from '../../hooks/useAbortableFetch';
 
 interface CodeViewerProps {
   repositoryFullName: string;
@@ -17,53 +18,29 @@ const CodeViewer: React.FC<CodeViewerProps> = ({
   filePath,
   defaultBranch = 'main',
 }) => {
-  const [content, setContent] = useState<string | null>(null);
-  const [loading, setLoading] = useState<boolean>(false);
-  const [error, setError] = useState<string | null>(null);
-
   const extension = filePath?.split('.').pop()?.toLowerCase();
   const isImage =
-    extension &&
+    !!extension &&
     ['png', 'jpg', 'jpeg', 'gif', 'svg', 'webp', 'ico'].includes(extension);
   const rawUrl = filePath
     ? `https://cdn.jsdelivr.net/gh/${repositoryFullName}@${defaultBranch}/${filePath}`
     : '';
 
-  useEffect(() => {
-    const controller = new AbortController();
-
-    const fetchContent = async () => {
-      if (!filePath || isImage) {
-        // Don't fetch text content for images or if no file selected
-        setContent(null);
-        setLoading(false);
-        return;
-      }
-
-      setLoading(true);
-      setError(null);
-      try {
-        // Use raw.githubusercontent.com
-        const response = await axios.get(rawUrl, {
-          transformResponse: [(data) => data],
-          signal: controller.signal,
-        }); // Force text
-        if (controller.signal.aborted) return;
-        setContent(response.data);
-      } catch (err) {
-        if (axios.isCancel(err) || controller.signal.aborted) return;
-        console.error('Failed to fetch file content', err);
-        setError(
-          'Could not load file content. It might be binary or too large.',
-        );
-      } finally {
-        if (!controller.signal.aborted) setLoading(false);
-      }
-    };
-
-    fetchContent();
-    return () => controller.abort();
-  }, [repositoryFullName, filePath, defaultBranch, isImage, rawUrl]);
+  const {
+    data: content,
+    loading,
+    error,
+  } = useAbortableFetch<string>(
+    async (signal) => {
+      const response = await axios.get(rawUrl, {
+        transformResponse: [(data) => data],
+        signal,
+      });
+      return response.data as string;
+    },
+    [rawUrl],
+    { enabled: !!filePath && !isImage },
+  );
 
   if (!filePath) {
     return (
@@ -93,7 +70,7 @@ const CodeViewer: React.FC<CodeViewerProps> = ({
   if (error) {
     return (
       <Alert severity="error" sx={{ m: 2 }}>
-        {error}
+        Could not load file content. It might be binary or too large.
       </Alert>
     );
   }

--- a/src/components/repositories/ContributingViewer.tsx
+++ b/src/components/repositories/ContributingViewer.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { Box, Paper, CircularProgress, Alert } from '@mui/material';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
@@ -6,64 +6,50 @@ import rehypeRaw from 'rehype-raw';
 import axios from 'axios';
 import { STATUS_COLORS } from '../../theme';
 import { resolveRelativeUrl } from './MarkdownRenderers';
+import { useAbortableFetch } from '../../hooks/useAbortableFetch';
 
 interface ContributingViewerProps {
   repositoryFullName: string; // e.g., "opentensor/bittensor"
 }
 
+type ContributingData = { content: string; branch: string };
+
+const BRANCHES = ['main', 'master'];
+const PATHS = [
+  'CONTRIBUTING.md',
+  '.github/CONTRIBUTING.md',
+  'docs/CONTRIBUTING.md',
+];
+
 const ContributingViewer: React.FC<ContributingViewerProps> = ({
   repositoryFullName,
 }) => {
-  const [content, setContent] = useState<string | null>(null);
-  const [defaultBranch, setDefaultBranch] = useState<string>('main');
-  const [loading, setLoading] = useState<boolean>(true);
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    const controller = new AbortController();
-
-    const fetchContributing = async () => {
-      setLoading(true);
-      setError(null);
-
-      const branches = ['main', 'master'];
-      const paths = [
-        'CONTRIBUTING.md',
-        '.github/CONTRIBUTING.md',
-        'docs/CONTRIBUTING.md',
-      ];
-
-      for (const branch of branches) {
-        for (const path of paths) {
-          if (controller.signal.aborted) return;
+  const { data, loading, error } = useAbortableFetch<ContributingData>(
+    async (signal) => {
+      for (const branch of BRANCHES) {
+        for (const path of PATHS) {
           try {
             const response = await axios.get(
               `https://cdn.jsdelivr.net/gh/${repositoryFullName}@${branch}/${path}`,
-              { signal: controller.signal },
+              { signal },
             );
-            if (controller.signal.aborted) return;
             if (response.status === 200 && response.data) {
-              setContent(response.data);
-              setDefaultBranch(branch);
-              setLoading(false);
-              return;
+              return { content: response.data, branch };
             }
           } catch (err) {
-            if (axios.isCancel(err) || controller.signal.aborted) return;
+            if (axios.isCancel(err)) throw err;
             // Continue to next combination
           }
         }
       }
+      throw new Error('No contributing guidelines found for this repository.');
+    },
+    [repositoryFullName],
+    { enabled: !!repositoryFullName },
+  );
 
-      if (controller.signal.aborted) return;
-      // If we get here, nothing was found
-      setError('No contributing guidelines found for this repository.');
-      setLoading(false);
-    };
-
-    if (repositoryFullName) fetchContributing();
-    return () => controller.abort();
-  }, [repositoryFullName]);
+  const content = data?.content ?? null;
+  const defaultBranch = data?.branch ?? 'main';
 
   if (loading) {
     return (
@@ -83,7 +69,7 @@ const ContributingViewer: React.FC<ContributingViewerProps> = ({
           border: '1px solid rgba(2, 136, 209, 0.2)',
         }}
       >
-        {error}
+        {error.message}
       </Alert>
     );
   }

--- a/src/components/repositories/ReadmeViewer.tsx
+++ b/src/components/repositories/ReadmeViewer.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { Box, CircularProgress, Alert, Paper } from '@mui/material';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
@@ -6,56 +6,38 @@ import rehypeRaw from 'rehype-raw';
 import axios from 'axios';
 import { STATUS_COLORS } from '../../theme';
 import { resolveRelativeUrl } from './MarkdownRenderers';
+import { useAbortableFetch } from '../../hooks/useAbortableFetch';
 
 interface ReadmeViewerProps {
   repositoryFullName: string; // e.g., "opentensor/bittensor"
 }
 
+type ReadmeData = { content: string; branch: string };
+
 const ReadmeViewer: React.FC<ReadmeViewerProps> = ({ repositoryFullName }) => {
-  const [content, setContent] = useState<string | null>(null);
-  const [defaultBranch, setDefaultBranch] = useState<string>('main');
-  const [loading, setLoading] = useState<boolean>(true);
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    const controller = new AbortController();
-
-    const fetchReadme = async () => {
-      setLoading(true);
-      setError(null);
+  const { data, loading, error } = useAbortableFetch<ReadmeData>(
+    async (signal) => {
       try {
-        // Try 'main' branch first
-        try {
-          const response = await axios.get(
-            `https://cdn.jsdelivr.net/gh/${repositoryFullName}@main/README.md`,
-            { signal: controller.signal },
-          );
-          if (controller.signal.aborted) return;
-          setContent(response.data);
-          setDefaultBranch('main');
-        } catch (err) {
-          if (axios.isCancel(err) || controller.signal.aborted) return;
-          // Fallback to 'master' branch
-          const response = await axios.get(
-            `https://cdn.jsdelivr.net/gh/${repositoryFullName}@master/README.md`,
-            { signal: controller.signal },
-          );
-          if (controller.signal.aborted) return;
-          setContent(response.data);
-          setDefaultBranch('master');
-        }
+        const response = await axios.get(
+          `https://cdn.jsdelivr.net/gh/${repositoryFullName}@main/README.md`,
+          { signal },
+        );
+        return { content: response.data, branch: 'main' };
       } catch (err) {
-        if (axios.isCancel(err) || controller.signal.aborted) return;
-        console.error('Failed to fetch README', err);
-        setError('Could not load README.md');
-      } finally {
-        if (!controller.signal.aborted) setLoading(false);
+        if (axios.isCancel(err)) throw err;
+        const response = await axios.get(
+          `https://cdn.jsdelivr.net/gh/${repositoryFullName}@master/README.md`,
+          { signal },
+        );
+        return { content: response.data, branch: 'master' };
       }
-    };
+    },
+    [repositoryFullName],
+    { enabled: !!repositoryFullName },
+  );
 
-    if (repositoryFullName) fetchReadme();
-    return () => controller.abort();
-  }, [repositoryFullName]);
+  const content = data?.content ?? null;
+  const defaultBranch = data?.branch ?? 'main';
 
   if (loading) {
     return (
@@ -71,7 +53,7 @@ const ReadmeViewer: React.FC<ReadmeViewerProps> = ({ repositoryFullName }) => {
         severity="warning"
         sx={{ backgroundColor: 'rgba(255, 152, 0, 0.1)', color: '#ff9800' }}
       >
-        {error}
+        Could not load README.md
       </Alert>
     );
   }

--- a/src/hooks/useAbortableFetch.ts
+++ b/src/hooks/useAbortableFetch.ts
@@ -1,0 +1,70 @@
+import { useEffect, useRef, useState, type DependencyList } from 'react';
+import axios from 'axios';
+
+export type AbortableFetchState<T> = {
+  data: T | null;
+  loading: boolean;
+  error: Error | null;
+};
+
+export type UseAbortableFetchOptions = {
+  enabled?: boolean;
+};
+
+const isCancellation = (err: unknown): boolean => {
+  if (axios.isCancel(err)) return true;
+  if (err && typeof err === 'object' && 'name' in err) {
+    const name = (err as { name?: string }).name;
+    return name === 'AbortError' || name === 'CanceledError';
+  }
+  return false;
+};
+
+export function useAbortableFetch<T>(
+  fetcher: (signal: AbortSignal) => Promise<T>,
+  deps: DependencyList,
+  options: UseAbortableFetchOptions = {},
+): AbortableFetchState<T> {
+  const { enabled = true } = options;
+
+  const fetcherRef = useRef(fetcher);
+  fetcherRef.current = fetcher;
+
+  const [data, setData] = useState<T | null>(null);
+  const [loading, setLoading] = useState<boolean>(enabled);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    if (!enabled) {
+      setData(null);
+      setError(null);
+      setLoading(false);
+      return;
+    }
+
+    const controller = new AbortController();
+    setLoading(true);
+    setError(null);
+
+    fetcherRef
+      .current(controller.signal)
+      .then((result) => {
+        if (controller.signal.aborted) return;
+        setData(result);
+      })
+      .catch((err: unknown) => {
+        if (controller.signal.aborted || isCancellation(err)) return;
+        setError(err instanceof Error ? err : new Error(String(err)));
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setLoading(false);
+      });
+
+    return () => controller.abort();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [enabled, ...deps]);
+
+  return { data, loading, error };
+}
+
+export default useAbortableFetch;


### PR DESCRIPTION
## Summary

Extracts a shared `useAbortableFetch` hook and migrates the three repository file viewers (`CodeViewer`, `ReadmeViewer`, `ContributingViewer`) onto it. Each viewer previously reimplemented `AbortController` + `axios.isCancel` + `signal.aborted` guards inline, and the three implementations had drifted in rigor (e.g. `ContributingViewer` checked `signal.aborted` only at the top of each loop iteration, while `CodeViewer` checked after every `await`). The new hook owns all cancellation bookkeeping so viewers express only their domain fetch logic.

### Changes

- **New:** `src/hooks/useAbortableFetch.ts` — generic hook with signature `useAbortableFetch<T>(fetcher, deps, { enabled })` returning `{ data, loading, error }`. Ignores `axios.isCancel` / `AbortError` / `CanceledError`, guards every state setter against `signal.aborted`, resets state when `enabled` flips off.
- **Migrated:** `src/components/repositories/CodeViewer.tsx` — uses `enabled: !!filePath && !isImage` to short-circuit for images/empty selection.
- **Migrated:** `src/components/repositories/ReadmeViewer.tsx` — preserves `main` → `master` branch fallback; re-throws cancellation so the outer fallback is skipped on abort.
- **Migrated:** `src/components/repositories/ContributingViewer.tsx` — preserves the `branches × paths` search loop; "not found" surfaced as a thrown `Error`.

### Behavior

No user-visible change intended. Loading spinners, error alerts, README branch fallback, and contributing-path search all behave identically. The fix is purely structural: removes ~30 lines of duplicated plumbing per viewer and eliminates the footgun of forgetting a `signal.aborted` check in future edits.

## Related Issues

Closes #336

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

Not applicable — no UI/visual changes. Loading, error, and rendered output are byte-identical to the prior implementation.

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes *(N/A — no visual changes)*
