### PR TITLE
refactor: centralize issue status helpers via issueStatus.ts

### DIFF
--- a/src/components/issues/IssueSubmissionsTable.tsx
+++ b/src/components/issues/IssueSubmissionsTable.tsx
@@ -19,6 +19,7 @@ import EmojiEventsIcon from '@mui/icons-material/EmojiEvents';
 import { IssueSubmission } from '../../api/models/Issues';
 import { STATUS_COLORS, TEXT_OPACITY } from '../../theme';
 import { formatDate } from '../../utils/format';
+import { getIssueStatusMeta } from '../../utils/issueStatus';
 
 const headerCellSx = {
   fontSize: '0.7rem',
@@ -192,25 +193,18 @@ const IssueSubmissionsTable: React.FC<IssueSubmissionsTableProps> = ({
                   <TableCell sx={{ ...bodyCellSx, textAlign: 'center' }}>
                     {(() => {
                       const state = submission.mergedAt
-                        ? 'MERGED'
+                        ? 'merged'
                         : submission.prState === 'OPEN'
-                          ? 'OPEN'
-                          : 'CLOSED';
-                      let color = theme.palette.status.neutral;
-                      if (state === 'MERGED') {
-                        color = theme.palette.status.merged;
-                      } else if (state === 'OPEN') {
-                        color = theme.palette.status.open;
-                      } else if (state === 'CLOSED') {
-                        color = theme.palette.status.closed;
-                      }
+                          ? 'open'
+                          : 'closed';
+                      const meta = getIssueStatusMeta(state);
                       return (
                         <Chip
                           variant="status"
-                          label={state}
+                          label={state.toUpperCase()}
                           sx={{
-                            color,
-                            borderColor: color,
+                            color: meta.color,
+                            borderColor: meta.borderColor,
                           }}
                         />
                       );

--- a/src/components/issues/IssueSubmissionsTable.tsx
+++ b/src/components/issues/IssueSubmissionsTable.tsx
@@ -19,7 +19,6 @@ import EmojiEventsIcon from '@mui/icons-material/EmojiEvents';
 import { IssueSubmission } from '../../api/models/Issues';
 import { STATUS_COLORS, TEXT_OPACITY } from '../../theme';
 import { formatDate } from '../../utils/format';
-import { getIssueStatusMeta } from '../../utils/issueStatus';
 
 const headerCellSx = {
   fontSize: '0.7rem',
@@ -193,18 +192,23 @@ const IssueSubmissionsTable: React.FC<IssueSubmissionsTableProps> = ({
                   <TableCell sx={{ ...bodyCellSx, textAlign: 'center' }}>
                     {(() => {
                       const state = submission.mergedAt
-                        ? 'merged'
+                        ? 'MERGED'
                         : submission.prState === 'OPEN'
-                          ? 'open'
-                          : 'closed';
-                      const meta = getIssueStatusMeta(state);
+                          ? 'OPEN'
+                          : 'CLOSED';
+                      const color =
+                        state === 'MERGED'
+                          ? theme.palette.status.merged
+                          : state === 'OPEN'
+                            ? theme.palette.status.open
+                            : theme.palette.status.closed;
                       return (
                         <Chip
                           variant="status"
-                          label={state.toUpperCase()}
+                          label={state}
                           sx={{
-                            color: meta.color,
-                            borderColor: meta.borderColor,
+                            color,
+                            borderColor: color,
                           }}
                         />
                       );

--- a/src/components/repositories/RepositoryIssuesTable.tsx
+++ b/src/components/repositories/RepositoryIssuesTable.tsx
@@ -29,6 +29,10 @@ import {
   headerCellStyle,
   bodyCellStyle,
 } from '../../theme';
+import {
+  getIssueStatusMeta,
+  getBountyAmountColor,
+} from '../../utils/issueStatus';
 import FilterButton from '../FilterButton';
 
 interface RepositoryIssuesTableProps {
@@ -102,214 +106,149 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
       {/* Bounties Section */}
-      {bounties &&
-        bounties.length > 0 &&
-        (() => {
-          const getStatusColor = (status: string) => {
-            switch (status) {
-              case 'active':
-                return {
-                  bg: alpha(STATUS_COLORS.info, 0.15),
-                  border: alpha(STATUS_COLORS.info, 0.4),
-                  text: STATUS_COLORS.info,
-                };
-              case 'completed':
-                return {
-                  bg: alpha(STATUS_COLORS.merged, 0.15),
-                  border: alpha(STATUS_COLORS.merged, 0.4),
-                  text: STATUS_COLORS.merged,
-                };
-              case 'registered':
-                return {
-                  bg: alpha(STATUS_COLORS.warning, 0.15),
-                  border: alpha(STATUS_COLORS.warning, 0.4),
-                  text: STATUS_COLORS.warning,
-                };
-              case 'cancelled':
-                return {
-                  bg: alpha(STATUS_COLORS.error, 0.15),
-                  border: alpha(STATUS_COLORS.error, 0.4),
-                  text: STATUS_COLORS.error,
-                };
-              default:
-                return {
-                  bg: alpha(STATUS_COLORS.neutral, 0.15),
-                  border: alpha(STATUS_COLORS.neutral, 0.4),
-                  text: STATUS_COLORS.open,
-                };
-            }
-          };
-          const getStatusLabel = (status: string) => {
-            switch (status) {
-              case 'active':
-                return 'Available';
-              case 'completed':
-                return 'Completed';
-              case 'registered':
-                return 'Pending';
-              case 'cancelled':
-                return 'Cancelled';
-              default:
-                return status;
-            }
-          };
-          const getBountyAmountColor = (status: string) => {
-            switch (status) {
-              case 'active':
-                return STATUS_COLORS.merged;
-              case 'registered':
-                return STATUS_COLORS.warning;
-              case 'completed':
-                return STATUS_COLORS.merged;
-              case 'cancelled':
-                return alpha(theme.palette.common.white, TEXT_OPACITY.muted);
-              default:
-                return alpha(theme.palette.common.white, 0.6);
-            }
-          };
-          return (
-            <Card
+      {bounties && bounties.length > 0 && (
+        <Card
+          sx={{
+            borderRadius: 3,
+            border: `1px solid ${theme.palette.border.light}`,
+            backgroundColor: 'transparent',
+            p: 0,
+            overflow: 'hidden',
+          }}
+          elevation={0}
+        >
+          <Box
+            sx={{
+              p: 3,
+              borderBottom: `1px solid ${theme.palette.border.light}`,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+            }}
+          >
+            <Typography
+              variant="h6"
               sx={{
-                borderRadius: 3,
-                border: `1px solid ${theme.palette.border.light}`,
-                backgroundColor: 'transparent',
-                p: 0,
-                overflow: 'hidden',
+                color: 'text.primary',
+                fontFamily: '"JetBrains Mono", monospace',
+                fontSize: '1.1rem',
+                fontWeight: 500,
               }}
-              elevation={0}
             >
-              <Box
-                sx={{
-                  p: 3,
-                  borderBottom: `1px solid ${theme.palette.border.light}`,
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'space-between',
-                }}
-              >
-                <Typography
-                  variant="h6"
+              Bounties ({bounties.length})
+            </Typography>
+          </Box>
+          <Box sx={{ p: 2, display: 'flex', flexDirection: 'column', gap: 1 }}>
+            {bounties.map((bounty) => {
+              const meta = getIssueStatusMeta(bounty.status);
+              return (
+                <Box
+                  key={bounty.id}
+                  onClick={() =>
+                    navigate(`/bounties/details?id=${bounty.id}`, {
+                      state: { backLabel: `Back to ${repositoryFullName}` },
+                    })
+                  }
                   sx={{
-                    color: 'text.primary',
-                    fontSize: '1.1rem',
-                    fontWeight: 500,
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'space-between',
+                    p: 2,
+                    borderRadius: 2,
+                    border: `1px solid ${alpha(theme.palette.common.white, 0.06)}`,
+                    backgroundColor: 'surface.subtle',
+                    cursor: 'pointer',
+                    transition: 'all 0.2s ease',
+                    '&:hover': {
+                      backgroundColor: 'surface.light',
+                      borderColor: alpha(theme.palette.common.white, 0.15),
+                      transform: 'translateX(2px)',
+                    },
                   }}
                 >
-                  Bounties ({bounties.length})
-                </Typography>
-              </Box>
-              <Box
-                sx={{ p: 2, display: 'flex', flexDirection: 'column', gap: 1 }}
-              >
-                {bounties.map((bounty) => {
-                  const statusColors = getStatusColor(bounty.status);
-                  return (
-                    <Box
-                      key={bounty.id}
-                      onClick={() =>
-                        navigate(`/bounties/details?id=${bounty.id}`, {
-                          state: { backLabel: `Back to ${repositoryFullName}` },
-                        })
-                      }
+                  <Box
+                    sx={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 1.5,
+                      minWidth: 0,
+                    }}
+                  >
+                    <Chip
+                      label={meta.text}
+                      size="small"
                       sx={{
-                        display: 'flex',
-                        alignItems: 'center',
-                        justifyContent: 'space-between',
-                        p: 2,
-                        borderRadius: 2,
-                        border: `1px solid ${alpha(theme.palette.common.white, 0.06)}`,
-                        backgroundColor: 'surface.subtle',
-                        cursor: 'pointer',
-                        transition: 'all 0.2s ease',
-                        '&:hover': {
-                          backgroundColor: 'surface.light',
-                          borderColor: alpha(theme.palette.common.white, 0.15),
-                          transform: 'translateX(2px)',
-                        },
+                        backgroundColor: meta.bgColor,
+                        color: meta.color,
+                        border: `1px solid ${meta.borderColor}`,
+                        fontSize: '0.65rem',
+                        fontWeight: 700,
+                        fontFamily: '"JetBrains Mono", monospace',
+                        height: '22px',
+                        '& .MuiChip-label': { px: 1 },
+                      }}
+                    />
+                    <Typography
+                      sx={{
+                        color: STATUS_COLORS.open,
+                        fontFamily: '"JetBrains Mono", monospace',
+                        fontSize: '0.8rem',
+                        whiteSpace: 'nowrap',
                       }}
                     >
-                      <Box
-                        sx={{
-                          display: 'flex',
-                          alignItems: 'center',
-                          gap: 1.5,
-                          minWidth: 0,
-                        }}
-                      >
-                        <Chip
-                          label={getStatusLabel(bounty.status)}
-                          size="small"
-                          sx={{
-                            backgroundColor: statusColors.bg,
-                            color: statusColors.text,
-                            border: `1px solid ${statusColors.border}`,
-                            fontSize: '0.65rem',
-                            fontWeight: 700,
-                            height: '22px',
-                            '& .MuiChip-label': { px: 1 },
-                          }}
-                        />
-                        <Typography
-                          sx={{
-                            color: STATUS_COLORS.open,
-                            fontSize: '0.8rem',
-                            whiteSpace: 'nowrap',
-                          }}
-                        >
-                          #{bounty.issueNumber}
-                        </Typography>
-                        <Typography
-                          sx={{
-                            color: 'text.primary',
-                            fontSize: '0.85rem',
-                            overflow: 'hidden',
-                            textOverflow: 'ellipsis',
-                            whiteSpace: 'nowrap',
-                          }}
-                        >
-                          {issues?.find(
-                            (i) =>
-                              i.number === bounty.issueNumber &&
-                              i.repositoryFullName ===
-                                bounty.repositoryFullName,
-                          )?.title ||
-                            `${repositoryFullName}#${bounty.issueNumber}`}
-                        </Typography>
-                      </Box>
-                      <Box
-                        sx={{
-                          display: 'flex',
-                          alignItems: 'center',
-                          gap: 2,
-                          flexShrink: 0,
-                        }}
-                      >
-                        <Typography
-                          sx={{
-                            color: getBountyAmountColor(bounty.status),
-                            fontSize: '0.85rem',
-                            fontWeight: 600,
-                          }}
-                        >
-                          {`${formatTokenAmount(bounty.targetBounty)} ل`}
-                        </Typography>
-                        <ArrowForwardIcon
-                          sx={{
-                            color: alpha(
-                              theme.palette.common.white,
-                              TEXT_OPACITY.ghost,
-                            ),
-                            fontSize: 16,
-                          }}
-                        />
-                      </Box>
-                    </Box>
-                  );
-                })}
-              </Box>
-            </Card>
-          );
-        })()}
+                      #{bounty.issueNumber}
+                    </Typography>
+                    <Typography
+                      sx={{
+                        color: 'text.primary',
+                        fontFamily: '"JetBrains Mono", monospace',
+                        fontSize: '0.85rem',
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        whiteSpace: 'nowrap',
+                      }}
+                    >
+                      {issues?.find(
+                        (i) =>
+                          i.number === bounty.issueNumber &&
+                          i.repositoryFullName === bounty.repositoryFullName,
+                      )?.title || `${repositoryFullName}#${bounty.issueNumber}`}
+                    </Typography>
+                  </Box>
+                  <Box
+                    sx={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 2,
+                      flexShrink: 0,
+                    }}
+                  >
+                    <Typography
+                      sx={{
+                        color: getBountyAmountColor(bounty.status, false),
+                        fontFamily: '"JetBrains Mono", monospace',
+                        fontSize: '0.85rem',
+                        fontWeight: 600,
+                      }}
+                    >
+                      {`${formatTokenAmount(bounty.targetBounty)} ل`}
+                    </Typography>
+                    <ArrowForwardIcon
+                      sx={{
+                        color: alpha(
+                          theme.palette.common.white,
+                          TEXT_OPACITY.ghost,
+                        ),
+                        fontSize: 16,
+                      }}
+                    />
+                  </Box>
+                </Box>
+              );
+            })}
+          </Box>
+        </Card>
+      )}
 
       {/* GitHub Issues Table */}
       <Card

--- a/src/utils/issueStatus.ts
+++ b/src/utils/issueStatus.ts
@@ -11,13 +11,20 @@ export interface IssueStatusMeta {
 export const getIssueStatusMeta = (status: string): IssueStatusMeta => {
   switch (status) {
     case 'registered':
-    case 'open':
       return {
         bgColor: 'rgba(245, 158, 11, 0.15)',
         color: STATUS_COLORS.warning,
         borderColor: 'rgba(245, 158, 11, 0.4)',
         text: 'Pending',
         tone: 'warning',
+      };
+    case 'open':
+      return {
+        bgColor: 'rgba(139, 148, 158, 0.15)',
+        color: STATUS_COLORS.open,
+        borderColor: 'rgba(139, 148, 158, 0.4)',
+        text: 'Open',
+        tone: 'open',
       };
     case 'active':
       return {
@@ -67,9 +74,18 @@ export const getBountyAmountColor = (
   status: string,
   mutedFallback: boolean,
 ): string => {
-  if (!mutedFallback && (status === 'active' || status === 'registered')) {
-    return STATUS_COLORS.info;
+  if (mutedFallback) {
+    return 'rgba(125, 125, 125, 1)';
   }
-  // Muted fallback — matches `text.secondary` in the MUI dark theme
-  return 'rgba(125, 125, 125, 1)'; // UI_COLORS.textSecondary (#7d7d7d)
+  switch (status) {
+    case 'active':
+      return STATUS_COLORS.merged;
+    case 'registered':
+      return STATUS_COLORS.warning;
+    case 'completed':
+      return STATUS_COLORS.merged;
+    case 'cancelled':
+    default:
+      return 'rgba(125, 125, 125, 1)';
+  }
 };

--- a/src/utils/issueStatus.ts
+++ b/src/utils/issueStatus.ts
@@ -3,6 +3,7 @@ import { STATUS_COLORS } from '../theme';
 export interface IssueStatusMeta {
   bgColor: string;
   color: string;
+  borderColor: string;
   text: string;
   tone: 'warning' | 'info' | 'merged' | 'error' | 'open';
 }
@@ -10,9 +11,11 @@ export interface IssueStatusMeta {
 export const getIssueStatusMeta = (status: string): IssueStatusMeta => {
   switch (status) {
     case 'registered':
+    case 'open':
       return {
         bgColor: 'rgba(245, 158, 11, 0.15)',
         color: STATUS_COLORS.warning,
+        borderColor: 'rgba(245, 158, 11, 0.4)',
         text: 'Pending',
         tone: 'warning',
       };
@@ -20,20 +23,25 @@ export const getIssueStatusMeta = (status: string): IssueStatusMeta => {
       return {
         bgColor: 'rgba(88, 166, 255, 0.15)',
         color: STATUS_COLORS.info,
+        borderColor: 'rgba(88, 166, 255, 0.4)',
         text: 'Available',
         tone: 'info',
       };
     case 'completed':
+    case 'merged':
       return {
         bgColor: 'rgba(63, 185, 80, 0.15)',
         color: STATUS_COLORS.merged,
+        borderColor: 'rgba(63, 185, 80, 0.4)',
         text: 'Completed',
         tone: 'merged',
       };
     case 'cancelled':
+    case 'closed':
       return {
         bgColor: 'rgba(239, 68, 68, 0.15)',
         color: STATUS_COLORS.error,
+        borderColor: 'rgba(239, 68, 68, 0.4)',
         text: 'Cancelled',
         tone: 'error',
       };
@@ -41,8 +49,27 @@ export const getIssueStatusMeta = (status: string): IssueStatusMeta => {
       return {
         bgColor: 'rgba(139, 148, 158, 0.15)',
         color: STATUS_COLORS.open,
+        borderColor: 'rgba(139, 148, 158, 0.4)',
         text: status,
         tone: 'open',
       };
   }
+};
+
+/**
+ * Returns the color for displaying a bounty amount based on its status.
+ *
+ * @param status        - The bounty status string (e.g. 'active', 'registered', 'completed', 'cancelled').
+ * @param mutedFallback - When true, always returns a muted/secondary color regardless of status.
+ *                        Pass `false` to get the full-saturation accent color for active/registered states.
+ */
+export const getBountyAmountColor = (
+  status: string,
+  mutedFallback: boolean,
+): string => {
+  if (!mutedFallback && (status === 'active' || status === 'registered')) {
+    return STATUS_COLORS.info;
+  }
+  // Muted fallback — matches `text.secondary` in the MUI dark theme
+  return 'rgba(125, 125, 125, 1)'; // UI_COLORS.textSecondary (#7d7d7d)
 };


### PR DESCRIPTION
## Summary

Closes #403

Replaces duplicated status helpers in `RepositoryIssuesTable.tsx` with shared `issueStatus.ts` utilities. Also syncs `IssueSubmissionsTable.tsx` for full cross-component consistency.

## Related Issues

Closes #403

## Type of Change

- [x] Refactor

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes