### PR TITLE
feat: grey out stale repos and scores outside 35-day scoring window

### DIFF
--- a/src/components/miners/MinerRepositoriesTable.tsx
+++ b/src/components/miners/MinerRepositoriesTable.tsx
@@ -39,6 +39,7 @@ import {
   sortMinerRepoStats,
   hasActiveFilters,
   getDisplayCount,
+  isOutsideScoringWindow,
 } from '../../utils/ExplorerUtils';
 
 interface MinerRepositoriesTableProps {
@@ -343,14 +344,15 @@ const RepoTableRow: React.FC<RepoTableRowProps> = ({
   const owner = repo.repository.split('/')[0];
   const avatarBgColor = getAvatarBgColor(owner);
   const avgPerPr = repo.prs > 0 ? (repo.score / repo.prs).toFixed(4) : '\u2014';
-
+  const isStale = isOutsideScoringWindow(repo.latestPrDate);
   return (
     <TableRow
       sx={{
+        opacity: isStale ? 0.4 : 1,
         '&:hover': {
           backgroundColor: 'surface.light',
         },
-        transition: 'background-color 0.2s',
+        transition: 'background-color 0.2s, opacity 0.2s',
       }}
     >
       <TableCell sx={bodyCellStyle}>

--- a/src/components/miners/MinerScoreBreakdown.tsx
+++ b/src/components/miners/MinerScoreBreakdown.tsx
@@ -28,6 +28,7 @@ import { STATUS_COLORS, tooltipSlotProps } from '../../theme';
 import {
   parseNumber,
   calculateOpenIssueThreshold,
+  isOutsideScoringWindow,
 } from '../../utils/ExplorerUtils';
 import { credibilityColor } from '../../utils/format';
 import { buildMergedPillDefs } from '../../utils/multiplierDefs';
@@ -134,6 +135,7 @@ const PrScoreRow: React.FC<PrScoreRowProps> = ({ pr, onNavigateToPr }) => {
   const isClosed = pr.prState === 'CLOSED' && !pr.mergedAt;
   const isOpen = !pr.mergedAt && pr.prState !== 'CLOSED';
   const collateral = parseFloat(pr.collateralScore || '0');
+  const isStale = isMerged && isOutsideScoringWindow(pr.mergedAt);
 
   const statusColor = isMerged
     ? STATUS_COLORS.merged
@@ -229,6 +231,7 @@ const PrScoreRow: React.FC<PrScoreRowProps> = ({ pr, onNavigateToPr }) => {
               : isOpen
                 ? STATUS_COLORS.warningOrange
                 : 'text.primary',
+            opacity: isStale ? 0.4 : 1,
             flexShrink: 0,
           }}
         >

--- a/src/utils/ExplorerUtils.ts
+++ b/src/utils/ExplorerUtils.ts
@@ -244,7 +244,10 @@ export const aggregatePRsByRepository = (
     if (isMergedPr(pr)) {
       existing.tokenScore += parseFloat(String(pr.tokenScore ?? '0'));
     }
-    if (pr.mergedAt && (!existing.latestPrDate || pr.mergedAt > existing.latestPrDate)) {
+    if (
+      pr.mergedAt &&
+      (!existing.latestPrDate || pr.mergedAt > existing.latestPrDate)
+    ) {
       existing.latestPrDate = pr.mergedAt;
     }
     statsMap.set(pr.repository, existing);

--- a/src/utils/ExplorerUtils.ts
+++ b/src/utils/ExplorerUtils.ts
@@ -141,6 +141,7 @@ export interface RepoStats {
   score: number;
   tokenScore: number;
   weight: number;
+  latestPrDate?: string | null;
 }
 
 export type RepoSortField =
@@ -186,6 +187,21 @@ export const sortMinerRepoStats = (
 };
 
 // ---------------------------------------------------------------------------
+// Scoring window staleness check
+// ---------------------------------------------------------------------------
+
+export const SCORING_WINDOW_DAYS = 35;
+
+export const isOutsideScoringWindow = (
+  date: string | null | undefined,
+): boolean => {
+  if (!date) return false;
+  const cutoff = new Date();
+  cutoff.setDate(cutoff.getDate() - SCORING_WINDOW_DAYS);
+  return new Date(date) < cutoff;
+};
+
+// ---------------------------------------------------------------------------
 // Map builders – extract lookup maps from API data
 // ---------------------------------------------------------------------------
 
@@ -221,11 +237,15 @@ export const aggregatePRsByRepository = (
       score: 0,
       tokenScore: 0,
       weight: repoWeights.get(pr.repository) || 0,
+      latestPrDate: null as string | null,
     };
     existing.prs += 1;
     existing.score += parseFloat(pr.score || '0');
     if (isMergedPr(pr)) {
       existing.tokenScore += parseFloat(String(pr.tokenScore ?? '0'));
+    }
+    if (pr.mergedAt && (!existing.latestPrDate || pr.mergedAt > existing.latestPrDate)) {
+      existing.latestPrDate = pr.mergedAt;
     }
     statsMap.set(pr.repository, existing);
   }


### PR DESCRIPTION
## Summary
- Dim repository rows (`opacity: 0.4`) in the **Repositories** tab when the latest merged PR is older than 35 days
- Dim the **score value** in the overview tab's Score Breakdown for PRs merged outside the 35-day window
- Track `latestPrDate` per repository in `aggregatePRsByRepository` to support staleness detection

## Test plan
- [x] Open a miner details page with repos that have PRs older than 35 days
- [x] Verify repository rows in the Repositories tab are dimmed
- [x] Verify PR scores in the Overview tab's Score Breakdown are dimmed for stale PRs
- [x] Verify recent repos/PRs remain at full opacity
- [x] Run `npm run test` — all existing tests pass with updated fixtures

Before:
<img width="1826" height="799" alt="Before" src="https://github.com/user-attachments/assets/d1f2c6f1-5482-46e0-ba6b-570744c282c2" />

After:
<img width="1395" height="803" alt="After" src="https://github.com/user-attachments/assets/541b2fd7-25bc-4b33-ba5b-6f73392b0eeb" />

Fixes #507 