### PR TITLE
fix: improve sortable header keyboard accessibility and aria-sort semantics

### DIFF
--- a/src/components/leaderboard/TopRepositoriesTable.tsx
+++ b/src/components/leaderboard/TopRepositoriesTable.tsx
@@ -32,6 +32,7 @@ import {
   alpha,
   type SxProps,
   type Theme,
+  type SortDirection as MuiSortDirection,
 } from '@mui/material';
 import SearchIcon from '@mui/icons-material/Search';
 import BarChartIcon from '@mui/icons-material/BarChart';
@@ -432,34 +433,80 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
   }) => (
     <TableCell
       align={align}
+      sortDirection={
+        sortColumn === column ? (sortDirection as MuiSortDirection) : false
+      }
+      aria-sort={
+        sortColumn === column
+          ? sortDirection === 'asc'
+            ? 'ascending'
+            : 'descending'
+          : 'none'
+      }
       sx={{
         ...headerCellStyle,
         ...(sx || {}),
-        cursor: 'pointer',
         userSelect: 'none',
-        '&:hover': {
-          backgroundColor: 'surface.light',
-        },
       }}
-      onClick={() => handleSort(column)}
     >
       <Box
         sx={{
+          width: '100%',
           display: 'flex',
-          alignItems: 'center',
           justifyContent: align === 'right' ? 'flex-end' : 'flex-start',
-          gap: 0.5,
         }}
       >
-        {children}
-        {sortColumn === column && (
-          <Typography
-            component="span"
-            sx={{ fontSize: '0.7rem', opacity: 0.7 }}
-          >
-            {sortDirection === 'asc' ? '▲' : '▼'}
-          </Typography>
-        )}
+        <Box
+          role="button"
+          tabIndex={0}
+          aria-label={`Sort by ${String(children)}`}
+          onClick={() => handleSort(column)}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter' || event.key === ' ') {
+              event.preventDefault();
+              handleSort(column);
+            }
+          }}
+          sx={{
+            position: 'relative',
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 0.5,
+            cursor: 'pointer',
+            transition: 'color 0.2s',
+            '&:hover': {
+              color: 'text.primary',
+            },
+            '&::after': {
+              content: '""',
+              position: 'absolute',
+              inset: '-3px -6px',
+              borderRadius: 1,
+              opacity: 0,
+              pointerEvents: 'none',
+              transition: 'opacity 0.2s',
+            },
+            '&:focus-visible': {
+              outline: 'none',
+            },
+            '&:focus-visible::after': {
+              opacity: 1,
+              backgroundColor: 'surface.light',
+              boxShadow: (theme) =>
+                `0 0 0 2px ${theme.palette.background.default}, 0 0 0 4px ${theme.palette.primary.main}`,
+            },
+          }}
+        >
+          {children}
+          {sortColumn === column && (
+            <Typography
+              component="span"
+              sx={{ fontSize: '0.7rem', opacity: 0.7 }}
+            >
+              {sortDirection === 'asc' ? '▲' : '▼'}
+            </Typography>
+          )}
+        </Box>
       </Box>
     </TableCell>
   );


### PR DESCRIPTION
## Summary

Improves keyboard accessibility and sort-state semantics for the Repositories section table sortable headers.

What changed
- Added keyboard-operable sortable header content (Tab focus + Enter/Space to sort).
- Added explicit sort semantics on sortable header cells with aria-sort / sortDirection.
- Refined focus styling to highlight only the interactive header content area (not the whole column), while preserving right-edge header/value alignment.

Why
- Makes sorting usable without a mouse.
- Improves assistive technology support by exposing active sort direction.
- Keeps visual alignment and readability in the repositories leaderboard table.

## Related Issues
Fixes: #372

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

https://github.com/user-attachments/assets/d57b9069-39b6-4ac3-a954-5c2ebec1e585

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [ ] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
