### PR TITLE
Persist miner PR filter in URL

### DIFF
--- a/src/components/miners/MinerPRsTable.tsx
+++ b/src/components/miners/MinerPRsTable.tsx
@@ -116,10 +116,9 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
   const [searchQuery, setSearchQuery] = useState('');
   const [sortField, setSortField] = useState<PrSortField>('date');
   const [sortDir, setSortDir] = useState<SortDir>('desc');
-  const statusFilter: MinerStatusFilter = isMinerStatusFilter(
-    searchParams.get('prStatus'),
-  )
-    ? searchParams.get('prStatus')!
+  const prStatusParam = searchParams.get('prStatus');
+  const statusFilter: MinerStatusFilter = isMinerStatusFilter(prStatusParam)
+    ? prStatusParam
     : 'all';
 
   useEffect(() => {

--- a/src/components/miners/MinerPRsTable.tsx
+++ b/src/components/miners/MinerPRsTable.tsx
@@ -42,6 +42,13 @@ type SortDir = 'asc' | 'desc';
 
 const PAGE_SIZE = 20;
 
+const MINER_STATUS_FILTERS: readonly MinerStatusFilter[] = [
+  'all',
+  'open',
+  'merged',
+  'closed',
+];
+
 // Direction applied when a user first clicks a column header — string
 // columns feel natural ascending, numeric/date columns descending.
 const DEFAULT_SORT_DIR: Record<PrSortField, SortDir> = {
@@ -91,6 +98,11 @@ const getScoreTooltip = (pr: CommitLog): string | null => {
   return parts.join(' · ');
 };
 
+const isMinerStatusFilter = (
+  value: string | null,
+): value is MinerStatusFilter =>
+  value !== null && (MINER_STATUS_FILTERS as readonly string[]).includes(value);
+
 interface MinerPRsTableProps {
   githubId: string;
 }
@@ -101,14 +113,17 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
   const [searchParams, setSearchParams] = useSearchParams();
   const { data: prs, isLoading } = useMinerPRs(githubId);
   const [selectedAuthor, setSelectedAuthor] = useState<string | null>(null);
-  const [statusFilter, setStatusFilter] = useState<MinerStatusFilter>('all');
   const [searchQuery, setSearchQuery] = useState('');
   const [sortField, setSortField] = useState<PrSortField>('date');
   const [sortDir, setSortDir] = useState<SortDir>('desc');
+  const statusFilter: MinerStatusFilter = isMinerStatusFilter(
+    searchParams.get('prStatus'),
+  )
+    ? searchParams.get('prStatus')!
+    : 'all';
 
   useEffect(() => {
     setSelectedAuthor(null);
-    setStatusFilter('all');
     setSearchQuery('');
     setSortField('date');
     setSortDir('desc');
@@ -129,6 +144,22 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
       );
     },
     [page, setSearchParams],
+  );
+
+  const setStatusFilter = useCallback(
+    (next: MinerStatusFilter) => {
+      setSearchParams(
+        (prev) => {
+          const p = new URLSearchParams(prev);
+          if (next === 'all') p.delete('prStatus');
+          else p.set('prStatus', next);
+          p.delete('prPage');
+          return p;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
   );
 
   const handleSort = useCallback(
@@ -298,7 +329,6 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
                 selected={statusFilter === 'all'}
                 onClick={() => {
                   setStatusFilter('all');
-                  setPage(0);
                 }}
               />
               <ExplorerFilterButton
@@ -308,7 +338,6 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
                 selected={statusFilter === 'open'}
                 onClick={() => {
                   setStatusFilter('open');
-                  setPage(0);
                 }}
               />
               <ExplorerFilterButton
@@ -318,7 +347,6 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
                 selected={statusFilter === 'merged'}
                 onClick={() => {
                   setStatusFilter('merged');
-                  setPage(0);
                 }}
               />
               <ExplorerFilterButton
@@ -328,7 +356,6 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
                 selected={statusFilter === 'closed'}
                 onClick={() => {
                   setStatusFilter('closed');
-                  setPage(0);
                 }}
               />
             </Box>


### PR DESCRIPTION
## Summary
### Motivation
The pull request status filter was stored only in component state, so refreshing the miner details page or sharing the link reset the view back to All. Persisting the filter in the URL makes the page state durable, shareable, and consistent with existing URL-backed controls like pagination.

- persist the miner detail pull request status filter in the query string
- restore the selected filter on refresh and when opening a shared link
- reset PR pagination when the filter changes to keep URL state consistent

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

<img width="1801" height="772" alt="image" src="https://github.com/user-attachments/assets/3388124b-a454-4781-a11d-78be895259e8" />
<img width="1818" height="775" alt="image" src="https://github.com/user-attachments/assets/3624ac76-ae97-4a7e-ace0-40b975f30c9d" />
<img width="1818" height="774" alt="image" src="https://github.com/user-attachments/assets/b741cfd4-f65a-4d42-802b-dc640dc93993" />


## Checklist

- [ ] New components are modularized/separated where sensible
- [ ] Uses predefined theme (e.g. no hardcoded colors)
- [ ] Responsive/mobile checked
- [ ] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
