### PR TITLE
refactor: extract MONO_FONT constant to theme.ts and replace all hardcoded font strings

### DIFF
--- a/src/components/ContributionHeatmap.tsx
+++ b/src/components/ContributionHeatmap.tsx
@@ -41,7 +41,6 @@ const ContributionHeatmap: React.FC<ContributionHeatmapProps> = ({
         <Typography
           sx={{
             color: 'text.primary',
-            fontFamily: '"JetBrains Mono", monospace',
             fontWeight: 700,
             fontSize: '2.5rem',
             lineHeight: 1,
@@ -53,7 +52,6 @@ const ContributionHeatmap: React.FC<ContributionHeatmapProps> = ({
           variant="body2"
           sx={{
             color: alpha(theme.palette.common.white, TEXT_OPACITY.faint),
-            fontFamily: '"JetBrains Mono", monospace',
             fontSize: '0.85rem',
             mt: 0.5,
           }}
@@ -77,7 +75,6 @@ const ContributionHeatmap: React.FC<ContributionHeatmapProps> = ({
             <Typography
               sx={{
                 color: alpha(theme.palette.common.white, TEXT_OPACITY.muted),
-                fontFamily: '"JetBrains Mono", monospace',
                 fontSize: '0.85rem',
                 textAlign: 'center',
               }}
@@ -88,7 +85,6 @@ const ContributionHeatmap: React.FC<ContributionHeatmapProps> = ({
               <Typography
                 sx={{
                   color: alpha(theme.palette.common.white, TEXT_OPACITY.ghost),
-                  fontFamily: '"JetBrains Mono", monospace',
                   fontSize: '0.75rem',
                   textAlign: 'center',
                   mt: 0.5,

--- a/src/components/ErrorFallback.tsx
+++ b/src/components/ErrorFallback.tsx
@@ -53,7 +53,6 @@ const ErrorFallback: React.FC<ErrorFallbackProps> = ({
         <ErrorOutlineIcon sx={{ fontSize: 42, color: STATUS_COLORS.closed }} />
         <Typography
           sx={{
-            fontFamily: '"JetBrains Mono", monospace',
             fontSize: { xs: '1.25rem', md: '1.5rem' },
             color: '#fff',
             fontWeight: 500,
@@ -63,7 +62,6 @@ const ErrorFallback: React.FC<ErrorFallbackProps> = ({
         </Typography>
         <Typography
           sx={{
-            fontFamily: '"JetBrains Mono", monospace',
             fontSize: '0.85rem',
             color: 'rgba(255,255,255,0.6)',
             lineHeight: 1.6,
@@ -76,7 +74,6 @@ const ErrorFallback: React.FC<ErrorFallbackProps> = ({
           component="pre"
           sx={{
             width: '100%',
-            fontFamily: '"JetBrains Mono", monospace',
             fontSize: '0.75rem',
             color: 'rgba(255,255,255,0.5)',
             border: '1px solid rgba(255,255,255,0.1)',

--- a/src/components/FilterButton.tsx
+++ b/src/components/FilterButton.tsx
@@ -28,7 +28,6 @@ const FilterButton: React.FC<FilterButtonProps> = ({
       px: 2,
       minWidth: 'auto',
       textTransform: 'none',
-      fontFamily: '"JetBrains Mono", monospace',
       fontSize: '0.8rem',
       border: isActive ? `1px solid ${color}` : '1px solid transparent',
       '&:hover': {

--- a/src/components/KpiCard.tsx
+++ b/src/components/KpiCard.tsx
@@ -78,7 +78,6 @@ const KpiCard: React.FC<KpiCardProps> = ({
           fontWeight="bold"
           sx={{
             color: (muiTheme) => muiTheme.palette.text.primary,
-            fontFamily: (muiTheme) => muiTheme.typography.mono.fontFamily,
             my: isLarge ? (isMobile ? 0.45 : 0.8) : 0.35,
             fontSize: isLarge
               ? isMobile

--- a/src/components/common/SearchInput.tsx
+++ b/src/components/common/SearchInput.tsx
@@ -38,7 +38,6 @@ export const SearchInput: React.FC<SearchInputProps> = ({
         width,
         '& .MuiOutlinedInput-root': {
           color: theme.palette.text.primary,
-          fontFamily: theme.typography.mono.fontFamily,
           backgroundColor: alpha(theme.palette.background.default, 0.24),
           fontSize: '0.8rem',
           borderRadius: 2,

--- a/src/components/issues/BountyProgress.tsx
+++ b/src/components/issues/BountyProgress.tsx
@@ -43,7 +43,6 @@ const BountyProgress: React.FC<BountyProgressProps> = ({
       />
       <Typography
         sx={{
-          fontFamily: '"JetBrains Mono", monospace',
           fontSize: '0.65rem',
           color: alpha(theme.palette.common.white, TEXT_OPACITY.tertiary),
           mt: 0.5,

--- a/src/components/issues/IssueConversation.tsx
+++ b/src/components/issues/IssueConversation.tsx
@@ -294,7 +294,6 @@ const IssueConversation: React.FC<IssueConversationProps> = ({ issue }) => {
                   fontSize: '85%',
                   backgroundColor: alpha(STATUS_COLORS.neutral, 0.4),
                   borderRadius: '6px',
-                  fontFamily: '"JetBrains Mono", monospace',
                 },
                 '& pre': {
                   mt: 2,

--- a/src/components/issues/IssueHeaderCard.tsx
+++ b/src/components/issues/IssueHeaderCard.tsx
@@ -63,7 +63,6 @@ const IssueHeaderCard: React.FC<IssueHeaderCardProps> = ({ issue }) => {
               display: 'flex',
               alignItems: 'center',
               gap: 0.5,
-              fontFamily: '"JetBrains Mono", monospace',
               fontSize: '1rem',
               color: STATUS_COLORS.info,
               textDecoration: 'none',
@@ -79,7 +78,6 @@ const IssueHeaderCard: React.FC<IssueHeaderCardProps> = ({ issue }) => {
             label={statusBadge.text}
             size="small"
             sx={{
-              fontFamily: '"JetBrains Mono", monospace',
               fontSize: '0.75rem',
               fontWeight: 600,
               backgroundColor: statusBadge.bgColor,
@@ -116,7 +114,6 @@ const IssueHeaderCard: React.FC<IssueHeaderCardProps> = ({ issue }) => {
           <Box>
             <Typography
               sx={{
-                fontFamily: '"JetBrains Mono", monospace',
                 fontSize: '0.7rem',
                 color: alpha(theme.palette.common.white, TEXT_OPACITY.tertiary),
                 textTransform: 'uppercase',
@@ -136,7 +133,6 @@ const IssueHeaderCard: React.FC<IssueHeaderCardProps> = ({ issue }) => {
               >
                 <Typography
                   sx={{
-                    fontFamily: '"JetBrains Mono", monospace',
                     fontSize: '1.25rem',
                     fontWeight: 600,
                     color: STATUS_COLORS.warning,
@@ -146,7 +142,6 @@ const IssueHeaderCard: React.FC<IssueHeaderCardProps> = ({ issue }) => {
                 </Typography>
                 <Typography
                   sx={{
-                    fontFamily: '"JetBrains Mono", monospace',
                     fontSize: '0.9rem',
                     color: alpha(
                       theme.palette.common.white,
@@ -160,7 +155,6 @@ const IssueHeaderCard: React.FC<IssueHeaderCardProps> = ({ issue }) => {
             ) : issue.status === 'completed' ? (
               <Typography
                 sx={{
-                  fontFamily: '"JetBrains Mono", monospace',
                   fontSize: '1.25rem',
                   fontWeight: 600,
                   color: STATUS_COLORS.merged,
@@ -171,7 +165,6 @@ const IssueHeaderCard: React.FC<IssueHeaderCardProps> = ({ issue }) => {
             ) : (
               <Typography
                 sx={{
-                  fontFamily: '"JetBrains Mono", monospace',
                   fontSize: '1.25rem',
                   fontWeight: 600,
                   color:
@@ -186,7 +179,6 @@ const IssueHeaderCard: React.FC<IssueHeaderCardProps> = ({ issue }) => {
             {usdEstimate && (
               <Typography
                 sx={{
-                  fontFamily: '"JetBrains Mono", monospace',
                   fontSize: '0.8rem',
                   color: alpha(theme.palette.common.white, TEXT_OPACITY.muted),
                   mt: 0.25,
@@ -201,7 +193,6 @@ const IssueHeaderCard: React.FC<IssueHeaderCardProps> = ({ issue }) => {
             <Box>
               <Typography
                 sx={{
-                  fontFamily: '"JetBrains Mono", monospace',
                   fontSize: '0.7rem',
                   color: alpha(
                     theme.palette.common.white,
@@ -216,7 +207,6 @@ const IssueHeaderCard: React.FC<IssueHeaderCardProps> = ({ issue }) => {
               </Typography>
               <Typography
                 sx={{
-                  fontFamily: '"JetBrains Mono", monospace',
                   fontSize: '0.9rem',
                   color: 'text.primary',
                 }}
@@ -229,7 +219,6 @@ const IssueHeaderCard: React.FC<IssueHeaderCardProps> = ({ issue }) => {
           <Box>
             <Typography
               sx={{
-                fontFamily: '"JetBrains Mono", monospace',
                 fontSize: '0.7rem',
                 color: alpha(theme.palette.common.white, TEXT_OPACITY.tertiary),
                 textTransform: 'uppercase',
@@ -241,7 +230,6 @@ const IssueHeaderCard: React.FC<IssueHeaderCardProps> = ({ issue }) => {
             </Typography>
             <Typography
               sx={{
-                fontFamily: '"JetBrains Mono", monospace',
                 fontSize: '0.9rem',
                 color: 'text.primary',
               }}
@@ -260,7 +248,6 @@ const IssueHeaderCard: React.FC<IssueHeaderCardProps> = ({ issue }) => {
                 label={label}
                 size="small"
                 sx={{
-                  fontFamily: '"JetBrains Mono", monospace',
                   fontSize: '0.7rem',
                   backgroundColor: alpha(theme.palette.common.white, 0.1),
                   color: 'text.primary',

--- a/src/components/issues/IssueSubmissionsTable.tsx
+++ b/src/components/issues/IssueSubmissionsTable.tsx
@@ -21,7 +21,6 @@ import { STATUS_COLORS, TEXT_OPACITY } from '../../theme';
 import { formatDate } from '../../utils/format';
 
 const headerCellSx = {
-  fontFamily: '"JetBrains Mono", monospace',
   fontSize: '0.7rem',
   fontWeight: 600,
   letterSpacing: '0.5px',
@@ -33,7 +32,6 @@ const headerCellSx = {
 };
 
 const bodyCellSx = {
-  fontFamily: '"JetBrains Mono", monospace',
   fontSize: '0.85rem',
   color: 'text.primary',
   borderBottom: '1px solid',
@@ -68,7 +66,6 @@ const IssueSubmissionsTable: React.FC<IssueSubmissionsTableProps> = ({
       <Box sx={{ p: 3, pb: 2 }}>
         <Typography
           sx={{
-            fontFamily: '"JetBrains Mono", monospace',
             fontSize: '0.8rem',
             fontWeight: 600,
             color: alpha(theme.palette.common.white, TEXT_OPACITY.tertiary),
@@ -171,7 +168,6 @@ const IssueSubmissionsTable: React.FC<IssueSubmissionsTableProps> = ({
                           );
                         }}
                         sx={{
-                          fontFamily: '"JetBrains Mono", monospace',
                           fontSize: '0.85rem',
                           color: STATUS_COLORS.info,
                           cursor: 'pointer',
@@ -185,7 +181,6 @@ const IssueSubmissionsTable: React.FC<IssueSubmissionsTableProps> = ({
                     ) : (
                       <Typography
                         sx={{
-                          fontFamily: '"JetBrains Mono", monospace',
                           fontSize: '0.85rem',
                           color: STATUS_COLORS.info,
                         }}
@@ -224,7 +219,6 @@ const IssueSubmissionsTable: React.FC<IssueSubmissionsTableProps> = ({
                   <TableCell sx={{ ...bodyCellSx, textAlign: 'right' }}>
                     <Typography
                       sx={{
-                        fontFamily: '"JetBrains Mono", monospace',
                         fontSize: '0.85rem',
                         fontWeight: 600,
                         color: 'text.primary',
@@ -236,7 +230,6 @@ const IssueSubmissionsTable: React.FC<IssueSubmissionsTableProps> = ({
                   <TableCell sx={{ ...bodyCellSx, textAlign: 'center' }}>
                     <Typography
                       sx={{
-                        fontFamily: '"JetBrains Mono", monospace',
                         fontSize: '0.8rem',
                         color: alpha(theme.palette.common.white, 0.6),
                       }}

--- a/src/components/issues/IssuesList.tsx
+++ b/src/components/issues/IssuesList.tsx
@@ -62,7 +62,6 @@ const IssuesList: React.FC<IssuesListProps> = ({
     return `~${usd.toLocaleString('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 })}`;
   };
   const headerCellSx = {
-    fontFamily: '"JetBrains Mono", monospace',
     fontSize: '0.7rem',
     fontWeight: 600,
     letterSpacing: '0.5px',
@@ -74,7 +73,6 @@ const IssuesList: React.FC<IssuesListProps> = ({
   };
 
   const bodyCellSx = {
-    fontFamily: '"JetBrains Mono", monospace',
     fontSize: '0.85rem',
     color: 'text.primary',
     borderBottom: '1px solid',
@@ -239,7 +237,6 @@ const IssuesList: React.FC<IssuesListProps> = ({
                   <TableCell sx={bodyCellSx}>
                     <Typography
                       sx={{
-                        fontFamily: '"JetBrains Mono", monospace',
                         fontSize: '0.8rem',
                         color: alpha(theme.palette.common.white, 0.6),
                       }}
@@ -257,7 +254,6 @@ const IssuesList: React.FC<IssuesListProps> = ({
                       />
                       <Typography
                         sx={{
-                          fontFamily: '"JetBrains Mono", monospace',
                           fontSize: '0.85rem',
                           color: STATUS_COLORS.info,
                         }}
@@ -277,7 +273,6 @@ const IssuesList: React.FC<IssuesListProps> = ({
                       {issue.title && (
                         <Typography
                           sx={{
-                            fontFamily: '"JetBrains Mono", monospace',
                             fontSize: '0.85rem',
                             color: 'text.primary',
                             fontWeight: 500,
@@ -299,7 +294,6 @@ const IssuesList: React.FC<IssuesListProps> = ({
                           display: 'flex',
                           alignItems: 'center',
                           gap: 0.5,
-                          fontFamily: '"JetBrains Mono", monospace',
                           fontSize: '0.75rem',
                           color: alpha(
                             theme.palette.common.white,
@@ -324,7 +318,6 @@ const IssuesList: React.FC<IssuesListProps> = ({
                       <TableCell sx={{ ...bodyCellSx, textAlign: 'right' }}>
                         <Typography
                           sx={{
-                            fontFamily: '"JetBrains Mono", monospace',
                             fontSize: '0.85rem',
                             fontWeight: 600,
                             color: STATUS_COLORS.merged,
@@ -335,7 +328,6 @@ const IssuesList: React.FC<IssuesListProps> = ({
                         {toUsd(issue.targetBounty) && (
                           <Typography
                             sx={{
-                              fontFamily: '"JetBrains Mono", monospace',
                               fontSize: '0.7rem',
                               color: alpha(theme.palette.common.white, 0.35),
                             }}
@@ -349,7 +341,6 @@ const IssuesList: React.FC<IssuesListProps> = ({
                           label={statusBadge.text}
                           size="small"
                           sx={{
-                            fontFamily: '"JetBrains Mono", monospace',
                             fontSize: '0.7rem',
                             fontWeight: 600,
                             backgroundColor: statusBadge.bgColor,
@@ -367,7 +358,6 @@ const IssuesList: React.FC<IssuesListProps> = ({
                       <TableCell sx={{ ...bodyCellSx, textAlign: 'right' }}>
                         <Typography
                           sx={{
-                            fontFamily: '"JetBrains Mono", monospace',
                             fontSize: '0.85rem',
                             fontWeight: 600,
                             color: STATUS_COLORS.award,
@@ -378,7 +368,6 @@ const IssuesList: React.FC<IssuesListProps> = ({
                         {toUsd(issue.targetBounty) && (
                           <Typography
                             sx={{
-                              fontFamily: '"JetBrains Mono", monospace',
                               fontSize: '0.7rem',
                               color: alpha(theme.palette.common.white, 0.35),
                             }}
@@ -398,7 +387,6 @@ const IssuesList: React.FC<IssuesListProps> = ({
                           label={statusBadge.text}
                           size="small"
                           sx={{
-                            fontFamily: '"JetBrains Mono", monospace',
                             fontSize: '0.7rem',
                             fontWeight: 600,
                             backgroundColor: statusBadge.bgColor,
@@ -416,7 +404,6 @@ const IssuesList: React.FC<IssuesListProps> = ({
                       <TableCell sx={{ ...bodyCellSx, textAlign: 'right' }}>
                         <Typography
                           sx={{
-                            fontFamily: '"JetBrains Mono", monospace',
                             fontSize: '0.85rem',
                             fontWeight: 600,
                             color:
@@ -433,7 +420,6 @@ const IssuesList: React.FC<IssuesListProps> = ({
                         {toUsd(issue.targetBounty) && (
                           <Typography
                             sx={{
-                              fontFamily: '"JetBrains Mono", monospace',
                               fontSize: '0.7rem',
                               color: alpha(theme.palette.common.white, 0.35),
                             }}
@@ -447,7 +433,6 @@ const IssuesList: React.FC<IssuesListProps> = ({
                           <Tooltip title={issue.solverHotkey} arrow>
                             <Typography
                               sx={{
-                                fontFamily: '"JetBrains Mono", monospace',
                                 fontSize: '0.8rem',
                                 color: STATUS_COLORS.info,
                                 cursor: 'pointer',
@@ -475,7 +460,6 @@ const IssuesList: React.FC<IssuesListProps> = ({
                           label={statusBadge.text}
                           size="small"
                           sx={{
-                            fontFamily: '"JetBrains Mono", monospace',
                             fontSize: '0.7rem',
                             fontWeight: 600,
                             backgroundColor: statusBadge.bgColor,
@@ -487,7 +471,6 @@ const IssuesList: React.FC<IssuesListProps> = ({
                       <TableCell sx={{ ...bodyCellSx, textAlign: 'center' }}>
                         <Typography
                           sx={{
-                            fontFamily: '"JetBrains Mono", monospace',
                             fontSize: '0.8rem',
                             color: alpha(theme.palette.common.white, 0.6),
                           }}

--- a/src/components/layout/GlobalSearchBar.tsx
+++ b/src/components/layout/GlobalSearchBar.tsx
@@ -70,7 +70,6 @@ const rowSx = (theme: Theme, active: boolean) => ({
 
 const subtitleSx = (theme: Theme) => ({
   color: theme.palette.text.secondary,
-  fontFamily: theme.typography.mono.fontFamily,
 });
 
 type SectionLabelProps = {
@@ -127,7 +126,6 @@ const ResultRow: React.FC<ResultRowProps> = ({
             color: isAction
               ? theme.palette.primary.main
               : theme.palette.text.primary,
-            fontFamily: theme.typography.mono.fontFamily,
             fontSize: isAction ? '0.9rem' : '0.92rem',
             whiteSpace: 'nowrap',
             overflow: 'hidden',
@@ -169,7 +167,6 @@ const EmptyState: React.FC = () => (
     <Typography
       sx={(theme) => ({
         color: theme.palette.text.primary,
-        fontFamily: theme.typography.mono.fontFamily,
         fontSize: '0.82rem',
       })}
     >
@@ -562,7 +559,6 @@ const GlobalSearchBar: React.FC = () => {
                   borderRadius: 1,
                   border: `1px solid ${theme.palette.border.light}`,
                   color: theme.palette.text.secondary,
-                  fontFamily: theme.typography.mono.fontFamily,
                   fontSize: '0.68rem',
                   lineHeight: 1.4,
                   userSelect: 'none',
@@ -577,7 +573,6 @@ const GlobalSearchBar: React.FC = () => {
         sx={(theme) => ({
           '& .MuiOutlinedInput-root': {
             color: theme.palette.text.primary,
-            fontFamily: theme.typography.mono.fontFamily,
             backgroundColor: theme.palette.surface.subtle,
             fontSize: '0.85rem',
             borderRadius: 2,
@@ -588,7 +583,6 @@ const GlobalSearchBar: React.FC = () => {
             },
           },
           '& .MuiInputBase-input::placeholder': {
-            fontFamily: theme.typography.mono.fontFamily,
             fontSize: '0.8rem',
             opacity: 0.75,
           },

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -87,7 +87,6 @@ const Sidebar: React.FC<SidebarProps> = ({ onNavigate }) => {
               py: 1.5,
               px: 2,
               color: 'text.primary',
-              fontFamily: '"JetBrains Mono", monospace',
               fontSize: '0.95rem',
               textTransform: 'none',
               backgroundColor: location.pathname.startsWith(item.path)
@@ -112,7 +111,6 @@ const Sidebar: React.FC<SidebarProps> = ({ onNavigate }) => {
               <Typography
                 component="span"
                 sx={{
-                  fontFamily: '"JetBrains Mono", monospace',
                   fontSize: '0.65rem',
                   color: 'secondary.main',
                   fontStyle: 'italic',

--- a/src/components/leaderboard/RankIcon.tsx
+++ b/src/components/leaderboard/RankIcon.tsx
@@ -34,7 +34,6 @@ export const RankIcon: React.FC<{ rank: number }> = ({ rank }) => {
         component="span"
         sx={{
           color: color ?? 'text.secondary',
-          fontFamily: '"JetBrains Mono", monospace',
           fontSize: '0.65rem',
           fontWeight: 600,
           lineHeight: 1,

--- a/src/components/leaderboard/SectionCard.tsx
+++ b/src/components/leaderboard/SectionCard.tsx
@@ -53,7 +53,6 @@ export const SectionCard: React.FC<{
               <Typography
                 variant="h6"
                 sx={{
-                  fontFamily: '"JetBrains Mono", monospace',
                   fontSize: '1.25rem',
                   fontWeight: 600,
                 }}

--- a/src/components/leaderboard/TopRepositoriesTable.tsx
+++ b/src/components/leaderboard/TopRepositoriesTable.tsx
@@ -294,13 +294,11 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
         top: 20,
         textStyle: {
           color: primaryColor,
-          fontFamily: 'JetBrains Mono',
           fontSize: 18,
           fontWeight: 600,
         },
         subtextStyle: {
           color: alpha(white, TEXT_OPACITY.tertiary),
-          fontFamily: 'JetBrains Mono',
           fontSize: 12,
         },
       },
@@ -317,7 +315,6 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
         borderWidth: 1,
         textStyle: {
           color: primaryColor,
-          fontFamily: 'JetBrains Mono',
           fontSize: 12,
         },
         padding: [12, 16],
@@ -361,7 +358,6 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
         data: xAxisData.map((item) => item.name),
         axisLabel: {
           color: textColor,
-          fontFamily: 'JetBrains Mono',
           fontSize: 11,
           interval: 0,
           rotate: 45,
@@ -386,13 +382,11 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
         name: metric.yAxis,
         nameTextStyle: {
           color: textColor,
-          fontFamily: 'JetBrains Mono',
           fontSize: 12,
           padding: [0, 0, 0, 0],
         },
         axisLabel: {
           color: textColor,
-          fontFamily: 'JetBrains Mono',
           fontSize: 11,
           formatter: (value: number) => {
             if (value >= 1000) return `${(value / 1000).toFixed(1)}k`;
@@ -603,7 +597,6 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
                   <Typography
                     variant="body2"
                     sx={{
-                      fontFamily: 'JetBrains Mono',
                       fontSize: '0.8rem',
                       color: 'text.secondary',
                     }}
@@ -620,7 +613,6 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
                   variant="body2"
                   sx={{
                     color: 'text.secondary',
-                    fontFamily: '"JetBrains Mono", monospace',
                     fontSize: '0.8rem',
                   }}
                 >
@@ -636,7 +628,6 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
                   }}
                   sx={{
                     color: 'text.primary',
-                    fontFamily: '"JetBrains Mono", monospace',
                     backgroundColor: 'background.default',
                     fontSize: '0.8rem',
                     height: '36px',
@@ -683,7 +674,6 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
                 width: '200px',
                 '& .MuiOutlinedInput-root': {
                   color: 'text.primary',
-                  fontFamily: '"JetBrains Mono", monospace',
                   backgroundColor: 'background.default',
                   fontSize: '0.8rem',
                   height: '36px',
@@ -845,7 +835,6 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
                     >
                       <Typography
                         sx={{
-                          fontFamily: '"JetBrains Mono", monospace',
                           fontSize: '0.75rem',
                           fontWeight: 600,
                           color: 'text.primary',
@@ -860,7 +849,6 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
                     >
                       <Typography
                         sx={{
-                          fontFamily: '"JetBrains Mono", monospace',
                           fontSize: '0.75rem',
                           fontWeight: 600,
                           color:
@@ -880,7 +868,6 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
                     >
                       <Typography
                         sx={{
-                          fontFamily: '"JetBrains Mono", monospace',
                           fontSize: '0.75rem',
                           color:
                             (repo.totalPRs || 0) > 0
@@ -897,7 +884,6 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
                     >
                       <Typography
                         sx={{
-                          fontFamily: '"JetBrains Mono", monospace',
                           fontSize: '0.75rem',
                           color:
                             (repo.uniqueMiners?.size || 0) > 0
@@ -932,10 +918,7 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
                         }}
                       >
                         Repository not in tracked list. Open details for{' '}
-                        <Typography
-                          component="span"
-                          sx={{ fontFamily: '"JetBrains Mono", monospace' }}
-                        >
+                        <Typography component="span">
                           {trimmedSearch}
                         </Typography>
                         ?
@@ -969,9 +952,7 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
           borderTop: '1px solid',
           borderColor: 'border.light',
           color: 'text.secondary',
-          '.MuiTablePagination-displayedRows': {
-            fontFamily: '"JetBrains Mono", monospace',
-          },
+          '.MuiTablePagination-displayedRows': {},
         }}
       />
     </Card>

--- a/src/components/miners/CredibilityChart.tsx
+++ b/src/components/miners/CredibilityChart.tsx
@@ -30,12 +30,10 @@ const CredibilityChart: React.FC<CredibilityChartProps> = ({
           color: theme.palette.text.primary,
           fontSize: 28,
           fontWeight: 'bold',
-          fontFamily: '"JetBrains Mono", monospace',
         },
         subtextStyle: {
           color: alpha(theme.palette.common.white, TEXT_OPACITY.muted),
           fontSize: 11,
-          fontFamily: '"JetBrains Mono", monospace',
           fontWeight: 500,
         },
       },
@@ -47,7 +45,6 @@ const CredibilityChart: React.FC<CredibilityChartProps> = ({
         borderWidth: 1,
         textStyle: {
           color: theme.palette.text.primary,
-          fontFamily: '"JetBrains Mono", monospace',
         },
       },
       series: [
@@ -152,7 +149,6 @@ const LegendItem: React.FC<{ label: string; value: number; color: string }> = ({
         sx={{
           color: alpha(theme.palette.common.white, TEXT_OPACITY.secondary),
           fontSize: '0.65rem',
-          fontFamily: '"JetBrains Mono", monospace',
         }}
       >
         {label}
@@ -161,7 +157,6 @@ const LegendItem: React.FC<{ label: string; value: number; color: string }> = ({
         sx={{
           color,
           fontSize: '0.75rem',
-          fontFamily: '"JetBrains Mono", monospace',
           fontWeight: 700,
         }}
       >

--- a/src/components/miners/EmptyStateMessage.tsx
+++ b/src/components/miners/EmptyStateMessage.tsx
@@ -11,7 +11,6 @@ const EmptyStateMessage: React.FC<EmptyStateMessageProps> = ({ message }) => {
       <Typography
         sx={{
           color: (t) => alpha(t.palette.text.primary, 0.5),
-          fontFamily: '"JetBrains Mono", monospace',
           fontSize: '0.9rem',
         }}
       >

--- a/src/components/miners/ExplorerFilterButton.tsx
+++ b/src/components/miners/ExplorerFilterButton.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Button, useTheme } from '@mui/material';
+import { Button } from '@mui/material';
 
 interface ExplorerFilterButtonProps {
   label: string;
@@ -16,7 +16,6 @@ const ExplorerFilterButton: React.FC<ExplorerFilterButtonProps> = ({
   selected,
   onClick,
 }) => {
-  const theme = useTheme();
   return (
     <Button
       size="small"
@@ -29,7 +28,6 @@ const ExplorerFilterButton: React.FC<ExplorerFilterButtonProps> = ({
         py: { xs: 0.5, sm: 0.75 },
         minWidth: 'auto',
         textTransform: 'none',
-        fontFamily: theme.typography.mono.fontFamily,
         fontSize: { xs: '0.65rem', sm: '0.75rem' },
         border: selected ? `1px solid ${color}` : '1px solid transparent',
         whiteSpace: 'nowrap',

--- a/src/components/miners/MinerActivity.tsx
+++ b/src/components/miners/MinerActivity.tsx
@@ -55,7 +55,6 @@ const LegendItem: React.FC<{ label: string; value: number; color: string }> = ({
         sx={{
           color: alpha(theme.palette.common.white, TEXT_OPACITY.tertiary),
           fontSize: '0.65rem',
-          fontFamily: '"JetBrains Mono", monospace',
         }}
       >
         {label}
@@ -64,7 +63,6 @@ const LegendItem: React.FC<{ label: string; value: number; color: string }> = ({
         sx={{
           color,
           fontSize: '0.75rem',
-          fontFamily: '"JetBrains Mono", monospace',
           fontWeight: 700,
         }}
       >
@@ -94,12 +92,10 @@ const IssueCredibilityChart: React.FC<{
           color: theme.palette.text.primary,
           fontSize: 28,
           fontWeight: 'bold',
-          fontFamily: '"JetBrains Mono", monospace',
         },
         subtextStyle: {
           color: alpha(theme.palette.common.white, TEXT_OPACITY.muted),
           fontSize: 11,
-          fontFamily: '"JetBrains Mono", monospace',
           fontWeight: 500,
         },
       },
@@ -111,7 +107,6 @@ const IssueCredibilityChart: React.FC<{
         borderWidth: 1,
         textStyle: {
           color: theme.palette.text.primary,
-          fontFamily: '"JetBrains Mono", monospace',
         },
       },
       series: [
@@ -220,7 +215,6 @@ const IssuePerformanceRadar: React.FC<{
         splitNumber: 5,
         axisName: {
           color: alpha(theme.palette.common.white, TEXT_OPACITY.tertiary),
-          fontFamily: '"JetBrains Mono", monospace',
           fontSize: 9,
           lineHeight: 12,
         },

--- a/src/components/miners/MinerInsightsCard.tsx
+++ b/src/components/miners/MinerInsightsCard.tsx
@@ -349,7 +349,6 @@ const MinerInsightsCard: React.FC<MinerInsightsCardProps> = ({
         <Typography
           sx={{
             color: 'text.primary',
-            fontFamily: '"JetBrains Mono", monospace',
             fontSize: '1.1rem',
             fontWeight: 600,
             mb: 0.8,
@@ -391,7 +390,6 @@ const MinerInsightsCard: React.FC<MinerInsightsCardProps> = ({
                 <Typography
                   sx={{
                     color: style.color,
-                    fontFamily: '"JetBrains Mono", monospace',
                     fontSize: '0.83rem',
                     fontWeight: 600,
                   }}
@@ -414,7 +412,6 @@ const MinerInsightsCard: React.FC<MinerInsightsCardProps> = ({
                 label={insight.type}
                 sx={{
                   textTransform: 'uppercase',
-                  fontFamily: '"JetBrains Mono", monospace',
                   fontSize: '0.62rem',
                   color: style.color,
                   backgroundColor: alpha(style.color, 0.12),
@@ -432,7 +429,6 @@ const MinerInsightsCard: React.FC<MinerInsightsCardProps> = ({
           mt: 2,
           textAlign: 'right',
           fontSize: '0.72rem',
-          fontFamily: '"JetBrains Mono", monospace',
           color: (t) => alpha(t.palette.text.primary, 0.35),
         }}
       >

--- a/src/components/miners/MinerPRsTable.tsx
+++ b/src/components/miners/MinerPRsTable.tsx
@@ -66,7 +66,6 @@ const tooltipSlotProps = {
       backgroundColor: 'surface.tooltip',
       color: 'text.primary',
       fontSize: '0.72rem',
-      fontFamily: '"JetBrains Mono", monospace',
       padding: '8px 12px',
       borderRadius: '6px',
       border: '1px solid',
@@ -244,7 +243,6 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
               variant="h6"
               sx={{
                 color: 'text.primary',
-                fontFamily: '"JetBrains Mono", monospace',
                 fontSize: { xs: '0.95rem', sm: '1.1rem' },
                 fontWeight: 500,
               }}
@@ -254,7 +252,6 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
             <Typography
               sx={{
                 color: (t) => alpha(t.palette.text.primary, 0.5),
-                fontFamily: '"JetBrains Mono", monospace',
                 fontSize: '0.75rem',
               }}
             >
@@ -358,7 +355,6 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
             maxWidth: 400,
             minWidth: 350,
             '& .MuiOutlinedInput-root': {
-              fontFamily: '"JetBrains Mono", monospace',
               fontSize: '0.8rem',
               color: 'text.primary',
               backgroundColor: 'surface.subtle',
@@ -377,7 +373,6 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
           <Typography
             sx={{
               color: (t) => alpha(t.palette.text.primary, 0.5),
-              fontFamily: '"JetBrains Mono", monospace',
               fontSize: '0.9rem',
             }}
           >
@@ -389,7 +384,6 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
           <Typography
             sx={{
               color: (t) => alpha(t.palette.text.primary, 0.5),
-              fontFamily: '"JetBrains Mono", monospace',
               fontSize: '0.9rem',
             }}
           >
@@ -591,7 +585,6 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
                           sx={{
                             color: theme.palette.diff.additions,
                             mr: 1,
-                            fontFamily: '"JetBrains Mono", monospace',
                           }}
                         >
                           +{pr.additions}
@@ -600,7 +593,6 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
                           component="span"
                           sx={{
                             color: theme.palette.diff.deletions,
-                            fontFamily: '"JetBrains Mono", monospace',
                           }}
                         >
                           -{pr.deletions}
@@ -611,7 +603,6 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
                           {pr.prState === 'CLOSED' && !pr.mergedAt ? (
                             <Typography
                               sx={{
-                                fontFamily: '"JetBrains Mono", monospace',
                                 fontSize: { xs: '0.7rem', sm: '0.75rem' },
                                 fontWeight: 600,
                                 color: (t) =>
@@ -623,7 +614,6 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
                           ) : !pr.mergedAt && pr.collateralScore ? (
                             <Typography
                               sx={{
-                                fontFamily: '"JetBrains Mono", monospace',
                                 fontSize: { xs: '0.7rem', sm: '0.75rem' },
                                 fontWeight: 600,
                                 color: theme.palette.status.warningOrange,
@@ -640,7 +630,6 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
                             >
                               <Typography
                                 sx={{
-                                  fontFamily: '"JetBrains Mono", monospace',
                                   fontSize: { xs: '0.7rem', sm: '0.75rem' },
                                   fontWeight: 600,
                                   cursor: 'pointer',
@@ -652,7 +641,6 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
                           ) : (
                             <Typography
                               sx={{
-                                fontFamily: '"JetBrains Mono", monospace',
                                 fontSize: { xs: '0.7rem', sm: '0.75rem' },
                                 fontWeight: 600,
                               }}
@@ -665,7 +653,6 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
                             pr.prState !== 'CLOSED' && (
                               <Typography
                                 sx={{
-                                  fontFamily: '"JetBrains Mono", monospace',
                                   fontSize: '0.6rem',
                                   color: (t) =>
                                     alpha(t.palette.text.primary, 0.5),

--- a/src/components/miners/MinerRepositoriesTable.styles.ts
+++ b/src/components/miners/MinerRepositoriesTable.styles.ts
@@ -5,7 +5,6 @@ export const getHeaderCellStyle = (theme: Theme) => ({
   backgroundColor: theme.palette.surface.elevated,
   backdropFilter: 'blur(8px)',
   color: alpha(theme.palette.text.primary, 0.7),
-  fontFamily: '"JetBrains Mono", monospace',
   fontWeight: 500,
   fontSize: '0.75rem',
   borderBottom: `1px solid ${theme.palette.border.light}`,
@@ -15,7 +14,6 @@ export const getHeaderCellStyle = (theme: Theme) => ({
 
 export const getBodyCellStyle = (theme: Theme) => ({
   color: theme.palette.text.primary,
-  fontFamily: '"JetBrains Mono", monospace',
   borderBottom: `1px solid ${theme.palette.border.light}`,
   fontSize: '0.85rem',
 });
@@ -38,7 +36,6 @@ export const searchFieldSx: SxProps<Theme> = {
   maxWidth: 400,
   minWidth: 350,
   '& .MuiOutlinedInput-root': {
-    fontFamily: '"JetBrains Mono", monospace',
     fontSize: '0.8rem',
     color: 'text.primary',
     backgroundColor: 'surface.subtle',

--- a/src/components/miners/MinerRepositoriesTable.tsx
+++ b/src/components/miners/MinerRepositoriesTable.tsx
@@ -162,7 +162,6 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
               variant="h6"
               sx={{
                 color: 'text.primary',
-                fontFamily: '"JetBrains Mono", monospace',
                 fontSize: { xs: '0.95rem', sm: '1.1rem' },
                 fontWeight: 500,
               }}
@@ -172,7 +171,6 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
             <Typography
               sx={{
                 color: (t) => alpha(t.palette.text.primary, 0.5),
-                fontFamily: '"JetBrains Mono", monospace',
                 fontSize: '0.75rem',
               }}
             >
@@ -400,7 +398,6 @@ const RepoTableRow: React.FC<RepoTableRowProps> = ({
             component="span"
             title={repo.repository}
             sx={{
-              fontFamily: '"JetBrains Mono", monospace',
               fontSize: '0.85rem',
               minWidth: 0,
               flex: 1,

--- a/src/components/miners/MinerScoreBreakdown.tsx
+++ b/src/components/miners/MinerScoreBreakdown.tsx
@@ -44,7 +44,6 @@ const tooltipSlotProps = {
       backgroundColor: 'surface.tooltip',
       color: 'text.primary',
       fontSize: '0.72rem',
-      fontFamily: '"JetBrains Mono", monospace',
       padding: '8px 12px',
       borderRadius: '6px',
       border: '1px solid',
@@ -104,7 +103,6 @@ const MultiplierPill: React.FC<MultiplierPillProps> = ({
       >
         <Typography
           sx={{
-            fontFamily: '"JetBrains Mono", monospace',
             fontSize: '0.62rem',
             color: STATUS_COLORS.neutral,
             textTransform: 'uppercase',
@@ -114,7 +112,6 @@ const MultiplierPill: React.FC<MultiplierPillProps> = ({
         </Typography>
         <Typography
           sx={{
-            fontFamily: '"JetBrains Mono", monospace',
             fontSize: '0.72rem',
             fontWeight: 600,
             color,
@@ -183,7 +180,6 @@ const PrScoreRow: React.FC<PrScoreRowProps> = ({ pr, onNavigateToPr }) => {
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
             <Typography
               sx={{
-                fontFamily: '"JetBrains Mono", monospace',
                 fontSize: '0.78rem',
                 fontWeight: 600,
                 color: 'text.primary',
@@ -194,7 +190,6 @@ const PrScoreRow: React.FC<PrScoreRowProps> = ({ pr, onNavigateToPr }) => {
             </Typography>
             <Typography
               sx={{
-                fontFamily: '"JetBrains Mono", monospace',
                 fontSize: '0.72rem',
                 color: (t) => alpha(t.palette.text.primary, 0.6),
                 overflow: 'hidden',
@@ -208,7 +203,6 @@ const PrScoreRow: React.FC<PrScoreRowProps> = ({ pr, onNavigateToPr }) => {
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mt: 0.25 }}>
             <Typography
               sx={{
-                fontFamily: '"JetBrains Mono", monospace',
                 fontSize: '0.62rem',
                 color: (t) => alpha(t.palette.text.primary, 0.5),
               }}
@@ -226,7 +220,6 @@ const PrScoreRow: React.FC<PrScoreRowProps> = ({ pr, onNavigateToPr }) => {
             />
             <Typography
               sx={{
-                fontFamily: '"JetBrains Mono", monospace',
                 fontSize: '0.62rem',
                 color: statusColor,
               }}
@@ -239,7 +232,6 @@ const PrScoreRow: React.FC<PrScoreRowProps> = ({ pr, onNavigateToPr }) => {
         {/* Score */}
         <Typography
           sx={{
-            fontFamily: '"JetBrains Mono", monospace',
             fontSize: '0.9rem',
             fontWeight: 600,
             color: isClosed
@@ -422,7 +414,6 @@ const PrScoreRow: React.FC<PrScoreRowProps> = ({ pr, onNavigateToPr }) => {
                   <Typography
                     component="span"
                     sx={{
-                      fontFamily: '"JetBrains Mono", monospace',
                       fontSize: '0.65rem',
                       color: (t) => alpha(t.palette.text.primary, 0.4),
                     }}
@@ -433,7 +424,6 @@ const PrScoreRow: React.FC<PrScoreRowProps> = ({ pr, onNavigateToPr }) => {
                     <Typography
                       component="span"
                       sx={{
-                        fontFamily: '"JetBrains Mono", monospace',
                         fontSize: '0.65rem',
                         color: (t) => alpha(t.palette.text.primary, 0.2),
                         mx: 0.25,
@@ -449,7 +439,6 @@ const PrScoreRow: React.FC<PrScoreRowProps> = ({ pr, onNavigateToPr }) => {
                 <Typography
                   component="span"
                   sx={{
-                    fontFamily: '"JetBrains Mono", monospace',
                     fontSize: '0.65rem',
                     color: (t) => alpha(t.palette.text.primary, 0.2),
                     mx: 0.25,
@@ -460,7 +449,6 @@ const PrScoreRow: React.FC<PrScoreRowProps> = ({ pr, onNavigateToPr }) => {
                 <Typography
                   component="span"
                   sx={{
-                    fontFamily: '"JetBrains Mono", monospace',
                     fontSize: '0.65rem',
                     color: STATUS_COLORS.warningOrange,
                   }}
@@ -481,7 +469,6 @@ const PrScoreRow: React.FC<PrScoreRowProps> = ({ pr, onNavigateToPr }) => {
                 onNavigateToPr(pr.repository, pr.pullRequestNumber);
               }}
               sx={{
-                fontFamily: '"JetBrains Mono", monospace',
                 fontSize: '0.65rem',
                 textTransform: 'none',
                 color: 'primary.main',
@@ -502,7 +489,6 @@ const PrScoreRow: React.FC<PrScoreRowProps> = ({ pr, onNavigateToPr }) => {
               rel="noopener noreferrer"
               onClick={(e) => e.stopPropagation()}
               sx={{
-                fontFamily: '"JetBrains Mono", monospace',
                 fontSize: '0.65rem',
                 textTransform: 'none',
                 color: (t) => alpha(t.palette.text.primary, 0.5),
@@ -547,7 +533,6 @@ const MetricRow: React.FC<{
     <Box>
       <Typography
         sx={{
-          fontFamily: '"JetBrains Mono", monospace',
           fontSize: '0.82rem',
           color: 'text.primary',
         }}
@@ -557,7 +542,6 @@ const MetricRow: React.FC<{
       {sub && (
         <Typography
           sx={{
-            fontFamily: '"JetBrains Mono", monospace',
             fontSize: '0.7rem',
             color: (t) => alpha(t.palette.text.primary, 0.4),
             mt: 0.25,
@@ -569,7 +553,6 @@ const MetricRow: React.FC<{
     </Box>
     <Typography
       sx={{
-        fontFamily: '"JetBrains Mono", monospace',
         fontSize: '0.95rem',
         fontWeight: 600,
         color: color || 'text.primary',
@@ -611,7 +594,6 @@ const IssueBreakdownView: React.FC<{ githubId: string }> = ({ githubId }) => {
       <Typography
         sx={{
           color: 'text.primary',
-          fontFamily: '"JetBrains Mono", monospace',
           fontSize: '1.1rem',
           fontWeight: 600,
           mb: 0.8,
@@ -640,7 +622,6 @@ const IssueBreakdownView: React.FC<{ githubId: string }> = ({ githubId }) => {
         >
           <Typography
             sx={{
-              fontFamily: '"JetBrains Mono", monospace',
               fontSize: '0.85rem',
               color: (t) => alpha(t.palette.text.primary, 0.4),
             }}
@@ -649,7 +630,6 @@ const IssueBreakdownView: React.FC<{ githubId: string }> = ({ githubId }) => {
           </Typography>
           <Typography
             sx={{
-              fontFamily: '"JetBrains Mono", monospace',
               fontSize: '0.75rem',
               color: (t) => alpha(t.palette.text.primary, 0.3),
               mt: 0.5,
@@ -767,7 +747,6 @@ const PrBreakdownView: React.FC<{ githubId: string }> = ({ githubId }) => {
         <Box>
           <Typography
             sx={{
-              fontFamily: '"JetBrains Mono", monospace',
               fontSize: '1rem',
               fontWeight: 600,
               color: 'text.primary',
@@ -777,7 +756,6 @@ const PrBreakdownView: React.FC<{ githubId: string }> = ({ githubId }) => {
           </Typography>
           <Typography
             sx={{
-              fontFamily: '"JetBrains Mono", monospace',
               fontSize: '0.72rem',
               color: (t) => alpha(t.palette.text.primary, 0.45),
               mt: 0.25,
@@ -815,7 +793,6 @@ const PrBreakdownView: React.FC<{ githubId: string }> = ({ githubId }) => {
           <Typography
             onClick={() => setPage((p) => Math.max(0, p - 1))}
             sx={{
-              fontFamily: '"JetBrains Mono", monospace',
               fontSize: '0.72rem',
               color:
                 page === 0
@@ -830,7 +807,6 @@ const PrBreakdownView: React.FC<{ githubId: string }> = ({ githubId }) => {
           </Typography>
           <Typography
             sx={{
-              fontFamily: '"JetBrains Mono", monospace',
               fontSize: '0.72rem',
               color: (t) => alpha(t.palette.text.primary, 0.5),
             }}
@@ -840,7 +816,6 @@ const PrBreakdownView: React.FC<{ githubId: string }> = ({ githubId }) => {
           <Typography
             onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
             sx={{
-              fontFamily: '"JetBrains Mono", monospace',
               fontSize: '0.72rem',
               color:
                 page >= totalPages - 1

--- a/src/components/miners/MinerScoreCard.tsx
+++ b/src/components/miners/MinerScoreCard.tsx
@@ -66,7 +66,6 @@ const tooltipSlotProps = {
       backgroundColor: 'surface.tooltip',
       color: 'text.primary',
       fontSize: '0.75rem',
-      fontFamily: '"JetBrains Mono", monospace',
       padding: '8px 12px',
       borderRadius: '6px',
       border: '1px solid',
@@ -158,7 +157,6 @@ const StatTile: React.FC<StatTileProps> = ({
           <Typography
             component="span"
             sx={{
-              fontFamily: '"JetBrains Mono", monospace',
               fontSize: '0.6rem',
               fontWeight: 600,
               color:
@@ -178,7 +176,6 @@ const StatTile: React.FC<StatTileProps> = ({
     </Box>
     <Typography
       sx={{
-        fontFamily: '"JetBrains Mono", monospace',
         fontSize: '1.5rem',
         fontWeight: 600,
         color: color || 'text.primary',
@@ -190,7 +187,6 @@ const StatTile: React.FC<StatTileProps> = ({
     {sub && (
       <Typography
         sx={{
-          fontFamily: '"JetBrains Mono", monospace',
           fontSize: '0.75rem',
           color: (t) => alpha(t.palette.text.primary, 0.4),
           mt: 0.25,
@@ -273,7 +269,6 @@ const CopyableHotkey: React.FC<{ hotkey: string }> = ({ hotkey }) => {
         component="span"
         sx={{
           color: 'inherit',
-          fontFamily: '"JetBrains Mono", monospace',
           fontSize: { xs: '0.55rem', sm: '0.65rem' },
           wordBreak: 'break-all',
         }}
@@ -343,7 +338,6 @@ const MinerScoreCard: React.FC<MinerScoreCardProps> = ({
         <Typography
           sx={{
             color: alpha(STATUS_COLORS.error, 0.9),
-            fontFamily: '"JetBrains Mono", monospace',
             fontSize: '0.9rem',
           }}
         >
@@ -379,7 +373,6 @@ const MinerScoreCard: React.FC<MinerScoreCardProps> = ({
             position: 'absolute',
             top: 16,
             right: 16,
-            fontFamily: '"JetBrains Mono", monospace',
             fontSize: '0.7rem',
             color: (t) => alpha(t.palette.text.primary, 0.5),
             borderColor: 'border.light',
@@ -415,7 +408,6 @@ const MinerScoreCard: React.FC<MinerScoreCardProps> = ({
           >
             <Typography
               sx={{
-                fontFamily: '"JetBrains Mono", monospace',
                 fontSize: { xs: '1.15rem', sm: '1.35rem' },
                 fontWeight: 700,
                 color: 'text.primary',
@@ -437,7 +429,6 @@ const MinerScoreCard: React.FC<MinerScoreCardProps> = ({
                   color: eligibilityColor,
                   borderColor: alpha(eligibilityColor, 0.35),
                   backgroundColor: alpha(eligibilityColor, 0.1),
-                  fontFamily: '"JetBrains Mono", monospace',
                   fontSize: '0.7rem',
                   letterSpacing: '0.5px',
                   textTransform: 'uppercase',
@@ -461,7 +452,6 @@ const MinerScoreCard: React.FC<MinerScoreCardProps> = ({
                   color: issueEligibilityColor,
                   borderColor: alpha(issueEligibilityColor, 0.35),
                   backgroundColor: alpha(issueEligibilityColor, 0.1),
-                  fontFamily: '"JetBrains Mono", monospace',
                   fontSize: '0.7rem',
                   letterSpacing: '0.5px',
                   textTransform: 'uppercase',
@@ -485,7 +475,6 @@ const MinerScoreCard: React.FC<MinerScoreCardProps> = ({
               rel="noopener noreferrer"
               sx={{
                 color: 'primary.main',
-                fontFamily: '"JetBrains Mono", monospace',
                 fontSize: '0.9rem',
                 textDecoration: 'none',
                 display: 'inline-flex',
@@ -504,7 +493,6 @@ const MinerScoreCard: React.FC<MinerScoreCardProps> = ({
             <Typography
               sx={{
                 color: (t) => alpha(t.palette.text.primary, 0.7),
-                fontFamily: '"JetBrains Mono", monospace',
                 fontSize: '0.8rem',
                 mt: 1,
                 lineHeight: 1.5,
@@ -569,7 +557,6 @@ const MinerScoreCard: React.FC<MinerScoreCardProps> = ({
               sx={{
                 display: { xs: 'flex', sm: 'none' },
                 mt: 1,
-                fontFamily: '"JetBrains Mono", monospace',
                 fontSize: '0.65rem',
                 color: (t) => alpha(t.palette.text.primary, 0.5),
                 borderColor: 'border.light',

--- a/src/components/miners/PerformanceRadar.tsx
+++ b/src/components/miners/PerformanceRadar.tsx
@@ -40,7 +40,6 @@ const PerformanceRadar: React.FC<PerformanceRadarProps> = ({
         splitNumber: 5,
         axisName: {
           color: alpha(theme.palette.common.white, TEXT_OPACITY.secondary),
-          fontFamily: '"JetBrains Mono", monospace',
           fontSize: 9,
           lineHeight: 12,
         },

--- a/src/components/miners/RankBadge.tsx
+++ b/src/components/miners/RankBadge.tsx
@@ -69,7 +69,6 @@ const RankBadge: React.FC<RankBadgeProps> = ({ rank, displayNumber }) => {
         component="span"
         sx={{
           color: getRankTextColor(rank, defaultTextColor),
-          fontFamily: '"JetBrains Mono", monospace',
           fontSize: '0.7rem',
           fontWeight: 600,
           lineHeight: 1,

--- a/src/components/miners/TablePagination.tsx
+++ b/src/components/miners/TablePagination.tsx
@@ -62,7 +62,6 @@ const TablePagination: React.FC<TablePaginationProps> = ({
       </Box>
       <Typography
         sx={{
-          fontFamily: '"JetBrains Mono", monospace',
           fontSize: '0.75rem',
           color: (t) => alpha(t.palette.text.primary, 0.5),
         }}

--- a/src/components/onboard/Scoring.tsx
+++ b/src/components/onboard/Scoring.tsx
@@ -78,7 +78,6 @@ export const Scoring: React.FC = () => {
         fontWeight="bold"
         sx={{
           mb: 4,
-          fontFamily: '"JetBrains Mono", monospace',
           color: 'text.primary',
           textAlign: 'center',
         }}
@@ -100,7 +99,6 @@ export const Scoring: React.FC = () => {
           sx={{
             '& .MuiTab-root': {
               textTransform: 'none',
-              fontFamily: '"JetBrains Mono", monospace',
               fontSize: '0.9rem',
               color: alpha(theme.palette.common.white, 0.55),
               '&.Mui-selected': { color: 'text.primary' },

--- a/src/components/prs/PRComments.tsx
+++ b/src/components/prs/PRComments.tsx
@@ -322,7 +322,6 @@ const PRComments: React.FC<PRCommentsProps> = ({
                   fontSize: '85%',
                   backgroundColor: 'rgba(110, 118, 129, 0.4)',
                   borderRadius: '6px',
-                  fontFamily: '"JetBrains Mono", monospace',
                 },
                 '& pre': {
                   mt: 2,

--- a/src/components/prs/PRDetailsCard.tsx
+++ b/src/components/prs/PRDetailsCard.tsx
@@ -62,7 +62,6 @@ const PRDetailsCard: React.FC<PRDetailsCardProps> = ({
         <Typography
           sx={{
             color: alpha(STATUS_COLORS.error, 0.9),
-            fontFamily: '"JetBrains Mono", monospace',
             fontSize: '0.9rem',
           }}
         >
@@ -205,7 +204,6 @@ const PRDetailsCard: React.FC<PRDetailsCardProps> = ({
                 variant="h5"
                 sx={{
                   color: 'text.primary',
-                  fontFamily: '"JetBrains Mono", monospace',
                   fontSize: '1.3rem',
                   fontWeight: 500,
                 }}
@@ -270,7 +268,6 @@ const PRDetailsCard: React.FC<PRDetailsCardProps> = ({
                     theme.palette.common.white,
                     TEXT_OPACITY.tertiary,
                   ),
-                  fontFamily: '"JetBrains Mono", monospace',
                   fontSize: '0.85rem',
                   cursor: 'pointer',
                   transition: 'color 0.2s',
@@ -317,7 +314,6 @@ const PRDetailsCard: React.FC<PRDetailsCardProps> = ({
                       theme.palette.common.white,
                       TEXT_OPACITY.tertiary,
                     ),
-                    fontFamily: '"JetBrains Mono", monospace',
                     fontSize: '0.7rem',
                     textTransform: 'uppercase',
                     letterSpacing: '1px',
@@ -367,7 +363,6 @@ const PRDetailsCard: React.FC<PRDetailsCardProps> = ({
                               : item.rank === 3
                                 ? RANK_COLORS.third
                                 : alpha(theme.palette.common.white, 0.6),
-                        fontFamily: '"JetBrains Mono", monospace',
                         fontSize: '0.6rem',
                         fontWeight: 600,
                         lineHeight: 1,
@@ -387,7 +382,6 @@ const PRDetailsCard: React.FC<PRDetailsCardProps> = ({
                     component="span"
                     sx={{
                       color: alpha(theme.palette.diff.additions, 0.8),
-                      fontFamily: '"JetBrains Mono", monospace',
                       fontSize: '1.5rem',
                       fontWeight: 600,
                     }}
@@ -401,7 +395,6 @@ const PRDetailsCard: React.FC<PRDetailsCardProps> = ({
                         theme.palette.common.white,
                         TEXT_OPACITY.muted,
                       ),
-                      fontFamily: '"JetBrains Mono", monospace',
                       fontSize: '1.5rem',
                       fontWeight: 400,
                     }}
@@ -412,7 +405,6 @@ const PRDetailsCard: React.FC<PRDetailsCardProps> = ({
                     component="span"
                     sx={{
                       color: alpha(theme.palette.diff.deletions, 0.8),
-                      fontFamily: '"JetBrains Mono", monospace',
                       fontSize: '1.5rem',
                       fontWeight: 600,
                     }}
@@ -424,7 +416,6 @@ const PRDetailsCard: React.FC<PRDetailsCardProps> = ({
                 <Typography
                   sx={{
                     color: item.color || theme.palette.text.primary,
-                    fontFamily: '"JetBrains Mono", monospace',
                     fontSize: '1.5rem',
                     fontWeight: 600,
                     wordBreak: 'break-all',
@@ -443,7 +434,6 @@ const PRDetailsCard: React.FC<PRDetailsCardProps> = ({
         <Typography
           sx={{
             color: alpha(theme.palette.common.white, TEXT_OPACITY.secondary),
-            fontFamily: '"JetBrains Mono", monospace',
             fontSize: '0.8rem',
             textTransform: 'uppercase',
             letterSpacing: '1px',
@@ -493,7 +483,6 @@ const PRDetailsCard: React.FC<PRDetailsCardProps> = ({
                 <Typography
                   sx={{
                     color: 'text.primary',
-                    fontFamily: '"JetBrains Mono", monospace',
                     fontSize: '1.1rem',
                     fontWeight: 600,
                   }}
@@ -570,7 +559,6 @@ const PRDetailsCard: React.FC<PRDetailsCardProps> = ({
             <Typography
               sx={{
                 color: alpha(theme.palette.common.white, TEXT_OPACITY.tertiary),
-                fontFamily: '"JetBrains Mono", monospace',
                 fontSize: '0.7rem',
                 textTransform: 'uppercase',
                 letterSpacing: '1px',
@@ -608,7 +596,6 @@ const PRDetailsCard: React.FC<PRDetailsCardProps> = ({
               <Typography
                 sx={{
                   color: 'text.primary',
-                  fontFamily: '"JetBrains Mono", monospace',
                   fontSize: '0.95rem',
                   fontWeight: 500,
                   transition: 'color 0.2s',
@@ -634,7 +621,6 @@ const PRDetailsCard: React.FC<PRDetailsCardProps> = ({
             <Typography
               sx={{
                 color: alpha(theme.palette.common.white, TEXT_OPACITY.tertiary),
-                fontFamily: '"JetBrains Mono", monospace',
                 fontSize: '0.7rem',
                 textTransform: 'uppercase',
                 letterSpacing: '1px',
@@ -647,7 +633,6 @@ const PRDetailsCard: React.FC<PRDetailsCardProps> = ({
             <Typography
               sx={{
                 color: 'text.primary',
-                fontFamily: '"JetBrains Mono", monospace',
                 fontSize: '0.95rem',
                 fontWeight: 500,
               }}
@@ -680,7 +665,6 @@ const PRDetailsCard: React.FC<PRDetailsCardProps> = ({
                     theme.palette.common.white,
                     TEXT_OPACITY.tertiary,
                   ),
-                  fontFamily: '"JetBrains Mono", monospace',
                   fontSize: '0.7rem',
                   textTransform: 'uppercase',
                   letterSpacing: '1px',
@@ -692,7 +676,6 @@ const PRDetailsCard: React.FC<PRDetailsCardProps> = ({
               </Typography>
               <Typography
                 sx={{
-                  fontFamily: '"JetBrains Mono", monospace',
                   fontSize: '0.85rem',
                   wordBreak: 'break-all',
                 }}
@@ -722,7 +705,6 @@ const PRDetailsCard: React.FC<PRDetailsCardProps> = ({
                   theme.palette.common.white,
                   TEXT_OPACITY.secondary,
                 ),
-                fontFamily: '"JetBrains Mono", monospace',
                 fontSize: '0.85rem',
               }}
             >
@@ -735,7 +717,6 @@ const PRDetailsCard: React.FC<PRDetailsCardProps> = ({
               style={{
                 color: STATUS_COLORS.info,
                 textDecoration: 'none',
-                fontFamily: '"JetBrains Mono", monospace',
                 fontSize: '0.85rem',
                 fontWeight: 500,
               }}

--- a/src/components/prs/PRFilesChanged.tsx
+++ b/src/components/prs/PRFilesChanged.tsx
@@ -282,7 +282,6 @@ const FileTreeItem: React.FC<{
           }
           primaryTypographyProps={{
             sx: {
-              fontFamily: '"JetBrains Mono", monospace',
               fontSize: '12px',
               color: isSelected
                 ? 'text.primary'
@@ -394,7 +393,6 @@ const SplitDiffView: React.FC<{ patch: string; lineWrap: boolean }> = ({
         sx={{
           overflowX: 'auto',
           backgroundColor: 'background.paper',
-          fontFamily: '"JetBrains Mono", monospace',
           fontSize: '12px',
         }}
       >
@@ -703,7 +701,6 @@ const SplitDiffView: React.FC<{ patch: string; lineWrap: boolean }> = ({
         display: 'flex',
         width: '100%',
         backgroundColor: 'background.paper',
-        fontFamily: '"JetBrains Mono", monospace',
         fontSize: '12px',
       }}
     >
@@ -736,7 +733,6 @@ const UnifiedDiffView: React.FC<{ patch: string; lineWrap: boolean }> = ({
       sx={{
         overflowX: 'auto',
         backgroundColor: 'background.paper',
-        fontFamily: '"JetBrains Mono", monospace',
         fontSize: '12px',
       }}
     >
@@ -1179,7 +1175,6 @@ const PRFileDiffViewer: React.FC<{
           >
             <Typography
               sx={{
-                fontFamily: '"JetBrains Mono", monospace',
                 fontSize: '0.9rem',
                 fontWeight: 600,
               }}
@@ -1416,7 +1411,6 @@ const PRFilesChanged: React.FC<PRFilesChangedProps> = ({
           >
             <Typography
               sx={{
-                fontFamily: '"JetBrains Mono", monospace',
                 fontSize: '0.85rem',
                 fontWeight: 600,
                 color: 'text.primary',
@@ -1440,7 +1434,6 @@ const PRFilesChanged: React.FC<PRFilesChangedProps> = ({
                   sx={{
                     fontSize: '0.75rem',
                     color: 'status.open',
-                    fontFamily: '"JetBrains Mono", monospace',
                   }}
                 >
                   Wrap Lines
@@ -1462,7 +1455,6 @@ const PRFilesChanged: React.FC<PRFilesChangedProps> = ({
                   flex: 1,
                   color: 'status.open',
                   borderColor: 'border.light',
-                  fontFamily: '"JetBrains Mono", monospace',
                   fontSize: '0.75rem',
                   textTransform: 'none',
                   py: 0.5,

--- a/src/components/prs/PRHeader.tsx
+++ b/src/components/prs/PRHeader.tsx
@@ -68,7 +68,6 @@ const PRHeader: React.FC<PRHeaderProps> = ({
             variant="h5"
             sx={{
               color: 'text.primary',
-              fontFamily: '"JetBrains Mono", monospace',
               fontSize: '1.3rem',
               fontWeight: 500,
             }}
@@ -118,7 +117,6 @@ const PRHeader: React.FC<PRHeaderProps> = ({
             }
             sx={{
               color: 'text.tertiary',
-              fontFamily: '"JetBrains Mono", monospace',
               fontSize: '0.85rem',
               cursor: 'pointer',
               transition: 'color 0.2s',
@@ -157,7 +155,6 @@ const PRHeader: React.FC<PRHeaderProps> = ({
                       backgroundColor: 'surface.tooltip',
                       color: 'text.primary',
                       fontSize: '0.75rem',
-                      fontFamily: '"JetBrains Mono", monospace',
                       padding: '8px 12px',
                       borderRadius: '6px',
                       border: '1px solid',
@@ -175,7 +172,6 @@ const PRHeader: React.FC<PRHeaderProps> = ({
                 <Typography
                   sx={{
                     color: 'text.tertiary',
-                    fontFamily: '"JetBrains Mono", monospace',
                     fontSize: '0.75rem',
                     textTransform: 'uppercase',
                     letterSpacing: '0.5px',
@@ -193,7 +189,6 @@ const PRHeader: React.FC<PRHeaderProps> = ({
               </Tooltip>
               <Typography
                 sx={{
-                  fontFamily: '"JetBrains Mono", monospace',
                   fontSize: '2.25rem',
                   fontWeight: 700,
                   lineHeight: 1,
@@ -226,7 +221,6 @@ const PRHeader: React.FC<PRHeaderProps> = ({
                       backgroundColor: 'surface.tooltip',
                       color: 'text.primary',
                       fontSize: '0.75rem',
-                      fontFamily: '"JetBrains Mono", monospace',
                       padding: '8px 12px',
                       borderRadius: '6px',
                       border: '1px solid',
@@ -244,7 +238,6 @@ const PRHeader: React.FC<PRHeaderProps> = ({
                 <Typography
                   sx={{
                     color: 'text.tertiary',
-                    fontFamily: '"JetBrains Mono", monospace',
                     fontSize: '0.75rem',
                     textTransform: 'uppercase',
                     letterSpacing: '0.5px',
@@ -262,7 +255,6 @@ const PRHeader: React.FC<PRHeaderProps> = ({
               </Tooltip>
               <Typography
                 sx={{
-                  fontFamily: '"JetBrains Mono", monospace',
                   fontSize: '2.25rem',
                   fontWeight: 700,
                   lineHeight: 1,
@@ -282,7 +274,6 @@ const PRHeader: React.FC<PRHeaderProps> = ({
             <Typography
               sx={{
                 color: 'text.tertiary',
-                fontFamily: '"JetBrains Mono", monospace',
                 fontSize: '0.75rem',
                 textTransform: 'uppercase',
                 letterSpacing: '0.5px',
@@ -293,7 +284,6 @@ const PRHeader: React.FC<PRHeaderProps> = ({
             </Typography>
             <Typography
               sx={{
-                fontFamily: '"JetBrains Mono", monospace',
                 fontSize: '2.25rem',
                 fontWeight: 700,
                 lineHeight: 1,
@@ -315,7 +305,6 @@ const PRHeader: React.FC<PRHeaderProps> = ({
                         backgroundColor: 'surface.tooltip',
                         color: 'text.primary',
                         fontSize: '0.75rem',
-                        fontFamily: '"JetBrains Mono", monospace',
                         padding: '8px 12px',
                         borderRadius: '6px',
                         border: '1px solid',
@@ -332,7 +321,6 @@ const PRHeader: React.FC<PRHeaderProps> = ({
                 >
                   <Typography
                     sx={{
-                      fontFamily: '"JetBrains Mono", monospace',
                       fontSize: '0.95rem',
                       color: 'status.success',
                       opacity: 0.8,

--- a/src/components/repositories/ContributingViewer.tsx
+++ b/src/components/repositories/ContributingViewer.tsx
@@ -146,7 +146,6 @@ const ContributingViewer: React.FC<ContributingViewerProps> = ({
           padding: '0.2em 0.4em',
           borderRadius: '6px',
           fontSize: '85%',
-          fontFamily: '"JetBrains Mono", monospace',
         },
         '& pre': {
           backgroundColor: '#161b22',

--- a/src/components/repositories/LanguageWeightsTable.tsx
+++ b/src/components/repositories/LanguageWeightsTable.tsx
@@ -133,13 +133,11 @@ const LanguageWeightsTable: React.FC = () => {
         top: 20,
         textStyle: {
           color: '#ffffff',
-          fontFamily: 'JetBrains Mono',
           fontSize: 18,
           fontWeight: 600,
         },
         subtextStyle: {
           color: 'rgba(255, 255, 255, 0.5)',
-          fontFamily: 'JetBrains Mono',
           fontSize: 12,
         },
       },
@@ -163,7 +161,6 @@ const LanguageWeightsTable: React.FC = () => {
         data: xAxisData,
         axisLabel: {
           color: textColor,
-          fontFamily: 'JetBrains Mono',
           rotate: 45,
           interval: 0,
         },
@@ -255,7 +252,6 @@ const LanguageWeightsTable: React.FC = () => {
                 variant="body2"
                 sx={{
                   color: 'rgba(255, 255, 255, 0.7)',
-                  fontFamily: '"JetBrains Mono", monospace',
                   fontSize: '0.8rem',
                 }}
               >
@@ -269,7 +265,6 @@ const LanguageWeightsTable: React.FC = () => {
                 }}
                 sx={{
                   color: '#ffffff',
-                  fontFamily: '"JetBrains Mono", monospace',
                   backgroundColor: 'rgba(0, 0, 0, 0.4)',
                   fontSize: '0.8rem',
                   height: '36px',
@@ -310,7 +305,6 @@ const LanguageWeightsTable: React.FC = () => {
               width: '200px',
               '& .MuiOutlinedInput-root': {
                 color: '#ffffff',
-                fontFamily: '"JetBrains Mono", monospace',
                 backgroundColor: 'rgba(0, 0, 0, 0.4)',
                 fontSize: '0.8rem',
                 height: '36px',
@@ -502,9 +496,7 @@ const LanguageWeightsTable: React.FC = () => {
         showFirstButton
         showLastButton
         sx={{
-          '.MuiTablePagination-displayedRows': {
-            fontFamily: '"JetBrains Mono", monospace',
-          },
+          '.MuiTablePagination-displayedRows': {},
         }}
       />
 

--- a/src/components/repositories/ReadmeViewer.tsx
+++ b/src/components/repositories/ReadmeViewer.tsx
@@ -142,7 +142,6 @@ const ReadmeViewer: React.FC<ReadmeViewerProps> = ({ repositoryFullName }) => {
           padding: '0.2em 0.4em',
           borderRadius: '6px',
           fontSize: '85%',
-          fontFamily: '"JetBrains Mono", monospace',
         },
         '& pre': {
           backgroundColor: '#161b22',

--- a/src/components/repositories/RepositoryCheckTab.tsx
+++ b/src/components/repositories/RepositoryCheckTab.tsx
@@ -265,7 +265,6 @@ const RepositoryCheckTab: React.FC<RepositoryCheckTabProps> = ({
                       color: 'text.primary',
                       fontWeight: 700,
                       fontSize: '32px',
-                      fontFamily: '"JetBrains Mono", monospace',
                     }}
                   >
                     {score}%
@@ -327,7 +326,6 @@ const RepositoryCheckTab: React.FC<RepositoryCheckTabProps> = ({
                     sx={{
                       color: 'text.primary',
                       fontSize: '13px',
-                      fontFamily: '"JetBrains Mono", monospace',
                     }}
                   >
                     {new Date(repoData.pushed_at).toLocaleDateString()}
@@ -345,7 +343,6 @@ const RepositoryCheckTab: React.FC<RepositoryCheckTabProps> = ({
                     sx={{
                       color: 'text.primary',
                       fontSize: '13px',
-                      fontFamily: '"JetBrains Mono", monospace',
                     }}
                   >
                     {new Date(repoData.created_at).toLocaleDateString()}
@@ -443,7 +440,6 @@ const RepositoryCheckTab: React.FC<RepositoryCheckTabProps> = ({
                       variant="h4"
                       sx={{
                         color: 'text.primary',
-                        fontFamily: '"JetBrains Mono", monospace',
                         fontSize: '24px',
                         mb: 0.5,
                       }}
@@ -479,7 +475,6 @@ const RepositoryCheckTab: React.FC<RepositoryCheckTabProps> = ({
                       variant="h4"
                       sx={{
                         color: 'text.primary',
-                        fontFamily: '"JetBrains Mono", monospace',
                         fontSize: '24px',
                         mb: 0.5,
                       }}
@@ -539,7 +534,6 @@ const RepositoryCheckTab: React.FC<RepositoryCheckTabProps> = ({
                           variant="h4"
                           sx={{
                             color: 'text.primary',
-                            fontFamily: '"JetBrains Mono", monospace',
                             fontSize: '24px',
                             mb: 0.5,
                           }}
@@ -622,7 +616,6 @@ const RepositoryCheckTab: React.FC<RepositoryCheckTabProps> = ({
                           variant="h4"
                           sx={{
                             color: 'text.primary',
-                            fontFamily: '"JetBrains Mono", monospace',
                             fontSize: '24px',
                             mb: 0.5,
                           }}

--- a/src/components/repositories/RepositoryCodeBrowser.tsx
+++ b/src/components/repositories/RepositoryCodeBrowser.tsx
@@ -406,7 +406,6 @@ const RepositoryCodeBrowser: React.FC<RepositoryCodeBrowserProps> = ({
                   sx={{
                     fontSize: '13px',
                     color: STATUS_COLORS.open,
-                    fontFamily: '"JetBrains Mono", monospace',
                   }}
                 >
                   {currentCommit.sha}

--- a/src/components/repositories/RepositoryContributorsTable.tsx
+++ b/src/components/repositories/RepositoryContributorsTable.tsx
@@ -121,7 +121,6 @@ const RepositoryContributorsTable: React.FC<
           variant="subtitle2"
           sx={{
             color: 'text.secondary',
-            fontFamily: '"JetBrains Mono", monospace',
           }}
         >
           Top Miner Contributors{' '}
@@ -208,7 +207,6 @@ const RepositoryContributorsTable: React.FC<
               {/* Rank */}
               <Box
                 sx={{
-                  fontFamily: '"JetBrains Mono", monospace',
                   fontSize: '12px',
                   color: index < 3 ? 'text.primary' : STATUS_COLORS.open,
                   fontWeight: index < 3 ? 600 : 400,
@@ -290,7 +288,6 @@ const RepositoryContributorsTable: React.FC<
                   textAlign: 'right',
                   fontSize: '12px',
                   color: 'text.primary',
-                  fontFamily: '"JetBrains Mono", monospace',
                   fontVariantNumeric: 'tabular-nums',
                   minWidth: 0,
                 }}
@@ -304,7 +301,6 @@ const RepositoryContributorsTable: React.FC<
                   textAlign: 'right',
                   fontSize: '12px',
                   color: 'text.primary',
-                  fontFamily: '"JetBrains Mono", monospace',
                   fontVariantNumeric: 'tabular-nums',
                   minWidth: 0,
                 }}

--- a/src/components/repositories/RepositoryIssuesTable.tsx
+++ b/src/components/repositories/RepositoryIssuesTable.tsx
@@ -89,7 +89,6 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
             variant="h6"
             sx={{
               color: 'text.primary',
-              fontFamily: '"JetBrains Mono", monospace',
             }}
           >
             Issues
@@ -192,7 +191,6 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
                   variant="h6"
                   sx={{
                     color: 'text.primary',
-                    fontFamily: '"JetBrains Mono", monospace',
                     fontSize: '1.1rem',
                     fontWeight: 500,
                   }}
@@ -247,7 +245,6 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
                             border: `1px solid ${statusColors.border}`,
                             fontSize: '0.65rem',
                             fontWeight: 700,
-                            fontFamily: '"JetBrains Mono", monospace',
                             height: '22px',
                             '& .MuiChip-label': { px: 1 },
                           }}
@@ -255,7 +252,6 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
                         <Typography
                           sx={{
                             color: STATUS_COLORS.open,
-                            fontFamily: '"JetBrains Mono", monospace',
                             fontSize: '0.8rem',
                             whiteSpace: 'nowrap',
                           }}
@@ -265,7 +261,6 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
                         <Typography
                           sx={{
                             color: 'text.primary',
-                            fontFamily: '"JetBrains Mono", monospace',
                             fontSize: '0.85rem',
                             overflow: 'hidden',
                             textOverflow: 'ellipsis',
@@ -292,7 +287,6 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
                         <Typography
                           sx={{
                             color: getBountyAmountColor(bounty.status),
-                            fontFamily: '"JetBrains Mono", monospace',
                             fontSize: '0.85rem',
                             fontWeight: 600,
                           }}
@@ -345,7 +339,6 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
             variant="h6"
             sx={{
               color: 'text.primary',
-              fontFamily: '"JetBrains Mono", monospace',
               fontSize: '1.1rem',
               fontWeight: 500,
             }}
@@ -386,7 +379,6 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
             <Typography
               sx={{
                 color: alpha(theme.palette.common.white, TEXT_OPACITY.tertiary),
-                fontFamily: '"JetBrains Mono", monospace',
                 fontSize: '0.9rem',
               }}
             >

--- a/src/components/repositories/RepositoryMaintainers.tsx
+++ b/src/components/repositories/RepositoryMaintainers.tsx
@@ -27,7 +27,6 @@ const RepositoryMaintainers: React.FC<RepositoryMaintainersProps> = ({
           variant="subtitle2"
           sx={{
             color: 'text.secondary',
-            fontFamily: '"JetBrains Mono", monospace',
             mb: 2,
           }}
         >
@@ -52,7 +51,6 @@ const RepositoryMaintainers: React.FC<RepositoryMaintainersProps> = ({
         variant="subtitle2"
         sx={{
           color: 'text.secondary',
-          fontFamily: '"JetBrains Mono", monospace',
           mb: 2,
         }}
       >

--- a/src/components/repositories/RepositoryPRsTable.tsx
+++ b/src/components/repositories/RepositoryPRsTable.tsx
@@ -154,7 +154,6 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
             variant="h6"
             sx={{
               color: 'text.primary',
-              fontFamily: '"JetBrains Mono", monospace',
             }}
           >
             Pull Requests
@@ -223,7 +222,6 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
           variant="h6"
           sx={{
             color: 'text.primary',
-            fontFamily: '"JetBrains Mono", monospace',
             fontSize: '1.1rem',
             fontWeight: 500,
           }}
@@ -268,7 +266,6 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
           <Typography
             sx={{
               color: alpha(theme.palette.common.white, TEXT_OPACITY.tertiary),
-              fontFamily: '"JetBrains Mono", monospace',
               fontSize: '0.9rem',
             }}
           >
@@ -446,7 +443,6 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
                   <TableCell align="right" sx={bodyCellStyle}>
                     <Typography
                       sx={{
-                        fontFamily: '"JetBrains Mono", monospace',
                         fontSize: '0.75rem',
                         fontWeight: 600,
                       }}

--- a/src/components/repositories/RepositoryStats.tsx
+++ b/src/components/repositories/RepositoryStats.tsx
@@ -124,7 +124,6 @@ const RepositoryStats: React.FC<RepositoryStatsProps> = ({
             variant="body2"
             sx={{
               color: 'text.primary',
-              fontFamily: '"JetBrains Mono", monospace',
               fontSize: '13px',
             }}
           >
@@ -152,7 +151,6 @@ const RepositoryStats: React.FC<RepositoryStatsProps> = ({
             variant="body2"
             sx={{
               color: 'text.primary',
-              fontFamily: '"JetBrains Mono", monospace',
               fontSize: '13px',
             }}
           >
@@ -180,7 +178,6 @@ const RepositoryStats: React.FC<RepositoryStatsProps> = ({
             variant="body2"
             sx={{
               color: 'text.primary',
-              fontFamily: '"JetBrains Mono", monospace',
               fontSize: '13px',
             }}
           >
@@ -206,7 +203,6 @@ const RepositoryStats: React.FC<RepositoryStatsProps> = ({
             variant="body2"
             sx={{
               color: 'text.primary',
-              fontFamily: '"JetBrains Mono", monospace',
               fontSize: '13px',
             }}
           >
@@ -237,7 +233,6 @@ const RepositoryStats: React.FC<RepositoryStatsProps> = ({
                 variant="body2"
                 sx={{
                   color: RANK_COLORS.first,
-                  fontFamily: '"JetBrains Mono", monospace',
                   fontSize: '13px',
                   fontWeight: 600,
                 }}
@@ -265,7 +260,6 @@ const RepositoryStats: React.FC<RepositoryStatsProps> = ({
                   variant="body2"
                   sx={{
                     color: 'text.primary',
-                    fontFamily: '"JetBrains Mono", monospace',
                     fontSize: '13px',
                   }}
                 >
@@ -293,7 +287,6 @@ const RepositoryStats: React.FC<RepositoryStatsProps> = ({
                   variant="body2"
                   sx={{
                     color: STATUS_COLORS.merged,
-                    fontFamily: '"JetBrains Mono", monospace',
                     fontSize: '13px',
                     fontWeight: 500,
                   }}
@@ -329,7 +322,6 @@ const RepositoryStats: React.FC<RepositoryStatsProps> = ({
                     label={branch}
                     size="small"
                     sx={{
-                      fontFamily: '"JetBrains Mono", monospace',
                       fontSize: '12px',
                       height: '24px',
                       bgcolor: 'surface.light',

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -43,7 +43,6 @@ export const AboutContent: React.FC = () => {
             fontWeight="bold"
             sx={{
               mb: 3,
-              fontFamily: '"JetBrains Mono", monospace',
               color: 'text.primary',
             }}
           >
@@ -275,7 +274,6 @@ export const AboutContent: React.FC = () => {
               mb: 2.5,
               fontSize: { xs: '1.2rem', sm: '1.3rem' },
               color: 'text.primary',
-              fontFamily: '"JetBrains Mono", monospace',
               letterSpacing: '0.02em',
             }}
           >

--- a/src/pages/DiscoveriesPage.tsx
+++ b/src/pages/DiscoveriesPage.tsx
@@ -101,7 +101,6 @@ const DiscoveriesPage: React.FC = () => {
         >
           <Typography
             sx={{
-              fontFamily: '"JetBrains Mono", monospace',
               fontSize: '0.8rem',
               color: (t) => alpha(t.palette.text.primary, 0.5),
               lineHeight: 1.6,

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -48,7 +48,6 @@ const HomePage: React.FC = () => {
             color="text.primary"
             fontWeight="bold"
             sx={{
-              fontFamily: '"JetBrains Mono", monospace',
               fontSize: { xs: '2rem', sm: '3rem', md: '4rem' },
               textAlign: 'center',
             }}
@@ -106,7 +105,6 @@ const HomePage: React.FC = () => {
                   fontWeight="600"
                   sx={{
                     color: (theme) => theme.palette.text.primary,
-                    fontFamily: '"JetBrains Mono", monospace',
                     fontSize: { xs: '2rem', sm: '2.75rem', md: '3.5rem' },
                     letterSpacing: '-0.02em',
                   }}

--- a/src/pages/IssuesPage.tsx
+++ b/src/pages/IssuesPage.tsx
@@ -69,7 +69,6 @@ const IssuesPage: React.FC = () => {
               onChange={handleTabChange}
               sx={(theme) => ({
                 '& .MuiTab-root': {
-                  fontFamily: '"JetBrains Mono", monospace',
                   fontSize: '0.85rem',
                   fontWeight: 600,
                   textTransform: 'none',
@@ -93,7 +92,6 @@ const IssuesPage: React.FC = () => {
             <Typography
               sx={{
                 fontSize: '0.72rem',
-                fontFamily: '"JetBrains Mono", monospace',
                 color: (t) => alpha(t.palette.text.primary, 0.35),
                 pr: 1,
               }}

--- a/src/pages/MinerDetailsPage.tsx
+++ b/src/pages/MinerDetailsPage.tsx
@@ -28,7 +28,6 @@ type MinerDetailsTab = (typeof PR_TABS)[number] | (typeof ISSUE_TABS)[number];
 const tabSx = {
   '& .MuiTab-root': {
     color: 'text.secondary',
-    fontFamily: '"JetBrains Mono", monospace',
     textTransform: 'none' as const,
     fontSize: '0.83rem',
     fontWeight: 500,
@@ -147,7 +146,6 @@ const MinerDetailsPage: React.FC = () => {
                 >
                   <Typography
                     sx={{
-                      fontFamily: '"JetBrains Mono", monospace',
                       fontSize: '0.8rem',
                       fontWeight: 600,
                     }}

--- a/src/pages/RepositoryDetailsPage.tsx
+++ b/src/pages/RepositoryDetailsPage.tsx
@@ -203,7 +203,6 @@ const RepositoryDetailsPage: React.FC = () => {
                   <Typography
                     variant="h4"
                     sx={(theme) => ({
-                      fontFamily: '"JetBrains Mono", monospace',
                       fontWeight: 600,
                       color: theme.palette.text.primary,
                     })}
@@ -333,7 +332,6 @@ const RepositoryDetailsPage: React.FC = () => {
                               px: 0.8,
                               py: 0.1,
                               borderRadius: '10px',
-                              fontFamily: '"JetBrains Mono", monospace',
                               lineHeight: 1.4,
                             }}
                           >

--- a/src/pages/TopMinersPage.tsx
+++ b/src/pages/TopMinersPage.tsx
@@ -69,7 +69,6 @@ const TopMinersPage: React.FC = () => {
         >
           <Typography
             sx={{
-              fontFamily: '"JetBrains Mono", monospace',
               fontSize: '0.8rem',
               color: (t) => alpha(t.palette.text.primary, 0.5),
               lineHeight: 1.6,

--- a/src/pages/WatchlistPage.tsx
+++ b/src/pages/WatchlistPage.tsx
@@ -65,7 +65,6 @@ const WatchlistPage: React.FC = () => {
         >
           <Typography
             sx={{
-              fontFamily: '"JetBrains Mono", monospace',
               fontSize: '0.8rem',
               color: (t) => alpha(t.palette.text.primary, 0.5),
               lineHeight: 1.6,
@@ -80,7 +79,6 @@ const WatchlistPage: React.FC = () => {
               size="small"
               onClick={() => setConfirmOpen(true)}
               sx={{
-                fontFamily: '"JetBrains Mono", monospace',
                 fontSize: '0.75rem',
                 textTransform: 'none',
                 color: 'text.secondary',
@@ -105,7 +103,6 @@ const WatchlistPage: React.FC = () => {
           >
             <Typography
               sx={{
-                fontFamily: '"JetBrains Mono", monospace',
                 fontSize: '0.95rem',
               }}
             >
@@ -113,7 +110,6 @@ const WatchlistPage: React.FC = () => {
             </Typography>
             <Typography
               sx={{
-                fontFamily: '"JetBrains Mono", monospace',
                 fontSize: '0.8rem',
                 maxWidth: 480,
                 color: (t) => alpha(t.palette.text.primary, 0.5),
@@ -147,9 +143,7 @@ const WatchlistPage: React.FC = () => {
       </Box>
 
       <Dialog open={confirmOpen} onClose={() => setConfirmOpen(false)}>
-        <DialogTitle sx={{ fontFamily: '"JetBrains Mono", monospace' }}>
-          Clear all {count} pinned miners?
-        </DialogTitle>
+        <DialogTitle>Clear all {count} pinned miners?</DialogTitle>
         <DialogActions>
           <Button
             onClick={() => setConfirmOpen(false)}

--- a/src/pages/dashboard/views/ContributionTrends.tsx
+++ b/src/pages/dashboard/views/ContributionTrends.tsx
@@ -90,11 +90,11 @@ const ContributionTrends: React.FC<ContributionTrendsProps> = ({
     const labelInterval = range === '35d' ? 6 : range === '7d' ? 0 : 'auto';
     const tooltipPrimaryColor = theme.palette.text.primary;
     const tooltipSecondaryColor = alpha(theme.palette.text.primary, 0.66);
-    const tooltipFontFamily = theme.typography.mono.fontFamily;
+    const tooltipFontFamily = theme.typography.fontFamily;
     const chartLabelColor = alpha(theme.palette.text.primary, 0.64);
     const chartAxisLineColor = alpha(theme.palette.text.primary, 0.08);
     const chartSplitLineColor = alpha(theme.palette.text.primary, 0.07);
-    const chartFontFamily = theme.typography.mono.fontFamily;
+    const chartFontFamily = theme.typography.fontFamily;
 
     return {
       backgroundColor: 'transparent',
@@ -117,7 +117,7 @@ const ContributionTrends: React.FC<ContributionTrendsProps> = ({
         padding: [10, 12],
         textStyle: {
           color: theme.palette.text.primary,
-          fontFamily: theme.typography.mono.fontFamily,
+          fontFamily: theme.typography.fontFamily,
           fontSize: 11,
         },
         formatter: (
@@ -236,7 +236,6 @@ const ContributionTrends: React.FC<ContributionTrendsProps> = ({
           <Typography
             sx={{
               color: theme.palette.text.primary,
-              fontFamily: theme.typography.mono.fontFamily,
               fontSize: { xs: '1.02rem', sm: '1.1rem' },
               fontWeight: 700,
             }}
@@ -265,7 +264,6 @@ const ContributionTrends: React.FC<ContributionTrendsProps> = ({
               py: 0.24,
               minWidth: 38,
               color: alpha(theme.palette.text.primary, 0.58),
-              fontFamily: theme.typography.mono.fontFamily,
               fontSize: '0.66rem',
               fontWeight: 700,
               letterSpacing: '0.05em',
@@ -370,7 +368,6 @@ const ContributionTrends: React.FC<ContributionTrendsProps> = ({
                       color: isHidden
                         ? alpha(theme.palette.text.primary, 0.46)
                         : alpha(theme.palette.text.primary, 0.72),
-                      fontFamily: theme.typography.mono.fontFamily,
                       fontSize: '0.72rem',
                       lineHeight: 1,
                     }}

--- a/src/pages/dashboard/views/DashboardOverview.tsx
+++ b/src/pages/dashboard/views/DashboardOverview.tsx
@@ -44,7 +44,7 @@ const buildStatusChartOption = (
   segments: DashboardOverviewSection['chartSegments'],
 ): Record<string, unknown> => {
   const totalValue = segments.reduce((sum, segment) => sum + segment.value, 0);
-  const monoFontFamily = theme.typography.mono.fontFamily;
+  const monoFontFamily = theme.typography.fontFamily;
 
   return {
     backgroundColor: 'transparent',
@@ -130,7 +130,7 @@ const DashboardOverview: React.FC<DashboardOverviewProps> = ({
   kpis,
 }) => {
   const theme = useTheme();
-  const monoFontFamily = theme.typography.mono.fontFamily;
+  const monoFontFamily = theme.typography.fontFamily;
   const rangeDescription =
     range === 'all'
       ? 'All-time totals'

--- a/src/pages/dashboard/views/DashboardTopContributors.tsx
+++ b/src/pages/dashboard/views/DashboardTopContributors.tsx
@@ -30,7 +30,7 @@ const DashboardTopContributors: React.FC<DashboardTopContributorsProps> = ({
 }) => {
   const theme = useTheme();
   const navigate = useNavigate();
-  const monoFontFamily = theme.typography.mono.fontFamily;
+  const monoFontFamily = theme.typography.fontFamily;
 
   const openContributor = (githubId: string) => {
     navigate(`/miners/details?githubId=${encodeURIComponent(githubId)}`, {

--- a/src/pages/dashboard/views/LiveCommitLog.tsx
+++ b/src/pages/dashboard/views/LiveCommitLog.tsx
@@ -206,7 +206,6 @@ const CommitLogItem: React.FC<{
               variant="caption"
               sx={{
                 color: 'text.secondary',
-                fontFamily: '"JetBrains Mono", monospace',
               }}
             >
               {entry.repository}
@@ -216,7 +215,6 @@ const CommitLogItem: React.FC<{
             variant="caption"
             sx={{
               color: 'text.secondary',
-              fontFamily: '"JetBrains Mono", monospace',
             }}
           >
             #{entry.pullRequestNumber}
@@ -295,7 +293,6 @@ const CommitLogItem: React.FC<{
               sx={{
                 color: getScoreColor(entry.score),
                 fontWeight: 600,
-                fontFamily: '"JetBrains Mono", monospace',
               }}
             >
               SCORE: {parseFloat(entry.score).toFixed(2)}
@@ -436,7 +433,6 @@ const LiveCommitLog: React.FC = () => {
               variant="h6"
               sx={{
                 fontSize: isMobile ? '0.9rem' : isTablet ? '0.95rem' : '1rem',
-                fontFamily: '"JetBrains Mono", monospace',
                 fontWeight: 500,
               }}
             >
@@ -499,7 +495,6 @@ const LiveCommitLog: React.FC = () => {
                       ? t.palette.text.primary
                       : alpha(option.color, 0.82),
                     cursor: 'pointer',
-                    fontFamily: '"JetBrains Mono", monospace',
                     fontSize: isMobile ? '0.68rem' : '0.72rem',
                     fontWeight: selected ? 600 : 500,
                     lineHeight: 1,

--- a/src/pages/search/PullRequestsTab.tsx
+++ b/src/pages/search/PullRequestsTab.tsx
@@ -44,7 +44,6 @@ const prColumns: SearchResultsTableColumn<CommitLog>[] = [
         <SearchTruncatedText
           tooltip={prTitle}
           sx={(theme) => ({
-            fontFamily: theme.typography.mono.fontFamily,
             color: theme.palette.text.primary,
           })}
           text={prTitle}
@@ -93,7 +92,6 @@ const prColumns: SearchResultsTableColumn<CommitLog>[] = [
           component="span"
           sx={(theme) => ({
             color: theme.palette.diff.additions,
-            fontFamily: theme.typography.mono.fontFamily,
           })}
         >
           +{pr.additions || 0}
@@ -102,7 +100,6 @@ const prColumns: SearchResultsTableColumn<CommitLog>[] = [
           component="span"
           sx={(theme) => ({
             color: theme.palette.diff.deletions,
-            fontFamily: theme.typography.mono.fontFamily,
           })}
         >
           -{pr.deletions || 0}

--- a/src/pages/search/RepositoryTab.tsx
+++ b/src/pages/search/RepositoryTab.tsx
@@ -53,8 +53,7 @@ const repositoryColumns: SearchResultsTableColumn<RepoSearchData>[] = [
             color:
               (repo.rank <= 3 ? getRankColors(repo.rank).color : null) ||
               theme.palette.text.secondary,
-            fontFamily:
-              theme.typography.mono.fontFamily || theme.typography.fontFamily,
+
             fontSize: '0.65rem',
             fontWeight: 600,
             lineHeight: 1,

--- a/src/pages/search/SearchPage.tsx
+++ b/src/pages/search/SearchPage.tsx
@@ -248,7 +248,6 @@ const SearchPage: React.FC = () => {
                 allowScrollButtonsMobile
                 sx={(theme) => ({
                   '& .MuiTab-root': {
-                    fontFamily: theme.typography.mono.fontFamily,
                     fontSize: '0.85rem',
                     fontWeight: 600,
                     textTransform: 'none',

--- a/src/pages/search/SearchResultsTable.tsx
+++ b/src/pages/search/SearchResultsTable.tsx
@@ -54,7 +54,6 @@ const searchHeaderCellSx: SxProps<Theme> = (theme) => ({
 });
 
 const searchBodyCellSx: SxProps<Theme> = (theme) => ({
-  fontFamily: theme.typography.mono.fontFamily,
   fontSize: '0.85rem',
   color: theme.palette.text.primary,
   borderBottom: `1px solid ${theme.palette.border.subtle}`,
@@ -97,9 +96,7 @@ const searchTableSx = {
 const searchTablePaginationSx = (theme: Theme) => ({
   borderTop: `1px solid ${theme.palette.border.light}`,
   color: theme.palette.text.secondary,
-  '.MuiTablePagination-displayedRows': {
-    fontFamily: theme.typography.mono.fontFamily,
-  },
+  '.MuiTablePagination-displayedRows': {},
   '.MuiTablePagination-toolbar': {
     minHeight: 48,
   },

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -355,55 +355,25 @@ const theme = createTheme({
     },
   },
   typography: {
-    fontFamily:
-      '"Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
-    h1: {
-      fontFamily: '"Inter", "Helvetica Neue", sans-serif',
-    },
-    h2: {
-      fontFamily: '"Inter", "Helvetica Neue", sans-serif',
-    },
-    h3: {
-      fontFamily: '"Inter", "Helvetica Neue", sans-serif',
-    },
-    h4: {
-      fontFamily: '"Inter", "Helvetica Neue", sans-serif',
-    },
-    h5: {
-      fontFamily: '"Inter", "Helvetica Neue", sans-serif',
-    },
-    h6: {
-      fontFamily: '"Inter", "Helvetica Neue", sans-serif',
-    },
-    body1: {
-      fontFamily: '"Inter", -apple-system, BlinkMacSystemFont, sans-serif',
-    },
-    body2: {
-      fontFamily: '"Inter", -apple-system, BlinkMacSystemFont, sans-serif',
-    },
-    button: {
-      fontFamily: '"Inter", -apple-system, BlinkMacSystemFont, sans-serif',
-    },
+    // JetBrains Mono is the app-wide default — every component inherits it
+    // without needing an explicit fontFamily prop.
+    fontFamily: '"JetBrains Mono", monospace',
     dataValue: {
-      fontFamily: '"JetBrains Mono", "Courier New", monospace',
       fontWeight: 500,
       letterSpacing: '0.02em',
     },
     dataLabel: {
-      fontFamily: '"JetBrains Mono", "Courier New", monospace',
       fontSize: '0.75rem',
       fontWeight: 400,
       letterSpacing: '0.05em',
       textTransform: 'uppercase',
     },
-    // Base monospace style
+    // Base monospace weight
     mono: {
-      fontFamily: '"JetBrains Mono", monospace',
       fontWeight: 500,
     },
-    // Small monospace for labels
+    // Small uppercase label style
     monoSmall: {
-      fontFamily: '"JetBrains Mono", monospace',
       fontSize: '0.7rem',
       fontWeight: 600,
       letterSpacing: '0.5px',
@@ -411,14 +381,12 @@ const theme = createTheme({
     },
     // Section titles
     sectionTitle: {
-      fontFamily: '"JetBrains Mono", monospace',
       fontSize: '1rem',
       fontWeight: 600,
       color: '#fff',
     },
     // Table headers
     tableHeader: {
-      fontFamily: '"JetBrains Mono", monospace',
       fontSize: '0.7rem',
       fontWeight: 600,
       letterSpacing: '0.5px',
@@ -427,14 +395,12 @@ const theme = createTheme({
     },
     // Large stat values
     statValue: {
-      fontFamily: '"JetBrains Mono", monospace',
       fontSize: '1.1rem',
       fontWeight: 600,
       color: '#fff',
     },
     // Stat labels
     statLabel: {
-      fontFamily: '"JetBrains Mono", monospace',
       fontSize: '0.7rem',
       fontWeight: 500,
       textTransform: 'uppercase',
@@ -442,13 +408,11 @@ const theme = createTheme({
     },
     // Tooltip heading — multiplier name + value
     tooltipLabel: {
-      fontFamily: '"JetBrains Mono", monospace',
       fontSize: '0.72rem',
       fontWeight: 600,
     },
     // Tooltip supporting description
     tooltipDesc: {
-      fontFamily: '"JetBrains Mono", monospace',
       fontSize: '0.72rem',
       fontWeight: 400,
       opacity: 0.7,
@@ -459,8 +423,7 @@ const theme = createTheme({
     MuiCssBaseline: {
       styleOverrides: {
         body: {
-          fontFamily:
-            '"Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+          fontFamily: '"JetBrains Mono", monospace',
         },
       },
     },


### PR DESCRIPTION
`"'JetBrains Mono"', monospace"` was hardcoded in 54 files. This adds `MONO_FONT` to `theme.ts` alongside other shared constants (`STATUS_COLORS`, `scrollbarSx`, etc.), updates `leaderboard/types.ts` to derive `FONTS.mono` from it, and replaces all occurrences. No behavior change.