### PR TITLE
fix: compute PR lines changed from per-PR data instead of unpopulated aggregate fields

### DIFF
--- a/src/components/miners/MinerScoreCard.tsx
+++ b/src/components/miners/MinerScoreCard.tsx
@@ -324,6 +324,14 @@ const MinerScoreCard: React.FC<MinerScoreCardProps> = ({
     }, 0);
   }, [prs]);
 
+  const totalLinesChanged = useMemo(() => {
+    if (!prs || prs.length === 0) return 0;
+    return prs.reduce(
+      (sum, pr) => sum + (pr.additions || 0) + (pr.deletions || 0),
+      0,
+    );
+  }, [prs]);
+
   if (isLoading) {
     return (
       <Card sx={{ p: 4, textAlign: 'center' }} elevation={0}>
@@ -605,7 +613,7 @@ const MinerScoreCard: React.FC<MinerScoreCardProps> = ({
             <StatTile
               label="PRs"
               value={String(minerStats.totalPrs || 0)}
-              sub={`${Number((minerStats.totalAdditions ?? 0) + (minerStats.totalDeletions ?? 0)).toLocaleString()} lines`}
+              sub={`${totalLinesChanged.toLocaleString()} lines`}
               rank={rankings?.totalPrs}
             />
           </Grid>


### PR DESCRIPTION
## Summary

Fix the PRs stat card on the miner detail page showing "0 lines" for every miner. The card read `minerStats.totalAdditions` and `minerStats.totalDeletions`, but the `/miners/{githubId}` API endpoint never populates these fields (both return `null`). The per-PR data (`additions`/`deletions`) is already fetched by `useMinerPRs` in the same component.

The fix adds a `useMemo` that computes total lines from the already-loaded `prs` array and uses that value in the stat tile.

## Related Issues

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

**Before:** <img width="1011" height="717" alt="Screenshot 2026-04-16 141724" src="https://github.com/user-attachments/assets/a2b80904-00c4-411f-a4b5-4ded019b86a3" />

**After:** <img width="1336" height="902" alt="Screenshot 2026-04-16 141623" src="https://github.com/user-attachments/assets/efad2a8e-f69c-4055-ae60-d51d506ac79b" />

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes