### PR TITLE
fix: make repositories search placeholder fully visible

### DIFF
--- a/src/components/leaderboard/TopRepositoriesTable.tsx
+++ b/src/components/leaderboard/TopRepositoriesTable.tsx
@@ -589,7 +589,7 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
             </FormControl>
 
             <TextField
-              placeholder="Search or enter owner/repo..."
+              placeholder="Search or enter owner/repository"
               size="small"
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
@@ -611,7 +611,12 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
                 ),
               }}
               sx={{
-                width: '200px',
+                width: { xs: '100%', sm: '300px' },
+                maxWidth: '100%',
+                transition: 'width 0.2s ease',
+                '&:focus-within': {
+                  width: { xs: '100%', sm: '340px' },
+                },
                 '& .MuiOutlinedInput-root': {
                   color: '#ffffff',
                   fontFamily: '"JetBrains Mono", monospace',


### PR DESCRIPTION
## Summary
- increase the repositories search input width so the full placeholder guidance is visible by default
- add responsive sizing and focus expansion to improve readability while typing without breaking smaller layouts
- keep existing search behavior unchanged while improving clarity of the owner/repository hint

## Test plan
- [x] open the Repositories page and verify the placeholder text is fully visible on initial render
- [x] click/focus the search input and verify the full hint remains visible
- [x] confirm the field still behaves correctly on small and desktop viewport sizes

Closes #409