### PR TITLE
fix: standardize date formatting with formatDate utility

### DIFF
--- a/src/components/issues/IssueConversation.tsx
+++ b/src/components/issues/IssueConversation.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { formatDate } from '../../utils/format';
 import {
   Box,
   Typography,
@@ -203,11 +204,7 @@ const IssueConversation: React.FC<IssueConversationProps> = ({ issue }) => {
                   component="span"
                   sx={{ fontSize: 'inherit', color: 'inherit' }}
                 >
-                  {new Date(item.createdAt).toLocaleDateString('en-US', {
-                    month: 'short',
-                    day: 'numeric',
-                    year: 'numeric',
-                  })}
+                  {formatDate(item.createdAt)}
                 </Typography>
               </Box>
 

--- a/src/components/prs/PRComments.tsx
+++ b/src/components/prs/PRComments.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { formatDate } from '../../utils/format';
 import {
   Box,
   Typography,
@@ -231,11 +232,7 @@ const PRComments: React.FC<PRCommentsProps> = ({
                   component="span"
                   sx={{ fontSize: 'inherit', color: 'inherit' }}
                 >
-                  {new Date(item.createdAt).toLocaleDateString('en-US', {
-                    month: 'short',
-                    day: 'numeric',
-                    year: 'numeric',
-                  })}
+                  {formatDate(item.createdAt)}
                 </Typography>
               </Box>
 

--- a/src/components/repositories/RepositoryCheckTab.tsx
+++ b/src/components/repositories/RepositoryCheckTab.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useMemo } from 'react';
+import { formatDate } from '../../utils/format';
 import {
   Box,
   Grid,
@@ -330,7 +331,7 @@ const RepositoryCheckTab: React.FC<RepositoryCheckTabProps> = ({
                       fontFamily: '"JetBrains Mono", monospace',
                     }}
                   >
-                    {new Date(repoData.pushed_at).toLocaleDateString()}
+                    {formatDate(repoData.pushed_at)}
                   </Typography>
                 </Box>
                 <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
@@ -348,7 +349,7 @@ const RepositoryCheckTab: React.FC<RepositoryCheckTabProps> = ({
                       fontFamily: '"JetBrains Mono", monospace',
                     }}
                   >
-                    {new Date(repoData.created_at).toLocaleDateString()}
+                    {formatDate(repoData.created_at)}
                   </Typography>
                 </Box>
                 <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>

--- a/src/pages/RepositoryDetailsPage.tsx
+++ b/src/pages/RepositoryDetailsPage.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useSearchParams, useNavigate } from 'react-router-dom';
+import { formatDate } from '../utils/format';
 import {
   Alert,
   Box,
@@ -228,7 +229,7 @@ const RepositoryDetailsPage: React.FC = () => {
                     if (currentRepo?.inactiveAt) {
                       return (
                         <Chip
-                          label={`Inactive since ${new Date(currentRepo.inactiveAt).toLocaleDateString()}`}
+                          label={`Inactive since ${formatDate(currentRepo.inactiveAt)}`}
                           sx={(theme) => ({
                             backgroundColor: alpha(STATUS_COLORS.error, 0.1),
                             color: theme.palette.status.error,


### PR DESCRIPTION
## Summary

Replace `toLocaleDateString()` calls with the existing `formatDate()` utility from `src/utils/format.ts` in four conflict-free files. This ensures consistent "MMM d, yyyy" formatting instead of locale-dependent output.

**Files changed:**
- `RepositoryCheckTab.tsx` — 2 occurrences (pushed_at, created_at)
- `RepositoryDetailsPage.tsx` — 1 occurrence (inactiveAt)
- `IssueConversation.tsx` — 1 occurrence (comment date)
- `PRComments.tsx` — 1 occurrence (comment date)

Note: Additional files with `toLocaleDateString()` exist (`MinerPRsTable`, `RepositoryPRsTable`, `RepositoryIssuesTable`, `ContributionHeatmap`) but are touched by active PRs (#313, #333, #344, #371). Those will be addressed after those PRs merge.

## Related Issues

Fixes #397

## Type of Change

- [x] Bug fix
- [ ] Refactor
- [ ] New feature
- [ ] Documentation
- [ ] Other (describe below)

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes