### PR TITLE
fix: remove irrelevant PRs sort from discoveries leaderboard

### DIFF
--- a/src/components/leaderboard/TopMinersTable.tsx
+++ b/src/components/leaderboard/TopMinersTable.tsx
@@ -31,7 +31,7 @@ interface TopMinersTableProps {
 
 const getAllowedSortOptions = (variant: LeaderboardVariant): SortOption[] =>
   variant === 'discoveries'
-    ? ['totalScore', 'usdPerDay', 'totalPRs', 'totalIssues', 'credibility']
+    ? ['totalScore', 'usdPerDay', 'totalIssues', 'credibility']
     : ['totalScore', 'usdPerDay', 'totalPRs', 'credibility'];
 
 const getSortOptionFromQuery = (
@@ -311,7 +311,9 @@ const SortButtons: React.FC<SortButtonsProps> = ({
     {[
       { label: 'Score', value: 'totalScore' },
       { label: 'Earnings', value: 'usdPerDay' },
-      { label: 'PRs', value: 'totalPRs' },
+      ...(variant !== 'discoveries'
+        ? [{ label: 'PRs', value: 'totalPRs' as const }]
+        : []),
       ...(variant === 'discoveries'
         ? [{ label: 'Issues', value: 'totalIssues' as const }]
         : []),


### PR DESCRIPTION
## Summary
Fixes #376 . The Discoveries leaderboard showed a "PRs" sort button that sorted miners by their OSS pull request count - a metric unrelated to issue discovery performance.

## Root cause
`TopMinersTable` rendered the "PRs" sort button unconditionally for all variants. `DiscoveriesPage` mapped `totalPRs` from `stat.totalPrs` (the OSS PR count). Clicking "PRs" on the discoveries page sorted by OSS activity, producing a misleading ranking.

## Fix
1. Removed `'totalPRs'` from `getAllowedSortOptions` for the `'discoveries'` variant - `?sort=totalPRs` in a discoveries URL now falls back to `totalScore` instead of silently sorting by the wrong metric.
2. Conditionally render the "PRs" sort button only when `variant !== 'discoveries'` - mirrors the existing pattern where "Issues" is only shown for `variant === 'discoveries'`.

## Type of Change
- [x] Bug fix (data integrity - misleading sort on a leaderboard)

## Testing
- [ ] `npm run build`
- [ ] `npm run lint:fix`
- [ ] Manual on `/discoveries`:
  - Sort buttons: Score, Earnings, Issues, Credibility (no "PRs")
  - URL `?sort=totalPRs` falls back to Score sort (not silently accepted)
- [ ] Manual on `/top-miners`:
  - Sort buttons unchanged: Score, Earnings, PRs, Credibility (no "Issues")

## Checklist
- [x] No behavior change on `/top-miners`
- [x] No new dependencies
- [x] Single file touched

## Video file to upload

https://github.com/user-attachments/assets/3cdbe9ed-c8f8-404d-a725-e946439264fe

