### PR TITLE
refactor: use shared TablePagination in MinerPRsTabl

### DIFF
--- a/src/components/miners/MinerPRsTable.tsx
+++ b/src/components/miners/MinerPRsTable.tsx
@@ -20,11 +20,7 @@ import {
   useTheme,
   type Theme,
 } from '@mui/material';
-import {
-  Search as SearchIcon,
-  NavigateBefore as PrevIcon,
-  NavigateNext as NextIcon,
-} from '@mui/icons-material';
+import { Search as SearchIcon } from '@mui/icons-material';
 import { useMinerPRs, type CommitLog } from '../../api';
 import {
   getPrStatusCounts,
@@ -34,6 +30,7 @@ import {
 } from '../../utils';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import ExplorerFilterButton from './ExplorerFilterButton';
+import TablePagination from './TablePagination';
 import { type MinerStatusFilter } from '../../utils/ExplorerUtils';
 
 type PrSortField = 'number' | 'repository' | 'score' | 'lines' | 'date';
@@ -699,57 +696,11 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
             </Table>
           </TableContainer>
 
-          {/* Pagination */}
-          {totalPages > 1 && (
-            <Box
-              sx={{
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                gap: 2,
-                py: 1.5,
-                borderTop: '1px solid',
-                borderColor: 'border.subtle',
-              }}
-            >
-              <Box
-                onClick={() => setPage((p) => Math.max(0, p - 1))}
-                sx={{
-                  cursor: page > 0 ? 'pointer' : 'default',
-                  opacity: page > 0 ? 1 : 0.3,
-                  display: 'flex',
-                  alignItems: 'center',
-                  color: (t) => alpha(t.palette.text.primary, 0.6),
-                  '&:hover': page > 0 ? { color: 'text.primary' } : {},
-                }}
-              >
-                <PrevIcon sx={{ fontSize: '1.2rem' }} />
-              </Box>
-              <Typography
-                sx={{
-                  fontFamily: '"JetBrains Mono", monospace',
-                  fontSize: '0.75rem',
-                  color: (t) => alpha(t.palette.text.primary, 0.5),
-                }}
-              >
-                {page + 1} / {totalPages}
-              </Typography>
-              <Box
-                onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
-                sx={{
-                  cursor: page < totalPages - 1 ? 'pointer' : 'default',
-                  opacity: page < totalPages - 1 ? 1 : 0.3,
-                  display: 'flex',
-                  alignItems: 'center',
-                  color: (t) => alpha(t.palette.text.primary, 0.6),
-                  '&:hover':
-                    page < totalPages - 1 ? { color: 'text.primary' } : {},
-                }}
-              >
-                <NextIcon sx={{ fontSize: '1.2rem' }} />
-              </Box>
-            </Box>
-          )}
+          <TablePagination
+            page={page}
+            totalPages={totalPages}
+            onPageChange={setPage}
+          />
         </>
       )}
     </Card>


### PR DESCRIPTION
## Summary

`MinerPRsTable` had 50 lines of hand-written prev/next pagination that was identical to the existing `TablePagination` component in the same directory. This PR replaces the inline block with the shared component and removes the now-unused icon imports.

No visual or behavioral change — the rendered output is the same.

## Related Issues

fixes: #343 

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes