### PR TITLE
fix(miner-activity): show contribution heatmap tooltips immediately on hover

### DIFF
--- a/src/components/ContributionHeatmap.tsx
+++ b/src/components/ContributionHeatmap.tsx
@@ -131,6 +131,17 @@ const ContributionHeatmap: React.FC<ContributionHeatmapProps> = ({
                 title={`${activity.count} contribution${activity.count !== 1 ? 's' : ''} on ${new Date(activity.date).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}`}
                 arrow
                 placement="top"
+                enterDelay={0}
+                enterNextDelay={0}
+                leaveDelay={0}
+                disableInteractive
+                slotProps={{
+                  popper: {
+                    sx: {
+                      zIndex: theme.zIndex.tooltip,
+                    },
+                  },
+                }}
               >
                 {block}
               </Tooltip>


### PR DESCRIPTION
## Summary

Fix tooltip hover behavior in the **Miner Activity** heatmap so titles appear immediately and update reliably while moving between day cells.

### Changes
Updated tooltip config in `src/components/ContributionHeatmap.tsx` (shared heatmap component used by Miner Activity):
- `enterDelay={0}`
- `enterNextDelay={0}`
- `leaveDelay={0}`
- `disableInteractive`
- `slotProps.popper.sx.zIndex = theme.zIndex.tooltip`

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

before:
[401b7bc0-54d7-4861-9fd2-bade32779fe5.webm](https://github.com/user-attachments/assets/383be519-85ae-42a3-8608-99ca301e0008)


after:
[eff242d9-4bd7-4f64-9bbd-d7f55a6a56db.webm](https://github.com/user-attachments/assets/049c2554-1f17-4416-8551-a57a895a7d1d)

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes