### PR TITLE
refactor: add shared github.ts URL helpers for RepositoryCodeBrowser

### DIFF
--- a/src/components/repositories/RepositoryCodeBrowser.tsx
+++ b/src/components/repositories/RepositoryCodeBrowser.tsx
@@ -14,6 +14,12 @@ import {
   Avatar,
 } from '@mui/material';
 import axios from 'axios';
+import {
+  githubCommitDetailUrl,
+  githubCommitsUrl,
+  githubGitTreeUrl,
+  githubRepoUrl,
+} from '../../constants/github';
 import { STATUS_COLORS } from '../../theme';
 import { formatDistanceToNow } from 'date-fns';
 import FolderIcon from '@mui/icons-material/Folder';
@@ -66,7 +72,7 @@ async function fetchCommitPayload(
   if (!c.committer?.id && !c.committer?.login && c.sha) {
     try {
       const { data } = await axios.get(
-        `https://api.github.com/repos/${repositoryFullName}/commits/${c.sha}`,
+        githubCommitDetailUrl(repositoryFullName, c.sha),
       );
       c = data;
     } catch {
@@ -138,13 +144,13 @@ const RepositoryCodeBrowser: React.FC<RepositoryCodeBrowserProps> = ({
       setLoading(true);
       try {
         const repoResponse = await axios.get(
-          `https://api.github.com/repos/${repositoryFullName}`,
+          githubRepoUrl(repositoryFullName),
         );
         const branch = repoResponse.data.default_branch || 'main';
         setDefaultBranch(branch);
 
         const treeResponse = await axios.get(
-          `https://api.github.com/repos/${repositoryFullName}/git/trees/${branch}?recursive=1`,
+          githubGitTreeUrl(repositoryFullName, branch, { recursive: true }),
         );
 
         if (treeResponse.data.tree) {
@@ -184,7 +190,7 @@ const RepositoryCodeBrowser: React.FC<RepositoryCodeBrowserProps> = ({
         }
 
         const response = await axios.get(
-          `https://api.github.com/repos/${repositoryFullName}/commits?${params.toString()}`,
+          githubCommitsUrl(repositoryFullName, params),
         );
 
         if (response.data && response.data.length > 0) {

--- a/src/components/repositories/RepositoryCodeBrowser.tsx
+++ b/src/components/repositories/RepositoryCodeBrowser.tsx
@@ -143,9 +143,7 @@ const RepositoryCodeBrowser: React.FC<RepositoryCodeBrowserProps> = ({
     const fetchRepoData = async () => {
       setLoading(true);
       try {
-        const repoResponse = await axios.get(
-          githubRepoUrl(repositoryFullName),
-        );
+        const repoResponse = await axios.get(githubRepoUrl(repositoryFullName));
         const branch = repoResponse.data.default_branch || 'main';
         setDefaultBranch(branch);
 

--- a/src/constants/github.ts
+++ b/src/constants/github.ts
@@ -1,0 +1,51 @@
+/**
+ * Central GitHub REST API and jsDelivr raw URL builders.
+ * Keeps host strings in one place for repository browser and related features.
+ */
+
+export const GITHUB_API_BASE = 'https://api.github.com' as const;
+
+export const JSDELIVR_GH_RAW_BASE = 'https://cdn.jsdelivr.net/gh' as const;
+
+/** `GET /repos/{owner}/{repo}` */
+export function githubRepoUrl(repositoryFullName: string) {
+  return `${GITHUB_API_BASE}/repos/${repositoryFullName}`;
+}
+
+/** `GET /repos/{owner}/{repo}/commits/{sha}` */
+export function githubCommitDetailUrl(repositoryFullName: string, sha: string) {
+  return `${githubRepoUrl(repositoryFullName)}/commits/${sha}`;
+}
+
+/** `GET /repos/{owner}/{repo}/git/trees/{ref}` */
+export function githubGitTreeUrl(
+  repositoryFullName: string,
+  treeSha: string,
+  options?: { recursive?: boolean },
+) {
+  const base = `${githubRepoUrl(repositoryFullName)}/git/trees/${treeSha}`;
+  return options?.recursive ? `${base}?recursive=1` : base;
+}
+
+/** `GET /repos/{owner}/{repo}/commits` */
+export function githubCommitsUrl(
+  repositoryFullName: string,
+  searchParams: URLSearchParams,
+) {
+  const q = searchParams.toString();
+  return q
+    ? `${githubRepoUrl(repositoryFullName)}/commits?${q}`
+    : `${githubRepoUrl(repositoryFullName)}/commits`;
+}
+
+/**
+ * Raw file URL via jsDelivr (`owner/repo@branch/path`).
+ * @param encodedPath Path with each segment URL-encoded (e.g. spaces → %20).
+ */
+export function jsDelivrRawFileUrl(
+  repositoryFullName: string,
+  branch: string,
+  encodedPath: string,
+) {
+  return `${JSDELIVR_GH_RAW_BASE}/${repositoryFullName}@${branch}/${encodedPath}`;
+}


### PR DESCRIPTION
## Summary

This change introduces `src/constants/github.ts`, a small module that owns **GitHub REST API** and **jsDelivr raw file** URL construction. `RepositoryCodeBrowser` is refactored to call these helpers instead of repeating inline `https://api.github.com/repos/...` and related templates.

### Motivation

- **Single source of truth** for external hosts (`api.github.com`, `cdn.jsdelivr.net/gh`), so future changes (mirrors, env-based bases, or path rules) touch one file.
- **Easier review** of all GitHub calls used by the code browser (repo metadata, git tree, commits list, single commit).
- **Consistency** with how we want to treat “magic strings” in the codebase.

### What changed

**Added `src/constants/github.ts`**

- `GITHUB_API_BASE` — `https://api.github.com`
- `JSDELIVR_GH_RAW_BASE` — `https://cdn.jsdelivr.net/gh`
- `githubRepoUrl(repositoryFullName)` — `GET /repos/{owner}/{repo}`
- `githubCommitDetailUrl(repositoryFullName, sha)` — `GET /repos/{owner}/{repo}/commits/{sha}`
- `githubGitTreeUrl(repositoryFullName, treeSha, { recursive })` — `GET /repos/{owner}/{repo}/git/trees/{ref}`
- `githubCommitsUrl(repositoryFullName, searchParams)` — `GET /repos/{owner}/{repo}/commits?...`
- `jsDelivrRawFileUrl(repositoryFullName, branch, encodedPath)` — raw file URL for a given branch and **per-segment encoded** path (available for other viewers / future use)

**Updated `src/components/repositories/RepositoryCodeBrowser.tsx`**

- Replaced four inline GitHub API URL strings with the helpers above.
- Behavior and request shapes are unchanged; only URL assembly is centralized.

### Out of scope

- No UI or styling changes.
- No change to rate limiting, auth, or error handling.
- Other files that still embed GitHub/jsDelivr URLs (e.g. `CodeViewer`, `ReadmeViewer`, `PRFilesChanged`) are **not** migrated in this PR unless you want a follow-up.

### How to verify

1. Open a repository **Code** tab, browse folders and open a file (if applicable).
2. Confirm tree loads, latest-commit header for directories still loads, and no new console errors.
3. Optionally: DevTools → Network → confirm requests still hit `api.github.com/repos/...` with the same paths as before.


## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes (N/A)