### PR TITLE
refactor: remove dead useIssue and useRepoChanges hooks

### DIFF
--- a/src/api/DashboardApi.ts
+++ b/src/api/DashboardApi.ts
@@ -2,7 +2,6 @@ import { useApiQuery } from './ApiUtils';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import axios from 'axios';
 import {
-  type RepoChanges,
   type CommitsTrend,
   type Stats,
   type Repository,
@@ -29,13 +28,6 @@ export const useStats = () => useDashboardQuery<Stats>('useStats', '/stats');
 
 export const useHistoricalTrend = () =>
   useDashboardQuery<CommitsTrend[]>('useHistoricalTrend', '/lines/hist-trend');
-
-export const useRepoChanges = (options?: { refetchInterval?: number }) =>
-  useDashboardQuery<RepoChanges[]>(
-    'useRepoChanges',
-    '/repos/commits',
-    options?.refetchInterval,
-  );
 
 // Shared cache key for the repositories dataset.
 export const getReposQueryKey = () =>

--- a/src/api/IssuesApi.ts
+++ b/src/api/IssuesApi.ts
@@ -52,18 +52,6 @@ export const useIssuesStats = () =>
   useApiQuery<IssuesStats>('useIssuesStats', '/issues/stats');
 
 /**
- * Fetch a single issue by ID.
- */
-export const useIssue = (id: number) =>
-  useApiQuery<IssueBounty>(
-    'useIssue',
-    `/issues/${id}`,
-    undefined,
-    undefined,
-    !!id,
-  );
-
-/**
  * Fetch issue details with GitHub data.
  */
 export const useIssueDetails = (id: number) =>

--- a/src/api/models/Dashboard.ts
+++ b/src/api/models/Dashboard.ts
@@ -1,13 +1,3 @@
-export type RepoChanges = {
-  repositoryFullName: string;
-  commits: number;
-  additions: number;
-  deletions: number;
-  linesChanged: number;
-  weight: string; // bc float
-  inactiveAt: string | null;
-};
-
 export type Repository = {
   fullName: string;
   owner: string;


### PR DESCRIPTION
## Summary
Remove two dead React Query hooks and one dead type:

- **`useIssue`** (`src/api/IssuesApi.ts`, line 57) — exported but never imported or used anywhere. The app uses `useIssueDetails` instead (which fetches richer data from `/issues/{id}/details`). Grep confirms zero references outside the definition.

- **`useRepoChanges`** (`src/api/DashboardApi.ts`, line 33) — exported but never imported or used anywhere. Grep confirms zero references outside the definition.

- **`RepoChanges`** type (`src/api/models/Dashboard.ts`, line 1) — only used by the dead `useRepoChanges` hook. No other references in the codebase.

## Related Issues
N/A (code cleanup)

## Type of Change
- [x] Refactoring (dead code removal)

## Testing
- [x] `eslint` — 0 errors on changed files
- [x] `tsc --noEmit` — no type errors introduced

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No behavior change — removed code was unreachable

cc @anderdc @landyndev