### PR TITLE
feat: persist filters and list state in URL query params

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -246,7 +246,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
       "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -290,7 +289,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.1.tgz",
       "integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -1148,7 +1146,6 @@
       "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.18.0.tgz",
       "integrity": "sha512-bbH/HaJZpFtXGvWg3TsBWG4eyt3gah3E7nCNU8GLyRjVoWcA91Vm/T+sjHfUcwgJSw9iLtucfHBoq+qW/T30aA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.23.9",
         "@mui/core-downloads-tracker": "^5.18.0",
@@ -2095,7 +2092,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -2141,7 +2137,6 @@
       "integrity": "sha512-Jz9ZztpB37dNC+HU2HI28Bs9QXpzCz+y/twHOwhyrIRdbuVDxSytJNDl6z/aAKlaRIwC7y8wJdkBv7FxYGgi0A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
         "@typescript-eslint/scope-manager": "8.56.1",
@@ -2171,7 +2166,6 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -2480,7 +2474,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2949,7 +2942,6 @@
       "resolved": "https://registry.npmjs.org/echarts/-/echarts-6.0.0.tgz",
       "integrity": "sha512-Tte/grDQRiETQP4xz3iZWSvoHrkCQtwqd6hs+mifXcjrCuo2iKWbajFObuLJVBlDIJlOzgQPd1hsaKt/3+OMkQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "2.3.0",
         "zrender": "6.0.0"
@@ -3100,7 +3092,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -5432,7 +5423,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5573,7 +5563,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -5614,7 +5603,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -6305,7 +6293,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6459,7 +6446,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -7058,7 +7044,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -7126,6 +7111,24 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vitest/node_modules/yaml": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/web-namespaces": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -246,6 +246,7 @@
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
       "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -289,6 +290,7 @@
       "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.1.tgz",
       "integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -1146,6 +1148,7 @@
       "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.18.0.tgz",
       "integrity": "sha512-bbH/HaJZpFtXGvWg3TsBWG4eyt3gah3E7nCNU8GLyRjVoWcA91Vm/T+sjHfUcwgJSw9iLtucfHBoq+qW/T30aA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.23.9",
         "@mui/core-downloads-tracker": "^5.18.0",
@@ -2092,6 +2095,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -2137,6 +2141,7 @@
       "integrity": "sha512-Jz9ZztpB37dNC+HU2HI28Bs9QXpzCz+y/twHOwhyrIRdbuVDxSytJNDl6z/aAKlaRIwC7y8wJdkBv7FxYGgi0A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
         "@typescript-eslint/scope-manager": "8.56.1",
@@ -2166,6 +2171,7 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -2474,6 +2480,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2942,6 +2949,7 @@
       "resolved": "https://registry.npmjs.org/echarts/-/echarts-6.0.0.tgz",
       "integrity": "sha512-Tte/grDQRiETQP4xz3iZWSvoHrkCQtwqd6hs+mifXcjrCuo2iKWbajFObuLJVBlDIJlOzgQPd1hsaKt/3+OMkQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "2.3.0",
         "zrender": "6.0.0"
@@ -3092,6 +3100,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -5423,6 +5432,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5563,6 +5573,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -5603,6 +5614,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -6293,6 +6305,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6446,6 +6459,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -7044,6 +7058,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -7111,24 +7126,6 @@
         "yaml": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vitest/node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/web-namespaces": {

--- a/src/components/leaderboard/TopMinersTable.tsx
+++ b/src/components/leaderboard/TopMinersTable.tsx
@@ -309,7 +309,8 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
                     nextSearchParams.delete(VISIBLE_QUERY_PARAM);
                   }
 
-                  return nextSearchParams.toString() === previousParams.toString()
+                  return nextSearchParams.toString() ===
+                    previousParams.toString()
                     ? previousParams
                     : nextSearchParams;
                 },

--- a/src/components/leaderboard/TopMinersTable.tsx
+++ b/src/components/leaderboard/TopMinersTable.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo } from 'react';
 import { Box, Typography, CircularProgress, Grid } from '@mui/material';
 import { alpha, useTheme, type Theme } from '@mui/material/styles';
 import { useSearchParams } from 'react-router-dom';
@@ -20,6 +20,8 @@ export type { MinerStats } from './types';
 const MINERS_PAGE_SIZE = 60;
 const SORT_QUERY_PARAM = 'sort';
 const ELIGIBLE_QUERY_PARAM = 'eligible';
