### PR TITLE
fix: redesign 404 page with recovery actions and consistent styling

### DIFF
--- a/src/pages/NotFoundPage.tsx
+++ b/src/pages/NotFoundPage.tsx
@@ -1,28 +1,102 @@
 import React from 'react';
-import { FaceFrownIcon } from '@heroicons/react/24/outline';
-import { Stack, Typography } from '@mui/material';
+import { Box, Button, Stack, Typography, alpha } from '@mui/material';
+import SearchOffIcon from '@mui/icons-material/SearchOff';
+import HomeIcon from '@mui/icons-material/Home';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import { useNavigate, useLocation } from 'react-router-dom';
 
-const NotFoundPage: React.FC = () => (
-  <Stack
-    sx={{
-      display: 'flex',
-      justifyContent: 'center',
-      alignItems: 'center',
-      width: '100%',
-      height: '100%',
-    }}
-    direction="row"
-    gap={2}
-  >
-    <Typography variant="h4">404 Not Found</Typography>
-    <FaceFrownIcon
-      style={{
-        height: 32,
-        width: 32,
-        backgroundColor: 'primary.main',
+const NotFoundPage: React.FC = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        minHeight: '70vh',
+        width: '100%',
+        px: { xs: 3, md: 6 },
       }}
-    />
-  </Stack>
-);
+    >
+      <Stack
+        spacing={2.5}
+        alignItems="flex-start"
+        sx={{ maxWidth: 520, width: '100%' }}
+      >
+        <SearchOffIcon
+          sx={{
+            fontSize: 48,
+            color: (t) => alpha(t.palette.text.primary, 0.3),
+          }}
+        />
+        <Typography
+          sx={{
+            fontFamily: '"JetBrains Mono", monospace',
+            fontSize: { xs: '1.5rem', md: '2rem' },
+            fontWeight: 600,
+            color: 'text.primary',
+          }}
+        >
+          Page not found
+        </Typography>
+        <Typography
+          sx={{
+            fontFamily: '"JetBrains Mono", monospace',
+            fontSize: '0.85rem',
+            color: (t) => alpha(t.palette.text.primary, 0.5),
+            lineHeight: 1.6,
+          }}
+        >
+          The URL you followed doesn't match any page. It may have been moved or
+          removed.
+        </Typography>
+        <Box
+          component="pre"
+          sx={{
+            width: '100%',
+            fontFamily: '"JetBrains Mono", monospace',
+            fontSize: '0.75rem',
+            color: (t) => alpha(t.palette.text.primary, 0.4),
+            border: '1px solid',
+            borderColor: 'border.light',
+            borderRadius: 1,
+            p: 1.5,
+            m: 0,
+            overflow: 'auto',
+            whiteSpace: 'pre-wrap',
+            wordBreak: 'break-all',
+          }}
+        >
+          {location.pathname}
+          {location.search}
+        </Box>
+        <Stack direction="row" spacing={1.5} sx={{ pt: 1 }}>
+          <Button
+            variant="outlined"
+            startIcon={<HomeIcon />}
+            onClick={() => navigate('/dashboard')}
+            sx={{ textTransform: 'none' }}
+          >
+            Go to Dashboard
+          </Button>
+          <Button
+            variant="outlined"
+            startIcon={<ArrowBackIcon />}
+            onClick={() => navigate(-1)}
+            sx={{
+              textTransform: 'none',
+              color: 'text.secondary',
+              borderColor: 'border.medium',
+            }}
+          >
+            Go back
+          </Button>
+        </Stack>
+      </Stack>
+    </Box>
+  );
+};
 
 export default NotFoundPage;


### PR DESCRIPTION
Fixes #382 

## Summary
Redesigns the 404 page from a dead-end "404 Not Found" placeholder into a styled, recoverable error page consistent with the rest of the app.

## What changed
- Replaced the Heroicons frown icon with MUI's `SearchOffIcon`
- Added two recovery actions: "Go to Dashboard" (primary) and "Go back" (secondary)
- Added a clear explanation and shows the current URL path
- Styled with JetBrains Mono + theme tokens, matching the app's dark aesthetic
- Removed the only `@heroicons/react` import in the codebase

## Why
Users who land on a 404 (stale bookmark, broken link, URL typo) currently see a bare "404 Not Found" with no way to navigate back to the app. The only escape is manually editing the URL bar. The old page also used Heroicons - the sole usage in the app - creating an inconsistency with the MUI icon system used everywhere else.

## Type of Change
- [x] Bug fix / UX improvement

## Testing
- [ ] `npm run build`
- [ ] `npm run lint:fix`
- [ ] Navigate to `/this-does-not-exist` - see the redesigned 404 with recovery buttons
- [ ] Click "Go to Dashboard" → lands on `/dashboard`
- [ ] Click "Go back" → returns to previous page
- [ ] Verify no other file imports from `@heroicons/react`

## Checklist
- [x] Single file changed (`NotFoundPage.tsx`)
- [x] No new dependencies
- [x] Consistent with app theme and icon system

## Video to upload

https://github.com/user-attachments/assets/cd6edfe3-f428-4e1a-91dd-262125b77466

