### PR TITLE
Refactor: extract AbortController logic into useAbortableFetch hook

### DIFF
--- a/src/components/repositories/CodeViewer.tsx
+++ b/src/components/repositories/CodeViewer.tsx
@@ -1,10 +1,11 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { scrollbarSx } from '../../theme';
 import { Box, Typography, CircularProgress, Alert } from '@mui/material';
 import axios from 'axios';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { vscDarkPlus } from 'react-syntax-highlighter/dist/esm/styles/prism';
 import ReactMarkdown from 'react-markdown';
+import useAbortableFetch from '../../hooks/useAbortableFetch';
 
 interface CodeViewerProps {
   repositoryFullName: string;
@@ -17,10 +18,6 @@ const CodeViewer: React.FC<CodeViewerProps> = ({
   filePath,
   defaultBranch = 'main',
 }) => {
-  const [content, setContent] = useState<string | null>(null);
-  const [loading, setLoading] = useState<boolean>(false);
-  const [error, setError] = useState<string | null>(null);
-
   const extension = filePath?.split('.').pop()?.toLowerCase();
   const isImage =
     extension &&
@@ -29,41 +26,21 @@ const CodeViewer: React.FC<CodeViewerProps> = ({
     ? `https://cdn.jsdelivr.net/gh/${repositoryFullName}@${defaultBranch}/${filePath}`
     : '';
 
-  useEffect(() => {
-    const controller = new AbortController();
-
-    const fetchContent = async () => {
-      if (!filePath || isImage) {
-        // Don't fetch text content for images or if no file selected
-        setContent(null);
-        setLoading(false);
-        return;
-      }
-
-      setLoading(true);
-      setError(null);
-      try {
-        // Use raw.githubusercontent.com
-        const response = await axios.get(rawUrl, {
-          transformResponse: [(data) => data],
-          signal: controller.signal,
-        }); // Force text
-        if (controller.signal.aborted) return;
-        setContent(response.data);
-      } catch (err) {
-        if (axios.isCancel(err) || controller.signal.aborted) return;
-        console.error('Failed to fetch file content', err);
-        setError(
-          'Could not load file content. It might be binary or too large.',
-        );
-      } finally {
-        if (!controller.signal.aborted) setLoading(false);
-      }
-    };
-
-    fetchContent();
-    return () => controller.abort();
-  }, [repositoryFullName, filePath, defaultBranch, isImage, rawUrl]);
+  const { data: content, loading, error } = useAbortableFetch<string>(
+    async (signal) => {
+      if (!filePath || isImage) return null;
+      const response = await axios.get(rawUrl, {
+        transformResponse: [(data) => data],
+        signal,
+      });
+      return response.data as string;
+    },
+    [repositoryFullName, filePath, defaultBranch, isImage, rawUrl],
+    {
+      initialLoading: false,
+      errorMessage: 'Could not load file content. It might be binary or too large.',
+    },
+  );
 
   if (!filePath) {
     return (

--- a/src/components/repositories/ContributingViewer.tsx
+++ b/src/components/repositories/ContributingViewer.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { Box, Paper, CircularProgress, Alert } from '@mui/material';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
@@ -6,6 +6,7 @@ import rehypeRaw from 'rehype-raw';
 import axios from 'axios';
 import { STATUS_COLORS } from '../../theme';
 import { resolveRelativeUrl } from './MarkdownRenderers';
+import useAbortableFetch from '../../hooks/useAbortableFetch';
 
 interface ContributingViewerProps {
   repositoryFullName: string; // e.g., "opentensor/bittensor"
@@ -14,17 +15,12 @@ interface ContributingViewerProps {
 const ContributingViewer: React.FC<ContributingViewerProps> = ({
   repositoryFullName,
 }) => {
-  const [content, setContent] = useState<string | null>(null);
-  const [defaultBranch, setDefaultBranch] = useState<string>('main');
-  const [loading, setLoading] = useState<boolean>(true);
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    const controller = new AbortController();
-
-    const fetchContributing = async () => {
-      setLoading(true);
-      setError(null);
+  const { data, loading, error } = useAbortableFetch<{
+    content: string;
+    defaultBranch: string;
+  }>(
+    async (signal) => {
+      if (!repositoryFullName) return null;
 
       const branches = ['main', 'master'];
       const paths = [
@@ -35,35 +31,29 @@ const ContributingViewer: React.FC<ContributingViewerProps> = ({
 
       for (const branch of branches) {
         for (const path of paths) {
-          if (controller.signal.aborted) return;
           try {
             const response = await axios.get(
               `https://cdn.jsdelivr.net/gh/${repositoryFullName}@${branch}/${path}`,
-              { signal: controller.signal },
+              { signal },
             );
-            if (controller.signal.aborted) return;
             if (response.status === 200 && response.data) {
-              setContent(response.data);
-              setDefaultBranch(branch);
-              setLoading(false);
-              return;
+              return { content: response.data as string, defaultBranch: branch };
             }
           } catch (err) {
-            if (axios.isCancel(err) || controller.signal.aborted) return;
+            if (axios.isCancel(err)) throw err;
             // Continue to next combination
           }
         }
       }
 
-      if (controller.signal.aborted) return;
-      // If we get here, nothing was found
-      setError('No contributing guidelines found for this repository.');
-      setLoading(false);
-    };
+      throw new Error('No contributing guidelines found for this repository.');
+    },
+    [repositoryFullName],
+    { errorMessage: 'No contributing guidelines found for this repository.' },
+  );
 
-    if (repositoryFullName) fetchContributing();
-    return () => controller.abort();
-  }, [repositoryFullName]);
+  const content = data?.content ?? null;
+  const defaultBranch = data?.defaultBranch ?? 'main';
 
   if (loading) {
     return (

--- a/src/components/repositories/ReadmeViewer.tsx
+++ b/src/components/repositories/ReadmeViewer.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { Box, CircularProgress, Alert, Paper } from '@mui/material';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
@@ -6,56 +6,41 @@ import rehypeRaw from 'rehype-raw';
 import axios from 'axios';
 import { STATUS_COLORS } from '../../theme';
 import { resolveRelativeUrl } from './MarkdownRenderers';
+import useAbortableFetch from '../../hooks/useAbortableFetch';
 
 interface ReadmeViewerProps {
   repositoryFullName: string; // e.g., "opentensor/bittensor"
 }
 
 const ReadmeViewer: React.FC<ReadmeViewerProps> = ({ repositoryFullName }) => {
-  const [content, setContent] = useState<string | null>(null);
-  const [defaultBranch, setDefaultBranch] = useState<string>('main');
-  const [loading, setLoading] = useState<boolean>(true);
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    const controller = new AbortController();
-
-    const fetchReadme = async () => {
-      setLoading(true);
-      setError(null);
+  const { data, loading, error } = useAbortableFetch<{
+    content: string;
+    defaultBranch: string;
+  }>(
+    async (signal) => {
+      if (!repositoryFullName) return null;
       try {
-        // Try 'main' branch first
-        try {
-          const response = await axios.get(
-            `https://cdn.jsdelivr.net/gh/${repositoryFullName}@main/README.md`,
-            { signal: controller.signal },
-          );
-          if (controller.signal.aborted) return;
-          setContent(response.data);
-          setDefaultBranch('main');
-        } catch (err) {
-          if (axios.isCancel(err) || controller.signal.aborted) return;
-          // Fallback to 'master' branch
-          const response = await axios.get(
-            `https://cdn.jsdelivr.net/gh/${repositoryFullName}@master/README.md`,
-            { signal: controller.signal },
-          );
-          if (controller.signal.aborted) return;
-          setContent(response.data);
-          setDefaultBranch('master');
-        }
+        const response = await axios.get(
+          `https://cdn.jsdelivr.net/gh/${repositoryFullName}@main/README.md`,
+          { signal },
+        );
+        return { content: response.data as string, defaultBranch: 'main' };
       } catch (err) {
-        if (axios.isCancel(err) || controller.signal.aborted) return;
-        console.error('Failed to fetch README', err);
-        setError('Could not load README.md');
-      } finally {
-        if (!controller.signal.aborted) setLoading(false);
+        if (axios.isCancel(err)) throw err;
+        // Fallback to 'master' branch
+        const response = await axios.get(
+          `https://cdn.jsdelivr.net/gh/${repositoryFullName}@master/README.md`,
+          { signal },
+        );
+        return { content: response.data as string, defaultBranch: 'master' };
       }
-    };
+    },
+    [repositoryFullName],
+    { errorMessage: 'Could not load README.md' },
+  );
 
-    if (repositoryFullName) fetchReadme();
-    return () => controller.abort();
-  }, [repositoryFullName]);
+  const content = data?.content ?? null;
+  const defaultBranch = data?.defaultBranch ?? 'main';
 
   if (loading) {
     return (

--- a/src/hooks/useAbortableFetch.ts
+++ b/src/hooks/useAbortableFetch.ts
@@ -1,0 +1,79 @@
+import { useState, useEffect, useRef } from 'react';
+import axios from 'axios';
+
+export interface FetchState<T> {
+  data: T | null;
+  loading: boolean;
+  error: string | null;
+}
+
+export type FetchFn<T> = (signal: AbortSignal) => Promise<T>;
+
+export interface UseAbortableFetchOptions {
+  /** Message surfaced in `error` when the fetch throws. Falls back to the
+   *  thrown error's own message when not provided. */
+  errorMessage?: string;
+  /** Whether the initial `loading` state should be `true` (default) or `false`. */
+  initialLoading?: boolean;
+}
+
+/**
+ * A hook that runs an async fetch function and automatically cancels it via an
+ * AbortController when the component unmounts or when the `deps` change.
+ *
+ * @param fetchFn  - Async function that receives an `AbortSignal` and returns data.
+ *                   Return `null` to skip the fetch (e.g. when a required param is missing).
+ * @param deps     - Dependency array – works exactly like `useEffect`'s second argument.
+ * @param options  - Optional configuration: `errorMessage` and `initialLoading`.
+ */
+function useAbortableFetch<T>(
+  fetchFn: FetchFn<T | null>,
+  deps: React.DependencyList,
+  options: UseAbortableFetchOptions = {},
+): FetchState<T> {
+  const { errorMessage, initialLoading = true } = options;
+  const [data, setData] = useState<T | null>(null);
+  const [loading, setLoading] = useState<boolean>(initialLoading);
+  const [error, setError] = useState<string | null>(null);
+
+  // Keep a stable reference to fetchFn so callers don't need to memoize it.
+  const fetchFnRef = useRef(fetchFn);
+  useEffect(() => {
+    fetchFnRef.current = fetchFn;
+  });
+
+  useEffect(() => {
+    const controller = new AbortController();
+    const { signal } = controller;
+
+    const run = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const result = await fetchFnRef.current(signal);
+        if (signal.aborted) return;
+        setData(result);
+      } catch (err) {
+        if (axios.isCancel(err) || signal.aborted) return;
+        throw err; // let the caller's fetchFn handle error reporting
+      } finally {
+        if (!signal.aborted) setLoading(false);
+      }
+    };
+
+    run().catch((err) => {
+      if (!signal.aborted) {
+        console.error('[useAbortableFetch]', err);
+        setError(errorMessage ?? (err instanceof Error ? err.message : String(err)));
+        setLoading(false);
+      }
+    });
+
+    return () => controller.abort();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, deps);
+
+  return { data, loading, error };
+}
+
+export default useAbortableFetch;


### PR DESCRIPTION
## Summary

Extract duplicated `AbortController` logic from `CodeViewer`, `ReadmeViewer`, and `ContributingViewer` into a single reusable `useAbortableFetch` hook. The hook centralises abort-on-unmount, abort-on-deps-change, axios cancel detection, loading/error state management, and per-caller error messages — removing ~120 lines of boilerplate across the three components.

## Related Issues

Resolves https://github.com/entrius/gittensor-ui/issues/336

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

Not applicable — no UI changes.

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [ ] Screenshots included for any UI/visual changes