### PR TITLE
refactor: remove dead useCommitLog hook

### DIFF
--- a/src/api/DashboardApi.ts
+++ b/src/api/DashboardApi.ts
@@ -47,18 +47,6 @@ export const useReposAndWeights = () =>
 export const useLanguagesAndWeights = () =>
   useDashboardQuery<LanguageWeight[]>('useLanguagesAndWeights', '/languages');
 
-export const useCommitLog = (
-  options?: { refetchInterval?: number },
-  page?: number,
-  limit?: number,
-) =>
-  useDashboardQuery<CommitLog[]>(
-    'useCommitLog',
-    '/commits',
-    options?.refetchInterval,
-    { page, limit },
-  );
-
 export const useInfiniteCommitLog = (options?: {
   refetchInterval?: number;
 }) => {


### PR DESCRIPTION
### Summary
- Removes `useCommitLog` which has been superseded by `useInfiniteCommitLog` and is not imported anywhere in the codebase.

### Why it's safe to remove
- No imports of `useCommitLog` exist outside its own definition.
- `useInfiniteCommitLog` in the same file covers the same endpoint (`/dash/commits`) with pagination support.
- The `CommitLog` type import is retained — it is still used by `useInfiniteCommitLog`.

### Changes
- `src/api/DashboardApi.ts` — deleted 12 lines (the `useCommitLog` function)
