### PR TITLE
fix(dashboard): closed unmerged PRs trend, custom date range, search shortcuts

### DIFF
--- a/src/components/layout/GlobalSearchBar.tsx
+++ b/src/components/layout/GlobalSearchBar.tsx
@@ -377,10 +377,37 @@ const GlobalSearchBar: React.FC = () => {
     }
   }, [activeIndex, navItems]);
 
-  // Global shortcuts: Cmd/Ctrl+K and "/" to focus the search input.
+  // Global shortcuts: Cmd/Ctrl+K, Cmd/Ctrl+F, and "/" to focus the search input.
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
+        e.preventDefault();
+        const input = inputRef.current;
+        if (input) {
+          input.focus();
+          input.select();
+        }
+        return;
+      }
+
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'f') {
+        const target =
+          (e.target as HTMLElement | null) ||
+          (document.activeElement as HTMLElement | null);
+        if (!target) return;
+        const tag = target.tagName;
+        const isEditable =
+          tag === 'INPUT' ||
+          tag === 'TEXTAREA' ||
+          target.isContentEditable === true;
+        if (isEditable) return;
+        if (
+          target.closest(
+            '[role="dialog"], [role="menu"], [role="listbox"], [aria-modal="true"]',
+          )
+        ) {
+          return;
+        }
         e.preventDefault();
         const input = inputRef.current;
         if (input) {
@@ -569,7 +596,7 @@ const GlobalSearchBar: React.FC = () => {
                   pointerEvents: 'none',
                 })}
               >
-                {isMac ? '⌘K' : 'Ctrl K'}
+                {isMac ? '⌘K' : 'Ctrl+K'}
               </Box>
             </InputAdornment>
           ),

--- a/src/pages/dashboard/dashboardData.ts
+++ b/src/pages/dashboard/dashboardData.ts
@@ -16,9 +16,15 @@ import {
 } from '../../utils';
 
 export type PresetTimeRange = '1d' | '7d' | '35d';
-export type TrendTimeRange = PresetTimeRange | 'all';
+export type CustomTrendRange = {
+  kind: 'custom';
+  from: string; // yyyy-mm-dd
+  to: string; // yyyy-mm-dd
+};
+export type TrendTimeRange = PresetTimeRange | 'all' | CustomTrendRange;
 export type TrendSeriesKey =
   | 'mergedPrs'
+  | 'closedUnmergedPrs'
   | 'issuesResolved'
   | 'prsOpened'
   | 'issuesOpened';
@@ -78,6 +84,7 @@ const RANGE_CONFIG: Record<
 
 const TREND_SERIES_KEYS: TrendSeriesKey[] = [
   'mergedPrs',
+  'closedUnmergedPrs',
   'issuesResolved',
   'prsOpened',
   'issuesOpened',
@@ -100,10 +107,36 @@ const isWithinWindow = (timestamp: number | null, window: WindowBounds) =>
 
 export const getRangeConfig = (range: PresetTimeRange) => RANGE_CONFIG[range];
 
+const isCustomRange = (range: TrendTimeRange): range is CustomTrendRange =>
+  typeof range === 'object' && range.kind === 'custom';
+
+const parseDateInputToUtcStartMs = (value: string): number | null => {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (!match) return null;
+  const year = Number(match[1]);
+  const month = Number(match[2]) - 1;
+  const day = Number(match[3]);
+  const timestamp = Date.UTC(year, month, day, 0, 0, 0, 0);
+  return Number.isFinite(timestamp) ? timestamp : null;
+};
+
 export const getWindowBounds = (
   range: TrendTimeRange,
   now = new Date(),
 ): WindowBounds => {
+  if (isCustomRange(range)) {
+    const fromMs = parseDateInputToUtcStartMs(range.from);
+    const toMs = parseDateInputToUtcStartMs(range.to);
+    const fallbackEndMs = now.getTime();
+    const fallbackStartMs = fallbackEndMs - 7 * DAY_MS;
+    if (fromMs === null || toMs === null) {
+      return { startMs: fallbackStartMs, endMs: fallbackEndMs };
+    }
+    const startMs = Math.min(fromMs, toMs);
+    const endMs = Math.max(fromMs, toMs) + DAY_MS;
+    return { startMs, endMs };
+  }
+
   if (range === 'all') {
     return { startMs: GITTENSOR_START_MS, endMs: now.getTime() };
   }
@@ -122,7 +155,7 @@ export const getPreviousWindowBounds = (
   }
 
   const current = getWindowBounds(range, now);
-  const { windowMs } = getRangeConfig(range);
+  const windowMs = current.endMs - current.startMs;
   return {
     startMs: current.startMs - windowMs,
     endMs: current.startMs,
@@ -166,6 +199,21 @@ const buildTrendBuckets = (
   range: TrendTimeRange,
   now = new Date(),
 ): Array<{ startMs: number; endMs: number; label: string }> => {
+  if (isCustomRange(range)) {
+    const { startMs, endMs } = getWindowBounds(range, now);
+    const totalMs = Math.max(DAY_MS, endMs - startMs);
+    const pointCount = Math.max(1, Math.ceil(totalMs / DAY_MS));
+
+    return Array.from({ length: pointCount }, (_, index) => {
+      const bucketStart = startMs + index * DAY_MS;
+      return {
+        startMs: bucketStart,
+        endMs: bucketStart + DAY_MS,
+        label: formatTrendBucketLabel(bucketStart, '7d'),
+      };
+    });
+  }
+
   if (range !== 'all') {
     const { points, bucketMs, windowMs } = getRangeConfig(range);
     const startMs = now.getTime() - windowMs;
@@ -242,6 +290,9 @@ export const buildDashboardTrendData = (
   now = new Date(),
 ): { labels: string[]; series: DashboardTrendSeries[] } => {
   const mergedPrTimestamps = prs.map((pr) => toTimestamp(pr.mergedAt));
+  const closedUnmergedPrTimestamps = prs
+    .filter((pr) => !pr.mergedAt)
+    .map((pr) => toTimestamp(pr.closedAt));
   const openedPrTimestamps = prs.map((pr) => toTimestamp(pr.prCreatedAt));
   const openedIssueTimestamps = issues.map((issue) =>
     toTimestamp(issue.createdAt),
@@ -252,6 +303,7 @@ export const buildDashboardTrendData = (
   const buckets = buildTrendBuckets(
     [
       ...mergedPrTimestamps,
+      ...closedUnmergedPrTimestamps,
       ...openedPrTimestamps,
       ...openedIssueTimestamps,
       ...resolvedIssueTimestamps,
@@ -260,6 +312,10 @@ export const buildDashboardTrendData = (
     now,
   );
   const mergedPrValues = bucketTimestamps(mergedPrTimestamps, buckets);
+  const closedUnmergedPrValues = bucketTimestamps(
+    closedUnmergedPrTimestamps,
+    buckets,
+  );
   const openedPrValues = bucketTimestamps(openedPrTimestamps, buckets);
   const openedIssueValues = bucketTimestamps(openedIssueTimestamps, buckets);
   const resolvedIssueValues = bucketTimestamps(
@@ -274,11 +330,13 @@ export const buildDashboardTrendData = (
       values:
         key === 'mergedPrs'
           ? mergedPrValues
-          : key === 'prsOpened'
-            ? openedPrValues
-            : key === 'issuesResolved'
-              ? resolvedIssueValues
-              : openedIssueValues,
+          : key === 'closedUnmergedPrs'
+            ? closedUnmergedPrValues
+            : key === 'prsOpened'
+              ? openedPrValues
+              : key === 'issuesResolved'
+                ? resolvedIssueValues
+                : openedIssueValues,
     })),
   };
 };

--- a/src/pages/dashboard/views/ContributionTrends.tsx
+++ b/src/pages/dashboard/views/ContributionTrends.tsx
@@ -1,10 +1,12 @@
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import {
   Box,
+  Button,
   Card,
   CardContent,
   CircularProgress,
   Stack,
+  TextField,
   ToggleButton,
   ToggleButtonGroup,
   Typography,
@@ -40,6 +42,12 @@ const TREND_SERIES_PRESENTATION: Record<
     lineWidth: 3,
     lineOpacity: 1,
   },
+  closedUnmergedPrs: {
+    label: 'Closed (Unmerged) PRs',
+    colorOpacity: 0.85,
+    lineWidth: 2,
+    lineOpacity: 0.86,
+  },
   issuesResolved: {
     label: 'Issues Resolved',
     colorOpacity: 0.85,
@@ -63,7 +71,9 @@ const TREND_SERIES_PRESENTATION: Record<
 const getTrendSeriesBaseColor = (theme: Theme, seriesKey: TrendSeriesKey) =>
   seriesKey === 'mergedPrs' || seriesKey === 'prsOpened'
     ? theme.palette.diff.additions
-    : theme.palette.status.award;
+    : seriesKey === 'closedUnmergedPrs'
+      ? theme.palette.status.closed
+      : theme.palette.status.award;
 
 const getTrendSeriesColor = (theme: Theme, seriesKey: TrendSeriesKey) =>
   alpha(
@@ -80,6 +90,23 @@ const ContributionTrends: React.FC<ContributionTrendsProps> = ({
 }) => {
   const theme = useTheme();
   const [hiddenSeries, setHiddenSeries] = useState<TrendSeriesKey[]>([]);
+  const today = new Date();
+  const defaultTo = today.toISOString().slice(0, 10);
+  const defaultFrom = new Date(today.getTime() - 6 * 24 * 60 * 60 * 1000)
+    .toISOString()
+    .slice(0, 10);
+  const [customFrom, setCustomFrom] = useState(defaultFrom);
+  const [customTo, setCustomTo] = useState(defaultTo);
+
+  const selectedRangeKey =
+    typeof range === 'string' ? range : ('custom' as const);
+
+  useEffect(() => {
+    if (typeof range === 'object' && range.kind === 'custom') {
+      setCustomFrom(range.from);
+      setCustomTo(range.to);
+    }
+  }, [range]);
 
   const visibleSeries = useMemo(
     () => series.filter((entry) => !hiddenSeries.includes(entry.key)),
@@ -87,7 +114,14 @@ const ContributionTrends: React.FC<ContributionTrendsProps> = ({
   );
 
   const chartOption = useMemo(() => {
-    const labelInterval = range === '35d' ? 6 : range === '7d' ? 0 : 'auto';
+    const labelInterval =
+      range === '35d'
+        ? 6
+        : range === '7d'
+          ? 0
+          : typeof range === 'object' && labels.length > 14
+            ? 2
+            : 'auto';
     const tooltipPrimaryColor = theme.palette.text.primary;
     const tooltipSecondaryColor = alpha(theme.palette.text.primary, 0.66);
     const tooltipFontFamily = theme.typography.mono.fontFamily;
@@ -247,12 +281,17 @@ const ContributionTrends: React.FC<ContributionTrendsProps> = ({
 
         <ToggleButtonGroup
           exclusive
-          value={range}
+          value={selectedRangeKey}
           onChange={(
             _event: React.MouseEvent<HTMLElement>,
-            nextRange: TrendTimeRange | null,
+            nextRange: '1d' | '7d' | '35d' | 'all' | 'custom' | null,
           ) => {
-            if (nextRange) onRangeChange(nextRange);
+            if (!nextRange) return;
+            if (nextRange === 'custom') {
+              onRangeChange({ kind: 'custom', from: customFrom, to: customTo });
+              return;
+            }
+            onRangeChange(nextRange);
           }}
           size="small"
           aria-label="Contribution timeline time range"
@@ -287,8 +326,48 @@ const ContributionTrends: React.FC<ContributionTrendsProps> = ({
           <ToggleButton value="7d">7D</ToggleButton>
           <ToggleButton value="35d">35D</ToggleButton>
           <ToggleButton value="all">All</ToggleButton>
+          <ToggleButton value="custom">Custom</ToggleButton>
         </ToggleButtonGroup>
       </Stack>
+
+      {selectedRangeKey === 'custom' && (
+        <Stack
+          direction={{ xs: 'column', sm: 'row' }}
+          spacing={1}
+          alignItems={{ xs: 'stretch', sm: 'center' }}
+          sx={{ mb: 1.1 }}
+        >
+          <TextField
+            size="small"
+            type="date"
+            label="From"
+            value={customFrom}
+            onChange={(event) => setCustomFrom(event.target.value)}
+            InputLabelProps={{ shrink: true }}
+          />
+          <TextField
+            size="small"
+            type="date"
+            label="To"
+            value={customTo}
+            onChange={(event) => setCustomTo(event.target.value)}
+            InputLabelProps={{ shrink: true }}
+          />
+          <Button
+            variant="outlined"
+            size="small"
+            onClick={() =>
+              onRangeChange({ kind: 'custom', from: customFrom, to: customTo })
+            }
+            sx={{
+              textTransform: 'none',
+              fontFamily: theme.typography.mono.fontFamily,
+            }}
+          >
+            Apply Range
+          </Button>
+        </Stack>
+      )}
 
       <Card
         elevation={0}

--- a/src/pages/dashboard/views/DashboardOverview.tsx
+++ b/src/pages/dashboard/views/DashboardOverview.tsx
@@ -134,7 +134,9 @@ const DashboardOverview: React.FC<DashboardOverviewProps> = ({
   const rangeDescription =
     range === 'all'
       ? 'All-time totals'
-      : `Deltas vs previous ${range.toUpperCase()} window`;
+      : typeof range === 'string'
+        ? `Deltas vs previous ${range.toUpperCase()} window`
+        : 'Deltas vs previous custom window';
 
   return (
     <>


### PR DESCRIPTION
## PR title

**fix(dashboard): closed-unmerged PR trend, custom date range, and search shortcut UX**


## Summary

This PR improves the Dashboard **Active Network** trends and global search shortcuts:

- Adds a **“Closed (Unmerged) PRs”** trend series using PRs with `closedAt` and no `mergedAt`, bucketed like the existing metrics.
- Extends the time range with a **Custom** mode: **From / To** `yyyy-mm-dd` inputs, **Apply Range**, and **daily** buckets for that window (preset buttons unchanged).
- Fixes the search shortcut badge from **“Ctrl K”** to **“Ctrl+K”** and adds **Ctrl/Cmd+F** to focus search when not typing in an editable field or inside dialogs/menus (same guard pattern as the `/` shortcut).


## Related Issues

#413

Fixes #413  


## Type of Change

- [x] Bug fix  
- [x] New feature  
- [ ] Refactor  
- [ ] Documentation  
- [ ] Other (describe below)

*(Shortcut label = bug fix; new series + custom range = new feature. If your template allows only one box, keep **New feature** and drop **Bug fix**, or the reverse—your call.)*


## Screenshots

<!-- Attach in the PR body on GitHub -->

- **After:** 

<img width="1872" height="880" alt="2026-04-16_09h48_38" src="https://github.com/user-attachments/assets/306ccb09-dd2a-42d7-ac76-9ccaa5f5e2e2" />



- **Before (optional):** 
<img width="1889" height="903" alt="2026-04-16_05h33_33" src="https://github.com/user-attachments/assets/0524b793-50d5-401b-8033-7e69a7264271" />



## Checklist

- [x] New components are modularized/separated where sensible *(changes stay in existing dashboard/search components; no large new surfaces)*  
- [x] Uses predefined theme (e.g. no hardcoded colors) *(uses theme palette, e.g. `status.closed` for the new series)*  
- [ ] Responsive/mobile checked *(please confirm on a narrow viewport: Custom row stacks; toggles still usable)*  
- [x] Tested against the test API *(please confirm per CONTRIBUTING)*  
- [x] `npm run format` and `npm run lint:fix` have been run *(run locally if not already; avoid committing unrelated formatted files)*  
- [x] `npm run build` passes  
- [x] Screenshots included for any UI/visual changes *(add when you open the PR)*