### PR TITLE
refactor: remove dead useRepositoryPRs hook

### DIFF
--- a/src/api/ReposApi.ts
+++ b/src/api/ReposApi.ts
@@ -1,7 +1,7 @@
 // Repository API hooks - uses /repos endpoints
 import { useApiQuery } from './ApiUtils';
 import { type RepositoryMaintainer, type RepositoryIssue } from './models';
-import { type CommitLog, type Repository } from './models/Dashboard';
+import { type Repository } from './models/Dashboard';
 
 /**
  * Helper to create /repos endpoint queries
@@ -49,15 +49,3 @@ export const useRepositoryIssues = (repo: string) =>
     `/${encodeURIComponent(repo)}/issues`,
   );
 
-/**
- * Get pull requests for a specific repository filtered by state
- * @param repo - Full repository name (e.g., "opentensor/btcli")
- * @param state - Optional filter: "open", "closed", "merged"
- */
-export const useRepositoryPRs = (repo: string, state?: string) =>
-  useReposQuery<CommitLog[]>(
-    'useRepositoryPRs',
-    `/${encodeURIComponent(repo)}/prs`,
-    undefined,
-    state ? { state } : undefined,
-  );


### PR DESCRIPTION

### Summary
- Removes `useRepositoryPRs` which is never imported anywhere in the codebase.

### Why it's safe to remove
- No imports of `useRepositoryPRs` exist outside its own definition.
- Also removes the now-orphaned `CommitLog` type import which was only needed by this hook.

### Changes
- `src/api/ReposApi.ts` — deleted 13 lines (the `useRepositoryPRs` function, its JSDoc comment, and the unused `CommitLog` import)
