### PR TITLE
refactor: replace hardcoded subnet IDs with constants in GettingStarted and FAQPage components

### DIFF
--- a/src/components/onboard/GettingStarted.tsx
+++ b/src/components/onboard/GettingStarted.tsx
@@ -165,11 +165,15 @@ const StepDetail: React.FC<{ step: number }> = ({ step }) => {
           </Typography>
           <NetworkTabs network={network} onChange={setNetwork} />
           {network === 'mainnet' ? (
-            <CodeBlock label={`mainnet (subnet ${PRODUCT_SUBNET.MAINNET})`}>{`btcli subnet register --netuid ${PRODUCT_SUBNET.MAINNET} \\
+            <CodeBlock
+              label={`mainnet (subnet ${PRODUCT_SUBNET.MAINNET})`}
+            >{`btcli subnet register --netuid ${PRODUCT_SUBNET.MAINNET} \\
   --wallet-name <WALLET_NAME> \\
   --hotkey <HOTKEY_NAME>`}</CodeBlock>
           ) : (
-            <CodeBlock label={`testnet (subnet ${PRODUCT_SUBNET.TESTNET})`}>{`btcli subnet register --netuid ${PRODUCT_SUBNET.TESTNET} \\
+            <CodeBlock
+              label={`testnet (subnet ${PRODUCT_SUBNET.TESTNET})`}
+            >{`btcli subnet register --netuid ${PRODUCT_SUBNET.TESTNET} \\
   --wallet-name <WALLET_NAME> \\
   --hotkey <HOTKEY_NAME> \\
   --network test`}</CodeBlock>

--- a/src/components/onboard/GettingStarted.tsx
+++ b/src/components/onboard/GettingStarted.tsx
@@ -3,6 +3,7 @@ import { Box, Typography, Stack, Button, Tabs, Tab } from '@mui/material';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import { alpha } from '@mui/material/styles';
+import { PRODUCT_SUBNET } from '../../constants/productSubnet';
 
 const MONO = '"JetBrains Mono", monospace';
 
@@ -164,11 +165,11 @@ const StepDetail: React.FC<{ step: number }> = ({ step }) => {
           </Typography>
           <NetworkTabs network={network} onChange={setNetwork} />
           {network === 'mainnet' ? (
-            <CodeBlock label="mainnet (subnet 74)">{`btcli subnet register --netuid 74 \\
+            <CodeBlock label={`mainnet (subnet ${PRODUCT_SUBNET.MAINNET})`}>{`btcli subnet register --netuid ${PRODUCT_SUBNET.MAINNET} \\
   --wallet-name <WALLET_NAME> \\
   --hotkey <HOTKEY_NAME>`}</CodeBlock>
           ) : (
-            <CodeBlock label="testnet (subnet 422)">{`btcli subnet register --netuid 422 \\
+            <CodeBlock label={`testnet (subnet ${PRODUCT_SUBNET.TESTNET})`}>{`btcli subnet register --netuid ${PRODUCT_SUBNET.TESTNET} \\
   --wallet-name <WALLET_NAME> \\
   --hotkey <HOTKEY_NAME> \\
   --network test`}</CodeBlock>
@@ -274,12 +275,12 @@ uv pip install -e .`}</CodeBlock>
             <CodeBlock label="mainnet">{`gitt miner post --pat <YOUR_PAT> \\
   --wallet <WALLET_NAME> \\
   --hotkey <HOTKEY_NAME> \\
-  --netuid 74`}</CodeBlock>
+  --netuid ${PRODUCT_SUBNET.MAINNET}`}</CodeBlock>
           ) : (
             <CodeBlock label="testnet">{`gitt miner post --pat <YOUR_PAT> \\
   --wallet <WALLET_NAME> \\
   --hotkey <HOTKEY_NAME> \\
-  --netuid 422 --network test`}</CodeBlock>
+  --netuid ${PRODUCT_SUBNET.TESTNET} --network test`}</CodeBlock>
           )}
           <Typography
             variant="body2"
@@ -306,12 +307,12 @@ uv pip install -e .`}</CodeBlock>
             <CodeBlock label="mainnet">{`gitt miner check \\
   --wallet <WALLET_NAME> \\
   --hotkey <HOTKEY_NAME> \\
-  --netuid 74`}</CodeBlock>
+  --netuid ${PRODUCT_SUBNET.MAINNET}`}</CodeBlock>
           ) : (
             <CodeBlock label="testnet">{`gitt miner check \\
   --wallet <WALLET_NAME> \\
   --hotkey <HOTKEY_NAME> \\
-  --netuid 422 --network test`}</CodeBlock>
+  --netuid ${PRODUCT_SUBNET.TESTNET} --network test`}</CodeBlock>
           )}
           <Typography
             variant="body2"

--- a/src/constants/productSubnet.ts
+++ b/src/constants/productSubnet.ts
@@ -1,0 +1,12 @@
+/**
+ * Gittensor product subnet netuids (Bittensor `netuid`) for onboarding copy,
+ * FAQ, and external links. Update here when mainnet/testnet assignments change.
+ */
+export const PRODUCT_SUBNET = {
+  MAINNET: 74,
+  TESTNET: 422,
+} as const;
+
+export function taostatsSubnetChartUrl(netuid: number) {
+  return `https://taostats.io/subnets/${netuid}/chart`;
+}

--- a/src/pages/FAQPage.tsx
+++ b/src/pages/FAQPage.tsx
@@ -3,6 +3,10 @@ import { Stack, Box } from '@mui/material';
 import { Page } from '../components/layout';
 import FAQ from '../components/FAQ';
 import { SEO } from '../components';
+import {
+  PRODUCT_SUBNET,
+  taostatsSubnetChartUrl,
+} from '../constants/productSubnet';
 
 export const FAQContent: React.FC = () => (
   <Box
@@ -46,7 +50,7 @@ export const FAQContent: React.FC = () => (
             provide utility value to the incentive mechanism or other aspects of
             a subnet. Check Gittensor's token page on{' '}
             <a
-              href="https://taostats.io/subnets/74/chart"
+              href={taostatsSubnetChartUrl(PRODUCT_SUBNET.MAINNET)}
               target="_blank"
               rel="noopener noreferrer"
               style={{ color: 'inherit', textDecoration: 'underline' }}
@@ -59,7 +63,7 @@ export const FAQContent: React.FC = () => (
       />
       <FAQ
         question="What is Gittensor?"
-        answer="Gittensor is subnet 74 within the Bittensor network that rewards open source software developers for their contributions. It distributes emissions, in the form of alpha tokens, to developers whose code has been integrated and merged into recognized GitHub repositories."
+        answer={`Gittensor is subnet ${PRODUCT_SUBNET.MAINNET} within the Bittensor network that rewards open source software developers for their contributions. It distributes emissions, in the form of alpha tokens, to developers whose code has been integrated and merged into recognized GitHub repositories.`}
       />
       <FAQ
         question="How do I start mining on Gittensor?"


### PR DESCRIPTION
## Summary

Centralize product subnet IDs by introducing `src/constants/productSubnet.ts` and replacing hardcoded netuids in onboarding and FAQ content.

### Changes
- Added `PRODUCT_SUBNET` constants:
  - `MAINNET`
  - `TESTNET`
- Added `taostatsSubnetChartUrl(netuid)` helper.
- Updated `GettingStarted.tsx` to use constants in command examples and subnet labels.
- Updated `FAQPage.tsx` to use constants for subnet references and Taostats subnet chart URL.

This removes scattered hardcoded subnet values and makes future netuid updates a single-file change.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes (N/A)