### PR TITLE
refactor: use REPO_OWNER_AVATAR_BACKGROUNDS constant in leaderboard types

### DIFF
--- a/src/components/leaderboard/types.ts
+++ b/src/components/leaderboard/types.ts
@@ -1,4 +1,8 @@
-import { RANK_COLORS, STATUS_COLORS } from '../../theme';
+import {
+  RANK_COLORS,
+  REPO_OWNER_AVATAR_BACKGROUNDS,
+  STATUS_COLORS,
+} from '../../theme';
 
 export interface MinerStats {
   id: string;
@@ -46,8 +50,8 @@ export const getRankColors = (rank: number) => {
 };
 
 export const getRepositoryOwnerAvatarBackground = (owner: string) => {
-  if (owner === 'opentensor') return 'common.white';
-  if (owner === 'bitcoin') return '#F7931A';
+  if (owner === 'opentensor') return REPO_OWNER_AVATAR_BACKGROUNDS.opentensor;
+  if (owner === 'bitcoin') return REPO_OWNER_AVATAR_BACKGROUNDS.bitcoin;
   return 'transparent';
 };
 


### PR DESCRIPTION
## Summary

Replace the hardcoded `'#F7931A'` (Bitcoin orange) and `'common.white'` in `getRepositoryOwnerAvatarBackground()` with the existing `REPO_OWNER_AVATAR_BACKGROUNDS` constant from `theme.ts`, which already defines these exact values.

## Related Issues

Fixes #395

## Type of Change

- [ ] Bug fix
- [x] Refactor
- [ ] New feature
- [ ] Documentation
- [ ] Other (describe below)

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes