### PR TITLE
refactor: remove dead routePaths

### DIFF
--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -98,13 +98,6 @@ const routesArray: AppRoute[] = [
   },
 ];
 
-export const routePaths = routesArray.reduce<Record<string, AppRoute>>(
-  (acc, x) => {
-    acc[x.path] = x;
-    return acc;
-  },
-  {},
-);
 
 // Matches a pathname against app route definitions so layout code can
 // read route-level UI metadata such as showGlobalSearch.


### PR DESCRIPTION
### Summary
- Removes `routePaths`, a route lookup map that is never imported anywhere in the codebase.

### Why it's safe to remove
- No imports of `routePaths` exist anywhere in the project, including tests.
- `getRouteForPathname` (retained, directly below) covers the same lookup pattern and is actively used.
- `routesArray` itself is retained — it is still used by the router and `getRouteForPathname`.

### Changes
- `src/routes.tsx` — deleted 7 lines (the `routePaths` reduce expression)
