### PR TITLE
feat: display code density and label multiplier in score breakdowns

### DIFF
--- a/src/components/miners/MinerScoreBreakdown.tsx
+++ b/src/components/miners/MinerScoreBreakdown.tsx
@@ -30,6 +30,7 @@ import {
   calculateOpenIssueThreshold,
 } from '../../utils/ExplorerUtils';
 import { credibilityColor } from '../../utils/format';
+import { buildMergedPillDefs } from '../../utils/multiplierDefs';
 
 type ViewMode = 'prs' | 'issues';
 
@@ -282,7 +283,7 @@ const PrScoreRow: React.FC<PrScoreRowProps> = ({ pr, onNavigateToPr }) => {
           }}
         >
           {/* Score multiplier chips — sourced from PR details API */}
-          {isMerged && (
+          {isMerged && prDetails && (
             <Box
               sx={{
                 display: 'flex',
@@ -291,109 +292,24 @@ const PrScoreRow: React.FC<PrScoreRowProps> = ({ pr, onNavigateToPr }) => {
                 alignItems: 'center',
               }}
             >
-              {prDetails?.credibilityMultiplier != null && (
+              {buildMergedPillDefs(prDetails).map((def) => (
                 <MultiplierPill
-                  label="cred"
-                  value={parseFloat(prDetails.credibilityMultiplier)}
+                  key={def.key}
+                  label={def.label}
+                  value={def.value}
+                  format={def.format}
                   tooltip={
                     <Stack direction="column">
                       <Typography variant="tooltipLabel">
-                        Credibility{' '}
-                        {Number(prDetails.credibilityMultiplier).toFixed(4)}×
+                        {def.tooltipTitle}
                       </Typography>
                       <Typography variant="tooltipDesc">
-                        Based on your PR success rate, scaled to reward
-                        consistency.
+                        {def.tooltipDesc}
                       </Typography>
                     </Stack>
                   }
                 />
-              )}
-              {prDetails?.repoWeightMultiplier != null && (
-                <MultiplierPill
-                  label="repo wt"
-                  value={parseFloat(prDetails.repoWeightMultiplier)}
-                  tooltip={
-                    <Stack direction="column">
-                      <Typography variant="tooltipLabel">
-                        Repo Weight{' '}
-                        {Number(prDetails.repoWeightMultiplier).toFixed(4)}×
-                      </Typography>
-                      <Typography variant="tooltipDesc">
-                        Based on repository weight and activity.
-                      </Typography>
-                    </Stack>
-                  }
-                />
-              )}
-              {prDetails?.issueMultiplier != null && (
-                <MultiplierPill
-                  label="issue"
-                  value={parseFloat(prDetails.issueMultiplier)}
-                  tooltip={
-                    <Stack direction="column">
-                      <Typography variant="tooltipLabel">
-                        Issue {Number(prDetails.issueMultiplier).toFixed(4)}×
-                      </Typography>
-                      <Typography variant="tooltipDesc">
-                        Bonus for PRs linked to issues.
-                      </Typography>
-                    </Stack>
-                  }
-                />
-              )}
-              {prDetails?.timeDecayMultiplier != null && (
-                <MultiplierPill
-                  label="decay"
-                  value={parseFloat(prDetails.timeDecayMultiplier)}
-                  tooltip={
-                    <Stack direction="column">
-                      <Typography variant="tooltipLabel">
-                        Time Decay{' '}
-                        {Number(prDetails.timeDecayMultiplier).toFixed(4)}×
-                      </Typography>
-                      <Typography variant="tooltipDesc">
-                        Recent PRs score higher.
-                      </Typography>
-                    </Stack>
-                  }
-                />
-              )}
-              {prDetails?.openPrSpamMultiplier != null && (
-                <MultiplierPill
-                  label="spam"
-                  value={parseFloat(prDetails.openPrSpamMultiplier)}
-                  tooltip={
-                    <Stack direction="column">
-                      <Typography variant="tooltipLabel">
-                        Open PR Spam{' '}
-                        {Number(prDetails.openPrSpamMultiplier).toFixed(4)}×
-                      </Typography>
-                      <Typography variant="tooltipDesc">
-                        Penalty for excessive open PRs.
-                      </Typography>
-                    </Stack>
-                  }
-                />
-              )}
-              {prDetails?.reviewQualityMultiplier != null && (
-                <MultiplierPill
-                  label="review"
-                  value={parseFloat(prDetails.reviewQualityMultiplier)}
-                  tooltip={
-                    <Stack direction="column">
-                      <Typography variant="tooltipLabel">
-                        Review Quality{' '}
-                        {Number(prDetails.reviewQualityMultiplier).toFixed(4)}×
-                      </Typography>
-                      <Typography variant="tooltipDesc">
-                        Multiplier based on the amount of requested changes the
-                        PR required.
-                      </Typography>
-                    </Stack>
-                  }
-                />
-              )}
+              ))}
             </Box>
           )}
 

--- a/src/components/prs/PRDetailsCard.tsx
+++ b/src/components/prs/PRDetailsCard.tsx
@@ -13,6 +13,7 @@ import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import { usePullRequestDetails } from '../../api';
 import { useNavigate } from 'react-router-dom';
 import theme, { RANK_COLORS, STATUS_COLORS, TEXT_OPACITY } from '../../theme';
+import { buildMultiplierGrid } from '../../utils/multiplierDefs';
 
 interface PRDetailsCardProps {
   repository: string;
@@ -108,50 +109,7 @@ const PRDetailsCard: React.FC<PRDetailsCardProps> = ({
     },
   ];
 
-  // For OPEN PRs: collateral = base_score × repo_weight × issue_multiplier × 20%
-  // Only show applicable multipliers
-  const multipliers: Array<{
-    label: string;
-    value: string;
-    isCredibility?: boolean;
-  }> = isOpenPR
-    ? [
-        {
-          label: 'Repo Weight',
-          value: `${parseFloat(prDetails.repoWeightMultiplier ?? '0').toFixed(2)}x`,
-        },
-        {
-          label: 'Issue Bonus',
-          value: `${parseFloat(prDetails.issueMultiplier ?? '0').toFixed(2)}x`,
-        },
-        {
-          label: 'Collateral %',
-          value: '20%',
-        },
-      ]
-    : [
-        {
-          label: 'Repo Weight',
-          value: `${parseFloat(prDetails.repoWeightMultiplier ?? '0').toFixed(2)}x`,
-        },
-        {
-          label: 'Issue Bonus',
-          value: `${parseFloat(prDetails.issueMultiplier ?? '0').toFixed(2)}x`,
-        },
-        {
-          label: 'Credibility',
-          value: `${parseFloat(prDetails.credibilityMultiplier ?? '0').toFixed(2)}x`,
-          isCredibility: true,
-        },
-        {
-          label: 'Review Quality',
-          value: `${parseFloat(prDetails.reviewQualityMultiplier ?? '0').toFixed(2)}x`,
-        },
-        {
-          label: 'Time Decay',
-          value: `${parseFloat(prDetails.timeDecayMultiplier ?? '0').toFixed(2)}x`,
-        },
-      ];
+  const multipliers = buildMultiplierGrid(prDetails, isOpenPR);
 
   return (
     <Card

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -2,3 +2,4 @@ export * from './format';
 export * from './ExplorerUtils';
 export * from './prStatus';
 export * from './issueStatus';
+export * from './multiplierDefs';

--- a/src/utils/multiplierDefs.ts
+++ b/src/utils/multiplierDefs.ts
@@ -1,0 +1,197 @@
+import type { PullRequestDetails } from '../api/models/Dashboard';
+
+export interface MultiplierPillDef {
+  key: string;
+  label: string;
+  value: number;
+  format: 'multiplier' | 'value' | 'percent';
+  tooltipTitle: string;
+  tooltipDesc: string;
+}
+
+export interface MultiplierGridEntry {
+  label: string;
+  value: string;
+  isCredibility?: boolean;
+}
+
+interface PillConfig {
+  key: string;
+  label: string;
+  field: keyof PullRequestDetails;
+  title: string;
+  desc: string;
+  format?: 'value';
+}
+
+function parseOpt(raw: string | number | undefined | null): number {
+  return parseFloat(String(raw ?? '0'));
+}
+function fmtMul(raw: string | number): string {
+  return `${Number(raw).toFixed(4)}×`;
+}
+function fmtVal(raw: string | number): string {
+  return Number(raw).toFixed(4);
+}
+function fmtGrid(raw: string | number, suffix: string = 'x'): string {
+  return `${parseFloat(String(raw)).toFixed(2)}${suffix}`;
+}
+
+function resolvePillLabel(pr: PullRequestDetails, cfg: PillConfig): string {
+  if (cfg.key !== 'label') return cfg.label;
+  const hasLabel = pr.label != null && pr.label.length > 0;
+  return hasLabel ? `label: ${pr.label}` : 'label';
+}
+
+function resolvePillTooltip(pr: PullRequestDetails, cfg: PillConfig): string {
+  if (cfg.key !== 'label') return cfg.desc;
+  const hasLabel = pr.label != null && pr.label.length > 0;
+  return hasLabel
+    ? `Label "${pr.label}" — adjusts score based on PR classification.`
+    : cfg.desc;
+}
+
+const PILL_CONFIGS: PillConfig[] = [
+  {
+    key: 'cred',
+    label: 'cred',
+    field: 'credibilityMultiplier',
+    title: 'Credibility',
+    desc: 'Based on your PR success rate, scaled to reward consistency.',
+  },
+  {
+    key: 'repoWt',
+    label: 'repo wt',
+    field: 'repoWeightMultiplier',
+    title: 'Repo Weight',
+    desc: 'Based on repository weight and activity.',
+  },
+  {
+    key: 'issue',
+    label: 'issue',
+    field: 'issueMultiplier',
+    title: 'Issue',
+    desc: 'Bonus for PRs linked to issues.',
+  },
+  {
+    key: 'decay',
+    label: 'decay',
+    field: 'timeDecayMultiplier',
+    title: 'Time Decay',
+    desc: 'Recent PRs score higher.',
+  },
+  {
+    key: 'spam',
+    label: 'spam',
+    field: 'openPrSpamMultiplier',
+    title: 'Open PR Spam',
+    desc: 'Penalty for excessive open PRs.',
+  },
+  {
+    key: 'review',
+    label: 'review',
+    field: 'reviewQualityMultiplier',
+    title: 'Review Quality',
+    desc: 'Multiplier based on the amount of requested changes the PR required.',
+  },
+  {
+    key: 'label',
+    label: 'label',
+    field: 'labelMultiplier',
+    title: 'Label Multiplier',
+    desc: 'Adjusts score based on PR classification.',
+  },
+  {
+    key: 'density',
+    label: 'density',
+    field: 'codeDensity',
+    title: 'Code Density',
+    desc: 'Ratio of meaningful code changes to total diff size.',
+    format: 'value',
+  },
+];
+
+export function buildMergedPillDefs(
+  pr: PullRequestDetails,
+): MultiplierPillDef[] {
+  return PILL_CONFIGS.filter((cfg) => pr[cfg.field] != null).map((cfg) => {
+    const raw = pr[cfg.field] as string | number;
+    const isValue = cfg.format === 'value';
+    return {
+      key: cfg.key,
+      label: resolvePillLabel(pr, cfg),
+      value: parseOpt(raw),
+      format: (cfg.format ?? 'multiplier') as MultiplierPillDef['format'],
+      tooltipTitle: `${cfg.title} ${isValue ? fmtVal(raw) : fmtMul(raw)}`,
+      tooltipDesc: resolvePillTooltip(pr, cfg),
+    };
+  });
+}
+
+interface GridConfig {
+  label: string;
+  field: keyof PullRequestDetails;
+  isCredibility?: boolean;
+}
+
+function resolveGridLabel(
+  pr: PullRequestDetails,
+  field: keyof PullRequestDetails,
+  fallback: string,
+): string {
+  if (field !== 'labelMultiplier') return fallback;
+  const hasLabel = pr.label != null && pr.label.length > 0;
+  return hasLabel ? `Label (${pr.label})` : 'Label';
+}
+
+function buildGridEntry(
+  pr: PullRequestDetails,
+  cfg: GridConfig,
+): MultiplierGridEntry {
+  return {
+    label: resolveGridLabel(pr, cfg.field, cfg.label),
+    value: fmtGrid(pr[cfg.field] ?? '0'),
+    ...(cfg.isCredibility ? { isCredibility: true } : {}),
+  };
+}
+
+function buildDensityEntry(pr: PullRequestDetails): MultiplierGridEntry | null {
+  if (pr.codeDensity == null) return null;
+  return { label: 'Code Density', value: Number(pr.codeDensity).toFixed(2) };
+}
+
+const OPEN_GRID: GridConfig[] = [
+  { label: 'Repo Weight', field: 'repoWeightMultiplier' },
+  { label: 'Issue Bonus', field: 'issueMultiplier' },
+];
+
+const MERGED_GRID: GridConfig[] = [
+  { label: 'Repo Weight', field: 'repoWeightMultiplier' },
+  { label: 'Issue Bonus', field: 'issueMultiplier' },
+  { label: 'Credibility', field: 'credibilityMultiplier', isCredibility: true },
+  { label: 'Review Quality', field: 'reviewQualityMultiplier' },
+  { label: 'Time Decay', field: 'timeDecayMultiplier' },
+];
+
+function appendOptionalEntries(
+  entries: MultiplierGridEntry[],
+  pr: PullRequestDetails,
+): MultiplierGridEntry[] {
+  if (pr.labelMultiplier != null)
+    entries.push(
+      buildGridEntry(pr, { label: 'Label', field: 'labelMultiplier' }),
+    );
+  const density = buildDensityEntry(pr);
+  if (density) entries.push(density);
+  return entries;
+}
+
+export function buildMultiplierGrid(
+  pr: PullRequestDetails,
+  isOpen: boolean,
+): MultiplierGridEntry[] {
+  const configs = isOpen ? OPEN_GRID : MERGED_GRID;
+  const entries = configs.map((cfg) => buildGridEntry(pr, cfg));
+  if (isOpen) entries.push({ label: 'Collateral %', value: '20%' });
+  return appendOptionalEntries(entries, pr);
+}


### PR DESCRIPTION
## Summary

Add `codeDensity` and `labelMultiplier` fields to the score breakdown on the miner page (as multiplier pills) and on the PR details page (as grid entries). Extracts a shared `multiplierDefs` utility to eliminate inline duplication and drive both views from config arrays.

## Related Issues

Closes #354

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

<!-- Include before/after screenshots for every UI/visual change. Remove this section if not applicable. -->

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [ ] Screenshots included for any UI/visual changes