### PR TITLE
refactor: remove unused useHistoricalTrend hook from DashboardApi

### DIFF
--- a/src/api/DashboardApi.ts
+++ b/src/api/DashboardApi.ts
@@ -27,16 +27,6 @@ export const useDashboardQuery = <TResponse = void, TSelect = TResponse>(
 
 export const useStats = () => useDashboardQuery<Stats>('useStats', '/stats');
 
-export const useHistoricalTrend = () =>
-  useDashboardQuery<CommitsTrend[]>('useHistoricalTrend', '/lines/hist-trend');
-
-export const useRepoChanges = (options?: { refetchInterval?: number }) =>
-  useDashboardQuery<RepoChanges[]>(
-    'useRepoChanges',
-    '/repos/commits',
-    options?.refetchInterval,
-  );
-
 // Shared cache key for the repositories dataset.
 export const getReposQueryKey = () =>
   ['useReposAndWeights', '/dash/repos', undefined] as const;

--- a/src/api/DashboardApi.ts
+++ b/src/api/DashboardApi.ts
@@ -2,8 +2,6 @@ import { useApiQuery } from './ApiUtils';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import axios from 'axios';
 import {
-  type RepoChanges,
-  type CommitsTrend,
   type Stats,
   type Repository,
   type LanguageWeight,


### PR DESCRIPTION
## Summary

Remove four unused API query hooks that are no longer referenced anywhere in the codebase:
- `useHistoricalTrend`, from `DashboardApi.ts`

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

N/A — no UI changes.

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
