### PR TITLE
fix(layout): prevent mobile scroll area from hiding under fixed header

### DIFF
--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -126,12 +126,13 @@ const AppLayout: React.FC = () => {
           flexGrow: 1,
           maxWidth: '1920px', // Max content width for ultra-wide screens
           width: '100%',
+          height: { xs: 'calc(100vh - 64px)', md: '100vh' },
+          mt: { xs: '64px', md: 0 },
           overflowY: 'auto',
           overflowX: 'hidden',
           display: 'flex',
           flexDirection: 'column',
           px: { xs: 1, sm: 2, md: 3 },
-          pt: isMobile ? '64px' : 0, // Padding for mobile header
           alignItems: 'center',
         }}
       >


### PR DESCRIPTION
## Summary

Fix mobile layout so the main scroll container starts below the fixed top app bar, preventing the scrollbar/content from being hidden behind the header.

### What changed
- Updated `src/components/layout/AppLayout.tsx`:
  - Set mobile main container height to `calc(100vh - 64px)`
  - Added mobile top margin `64px` to offset fixed header
  - Removed mobile top padding workaround

This ensures the scrollable `<main>` region is correctly positioned under the fixed header on mobile devices.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

Before:
<img width="984" height="869" alt="image" src="https://github.com/user-attachments/assets/d0793ba0-ebcd-4b96-a0ca-410a25b348d5" />


After:
<img width="984" height="869" alt="image" src="https://github.com/user-attachments/assets/9a5e35bc-213f-46a2-a71f-597168eec2a6" />

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes