### PR TITLE
refactor: replace hardcoded colors with theme tokens

### DIFF
--- a/src/components/repositories/CodeViewer.tsx
+++ b/src/components/repositories/CodeViewer.tsx
@@ -1,6 +1,13 @@
 import React, { useState, useEffect } from 'react';
 import { scrollbarSx } from '../../theme';
-import { Box, Typography, CircularProgress, Alert } from '@mui/material';
+import {
+  Box,
+  Typography,
+  CircularProgress,
+  Alert,
+  alpha,
+  useTheme,
+} from '@mui/material';
 import axios from 'axios';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { vscDarkPlus } from 'react-syntax-highlighter/dist/esm/styles/prism';
@@ -17,6 +24,7 @@ const CodeViewer: React.FC<CodeViewerProps> = ({
   filePath,
   defaultBranch = 'main',
 }) => {
+  const theme = useTheme();
   const [content, setContent] = useState<string | null>(null);
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
@@ -107,7 +115,7 @@ const CodeViewer: React.FC<CodeViewerProps> = ({
           display: 'flex',
           justifyContent: 'center',
           alignItems: 'center',
-          backgroundColor: '#0d1117',
+          backgroundColor: theme.palette.background.default,
           p: 4,
         }}
       >
@@ -119,9 +127,9 @@ const CodeViewer: React.FC<CodeViewerProps> = ({
             maxWidth: '100%',
             maxHeight: '100%',
             objectFit: 'contain',
-            border: '1px solid #30363d',
+            border: `1px solid ${theme.palette.border.light}`,
             borderRadius: '6px',
-            backgroundColor: '#161b22', // slight background to see transparent pngs better
+            backgroundColor: theme.palette.surface.elevated,
           }}
         />
       </Box>
@@ -139,23 +147,23 @@ const CodeViewer: React.FC<CodeViewerProps> = ({
           ...scrollbarSx,
           '& img': { maxWidth: '100%' },
           '& pre': {
-            backgroundColor: '#1e1e1e',
+            backgroundColor: theme.palette.surface.tooltip,
             p: 2,
             borderRadius: 1,
             overflowX: 'auto',
           },
           '& code': {
             fontFamily: 'monospace',
-            backgroundColor: 'rgba(255,255,255,0.1)',
+            backgroundColor: alpha(theme.palette.common.white, 0.1),
             px: 0.5,
             borderRadius: 0.5,
           },
           '& h1, & h2, & h3': {
-            color: '#fff',
-            borderBottom: '1px solid #30363d',
+            color: theme.palette.text.primary,
+            borderBottom: `1px solid ${theme.palette.border.light}`,
             pb: 1,
           },
-          color: '#c9d1d9',
+          color: theme.palette.text.tertiary,
           lineHeight: 1.6,
         }}
       >
@@ -170,7 +178,7 @@ const CodeViewer: React.FC<CodeViewerProps> = ({
         height: '100%',
         width: '100%',
         overflow: 'hidden',
-        backgroundColor: '#1e1e1e',
+        backgroundColor: theme.palette.surface.tooltip,
         fontSize: '14px',
         '& pre': {
           ...scrollbarSx,

--- a/src/components/repositories/ContributingViewer.tsx
+++ b/src/components/repositories/ContributingViewer.tsx
@@ -1,11 +1,18 @@
 import React, { useState, useEffect } from 'react';
-import { Box, Paper, CircularProgress, Alert } from '@mui/material';
+import {
+  Box,
+  Paper,
+  CircularProgress,
+  Alert,
+  alpha,
+  useTheme,
+} from '@mui/material';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import rehypeRaw from 'rehype-raw';
 import axios from 'axios';
-import { STATUS_COLORS } from '../../theme';
 import { resolveRelativeUrl } from './MarkdownRenderers';
+import { markdownDocumentPaperSx } from '../../theme';
 
 interface ContributingViewerProps {
   repositoryFullName: string; // e.g., "opentensor/bittensor"
@@ -14,6 +21,7 @@ interface ContributingViewerProps {
 const ContributingViewer: React.FC<ContributingViewerProps> = ({
   repositoryFullName,
 }) => {
+  const theme = useTheme();
   const [content, setContent] = useState<string | null>(null);
   const [defaultBranch, setDefaultBranch] = useState<string>('main');
   const [loading, setLoading] = useState<boolean>(true);
@@ -78,9 +86,9 @@ const ContributingViewer: React.FC<ContributingViewerProps> = ({
       <Alert
         severity="info"
         sx={{
-          backgroundColor: 'rgba(2, 136, 209, 0.1)',
-          color: '#0288d1',
-          border: '1px solid rgba(2, 136, 209, 0.2)',
+          backgroundColor: alpha(theme.palette.info.main, 0.1),
+          color: theme.palette.info.main,
+          border: `1px solid ${alpha(theme.palette.info.main, 0.2)}`,
         }}
       >
         {error}
@@ -89,95 +97,7 @@ const ContributingViewer: React.FC<ContributingViewerProps> = ({
   }
 
   return (
-    <Paper
-      elevation={0}
-      sx={{
-        p: { xs: 2, md: 5 },
-        pt: { xs: 2, md: 0 },
-        maxWidth: '900px',
-        mx: 'auto',
-        backgroundColor: 'transparent',
-        color: '#c9d1d9',
-        fontFamily:
-          '-apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif',
-        lineHeight: 1.6,
-        '& h1': {
-          fontSize: '2em',
-          borderBottom: '1px solid #30363d',
-          pb: 0.3,
-          mb: 3,
-          mt: 1,
-          fontWeight: 600,
-          color: '#ffffff',
-        },
-        '& h2': {
-          fontSize: '1.5em',
-          borderBottom: '1px solid #30363d',
-          pb: 0.3,
-          mb: 3,
-          mt: 2,
-          fontWeight: 600,
-          color: '#ffffff',
-        },
-        '& h3': {
-          fontSize: '1.25em',
-          mb: 2,
-          mt: 3,
-          fontWeight: 600,
-          color: '#ffffff',
-        },
-        '& p': { marginBottom: '16px', fontSize: '16px' },
-        '& a': {
-          color: STATUS_COLORS.info,
-          textDecoration: 'none',
-          '&:hover': { textDecoration: 'underline' },
-        },
-        '& ul, & ol': { marginBottom: '16px', paddingLeft: '2em' },
-        '& li': { marginBottom: '4px' },
-        '& blockquote': {
-          borderLeft: '4px solid #30363d',
-          padding: '0 1em',
-          color: STATUS_COLORS.open,
-          marginLeft: 0,
-          marginBottom: '16px',
-        },
-        '& code': {
-          backgroundColor: 'rgba(110, 118, 129, 0.4)',
-          padding: '0.2em 0.4em',
-          borderRadius: '6px',
-          fontSize: '85%',
-        },
-        '& pre': {
-          backgroundColor: '#161b22',
-          padding: '16px',
-          overflow: 'auto',
-          borderRadius: '6px',
-          marginBottom: '16px',
-          '& code': {
-            backgroundColor: 'transparent',
-            padding: 0,
-            fontSize: '100%',
-            color: '#c9d1d9',
-          },
-        },
-        '& table': {
-          borderCollapse: 'collapse',
-          width: '100%',
-          marginBottom: '16px',
-          display: 'block',
-          overflowX: 'auto',
-        },
-        '& th': {
-          fontWeight: 600,
-          border: '1px solid #30363d',
-          padding: '6px 13px',
-          textAlign: 'left',
-        },
-        '& td': { border: '1px solid #30363d', padding: '6px 13px' },
-        '& tr:nth-of-type(2n)': { backgroundColor: '#161b22' },
-        '& img': { backgroundColor: 'transparent' },
-      }}
-    >
+    <Paper elevation={0} sx={markdownDocumentPaperSx(theme)}>
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
         rehypePlugins={[rehypeRaw]}

--- a/src/components/repositories/FileExplorer.tsx
+++ b/src/components/repositories/FileExplorer.tsx
@@ -6,6 +6,8 @@ import {
   ListItemButton,
   ListItemIcon,
   ListItemText,
+  alpha,
+  useTheme,
 } from '@mui/material';
 import FolderIcon from '@mui/icons-material/Folder';
 import FolderOpenIcon from '@mui/icons-material/FolderOpen';
@@ -34,8 +36,10 @@ const FileItem: React.FC<{
   onSelect: (path: string) => void;
   selectedFile: string | null;
 }> = ({ node, level, onSelect, selectedFile }) => {
+  const theme = useTheme();
   const [open, setOpen] = useState(false);
   const isSelected = selectedFile === node.path;
+  const accent = theme.palette.status.info;
 
   const handleClick = () => {
     if (node.type === 'tree') {
@@ -68,16 +72,14 @@ const FileItem: React.FC<{
           py: 0.25,
           minHeight: 24,
           height: 24,
-          backgroundColor: isSelected
-            ? 'rgba(56, 139, 253, 0.15)'
-            : 'transparent',
+          backgroundColor: isSelected ? alpha(accent, 0.15) : 'transparent',
           borderLeft: isSelected
-            ? '2px solid #388bfd'
+            ? `2px solid ${accent}`
             : '2px solid transparent',
           '&:hover': {
             backgroundColor: isSelected
-              ? 'rgba(56, 139, 253, 0.15)'
-              : 'rgba(255, 255, 255, 0.04)',
+              ? alpha(accent, 0.15)
+              : alpha(theme.palette.common.white, 0.04),
           },
           transition: 'all 0.1s ease-in-out',
         }}
@@ -123,7 +125,9 @@ const FileItem: React.FC<{
               fontFamily:
                 'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif',
               fontSize: '13px',
-              color: isSelected ? '#fff' : STATUS_COLORS.open,
+              color: isSelected
+                ? theme.palette.text.primary
+                : STATUS_COLORS.open,
               whiteSpace: 'nowrap',
               overflow: 'hidden',
               textOverflow: 'ellipsis',

--- a/src/components/repositories/LanguageWeightsTable.tsx
+++ b/src/components/repositories/LanguageWeightsTable.tsx
@@ -20,18 +20,21 @@ import {
   IconButton,
   Collapse,
   Tooltip,
+  alpha,
+  useTheme,
 } from '@mui/material';
 import { Search, Check, Close } from '@mui/icons-material';
 import ReactECharts from 'echarts-for-react';
 import BarChartIcon from '@mui/icons-material/BarChart';
 import TableChartIcon from '@mui/icons-material/TableChart';
-import theme, { scrollbarSx } from '../../theme';
+import { scrollbarSx, TEXT_OPACITY } from '../../theme';
 import { useLanguagesAndWeights } from '../../api';
 
 type SortField = 'extension' | 'weight' | 'language';
 type SortOrder = 'asc' | 'desc';
 
 const LanguageWeightsTable: React.FC = () => {
+  const theme = useTheme();
   const { data: languages, isLoading } = useLanguagesAndWeights();
   const [searchQuery, setSearchQuery] = useState('');
   const [sortField, setSortField] = useState<SortField>('weight');
@@ -113,9 +116,9 @@ const LanguageWeightsTable: React.FC = () => {
     return filteredAndSortedLanguages.slice(startIndex, endIndex);
   }, [filteredAndSortedLanguages, page, rowsPerPage]);
 
-  const getChartOption = () => {
+  const chartOption = useMemo(() => {
     const chartData = filteredAndSortedLanguages;
-    const textColor = 'rgba(255, 255, 255, 0.85)';
+    const textColor = alpha(theme.palette.common.white, 0.85);
     const gridColor = theme.palette.border.subtle;
 
     const xAxisData = chartData.map((item) => item.extension);
@@ -132,22 +135,27 @@ const LanguageWeightsTable: React.FC = () => {
         left: 'center',
         top: 20,
         textStyle: {
-          color: '#ffffff',
+          color: theme.palette.text.primary,
+          fontFamily: 'JetBrains Mono',
           fontSize: 18,
           fontWeight: 600,
         },
         subtextStyle: {
-          color: 'rgba(255, 255, 255, 0.5)',
+          color: alpha(theme.palette.common.white, TEXT_OPACITY.tertiary),
+          fontFamily: 'JetBrains Mono',
           fontSize: 12,
         },
       },
       tooltip: {
         trigger: 'axis',
         axisPointer: { type: 'shadow' },
-        backgroundColor: 'rgba(15, 15, 18, 0.95)',
-        borderColor: 'rgba(255, 255, 255, 0.15)',
+        backgroundColor: alpha(theme.palette.background.default, 0.95),
+        borderColor: alpha(theme.palette.common.white, 0.15),
         borderWidth: 1,
-        textStyle: { color: '#fff', fontFamily: 'JetBrains Mono' },
+        textStyle: {
+          color: theme.palette.text.primary,
+          fontFamily: 'JetBrains Mono',
+        },
       },
       grid: {
         left: '3%',
@@ -161,6 +169,7 @@ const LanguageWeightsTable: React.FC = () => {
         data: xAxisData,
         axisLabel: {
           color: textColor,
+          fontFamily: 'JetBrains Mono',
           rotate: 45,
           interval: 0,
         },
@@ -185,8 +194,8 @@ const LanguageWeightsTable: React.FC = () => {
               x2: 0,
               y2: 1,
               colorStops: [
-                { offset: 0, color: '#3f51b5' },
-                { offset: 1, color: '#2196f3' },
+                { offset: 0, color: theme.palette.primary.main },
+                { offset: 1, color: theme.palette.status.info },
               ],
             },
             borderRadius: [4, 4, 0, 0],
@@ -194,7 +203,7 @@ const LanguageWeightsTable: React.FC = () => {
         },
       ],
     };
-  };
+  }, [filteredAndSortedLanguages, theme]);
 
   // Scroll to top when rows per page changes
   useEffect(() => {
@@ -229,13 +238,15 @@ const LanguageWeightsTable: React.FC = () => {
               onClick={() => setShowChart(!showChart)}
               size="small"
               sx={{
-                color: showChart ? '#ffffff' : 'rgba(255, 255, 255, 0.5)',
-                border: '1px solid rgba(255, 255, 255, 0.1)',
+                color: showChart
+                  ? theme.palette.text.primary
+                  : alpha(theme.palette.common.white, TEXT_OPACITY.muted),
+                border: `1px solid ${theme.palette.border.light}`,
                 borderRadius: 2,
                 padding: '6px',
                 '&:hover': {
-                  backgroundColor: 'rgba(255, 255, 255, 0.05)',
-                  borderColor: 'rgba(255, 255, 255, 0.2)',
+                  backgroundColor: theme.palette.surface.subtle,
+                  borderColor: theme.palette.border.medium,
                 },
               }}
             >
@@ -251,7 +262,11 @@ const LanguageWeightsTable: React.FC = () => {
               <Typography
                 variant="body2"
                 sx={{
-                  color: 'rgba(255, 255, 255, 0.7)',
+                  color: alpha(
+                    theme.palette.common.white,
+                    TEXT_OPACITY.secondary,
+                  ),
+                  fontFamily: '"JetBrains Mono", monospace',
                   fontSize: '0.8rem',
                 }}
               >
@@ -264,15 +279,16 @@ const LanguageWeightsTable: React.FC = () => {
                   setPage(0);
                 }}
                 sx={{
-                  color: '#ffffff',
-                  backgroundColor: 'rgba(0, 0, 0, 0.4)',
+                  color: theme.palette.text.primary,
+                  fontFamily: '"JetBrains Mono", monospace',
+                  backgroundColor: alpha(theme.palette.common.black, 0.4),
                   fontSize: '0.8rem',
                   height: '36px',
                   borderRadius: 2,
                   minWidth: '80px',
-                  '& fieldset': { borderColor: 'rgba(255, 255, 255, 0.1)' },
+                  '& fieldset': { borderColor: theme.palette.border.light },
                   '&:hover fieldset': {
-                    borderColor: 'rgba(255, 255, 255, 0.2)',
+                    borderColor: theme.palette.border.medium,
                   },
                   '&.Mui-focused fieldset': { borderColor: 'primary.main' },
                   '& .MuiSelect-select': {
@@ -296,7 +312,13 @@ const LanguageWeightsTable: React.FC = () => {
               startAdornment: (
                 <InputAdornment position="start">
                   <Search
-                    sx={{ color: 'rgba(255, 255, 255, 0.5)', fontSize: '1rem' }}
+                    sx={{
+                      color: alpha(
+                        theme.palette.common.white,
+                        TEXT_OPACITY.muted,
+                      ),
+                      fontSize: '1rem',
+                    }}
                   />
                 </InputAdornment>
               ),
@@ -304,13 +326,16 @@ const LanguageWeightsTable: React.FC = () => {
             sx={{
               width: '200px',
               '& .MuiOutlinedInput-root': {
-                color: '#ffffff',
-                backgroundColor: 'rgba(0, 0, 0, 0.4)',
+                color: theme.palette.text.primary,
+                fontFamily: '"JetBrains Mono", monospace',
+                backgroundColor: alpha(theme.palette.common.black, 0.4),
                 fontSize: '0.8rem',
                 height: '36px',
                 borderRadius: 2,
-                '& fieldset': { borderColor: 'rgba(255, 255, 255, 0.1)' },
-                '&:hover fieldset': { borderColor: 'rgba(255, 255, 255, 0.2)' },
+                '& fieldset': { borderColor: theme.palette.border.light },
+                '&:hover fieldset': {
+                  borderColor: theme.palette.border.medium,
+                },
                 '&.Mui-focused fieldset': { borderColor: 'primary.main' },
               },
             }}
@@ -322,14 +347,14 @@ const LanguageWeightsTable: React.FC = () => {
         <Box
           sx={{
             p: 2,
-            borderBottom: '1px solid rgba(255, 255, 255, 0.1)',
+            borderBottom: `1px solid ${theme.palette.border.light}`,
             height: '500px',
-            backgroundColor: 'rgba(0,0,0,0.2)',
+            backgroundColor: alpha(theme.palette.common.black, 0.2),
           }}
         >
           {showChart && filteredAndSortedLanguages.length > 0 && (
             <ReactECharts
-              option={getChartOption()}
+              option={chartOption}
               style={{ height: '100%', width: '100%' }}
             />
           )}
@@ -356,9 +381,12 @@ const LanguageWeightsTable: React.FC = () => {
               <TableRow>
                 <TableCell
                   sx={{
-                    backgroundColor: 'rgba(18, 18, 20, 0.95)',
+                    backgroundColor: alpha(
+                      theme.palette.background.paper,
+                      0.95,
+                    ),
                     backdropFilter: 'blur(8px)',
-                    borderBottom: '1px solid rgba(255, 255, 255, 0.1)',
+                    borderBottom: `1px solid ${theme.palette.border.light}`,
                   }}
                 >
                   <TableSortLabel
@@ -379,9 +407,12 @@ const LanguageWeightsTable: React.FC = () => {
                 </TableCell>
                 <TableCell
                   sx={{
-                    backgroundColor: 'rgba(18, 18, 20, 0.95)',
+                    backgroundColor: alpha(
+                      theme.palette.background.paper,
+                      0.95,
+                    ),
                     backdropFilter: 'blur(8px)',
-                    borderBottom: '1px solid rgba(255, 255, 255, 0.1)',
+                    borderBottom: `1px solid ${theme.palette.border.light}`,
                   }}
                 >
                   <TableSortLabel
@@ -403,9 +434,12 @@ const LanguageWeightsTable: React.FC = () => {
                 <TableCell
                   align="center"
                   sx={{
-                    backgroundColor: 'rgba(18, 18, 20, 0.95)',
+                    backgroundColor: alpha(
+                      theme.palette.background.paper,
+                      0.95,
+                    ),
                     backdropFilter: 'blur(8px)',
-                    borderBottom: '1px solid rgba(255, 255, 255, 0.1)',
+                    borderBottom: `1px solid ${theme.palette.border.light}`,
                   }}
                 >
                   <Tooltip title="Indicates if this extension supports token-based scoring. Token scoring uses AST parsing for more accurate contribution measurement.">
@@ -417,9 +451,12 @@ const LanguageWeightsTable: React.FC = () => {
                 <TableCell
                   align="right"
                   sx={{
-                    backgroundColor: 'rgba(18, 18, 20, 0.95)',
+                    backgroundColor: alpha(
+                      theme.palette.background.paper,
+                      0.95,
+                    ),
                     backdropFilter: 'blur(8px)',
-                    borderBottom: '1px solid rgba(255, 255, 255, 0.1)',
+                    borderBottom: `1px solid ${theme.palette.border.light}`,
                   }}
                 >
                   <TableSortLabel

--- a/src/components/repositories/ReadmeViewer.tsx
+++ b/src/components/repositories/ReadmeViewer.tsx
@@ -1,17 +1,25 @@
 import React, { useState, useEffect } from 'react';
-import { Box, CircularProgress, Alert, Paper } from '@mui/material';
+import {
+  Box,
+  CircularProgress,
+  Alert,
+  Paper,
+  alpha,
+  useTheme,
+} from '@mui/material';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import rehypeRaw from 'rehype-raw';
 import axios from 'axios';
-import { STATUS_COLORS } from '../../theme';
 import { resolveRelativeUrl } from './MarkdownRenderers';
+import { markdownDocumentPaperSx } from '../../theme';
 
 interface ReadmeViewerProps {
   repositoryFullName: string; // e.g., "opentensor/bittensor"
 }
 
 const ReadmeViewer: React.FC<ReadmeViewerProps> = ({ repositoryFullName }) => {
+  const theme = useTheme();
   const [content, setContent] = useState<string | null>(null);
   const [defaultBranch, setDefaultBranch] = useState<string>('main');
   const [loading, setLoading] = useState<boolean>(true);
@@ -69,7 +77,10 @@ const ReadmeViewer: React.FC<ReadmeViewerProps> = ({ repositoryFullName }) => {
     return (
       <Alert
         severity="warning"
-        sx={{ backgroundColor: 'rgba(255, 152, 0, 0.1)', color: '#ff9800' }}
+        sx={{
+          backgroundColor: alpha(theme.palette.warning.main, 0.1),
+          color: theme.palette.warning.main,
+        }}
       >
         {error}
       </Alert>
@@ -77,110 +88,7 @@ const ReadmeViewer: React.FC<ReadmeViewerProps> = ({ repositoryFullName }) => {
   }
 
   return (
-    <Paper
-      elevation={0}
-      sx={{
-        p: { xs: 2, md: 5 },
-        pt: { xs: 2, md: 0 }, // Reduce top padding
-        maxWidth: '900px',
-        mx: 'auto',
-        backgroundColor: 'transparent', // Seamless look
-        color: '#c9d1d9', // GitHub Dark Text
-        fontFamily:
-          '-apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif',
-        lineHeight: 1.6,
-        '& h1': {
-          fontSize: '2em',
-          borderBottom: '1px solid #30363d',
-          pb: 0.3,
-          mb: 3,
-          mt: 1,
-          fontWeight: 600,
-          color: '#ffffff',
-        },
-        '& h2': {
-          fontSize: '1.5em',
-          borderBottom: '1px solid #30363d',
-          pb: 0.3,
-          mb: 3,
-          mt: 2,
-          fontWeight: 600,
-          color: '#ffffff',
-        },
-        '& h3': {
-          fontSize: '1.25em',
-          mb: 2,
-          mt: 3,
-          fontWeight: 600,
-          color: '#ffffff',
-        },
-        '& p': {
-          marginBottom: '16px',
-          fontSize: '16px',
-        },
-        '& a': {
-          color: STATUS_COLORS.info,
-          textDecoration: 'none',
-          '&:hover': { textDecoration: 'underline' },
-        },
-        '& ul, & ol': {
-          marginBottom: '16px',
-          paddingLeft: '2em',
-        },
-        '& li': {
-          marginBottom: '4px',
-        },
-        '& blockquote': {
-          borderLeft: '4px solid #30363d',
-          padding: '0 1em',
-          color: STATUS_COLORS.open,
-          marginLeft: 0,
-          marginBottom: '16px',
-        },
-        '& code': {
-          backgroundColor: 'rgba(110, 118, 129, 0.4)',
-          padding: '0.2em 0.4em',
-          borderRadius: '6px',
-          fontSize: '85%',
-        },
-        '& pre': {
-          backgroundColor: '#161b22',
-          padding: '16px',
-          overflow: 'auto',
-          borderRadius: '6px',
-          marginBottom: '16px',
-          '& code': {
-            backgroundColor: 'transparent',
-            padding: 0,
-            fontSize: '100%',
-            color: '#c9d1d9',
-          },
-        },
-        '& table': {
-          borderCollapse: 'collapse',
-          width: '100%',
-          marginBottom: '16px',
-          display: 'block',
-          overflowX: 'auto',
-        },
-        '& th': {
-          fontWeight: 600,
-          border: '1px solid #30363d',
-          padding: '6px 13px',
-          textAlign: 'left',
-        },
-        '& td': {
-          border: '1px solid #30363d',
-          padding: '6px 13px',
-        },
-        '& tr:nth-of-type(2n)': {
-          backgroundColor: '#161b22',
-        },
-        '& img': {
-          backgroundColor: 'transparent',
-        },
-      }}
-    >
+    <Paper elevation={0} sx={markdownDocumentPaperSx(theme)}>
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
         rehypePlugins={[rehypeRaw]}

--- a/src/components/repositories/RepositoryCodeBrowser.tsx
+++ b/src/components/repositories/RepositoryCodeBrowser.tsx
@@ -12,6 +12,7 @@ import {
   Link,
   Breadcrumbs,
   Avatar,
+  useTheme,
 } from '@mui/material';
 import axios from 'axios';
 import { STATUS_COLORS } from '../../theme';
@@ -121,6 +122,7 @@ function resolveGithubCommitAttribution(
 const RepositoryCodeBrowser: React.FC<RepositoryCodeBrowserProps> = ({
   repositoryFullName,
 }) => {
+  const theme = useTheme();
   const [tree, setTree] = useState<FileNode[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -303,7 +305,9 @@ const RepositoryCodeBrowser: React.FC<RepositoryCodeBrowserProps> = ({
             onClick={() => handleNavigate(null)}
             sx={{
               fontWeight: !currentPath ? 600 : 400,
-              color: !currentPath ? '#c9d1d9' : STATUS_COLORS.info,
+              color: !currentPath
+                ? theme.palette.text.tertiary
+                : STATUS_COLORS.info,
               cursor: !currentPath ? 'default' : 'pointer',
               fontSize: '14px',
             }}
@@ -322,7 +326,9 @@ const RepositoryCodeBrowser: React.FC<RepositoryCodeBrowserProps> = ({
                 onClick={() => !isLast && handleNavigate(path)}
                 sx={{
                   fontWeight: isLast ? 600 : 400,
-                  color: isLast ? '#c9d1d9' : STATUS_COLORS.info,
+                  color: isLast
+                    ? theme.palette.text.tertiary
+                    : STATUS_COLORS.info,
                   cursor: isLast ? 'default' : 'pointer',
                   fontSize: '14px',
                 }}
@@ -339,10 +345,10 @@ const RepositoryCodeBrowser: React.FC<RepositoryCodeBrowserProps> = ({
         <Paper
           elevation={0}
           sx={{
-            border: '1px solid #30363d',
+            border: `1px solid ${theme.palette.border.light}`,
             borderBottom: 'none',
             borderRadius: '6px 6px 0 0',
-            backgroundColor: '#161b22',
+            backgroundColor: theme.palette.surface.elevated,
             p: 2,
             display: 'flex',
             alignItems: 'center',
@@ -375,7 +381,7 @@ const RepositoryCodeBrowser: React.FC<RepositoryCodeBrowserProps> = ({
                   sx={{
                     fontSize: '13px',
                     fontWeight: 600,
-                    color: '#c9d1d9',
+                    color: theme.palette.text.tertiary,
                     whiteSpace: 'nowrap',
                   }}
                 >
@@ -438,9 +444,9 @@ const RepositoryCodeBrowser: React.FC<RepositoryCodeBrowserProps> = ({
           component={Paper}
           elevation={0}
           sx={{
-            border: '1px solid #30363d',
+            border: `1px solid ${theme.palette.border.light}`,
             borderRadius: isFile ? '6px' : '0 0 6px 6px', // Connect to header
-            backgroundColor: '#0d1117',
+            backgroundColor: theme.palette.background.paper,
           }}
         >
           <Table size="small">
@@ -450,7 +456,9 @@ const RepositoryCodeBrowser: React.FC<RepositoryCodeBrowserProps> = ({
                 <TableRow
                   hover
                   sx={{
-                    '&:hover': { backgroundColor: '#161b22' },
+                    '&:hover': {
+                      backgroundColor: theme.palette.surface.elevated,
+                    },
                     cursor: 'pointer',
                   }}
                 >
@@ -465,7 +473,7 @@ const RepositoryCodeBrowser: React.FC<RepositoryCodeBrowserProps> = ({
                     }}
                     sx={{
                       color: STATUS_COLORS.info,
-                      borderBottom: '1px solid #21262d',
+                      borderBottom: `1px solid ${theme.palette.border.subtle}`,
                       py: 1,
                       fontSize: '13px',
                       fontWeight: 600,
@@ -481,21 +489,25 @@ const RepositoryCodeBrowser: React.FC<RepositoryCodeBrowserProps> = ({
                   hover
                   onClick={() => handleNavigate(node.path)}
                   sx={{
-                    '&:hover': { backgroundColor: '#161b22' },
+                    '&:hover': {
+                      backgroundColor: theme.palette.surface.elevated,
+                    },
                     cursor: 'pointer',
                     transition: 'background-color 0.1s',
                   }}
                 >
                   <TableCell
                     sx={{
-                      borderBottom: '1px solid #21262d',
+                      borderBottom: `1px solid ${theme.palette.border.subtle}`,
                       py: 1,
                       width: '32px',
                       pl: 2,
                     }}
                   >
                     {node.type === 'tree' ? (
-                      <FolderIcon sx={{ color: '#54aeff', fontSize: 16 }} />
+                      <FolderIcon
+                        sx={{ color: theme.palette.status.info, fontSize: 16 }}
+                      />
                     ) : (
                       <InsertDriveFileIcon
                         sx={{ color: STATUS_COLORS.open, fontSize: 16 }}
@@ -504,9 +516,9 @@ const RepositoryCodeBrowser: React.FC<RepositoryCodeBrowserProps> = ({
                   </TableCell>
                   <TableCell
                     sx={{
-                      borderBottom: '1px solid #21262d',
+                      borderBottom: `1px solid ${theme.palette.border.subtle}`,
                       py: 1,
-                      color: '#c9d1d9',
+                      color: theme.palette.text.tertiary,
                       fontSize: '14px',
                       fontWeight: node.type === 'tree' ? 600 : 400,
                     }}
@@ -515,7 +527,7 @@ const RepositoryCodeBrowser: React.FC<RepositoryCodeBrowserProps> = ({
                   </TableCell>
                   <TableCell
                     sx={{
-                      borderBottom: '1px solid #21262d',
+                      borderBottom: `1px solid ${theme.palette.border.subtle}`,
                       py: 1,
                       color: STATUS_COLORS.open,
                       fontSize: '13px',

--- a/src/components/repositories/RepositoryMaintainers.tsx
+++ b/src/components/repositories/RepositoryMaintainers.tsx
@@ -6,6 +6,8 @@ import {
   Tooltip,
   Link,
   Skeleton,
+  alpha,
+  useTheme,
 } from '@mui/material';
 import { useRepositoryMaintainers } from '../../api';
 import { STATUS_COLORS } from '../../theme';
@@ -17,6 +19,7 @@ interface RepositoryMaintainersProps {
 const RepositoryMaintainers: React.FC<RepositoryMaintainersProps> = ({
   repositoryFullName,
 }) => {
+  const theme = useTheme();
   const { data: maintainers, isLoading } =
     useRepositoryMaintainers(repositoryFullName);
 
@@ -83,7 +86,7 @@ const RepositoryMaintainers: React.FC<RepositoryMaintainersProps> = ({
                   '&:hover': {
                     transform: 'scale(1.1)',
                     borderColor: 'primary.main',
-                    boxShadow: '0 0 8px rgba(247, 129, 102, 0.4)',
+                    boxShadow: `0 0 8px ${alpha(theme.palette.primary.main, 0.4)}`,
                   },
                 }}
               />

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,4 +1,9 @@
-import { createTheme, alpha } from '@mui/material/styles';
+import {
+  createTheme,
+  alpha,
+  type Theme,
+  type SxProps,
+} from '@mui/material/styles';
 
 // Shared Color Constants (exported for use outside MUI components)
 export const UI_COLORS = {
@@ -96,6 +101,100 @@ export const TEXT_OPACITY = {
   faint: 0.3,
   ghost: 0.2,
 } as const;
+
+/** Theme-driven markdown document body (README, CONTRIBUTING, etc.). */
+export const markdownDocumentPaperSx = (theme: Theme): SxProps<Theme> => ({
+  p: { xs: 2, md: 5 },
+  pt: { xs: 2, md: 0 },
+  maxWidth: '900px',
+  mx: 'auto',
+  backgroundColor: 'transparent',
+  color: theme.palette.text.tertiary,
+  fontFamily:
+    '-apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif',
+  lineHeight: 1.6,
+  '& h1': {
+    fontSize: '2em',
+    borderBottom: `1px solid ${theme.palette.border.light}`,
+    pb: 0.3,
+    mb: 3,
+    mt: 1,
+    fontWeight: 600,
+    color: theme.palette.text.primary,
+  },
+  '& h2': {
+    fontSize: '1.5em',
+    borderBottom: `1px solid ${theme.palette.border.light}`,
+    pb: 0.3,
+    mb: 3,
+    mt: 2,
+    fontWeight: 600,
+    color: theme.palette.text.primary,
+  },
+  '& h3': {
+    fontSize: '1.25em',
+    mb: 2,
+    mt: 3,
+    fontWeight: 600,
+    color: theme.palette.text.primary,
+  },
+  '& p': { marginBottom: '16px', fontSize: '16px' },
+  '& a': {
+    color: STATUS_COLORS.info,
+    textDecoration: 'none',
+    '&:hover': { textDecoration: 'underline' },
+  },
+  '& ul, & ol': { marginBottom: '16px', paddingLeft: '2em' },
+  '& li': { marginBottom: '4px' },
+  '& blockquote': {
+    borderLeft: `4px solid ${theme.palette.border.light}`,
+    padding: '0 1em',
+    color: STATUS_COLORS.open,
+    marginLeft: 0,
+    marginBottom: '16px',
+  },
+  '& code': {
+    backgroundColor: alpha(theme.palette.grey[500], 0.4),
+    padding: '0.2em 0.4em',
+    borderRadius: '6px',
+    fontSize: '85%',
+    fontFamily: '"JetBrains Mono", monospace',
+  },
+  '& pre': {
+    backgroundColor: theme.palette.surface.elevated,
+    padding: '16px',
+    overflow: 'auto',
+    borderRadius: '6px',
+    marginBottom: '16px',
+    '& code': {
+      backgroundColor: 'transparent',
+      padding: 0,
+      fontSize: '100%',
+      color: theme.palette.text.tertiary,
+    },
+  },
+  '& table': {
+    borderCollapse: 'collapse',
+    width: '100%',
+    marginBottom: '16px',
+    display: 'block',
+    overflowX: 'auto',
+  },
+  '& th': {
+    fontWeight: 600,
+    border: `1px solid ${theme.palette.border.light}`,
+    padding: '6px 13px',
+    textAlign: 'left',
+  },
+  '& td': {
+    border: `1px solid ${theme.palette.border.light}`,
+    padding: '6px 13px',
+  },
+  '& tr:nth-of-type(2n)': {
+    backgroundColor: theme.palette.surface.elevated,
+  },
+  '& img': { backgroundColor: 'transparent' },
+});
 
 export const headerCellStyle = {
   backgroundColor: 'surface.tooltip',


### PR DESCRIPTION
## Summary
As the continuous work of refactoring to get rid of all hard coded color value usages in this https://github.com/entrius/gittensor-ui/pull/252

- Removes hardcoded color literals (#…, rgba(…)) from src/components/repositories and standardizes styling through the MUI theme (theme.palette, alpha(…), and shared exports from src/theme.ts).
- Introduces a small shared helper for README/CONTRIBUTING markdown so document styling stays consistent and theme-driven.

## Scope

- src/components/repositories/ContributingViewer.tsx
- src/components/repositories/ReadmeViewer.tsx
- src/components/repositories/CodeViewer.tsx
- src/components/repositories/FileExplorer.tsx
- src/components/repositories/LanguageWeightsTable.tsx
- src/components/repositories/RepositoryCodeBrowser.tsx
- src/components/repositories/RepositoryMaintainers.tsx
- New: markdownDocSx.ts (shared markdown document styling)

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

<!-- Include before/after screenshots for every UI/visual change. Remove this section if not applicable. -->

## Checklist

- [ ] New components are modularized/separated where sensible
- [ ] Uses predefined theme (e.g. no hardcoded colors)
- [ ] Responsive/mobile checked
- [ ] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [ ] Screenshots included for any UI/visual changes
