### PR TITLE
Fix: Add About and FAQ links to sidebar footer

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -137,7 +137,6 @@ const Sidebar: React.FC<SidebarProps> = ({ onNavigate }) => {
             direction="row"
             spacing={0.5}
             alignItems="center"
-            flexWrap="wrap"
             justifyContent="center"
           >
             <Typography
@@ -176,16 +175,14 @@ const Sidebar: React.FC<SidebarProps> = ({ onNavigate }) => {
             >
               FAQ
             </Typography>
-            <Divider
-              orientation="vertical"
-              flexItem
-              sx={{
-                borderColor: 'border.medium',
-                mx: 0.5,
-                height: '12px',
-                alignSelf: 'center',
-              }}
-            />
+          </Stack>
+          <Stack
+            direction="row"
+            spacing={0.5}
+            alignItems="center"
+            flexWrap="wrap"
+            justifyContent="center"
+          >
             <Typography
               variant="caption"
               component="a"

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -142,7 +142,7 @@ const Sidebar: React.FC<SidebarProps> = ({ onNavigate }) => {
             <Typography
               variant="caption"
               component="span"
-              onClick={() => handleNavigate('/about')}
+              onClick={() => handleNavigate('/onboard?tab=about')}
               sx={{
                 color: 'text.primary',
                 fontSize: '0.65rem',
@@ -165,7 +165,7 @@ const Sidebar: React.FC<SidebarProps> = ({ onNavigate }) => {
             <Typography
               variant="caption"
               component="span"
-              onClick={() => handleNavigate('/faq')}
+              onClick={() => handleNavigate('/onboard?tab=faq')}
               sx={{
                 color: 'text.primary',
                 fontSize: '0.65rem',

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -142,6 +142,52 @@ const Sidebar: React.FC<SidebarProps> = ({ onNavigate }) => {
           >
             <Typography
               variant="caption"
+              component="span"
+              onClick={() => handleNavigate('/about')}
+              sx={{
+                color: 'text.primary',
+                fontSize: '0.65rem',
+                cursor: 'pointer',
+                '&:hover': { textDecoration: 'underline' },
+              }}
+            >
+              About
+            </Typography>
+            <Divider
+              orientation="vertical"
+              flexItem
+              sx={{
+                borderColor: 'border.medium',
+                mx: 0.5,
+                height: '12px',
+                alignSelf: 'center',
+              }}
+            />
+            <Typography
+              variant="caption"
+              component="span"
+              onClick={() => handleNavigate('/faq')}
+              sx={{
+                color: 'text.primary',
+                fontSize: '0.65rem',
+                cursor: 'pointer',
+                '&:hover': { textDecoration: 'underline' },
+              }}
+            >
+              FAQ
+            </Typography>
+            <Divider
+              orientation="vertical"
+              flexItem
+              sx={{
+                borderColor: 'border.medium',
+                mx: 0.5,
+                height: '12px',
+                alignSelf: 'center',
+              }}
+            />
+            <Typography
+              variant="caption"
               component="a"
               href="https://docs.gittensor.io"
               target="_blank"


### PR DESCRIPTION
## Summary

The `/about` and `/faq` routes are registered in the router but no UI element links to them, making both pages unreachable without manually typing the URL. This adds "About" and "FAQ" as internal navigation links in the sidebar footer, placed before the existing external links (Docs, Community, Github, X). Both use the existing `handleNavigate()` pattern for client-side navigation and mobile drawer closing.

## Related Issues

Fixes #414

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

-Before 

<img width="235" height="807" alt="image" src="https://github.com/user-attachments/assets/ecdb7077-36b1-4578-aab4-1f3b7faac420" />


-After

<img width="227" height="919" alt="image" src="https://github.com/user-attachments/assets/0b1b4ecf-0be0-4fd3-994e-dc5d047b4d77" />

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes