### PR TITLE
fix: improve bounties help text spacing in header

### DIFF
--- a/src/pages/IssuesPage.tsx
+++ b/src/pages/IssuesPage.tsx
@@ -64,55 +64,67 @@ const IssuesPage: React.FC = () => {
               borderColor: theme.palette.border.light,
             })}
           >
-            <Tabs
-              value={tabIndex}
-              onChange={handleTabChange}
-              sx={(theme) => ({
-                '& .MuiTab-root': {
-                  fontSize: '0.85rem',
-                  fontWeight: 600,
-                  textTransform: 'none',
-                  color: theme.palette.text.secondary,
-                  minHeight: 48,
-                  '&.Mui-selected': {
-                    color: theme.palette.text.primary,
-                  },
-                },
-                '& .MuiTabs-indicator': {
-                  backgroundColor: theme.palette.text.primary,
-                  height: 2,
-                },
-              })}
-            >
-              <Tab label="Available Issues" />
-              <Tab label="Pending Issues" />
-              <Tab label="History" />
-            </Tabs>
-
-            <Typography
+            <Box
               sx={{
-                fontSize: '0.72rem',
-                color: (t) => alpha(t.palette.text.primary, 0.35),
-                pr: 1,
+                display: 'flex',
+                alignItems: 'flex-end',
+                justifyContent: 'space-between',
+                gap: 2,
+                flexWrap: 'wrap',
               }}
             >
-              Learn more about bounties in the{' '}
+              <Tabs
+                value={tabIndex}
+                onChange={handleTabChange}
+                sx={(theme) => ({
+                  '& .MuiTab-root': {
+                    fontSize: '0.85rem',
+                    fontWeight: 600,
+                    textTransform: 'none',
+                    color: theme.palette.text.secondary,
+                    minHeight: 48,
+                    '&.Mui-selected': {
+                      color: theme.palette.text.primary,
+                    },
+                  },
+                  '& .MuiTabs-indicator': {
+                    backgroundColor: theme.palette.text.primary,
+                    height: 2,
+                  },
+                })}
+              >
+                <Tab label="Available Issues" />
+                <Tab label="Pending Issues" />
+                <Tab label="History" />
+              </Tabs>
+
               <Typography
-                component="a"
-                href="https://docs.gittensor.io/issue-bounties.html"
-                target="_blank"
-                rel="noopener noreferrer"
                 sx={{
-                  color: 'primary.main',
-                  fontSize: 'inherit',
-                  fontFamily: 'inherit',
-                  textDecoration: 'none',
-                  '&:hover': { textDecoration: 'underline' },
+                  fontSize: '0.72rem',
+                  color: (t) => alpha(t.palette.text.primary, 0.35),
+                  pr: 1,
+                  mb: { xs: 1, md: 0 },
+                  textAlign: { xs: 'left', md: 'right' },
                 }}
               >
-                docs
+                Learn more about bounties in the{' '}
+                <Typography
+                  component="a"
+                  href="https://docs.gittensor.io/issue-bounties.html"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  sx={{
+                    color: 'primary.main',
+                    fontSize: 'inherit',
+                    fontFamily: 'inherit',
+                    textDecoration: 'none',
+                    '&:hover': { textDecoration: 'underline' },
+                  }}
+                >
+                  docs
+                </Typography>
               </Typography>
-            </Typography>
+            </Box>
           </Box>
 
           {/* Tab Content */}


### PR DESCRIPTION
## Summary
- Align the bounties help text with the tabs/header row so the section no longer appears cramped.
- Add responsive layout behavior so the help text remains readable and properly positioned on smaller screens.
- Preserve existing tab behavior and visual styling while improving spacing consistency.

## Test plan
- [x] Open `/bounties/available` and verify the help text is no longer crowded above the header content.
- [x] Confirm the help text appears inline on larger screens and wraps cleanly on smaller screens.
- [x] Verify tabs still render and navigate correctly across Available, Pending, and History.

Closes #386.