+const SEARCH_QUERY_PARAM = 'search';
+const VISIBLE_QUERY_PARAM = 'visible';
 
 interface TopMinersTableProps {
   miners: MinerStats[];
@@ -46,6 +48,17 @@ const getSortOptionFromQuery = (
     : 'totalScore';
 };
 
+const getVisibleCountFromQuery = (value: string | null): number => {
+  if (!value) return MINERS_PAGE_SIZE;
+
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed < MINERS_PAGE_SIZE) {
+    return MINERS_PAGE_SIZE;
+  }
+
+  return parsed;
+};
+
 const TopMinersTable: React.FC<TopMinersTableProps> = ({
   miners,
   isLoading,
@@ -55,14 +68,17 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
 }) => {
   const theme = useTheme();
   const [searchParams, setSearchParams] = useSearchParams();
-  const [searchQuery, setSearchQuery] = useState('');
+  const searchQuery = searchParams.get(SEARCH_QUERY_PARAM) ?? '';
   const sortParamValue = searchParams.get(SORT_QUERY_PARAM);
   const sortOption = useMemo(
     () => getSortOptionFromQuery(sortParamValue, variant),
     [sortParamValue, variant],
   );
   const showEligibleOnly = searchParams.get(ELIGIBLE_QUERY_PARAM) === 'true';
-  const [visibleCount, setVisibleCount] = useState(MINERS_PAGE_SIZE);
+  const visibleCount = useMemo(
+    () => getVisibleCountFromQuery(searchParams.get(VISIBLE_QUERY_PARAM)),
+    [searchParams],
+  );
 
   const handleSortChange = useCallback(
     (nextSortOption: SortOption) => {
@@ -75,6 +91,7 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
           } else {
             nextSearchParams.set(SORT_QUERY_PARAM, nextSortOption);
           }
+          nextSearchParams.delete(VISIBLE_QUERY_PARAM);
 
           return nextSearchParams.toString() === previousParams.toString()
             ? previousParams
@@ -98,6 +115,7 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
         } else {
           nextSearchParams.set(ELIGIBLE_QUERY_PARAM, 'true');
         }
+        nextSearchParams.delete(VISIBLE_QUERY_PARAM);
 
         return nextSearchParams.toString() === previousParams.toString()
           ? previousParams
@@ -150,8 +168,44 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
   }, [miners, searchQuery, showEligibleOnly, sortOption]);
 
   useEffect(() => {
-    setVisibleCount(MINERS_PAGE_SIZE);
-  }, [miners, searchQuery, showEligibleOnly, sortOption]);
+    if (visibleCount <= filteredMiners.length) return;
+
+    setSearchParams(
+      (previousParams) => {
+        const nextSearchParams = new URLSearchParams(previousParams);
+        nextSearchParams.delete(VISIBLE_QUERY_PARAM);
+
+        return nextSearchParams.toString() === previousParams.toString()
+          ? previousParams
+          : nextSearchParams;
+      },
+      { replace: true },
+    );
+  }, [filteredMiners.length, setSearchParams, visibleCount]);
+
+  const handleSearchChange = useCallback(
+    (nextQuery: string) => {
+      setSearchParams(
+        (previousParams) => {
+          const nextSearchParams = new URLSearchParams(previousParams);
+          const normalizedQuery = nextQuery.trim();
+
+          if (normalizedQuery) {
+            nextSearchParams.set(SEARCH_QUERY_PARAM, normalizedQuery);
+          } else {
+            nextSearchParams.delete(SEARCH_QUERY_PARAM);
+          }
+          nextSearchParams.delete(VISIBLE_QUERY_PARAM);
+
+          return nextSearchParams.toString() === previousParams.toString()
+            ? previousParams
+            : nextSearchParams;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
+  );
 
   const visibleMiners = useMemo(
     () => filteredMiners.slice(0, visibleCount),
@@ -199,7 +253,9 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
             />
           </Box>
         }
-        action={<SearchInput value={searchQuery} onChange={setSearchQuery} />}
+        action={
+          <SearchInput value={searchQuery} onChange={handleSearchChange} />
+        }
         sx={{
           mb: 2,
           position: 'sticky',
@@ -234,11 +290,32 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
 
         {remainingMiners > 0 && (
           <Box
-            onClick={() =>
-              setVisibleCount((prev) =>
-                Math.min(prev + MINERS_PAGE_SIZE, filteredMiners.length),
-              )
-            }
+            onClick={() => {
+              const nextVisibleCount = Math.min(
+                visibleCount + MINERS_PAGE_SIZE,
+                filteredMiners.length,
+              );
+
+              setSearchParams(
+                (previousParams) => {
+                  const nextSearchParams = new URLSearchParams(previousParams);
+
+                  if (nextVisibleCount > MINERS_PAGE_SIZE) {
+                    nextSearchParams.set(
+                      VISIBLE_QUERY_PARAM,
+                      String(nextVisibleCount),
+                    );
+                  } else {
+                    nextSearchParams.delete(VISIBLE_QUERY_PARAM);
+                  }
+
+                  return nextSearchParams.toString() === previousParams.toString()
+                    ? previousParams
+                    : nextSearchParams;
+                },
+                { replace: true },
+              );
+            }}
             sx={(theme) => ({
               py: 1.25,
               borderRadius: 2,


### PR DESCRIPTION
## Summary

Implemented URL state persistence for the Discoveries miners list so the page keeps context across refresh, navigation, and link sharing.

What changed
1. Added query param sync for Discoveries list controls:
    - search (search input)
    - sort (selected sort option)
    - eligible (eligible-only filter)
    - visible (number of loaded cards via “Show More”)
2. Preserved clean URL behavior by omitting default values when possible.
3. Reset visible when filters/sort/search change to avoid stale pagination state.
4. Added safety handling to clear invalid visible values when filtered results shrink.

Why this helps
1. Users can refresh without losing current list view.
2. Browser back/forward now restores prior list state.
3. Shared URLs open the same Discoveries view for collaborators.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

https://github.com/user-attachments/assets/f7dcddfe-1ed9-48ac-b116-ac7e12ff68da


## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [ ] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
