### PR TITLE
refactor: replace hardcoded colors in ErrorFallback with theme tokens

### DIFF
--- a/src/components/ErrorFallback.tsx
+++ b/src/components/ErrorFallback.tsx
@@ -25,7 +25,7 @@ const ErrorFallback: React.FC<ErrorFallbackProps> = ({
       ? {
           minHeight: '100vh',
           width: '100%',
-          backgroundColor: '#000',
+          backgroundColor: 'background.default',
           px: { xs: 3, md: 6 },
           py: { xs: 6, md: 10 },
         }
@@ -55,7 +55,7 @@ const ErrorFallback: React.FC<ErrorFallbackProps> = ({
           sx={{
             fontFamily: '"JetBrains Mono", monospace',
             fontSize: { xs: '1.25rem', md: '1.5rem' },
-            color: '#fff',
+            color: 'text.primary',
             fontWeight: 500,
           }}
         >
@@ -65,7 +65,7 @@ const ErrorFallback: React.FC<ErrorFallbackProps> = ({
           sx={{
             fontFamily: '"JetBrains Mono", monospace',
             fontSize: '0.85rem',
-            color: 'rgba(255,255,255,0.6)',
+            color: 'text.secondary',
             lineHeight: 1.6,
           }}
         >
@@ -78,8 +78,9 @@ const ErrorFallback: React.FC<ErrorFallbackProps> = ({
             width: '100%',
             fontFamily: '"JetBrains Mono", monospace',
             fontSize: '0.75rem',
-            color: 'rgba(255,255,255,0.5)',
-            border: '1px solid rgba(255,255,255,0.1)',
+            color: 'text.tertiary',
+            border: '1px solid',
+            borderColor: 'border.light',
             borderRadius: 1,
             p: 1.5,
             m: 0,


### PR DESCRIPTION
## Summary

Replace 5 hardcoded color values in `ErrorFallback.tsx` with existing MUI theme palette tokens:

- `'#000'` → `'background.default'`
- `'#fff'` → `'text.primary'`
- `'rgba(255,255,255,0.6)'` → `'text.secondary'`
- `'rgba(255,255,255,0.5)'` → `'text.tertiary'`
- `'rgba(255,255,255,0.1)'` border → `borderColor: 'border.light'`

Note: This component renders inside the `ThemeProvider` (wrapped by `ErrorBoundary` inside `AppLayout`), so theme tokens resolve correctly. The component already uses `STATUS_COLORS.closed` from the theme, confirming theme access works here.

## Related Issues

Fixes #401

## Type of Change

- [ ] Bug fix
- [x] Refactor
- [ ] New feature
- [ ] Documentation
- [ ] Other (describe below)

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes