### PR TITLE
fix: move issue score breakdown to Overview tab, remove mislabeled Issues tab

### DIFF
--- a/src/pages/MinerDetailsPage.tsx
+++ b/src/pages/MinerDetailsPage.tsx
@@ -179,10 +179,7 @@ const MinerDetailsPage: React.FC = () => {
             {activeTab === 'overview' && (
               <>
                 <MinerInsightsCard githubId={githubId} viewMode={viewMode} />
-                <MinerScoreBreakdown
-                  githubId={githubId}
-                  viewMode={viewMode}
-                />
+                <MinerScoreBreakdown githubId={githubId} viewMode={viewMode} />
               </>
             )}
 

--- a/src/pages/MinerDetailsPage.tsx
+++ b/src/pages/MinerDetailsPage.tsx
@@ -21,7 +21,7 @@ const PR_TABS = [
   'pull-requests',
   'repositories',
 ] as const;
-const ISSUE_TABS = ['overview', 'activity', 'issues', 'repositories'] as const;
+const ISSUE_TABS = ['overview', 'activity', 'repositories'] as const;
 type MinerDetailsTab = (typeof PR_TABS)[number] | (typeof ISSUE_TABS)[number];
 
 const tabSx = {
@@ -168,10 +168,9 @@ const MinerDetailsPage: React.FC = () => {
             >
               <Tab value="overview" label="Overview" />
               <Tab value="activity" label="Activity" />
-              <Tab
-                value={viewMode === 'issues' ? 'issues' : 'pull-requests'}
-                label={viewMode === 'issues' ? 'Issues' : 'Pull Requests'}
-              />
+              {viewMode === 'prs' && (
+                <Tab value="pull-requests" label="Pull Requests" />
+              )}
               <Tab value="repositories" label="Repositories" />
             </Tabs>
           </Box>
@@ -180,9 +179,10 @@ const MinerDetailsPage: React.FC = () => {
             {activeTab === 'overview' && (
               <>
                 <MinerInsightsCard githubId={githubId} viewMode={viewMode} />
-                {viewMode === 'prs' && (
-                  <MinerScoreBreakdown githubId={githubId} />
-                )}
+                <MinerScoreBreakdown
+                  githubId={githubId}
+                  viewMode={viewMode}
+                />
               </>
             )}
 
@@ -191,9 +191,6 @@ const MinerDetailsPage: React.FC = () => {
             )}
             {activeTab === 'pull-requests' && (
               <MinerPRsTable githubId={githubId} />
-            )}
-            {activeTab === 'issues' && (
-              <MinerScoreBreakdown githubId={githubId} viewMode="issues" />
             )}
             {activeTab === 'repositories' && (
               <MinerRepositoriesTable githubId={githubId} />


### PR DESCRIPTION
## Summary
Fixes the UX mislabeling reported. In issues mode (`?mode=issues`), the third tab was labeled "Issues" - implying a list of filed issues - but rendered `MinerScoreBreakdown` (aggregate stats). This PR moves the breakdown into the Overview tab (mirroring PR mode) and removes the empty tab.

## Root cause
In PR mode, Overview renders both `MinerInsightsCard` and `MinerScoreBreakdown`. In issues mode, Overview only rendered `MinerInsightsCard` - the breakdown was guarded behind `viewMode === 'prs'` and placed in a separate "Issues" tab instead. This created two problems:
1. The "Issues" tab label implies a paginated list (by analogy with "Pull Requests" → `MinerPRsTable`), but shows stats
2. The issues-mode Overview is shorter than PR-mode Overview because the breakdown is missing

## Fix
1. **Removed `'issues'` from `ISSUE_TABS`** - no tab renders without content. Anyone with `?tab=issues` in their URL gracefully falls back to Overview (where the content now lives).
2. **Always render `MinerScoreBreakdown` in Overview** - replaced `{viewMode === 'prs' && ...}` with `<MinerScoreBreakdown viewMode={viewMode} />`, so both PR and issue breakdowns appear symmetrically.
3. **Deleted the dead `activeTab === 'issues'` block** - now unreachable.

## What this does NOT do
- Does not add a `MinerIssuesTable` - that requires a backend endpoint (`GET /miners/{githubId}/issues`) which doesn't exist yet. Filed as a follow-up in the issue thread.
- Does not change PR mode behavior at all.

## Type of Change
- [x] Bug fix (UX mislabeling)

## Testing
- [ ] `npm run build`
- [ ] `npm run lint:fix`
- [ ] Manual:
  - `/miners/details?githubId=X&mode=issues` → Overview tab shows both `MinerInsightsCard` and `IssueBreakdownView` (score, credibility, solved/closed/open counts)
  - Tab bar in issues mode shows 3 tabs: Overview, Activity, Repositories (no "Issues" tab)
  - `/miners/details?githubId=X&mode=issues&tab=issues` → falls back to Overview cleanly
  - `/miners/details?githubId=X&mode=prs` → unchanged: Overview shows PR breakdown, "Pull Requests" tab still has `MinerPRsTable`

## Checklist
- [x] No behavior change in PR mode
- [x] No new dependencies
- [x] Single file touched: `src/pages/MinerDetailsPage.tsx`

## Video to Upload

https://github.com/user-attachments/assets/cccdd8e9-f4e7-40c6-a617-6708603f2a08

