### PR TITLE
feat(leaderboard): add list view to miners leaderboard

### DIFF
--- a/src/components/common/DataTable.tsx
+++ b/src/components/common/DataTable.tsx
@@ -1,0 +1,284 @@
+import React from 'react';
+import {
+  Alert,
+  Box,
+  CircularProgress,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  TableSortLabel,
+  Typography,
+  type TableCellProps,
+} from '@mui/material';
+import { type SxProps, type Theme } from '@mui/material/styles';
+import { type SystemStyleObject } from '@mui/system';
+import { LinkTableRow } from './linkBehavior';
+import { bodyCellStyle, headerCellStyle, scrollbarSx } from '../../theme';
+import { type SortOrder } from '../../utils/ExplorerUtils';
+
+export type DataTableColumn<T, SortKey extends string = never> = {
+  /**
+   * Stable identifier for the column. Must be unique within the `columns`
+   * array (used as the React key).
+   */
+  key: string;
+  header: React.ReactNode;
+  width?: string | number;
+  align?: TableCellProps['align'];
+  renderCell: (item: T) => React.ReactNode;
+  headerSx?: SystemStyleObject<Theme>;
+  cellSx?: SystemStyleObject<Theme> | ((item: T) => SystemStyleObject<Theme>);
+  /**
+   * Setting this makes the column sortable. The actual "first-click" order
+   * for this key lives in the hook (`useDataTableParams.defaultOrderOverrides`);
+   * DataTable only renders the hover arrow direction.
+   */
+  sortKey?: SortKey;
+};
+
+export type DataTableSort<SortKey extends string> = {
+  field: SortKey;
+  order: SortOrder;
+  onChange: (nextField: SortKey) => void;
+};
+
+export type DataTableProps<T, SortKey extends string = never> = {
+  columns: DataTableColumn<T, SortKey>[];
+  rows: T[];
+  getRowKey: (item: T) => React.Key;
+  isLoading?: boolean;
+  isError?: boolean;
+  errorLabel?: string;
+  emptyLabel?: string;
+  emptyState?: React.ReactNode;
+  minWidth?: number | string;
+  /**
+   * When set, each row renders as an `<a href>` (native new-tab / middle-click
+   * support). NOTE: because the row becomes `<a>`, cells must not contain
+   * nested `<a>` elements (invalid HTML). For tables with nested anchors,
+   * use `onRowClick` instead.
+   */
+  getRowHref?: (item: T) => string;
+  linkState?: Record<string, unknown>;
+  /**
+   * Alternative to `getRowHref` — for tables that trigger dialogs, toggle
+   * expansion, or render nested `<a>` elements in cells. Ignored when
+   * `getRowHref` is provided.
+   */
+  onRowClick?: (item: T) => void;
+  getRowSx?: (item: T) => SystemStyleObject<Theme>;
+  header?: React.ReactNode;
+  /**
+   * Rendered below the table body when rows are present. Use this slot
+   * for pagination components (the app uses several styles — pluggable).
+   */
+  pagination?: React.ReactNode;
+  /**
+   * Rendered after the table regardless of loading / empty / error state.
+   * For summary bars or any controls that should persist across states.
+   */
+  footer?: React.ReactNode;
+  sort?: DataTableSort<SortKey>;
+  /**
+   * Defaults to false. Sticky header only resolves against a scroll
+   * ancestor with a bounded height — the consumer must provide one.
+   */
+  stickyHeader?: boolean;
+};
+
+const containerSx: SxProps<Theme> = {
+  overflowX: 'auto',
+  ...scrollbarSx,
+};
+
+const tableSx = {
+  tableLayout: 'fixed',
+  width: '100%',
+} as const;
+
+const clickableRowSx: SxProps<Theme> = (theme) => ({
+  cursor: 'pointer',
+  transition: 'background-color 0.2s',
+  '&:hover': {
+    backgroundColor: theme.palette.surface.subtle,
+  },
+});
+
+export const DataTable = <T, SortKey extends string = never>({
+  columns,
+  rows,
+  getRowKey,
+  isLoading = false,
+  isError = false,
+  errorLabel = 'Something went wrong loading this table.',
+  emptyLabel = 'No results to display.',
+  emptyState,
+  minWidth,
+  getRowHref,
+  linkState,
+  onRowClick,
+  getRowSx,
+  header,
+  pagination,
+  footer,
+  sort,
+  stickyHeader = false,
+}: DataTableProps<T, SortKey>) => {
+  const showTable = !isLoading && !isError && rows.length > 0;
+  const showEmpty = !isLoading && !isError && rows.length === 0;
+
+  return (
+    <>
+      {header}
+      {isLoading ? (
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+          <CircularProgress />
+        </Box>
+      ) : null}
+      {isError && !isLoading ? (
+        <Alert severity="error" sx={{ m: 2 }}>
+          {errorLabel}
+        </Alert>
+      ) : null}
+      {showEmpty
+        ? (emptyState ?? (
+            <Box sx={{ p: 3 }}>
+              <Typography color="text.secondary">{emptyLabel}</Typography>
+            </Box>
+          ))
+        : null}
+      {showTable ? (
+        <>
+          <TableContainer sx={containerSx}>
+            <Table
+              stickyHeader={stickyHeader}
+              size="small"
+              sx={{ ...tableSx, ...(minWidth ? { minWidth } : {}) }}
+            >
+              <TableHead>
+                <TableRow>
+                  {columns.map((column) => {
+                    const { sortKey } = column;
+                    const isSortable = Boolean(sortKey && sort);
+                    const isActive = Boolean(
+                      isSortable && sort && sort.field === sortKey,
+                    );
+                    const ariaSort: TableCellProps['aria-sort'] = isSortable
+                      ? isActive && sort
+                        ? sort.order === 'asc'
+                          ? 'ascending'
+                          : 'descending'
+                        : 'none'
+                      : undefined;
+                    return (
+                      <TableCell
+                        key={column.key}
+                        align={column.align}
+                        aria-sort={ariaSort}
+                        sx={[
+                          headerCellStyle,
+                          ...(column.width !== undefined
+                            ? [{ width: column.width }]
+                            : []),
+                          ...(column.headerSx ? [column.headerSx] : []),
+                        ]}
+                      >
+                        {sortKey && sort ? (
+                          <TableSortLabel
+                            active={isActive}
+                            direction={isActive ? sort.order : 'desc'}
+                            onClick={() => sort.onChange(sortKey)}
+                          >
+                            {column.header}
+                          </TableSortLabel>
+                        ) : (
+                          column.header
+                        )}
+                      </TableCell>
+                    );
+                  })}
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {rows.map((item) => {
+                  const href = getRowHref?.(item);
+                  const customRowSx = getRowSx?.(item);
+                  const cells = columns.map((column) => {
+                    const customCellSx =
+                      typeof column.cellSx === 'function'
+                        ? column.cellSx(item)
+                        : column.cellSx;
+                    return (
+                      <TableCell
+                        key={column.key}
+                        align={column.align}
+                        sx={[
+                          bodyCellStyle,
+                          ...(column.width !== undefined
+                            ? [{ width: column.width }]
+                            : []),
+                          ...(customCellSx ? [customCellSx] : []),
+                        ]}
+                      >
+                        {column.renderCell(item)}
+                      </TableCell>
+                    );
+                  });
+                  if (href) {
+                    return (
+                      <LinkTableRow
+                        key={getRowKey(item)}
+                        href={href}
+                        linkState={linkState}
+                        sx={[
+                          clickableRowSx,
+                          ...(customRowSx ? [customRowSx] : []),
+                        ]}
+                      >
+                        {cells}
+                      </LinkTableRow>
+                    );
+                  }
+                  if (onRowClick) {
+                    return (
+                      <TableRow
+                        key={getRowKey(item)}
+                        role="button"
+                        tabIndex={0}
+                        onClick={() => onRowClick(item)}
+                        onKeyDown={(event) => {
+                          if (event.key === 'Enter' || event.key === ' ') {
+                            event.preventDefault();
+                            onRowClick(item);
+                          }
+                        }}
+                        sx={[
+                          clickableRowSx,
+                          ...(customRowSx ? [customRowSx] : []),
+                        ]}
+                      >
+                        {cells}
+                      </TableRow>
+                    );
+                  }
+                  return (
+                    <TableRow key={getRowKey(item)} sx={customRowSx}>
+                      {cells}
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </Table>
+          </TableContainer>
+          {pagination}
+        </>
+      ) : null}
+      {footer}
+    </>
+  );
+};
+
+export default DataTable;

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -1,3 +1,4 @@
 export * from './SearchInput';
 export * from './linkBehavior';
 export * from './WatchlistButton';
+export * from './DataTable';

--- a/src/components/leaderboard/MinersList.tsx
+++ b/src/components/leaderboard/MinersList.tsx
@@ -1,0 +1,277 @@
+import React from 'react';
+import { Avatar, Box, Card, Tooltip, Typography } from '@mui/material';
+import { useMinerGithubData, useMinerPRs } from '../../api';
+import { CHART_COLORS, scrollbarSx } from '../../theme';
+import { getGithubAvatarSrc, type SortOrder } from '../../utils/ExplorerUtils';
+import { DataTable, type DataTableColumn, WatchlistButton } from '../common';
+import { RankIcon } from './RankIcon';
+import {
+  type LeaderboardVariant,
+  type MinerStats,
+  type SortOption,
+} from './types';
+
+const SEGMENT_COLORS = [
+  CHART_COLORS.merged,
+  CHART_COLORS.open,
+  CHART_COLORS.closed,
+];
+
+const cellTypographySx = {
+  fontSize: '0.75rem',
+  fontWeight: 600,
+} as const;
+
+interface MinersListProps {
+  miners: MinerStats[];
+  variant: LeaderboardVariant;
+  sortOption: SortOption;
+  sortDirection: SortOrder;
+  onSort: (option: SortOption) => void;
+  getHref: (miner: MinerStats) => string;
+  linkState?: Record<string, unknown>;
+}
+
+export const MinersList: React.FC<MinersListProps> = ({
+  miners,
+  variant,
+  sortOption,
+  sortDirection,
+  onSort,
+  getHref,
+  linkState,
+}) => {
+  const isDiscoveries = variant === 'discoveries';
+  const prLabel = isDiscoveries ? 'Issues' : 'PRs';
+  const prSortKey: SortOption = isDiscoveries ? 'totalIssues' : 'totalPRs';
+
+  const columns: DataTableColumn<MinerStats, SortOption>[] = [
+    {
+      key: 'rank',
+      header: 'Rank',
+      width: '60px',
+      cellSx: { pr: 0 },
+      renderCell: (miner) => <RankIcon rank={miner.rank ?? 0} />,
+    },
+    {
+      key: 'miner',
+      header: 'Miner',
+      width: '25%',
+      cellSx: { pl: 1.5 },
+      renderCell: (miner) => <MinerIdentityCell miner={miner} />,
+    },
+    {
+      key: 'usdPerDay',
+      header: 'Earnings/day',
+      width: '14%',
+      align: 'right',
+      sortKey: 'usdPerDay',
+      renderCell: (miner) => (
+        <Typography
+          sx={{
+            ...cellTypographySx,
+            color: miner.isEligible ? 'status.merged' : 'text.secondary',
+          }}
+        >
+          ${Math.round(miner.usdPerDay || 0).toLocaleString()}
+        </Typography>
+      ),
+    },
+    {
+      key: 'activity',
+      header: prLabel,
+      width: '18%',
+      align: 'right',
+      sortKey: prSortKey,
+      renderCell: (miner) => (
+        <MinerActivitySegments miner={miner} variant={variant} />
+      ),
+    },
+    {
+      key: 'credibility',
+      header: 'Credibility',
+      width: '12%',
+      align: 'right',
+      sortKey: 'credibility',
+      renderCell: (miner) => (
+        <Typography sx={{ ...cellTypographySx, color: 'text.primary' }}>
+          {((miner.credibility ?? 0) * 100).toFixed(0)}%
+        </Typography>
+      ),
+    },
+    {
+      key: 'totalScore',
+      header: 'Score',
+      width: '11%',
+      align: 'right',
+      sortKey: 'totalScore',
+      renderCell: (miner) => (
+        <Typography sx={{ ...cellTypographySx, color: 'text.primary' }}>
+          {Number(miner.totalScore).toFixed(2)}
+        </Typography>
+      ),
+    },
+    {
+      key: 'watch',
+      header: '\u2605',
+      width: '52px',
+      align: 'center',
+      cellSx: { p: 0 },
+      renderCell: (miner) =>
+        miner.githubId ? (
+          <WatchlistButton githubId={miner.githubId} size="small" />
+        ) : null,
+    },
+  ];
+
+  return (
+    <Card
+      elevation={0}
+      sx={{
+        borderRadius: 3,
+        border: '1px solid',
+        borderColor: 'border.light',
+        backgroundColor: 'transparent',
+        overflow: 'hidden',
+        maxHeight: '75vh',
+        display: 'flex',
+        flexDirection: 'column',
+        '& .MuiTableContainer-root': {
+          flex: 1,
+          overflowY: 'auto',
+          ...scrollbarSx,
+        },
+      }}
+    >
+      <DataTable<MinerStats, SortOption>
+        columns={columns}
+        rows={miners}
+        getRowKey={(miner) => miner.id}
+        getRowHref={getHref}
+        linkState={linkState}
+        getRowSx={(miner) => ({
+          opacity: (miner.isEligible ?? false) ? 1 : 0.5,
+          transition: 'opacity 0.2s, background-color 0.2s',
+        })}
+        minWidth="900px"
+        stickyHeader
+        sort={{
+          field: sortOption,
+          order: sortDirection,
+          onChange: onSort,
+        }}
+      />
+    </Card>
+  );
+};
+
+interface MinerIdentityCellProps {
+  miner: MinerStats;
+}
+
+const MinerIdentityCell: React.FC<MinerIdentityCellProps> = ({ miner }) => {
+  const isNumericId = (value?: string) => !value || /^\d+$/.test(value);
+  const shouldFetch = !!miner.githubId && isNumericId(miner.author);
+  const { data: githubData } = useMinerGithubData(miner.githubId, shouldFetch);
+  const { data: prs } = useMinerPRs(miner.githubId, shouldFetch);
+
+  const username =
+    githubData?.login ||
+    prs?.[0]?.author ||
+    (!isNumericId(miner.author) ? miner.author : miner.githubId) ||
+    miner.githubId ||
+    '';
+  const avatarSrc = githubData?.avatarUrl || getGithubAvatarSrc(username);
+
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 0 }}>
+      <Avatar
+        src={avatarSrc}
+        sx={{
+          width: 24,
+          height: 24,
+          flexShrink: 0,
+          border: '1px solid',
+          borderColor: 'border.medium',
+        }}
+      />
+      <Tooltip title={username} placement="top">
+        <Typography
+          component="span"
+          sx={{
+            fontSize: '0.8rem',
+            fontWeight: 500,
+            color: 'text.primary',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+            maxWidth: '100%',
+            display: 'inline-block',
+          }}
+        >
+          {username}
+        </Typography>
+      </Tooltip>
+    </Box>
+  );
+};
+
+interface MinerActivitySegmentsProps {
+  miner: MinerStats;
+  variant: LeaderboardVariant;
+}
+
+const MinerActivitySegments: React.FC<MinerActivitySegmentsProps> = ({
+  miner,
+  variant,
+}) => {
+  const segments =
+    variant === 'discoveries'
+      ? [
+          { label: 'Solved', value: miner.totalSolvedIssues ?? 0 },
+          { label: 'Open', value: miner.totalOpenIssues ?? 0 },
+          { label: 'Closed', value: miner.totalClosedIssues ?? 0 },
+        ]
+      : [
+          { label: 'Merged', value: miner.totalMergedPrs ?? 0 },
+          { label: 'Open', value: miner.totalOpenPrs ?? 0 },
+          { label: 'Closed', value: miner.totalClosedPrs ?? 0 },
+        ];
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'flex-end',
+        gap: 1.25,
+      }}
+    >
+      {segments.map((segment, i) => (
+        <Tooltip
+          key={segment.label}
+          title={segment.label}
+          arrow
+          placement="top"
+        >
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.6 }}>
+            <Box
+              sx={{
+                width: 7,
+                height: 7,
+                borderRadius: '50%',
+                backgroundColor: SEGMENT_COLORS[i],
+                flexShrink: 0,
+              }}
+            />
+            <Typography
+              sx={{ fontSize: '0.75rem', fontWeight: 600, lineHeight: 1 }}
+            >
+              {segment.value}
+            </Typography>
+          </Box>
+        </Tooltip>
+      ))}
+    </Box>
+  );
+};

--- a/src/components/leaderboard/TopMinersTable.tsx
+++ b/src/components/leaderboard/TopMinersTable.tsx
@@ -1,11 +1,21 @@
 import React, { useCallback, useEffect, useMemo } from 'react';
-import { Box, Typography, CircularProgress, Grid } from '@mui/material';
+import {
+  Box,
+  Typography,
+  CircularProgress,
+  Grid,
+  Tooltip,
+} from '@mui/material';
 import { alpha, type Theme } from '@mui/material/styles';
-import { useSearchParams } from 'react-router-dom';
+import ViewModuleIcon from '@mui/icons-material/ViewModule';
+import ViewListIcon from '@mui/icons-material/ViewList';
 import { SectionCard } from './SectionCard';
 import { MinerCard } from './MinerCard';
+import { MinersList } from './MinersList';
 import { SearchInput } from '../common/SearchInput';
 import { STATUS_COLORS } from '../../theme';
+import { useDataTableParams } from '../../hooks/useDataTableParams';
+import { type SortOrder } from '../../utils/ExplorerUtils';
 import {
   type MinerStats,
   type SortOption,
@@ -13,14 +23,37 @@ import {
   FONTS,
 } from './types';
 
+type ViewMode = 'cards' | 'list';
+
 // Re-export MinerStats for backward compatibility
 export type { MinerStats } from './types';
 
 const MINERS_PAGE_SIZE = 60;
-const SORT_QUERY_PARAM = 'sort';
 const ELIGIBLE_QUERY_PARAM = 'eligible';
+const VIEW_QUERY_PARAM = 'view';
 const SEARCH_QUERY_PARAM = 'search';
 const VISIBLE_QUERY_PARAM = 'visible';
+const VIEW_STORAGE_KEY = 'leaderboard:viewMode';
+// Sort state (`sort`, `dir`) is owned by `useDataTableParams`. We reuse the
+// `page` param slot for our "show more" count via the paramKeys override.
+
+const readStoredViewMode = (): ViewMode => {
+  try {
+    return window.localStorage.getItem(VIEW_STORAGE_KEY) === 'list'
+      ? 'list'
+      : 'cards';
+  } catch {
+    return 'cards';
+  }
+};
+
+const writeStoredViewMode = (mode: ViewMode) => {
+  try {
+    window.localStorage.setItem(VIEW_STORAGE_KEY, mode);
+  } catch {
+    // localStorage unavailable (private mode, quota) — preference won't persist
+  }
+};
 
 interface TopMinersTableProps {
   miners: MinerStats[];
@@ -45,37 +78,27 @@ const getAllowedSortOptions = (variant: LeaderboardVariant): SortOption[] => {
   return ['totalScore', 'usdPerDay', 'totalPRs', 'credibility'];
 };
 
-const getSortOptionFromQuery = (
-  value: string | null,
-  variant: LeaderboardVariant,
-): SortOption => {
-  if (!value) return 'totalScore';
-
-  const allowedOptions = getAllowedSortOptions(variant);
-  return allowedOptions.includes(value as SortOption)
-    ? (value as SortOption)
-    : 'totalScore';
-};
-
 type EligibilityFilter = 'all' | 'eligible' | 'ineligible';
 
-const getEligibilityFilterFromQuery = (
-  value: string | null,
-): EligibilityFilter => {
-  if (value === 'true') return 'eligible';
-  if (value === 'false') return 'ineligible';
-  return 'all';
-};
-
-const getVisibleCountFromQuery = (value: string | null): number => {
-  if (!value) return MINERS_PAGE_SIZE;
-
-  const parsed = Number.parseInt(value, 10);
-  if (!Number.isFinite(parsed) || parsed < MINERS_PAGE_SIZE) {
-    return MINERS_PAGE_SIZE;
+const compareMiners = (
+  a: MinerStats,
+  b: MinerStats,
+  option: SortOption,
+): number => {
+  switch (option) {
+    case 'totalScore':
+      return a.totalScore - b.totalScore;
+    case 'usdPerDay':
+      return (a.usdPerDay ?? 0) - (b.usdPerDay ?? 0);
+    case 'totalPRs':
+      return a.totalPRs - b.totalPRs;
+    case 'totalIssues':
+      return (a.totalIssues ?? 0) - (b.totalIssues ?? 0);
+    case 'credibility':
+      return (a.credibility ?? 0) - (b.credibility ?? 0);
+    default:
+      return 0;
   }
-
-  return parsed;
 };
 
 const TopMinersTable: React.FC<TopMinersTableProps> = ({
@@ -86,92 +109,101 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
   variant = 'oss',
   showDualEligibilityBadges = false,
 }) => {
-  const [searchParams, setSearchParams] = useSearchParams();
-  const searchQuery = searchParams.get(SEARCH_QUERY_PARAM) ?? '';
-  const sortParamValue = searchParams.get(SORT_QUERY_PARAM);
-  const sortOption = useMemo(
-    () => getSortOptionFromQuery(sortParamValue, variant),
-    [sortParamValue, variant],
-  );
-  const eligibilityFilter = useMemo(
-    () => getEligibilityFilterFromQuery(searchParams.get(ELIGIBLE_QUERY_PARAM)),
-    [searchParams],
-  );
-  const visibleCount = useMemo(
-    () => getVisibleCountFromQuery(searchParams.get(VISIBLE_QUERY_PARAM)),
-    [searchParams],
+  const allowedSortKeys = useMemo(
+    () => getAllowedSortOptions(variant),
+    [variant],
   );
 
-  const handleSortChange = useCallback(
-    (nextSortOption: SortOption) => {
-      setSearchParams(
-        (previousParams) => {
-          const nextSearchParams = new URLSearchParams(previousParams);
+  // Stable filter configs — values are destructured below.
+  // `view` always writes the URL param (never returns null) — otherwise
+  // toggling back to 'cards' when the URL already has no `view` param
+  // produces a no-op `setSearchParams` call that doesn't trigger a
+  // re-render, so the UI stays stuck on the stale localStorage-sourced
+  // value until a manual refresh. Writing the param explicitly forces
+  // React to re-render through the URL change.
+  const filtersConfig = useMemo(
+    () => ({
+      view: {
+        paramKey: VIEW_QUERY_PARAM,
+        parse: (raw: string | null): ViewMode =>
+          raw === 'list'
+            ? 'list'
+            : raw === 'cards'
+              ? 'cards'
+              : readStoredViewMode(),
+        serialize: (value: ViewMode): string => value,
+        resetPageOnChange: false,
+      },
+      eligible: {
+        paramKey: ELIGIBLE_QUERY_PARAM,
+        parse: (raw: string | null): EligibilityFilter =>
+          raw === 'true' ? 'eligible' : raw === 'false' ? 'ineligible' : 'all',
+        serialize: (value: EligibilityFilter): string | null =>
+          value === 'all' ? null : value === 'eligible' ? 'true' : 'false',
+      },
+      search: {
+        paramKey: SEARCH_QUERY_PARAM,
+        parse: (raw: string | null): string => raw ?? '',
+        serialize: (value: string): string | null => value.trim() || null,
+      },
+    }),
+    [],
+  );
 
-          if (nextSortOption === 'totalScore') {
-            nextSearchParams.delete(SORT_QUERY_PARAM);
-          } else {
-            nextSearchParams.set(SORT_QUERY_PARAM, nextSortOption);
-          }
-          nextSearchParams.delete(VISIBLE_QUERY_PARAM);
-
-          return nextSearchParams.toString() === previousParams.toString()
-            ? previousParams
-            : nextSearchParams;
-        },
-        { replace: true },
-      );
+  const {
+    sortField: sortOption,
+    sortOrder: sortDirection,
+    setSort: handleSortChange,
+    page: storedVisibleCount,
+    setPage: setVisibleCount,
+    filters: {
+      view: viewMode,
+      eligible: eligibilityFilter,
+      search: searchQuery,
     },
-    [setSearchParams],
+    setFilter,
+  } = useDataTableParams<
+    SortOption,
+    { view: ViewMode; eligible: EligibilityFilter; search: string }
+  >({
+    sortKeys: allowedSortKeys,
+    defaultSortKey: 'totalScore',
+    // Reuse the hook's `page` slot for our "show more" count — setSort and
+    // filter changes reset it, which is the behavior we want.
+    paramKeys: { page: VISIBLE_QUERY_PARAM },
+    filters: filtersConfig,
+  });
+
+  // `page` is 0 when no visible param is set — clamp to the initial batch.
+  const visibleCount =
+    storedVisibleCount < MINERS_PAGE_SIZE
+      ? MINERS_PAGE_SIZE
+      : storedVisibleCount;
+
+  const handleViewModeChange = useCallback(
+    (nextMode: ViewMode) => {
+      // Persist the user's choice BEFORE updating the URL. When the serializer
+      // returns null ('cards' is the default), the URL param is dropped and
+      // the next render's parse falls back to localStorage — we need the new
+      // value to be stored by that point.
+      writeStoredViewMode(nextMode);
+      setFilter('view', nextMode);
+    },
+    [setFilter],
   );
 
   const handleEligibilityChange = useCallback(
-    (nextFilter: EligibilityFilter) => {
-      setSearchParams(
-        (previousParams) => {
-          const nextSearchParams = new URLSearchParams(previousParams);
-
-          if (nextFilter === 'all') {
-            nextSearchParams.delete(ELIGIBLE_QUERY_PARAM);
-          } else if (nextFilter === 'eligible') {
-            nextSearchParams.set(ELIGIBLE_QUERY_PARAM, 'true');
-          } else {
-            nextSearchParams.set(ELIGIBLE_QUERY_PARAM, 'false');
-          }
-          nextSearchParams.delete(VISIBLE_QUERY_PARAM);
-
-          return nextSearchParams.toString() === previousParams.toString()
-            ? previousParams
-            : nextSearchParams;
-        },
-        { replace: true },
-      );
-    },
-    [setSearchParams],
+    (nextFilter: EligibilityFilter) => setFilter('eligible', nextFilter),
+    [setFilter],
   );
 
-  // Helper to sort a list of miners
-  const sortMinersList = (list: MinerStats[], option: SortOption) =>
-    [...list].sort((a, b) => {
-      switch (option) {
-        case 'totalScore':
-          return b.totalScore - a.totalScore;
-        case 'usdPerDay':
-          return (b.usdPerDay ?? 0) - (a.usdPerDay ?? 0);
-        case 'totalPRs':
-          return b.totalPRs - a.totalPRs;
-        case 'totalIssues':
-          return (b.totalIssues ?? 0) - (a.totalIssues ?? 0);
-        case 'credibility':
-          return (b.credibility ?? 0) - (a.credibility ?? 0);
-        default:
-          return 0;
-      }
-    });
+  const handleSearchChange = useCallback(
+    (nextQuery: string) => setFilter('search', nextQuery),
+    [setFilter],
+  );
 
-  // Process and filter miners
   const filteredMiners = useMemo(() => {
-    let result = [...miners];
+    let result = miners;
 
     if (searchQuery) {
       const lowerQuery = searchQuery.toLowerCase();
@@ -188,51 +220,16 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
       result = result.filter((m) => !m.isEligible);
     }
 
-    return sortMinersList(result, sortOption).map((miner, index) => ({
-      ...miner,
-      rank: index + 1,
-    }));
-  }, [miners, searchQuery, eligibilityFilter, sortOption]);
+    const directionMultiplier = sortDirection === 'asc' ? 1 : -1;
+    return [...result]
+      .sort((a, b) => compareMiners(a, b, sortOption) * directionMultiplier)
+      .map((miner, index) => ({ ...miner, rank: index + 1 }));
+  }, [miners, searchQuery, eligibilityFilter, sortOption, sortDirection]);
 
   useEffect(() => {
     if (visibleCount <= filteredMiners.length) return;
-
-    setSearchParams(
-      (previousParams) => {
-        const nextSearchParams = new URLSearchParams(previousParams);
-        nextSearchParams.delete(VISIBLE_QUERY_PARAM);
-
-        return nextSearchParams.toString() === previousParams.toString()
-          ? previousParams
-          : nextSearchParams;
-      },
-      { replace: true },
-    );
-  }, [filteredMiners.length, setSearchParams, visibleCount]);
-
-  const handleSearchChange = useCallback(
-    (nextQuery: string) => {
-      setSearchParams(
-        (previousParams) => {
-          const nextSearchParams = new URLSearchParams(previousParams);
-          const normalizedQuery = nextQuery.trim();
-
-          if (normalizedQuery) {
-            nextSearchParams.set(SEARCH_QUERY_PARAM, normalizedQuery);
-          } else {
-            nextSearchParams.delete(SEARCH_QUERY_PARAM);
-          }
-          nextSearchParams.delete(VISIBLE_QUERY_PARAM);
-
-          return nextSearchParams.toString() === previousParams.toString()
-            ? previousParams
-            : nextSearchParams;
-        },
-        { replace: true },
-      );
-    },
-    [setSearchParams],
-  );
+    setVisibleCount(0);
+  }, [filteredMiners.length, visibleCount, setVisibleCount]);
 
   const visibleMiners = useMemo(
     () => filteredMiners.slice(0, visibleCount),
@@ -309,19 +306,26 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
           >
             <SortButtons
               sortOption={sortOption}
+              sortDirection={sortDirection}
               onSortChange={handleSortChange}
               variant={variant}
             />
-            <EligibilityToggle
-              value={eligibilityFilter}
-              onChange={handleEligibilityChange}
-            />
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+              <EligibilityToggle
+                value={eligibilityFilter}
+                onChange={handleEligibilityChange}
+              />
+              <ViewModeToggle
+                viewMode={viewMode}
+                onChange={handleViewModeChange}
+              />
+            </Box>
           </Box>
         </Box>
       </SectionCard>
 
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-        {filteredMiners.length > 0 && (
+        {filteredMiners.length > 0 && viewMode === 'cards' && (
           <Grid container spacing={2}>
             {visibleMiners.map((miner) => (
               <Grid item xs={12} sm={12} md={6} lg={4} xl={4} key={miner.id}>
@@ -337,6 +341,18 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
           </Grid>
         )}
 
+        {filteredMiners.length > 0 && viewMode === 'list' && (
+          <MinersList
+            miners={visibleMiners}
+            variant={variant}
+            sortOption={sortOption}
+            sortDirection={sortDirection}
+            onSort={handleSortChange}
+            getHref={getMinerHref}
+            linkState={linkState}
+          />
+        )}
+
         {remainingMiners > 0 && (
           <Box
             onClick={() => {
@@ -344,26 +360,9 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
                 visibleCount + MINERS_PAGE_SIZE,
                 filteredMiners.length,
               );
-
-              setSearchParams(
-                (previousParams) => {
-                  const nextSearchParams = new URLSearchParams(previousParams);
-
-                  if (nextVisibleCount > MINERS_PAGE_SIZE) {
-                    nextSearchParams.set(
-                      VISIBLE_QUERY_PARAM,
-                      String(nextVisibleCount),
-                    );
-                  } else {
-                    nextSearchParams.delete(VISIBLE_QUERY_PARAM);
-                  }
-
-                  return nextSearchParams.toString() ===
-                    previousParams.toString()
-                    ? previousParams
-                    : nextSearchParams;
-                },
-                { replace: true },
+              // Pass 0 when at/below the initial batch → hook deletes the param.
+              setVisibleCount(
+                nextVisibleCount > MINERS_PAGE_SIZE ? nextVisibleCount : 0,
               );
             }}
             sx={(theme) => ({
@@ -418,12 +417,14 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
 
 interface SortButtonsProps {
   sortOption: SortOption;
+  sortDirection: SortOrder;
   onSortChange: (option: SortOption) => void;
   variant: LeaderboardVariant;
 }
 
 const SortButtons: React.FC<SortButtonsProps> = ({
   sortOption,
+  sortDirection,
   onSortChange,
   variant,
 }) => (
@@ -445,50 +446,132 @@ const SortButtons: React.FC<SortButtonsProps> = ({
         ? [{ label: 'Issues', value: 'totalIssues' as const }]
         : []),
       { label: 'Credibility', value: 'credibility' },
-    ].map((option) => (
-      <Box
-        key={option.value}
-        onClick={() => onSortChange(option.value as SortOption)}
-        sx={(theme) => ({
-          px: 1.5,
-          height: 32,
-          display: 'flex',
-          alignItems: 'center',
-          borderRadius: 2,
-          cursor: 'pointer',
-          backgroundColor:
-            sortOption === option.value
+    ].map((option) => {
+      const isActive = sortOption === option.value;
+      return (
+        <Box
+          key={option.value}
+          onClick={() => onSortChange(option.value as SortOption)}
+          sx={(theme) => ({
+            px: 1.5,
+            height: 32,
+            display: 'flex',
+            alignItems: 'center',
+            gap: 0.5,
+            borderRadius: 2,
+            cursor: 'pointer',
+            backgroundColor: isActive
               ? alpha(theme.palette.text.primary, 0.1)
               : 'transparent',
-          color:
-            sortOption === option.value
-              ? theme.palette.text.primary
-              : STATUS_COLORS.open,
-          border: '1px solid',
-          borderColor:
-            sortOption === option.value
-              ? theme.palette.border.medium
-              : 'transparent',
-          transition: 'all 0.2s',
-          '&:hover': {
-            backgroundColor: theme.palette.surface.light,
-            color: theme.palette.text.primary,
-          },
-        })}
-      >
-        <Typography
-          sx={{
-            fontFamily: FONTS.mono,
-            fontSize: '0.75rem',
-            fontWeight: 600,
-          }}
+            color: isActive ? theme.palette.text.primary : STATUS_COLORS.open,
+            border: '1px solid',
+            borderColor: isActive ? theme.palette.border.medium : 'transparent',
+            transition: 'all 0.2s',
+            '&:hover': {
+              backgroundColor: theme.palette.surface.light,
+              color: theme.palette.text.primary,
+            },
+          })}
         >
-          {option.label}
-        </Typography>
-      </Box>
-    ))}
+          <Typography
+            sx={{
+              fontFamily: FONTS.mono,
+              fontSize: '0.75rem',
+              fontWeight: 600,
+            }}
+          >
+            {option.label}
+          </Typography>
+          {isActive && (
+            <Typography
+              component="span"
+              sx={{ fontSize: '0.7rem', opacity: 0.7 }}
+            >
+              {sortDirection === 'asc' ? '▲' : '▼'}
+            </Typography>
+          )}
+        </Box>
+      );
+    })}
   </Box>
 );
+
+interface ViewModeToggleProps {
+  viewMode: ViewMode;
+  onChange: (mode: ViewMode) => void;
+}
+
+const ViewModeToggle: React.FC<ViewModeToggleProps> = ({
+  viewMode,
+  onChange,
+}) => {
+  const options: {
+    value: ViewMode;
+    label: string;
+    Icon: typeof ViewListIcon;
+  }[] = [
+    { value: 'cards', label: 'Card view', Icon: ViewModuleIcon },
+    { value: 'list', label: 'List view', Icon: ViewListIcon },
+  ];
+
+  return (
+    <Box
+      sx={(theme) => ({
+        display: 'inline-flex',
+        height: 32,
+        borderRadius: 2,
+        border: '1px solid',
+        borderColor: theme.palette.border.light,
+        backgroundColor: theme.palette.surface.subtle,
+        overflow: 'hidden',
+      })}
+      role="group"
+      aria-label="Toggle view mode"
+    >
+      {options.map(({ value, label, Icon }) => {
+        const isActive = viewMode === value;
+        return (
+          <Tooltip key={value} title={label} placement="top" arrow>
+            <Box
+              component="button"
+              type="button"
+              onClick={() => onChange(value)}
+              aria-label={label}
+              aria-pressed={isActive}
+              sx={(theme) => ({
+                display: 'inline-flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                width: 36,
+                height: '100%',
+                border: 'none',
+                outline: 'none',
+                cursor: 'pointer',
+                backgroundColor: isActive
+                  ? alpha(theme.palette.text.primary, 0.1)
+                  : 'transparent',
+                color: isActive
+                  ? theme.palette.text.primary
+                  : STATUS_COLORS.open,
+                transition: 'all 0.2s',
+                '&:hover': {
+                  backgroundColor: theme.palette.surface.light,
+                  color: theme.palette.text.primary,
+                },
+                '&:focus-visible': {
+                  outline: `2px solid ${theme.palette.status.info}`,
+                  outlineOffset: -2,
+                },
+              })}
+            >
+              <Icon sx={{ fontSize: '1.05rem' }} />
+            </Box>
+          </Tooltip>
+        );
+      })}
+    </Box>
+  );
+};
 
 interface EligibilityToggleProps {
   value: EligibilityFilter;

--- a/src/components/leaderboard/index.ts
+++ b/src/components/leaderboard/index.ts
@@ -3,6 +3,7 @@ export { default as TopMinersTable } from './TopMinersTable';
 export { default as TopRepositoriesTable } from './TopRepositoriesTable';
 export { LeaderboardSidebar } from './LeaderboardSidebar';
 export { MinerCard } from './MinerCard';
+export { MinersList } from './MinersList';
 export { RankIcon } from './RankIcon';
 export { SectionCard } from './SectionCard';
 

--- a/src/components/miners/SortableHeaderCell.tsx
+++ b/src/components/miners/SortableHeaderCell.tsx
@@ -1,21 +1,21 @@
-import React from 'react';
+// TODO: remove after MinerRepositoriesTable migrates to DataTable (its only caller).
 import { TableCell, TableSortLabel } from '@mui/material';
-import { type RepoSortField, type SortOrder } from '../../utils/ExplorerUtils';
+import { type SortOrder } from '../../utils/ExplorerUtils';
 import { sortLabelSx } from './MinerRepositoriesTable.styles';
 
-interface SortableHeaderCellProps {
-  field: RepoSortField;
+interface SortableHeaderCellProps<TField extends string> {
+  field: TField;
   label: string;
   align?: 'left' | 'right';
   width?: string;
   defaultDirection: SortOrder;
-  activeField: RepoSortField;
+  activeField: TField;
   activeOrder: SortOrder;
-  onSort: (field: RepoSortField) => void;
+  onSort: (field: TField) => void;
   cellStyle: Record<string, unknown>;
 }
 
-const SortableHeaderCell: React.FC<SortableHeaderCellProps> = ({
+const SortableHeaderCell = <TField extends string>({
   field,
   label,
   align,
@@ -25,7 +25,7 @@ const SortableHeaderCell: React.FC<SortableHeaderCellProps> = ({
   activeOrder,
   onSort,
   cellStyle,
-}) => {
+}: SortableHeaderCellProps<TField>) => {
   const isActive = activeField === field;
   const direction = isActive ? activeOrder : defaultDirection;
 

--- a/src/hooks/useDataTableParams.ts
+++ b/src/hooks/useDataTableParams.ts
@@ -1,0 +1,313 @@
+import { useCallback, useMemo } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { type SortOrder } from '../utils/ExplorerUtils';
+
+type ParamKeys = {
+  sort: string;
+  order: string;
+  page: string;
+  rowsPerPage: string;
+};
+
+const DEFAULT_PARAM_KEYS: ParamKeys = {
+  sort: 'sort',
+  order: 'dir',
+  page: 'page',
+  rowsPerPage: 'rows',
+};
+
+/**
+ * Configuration for an additional URL-backed filter (search, enum, etc.)
+ * that should be co-located with the table's sort/pagination state.
+ */
+export type FilterConfig<T> = {
+  parse: (raw: string | null) => T;
+  /** Return `null` to delete the param (used for "default" values). */
+  serialize: (value: T) => string | null;
+  /** URL parameter name. Defaults to the filter's key in the `filters` map. */
+  paramKey?: string;
+  /**
+   * When true (default), changing this filter deletes the `page` slot —
+   * appropriate for filters that change the result set. Set to `false`
+   * for preferences like view mode that shouldn't reset pagination.
+   */
+  resetPageOnChange?: boolean;
+};
+
+export type UseDataTableParamsConfig<
+  SortKey extends string,
+  Filters extends Record<string, unknown> = Record<string, never>,
+> = {
+  sortKeys: readonly SortKey[];
+  defaultSortKey: SortKey;
+  defaultSortOrder?: SortOrder;
+  // Per-field override for the order applied the first time a column becomes
+  // active — string columns often feel natural ascending, numeric descending.
+  defaultOrderOverrides?: Partial<Record<SortKey, SortOrder>>;
+  defaultRowsPerPage?: number;
+  rowsPerPageOptions?: readonly number[];
+  // Override URL parameter names. Useful when multiple tables coexist on the
+  // same page (e.g. prefix with the table name).
+  paramKeys?: Partial<ParamKeys>;
+  /**
+   * Additional URL-backed filters beyond sort/pagination. Each entry
+   * provides `parse` / `serialize` so the hook stays type-safe.
+   */
+  filters?: { [K in keyof Filters]: FilterConfig<Filters[K]> };
+};
+
+export type UseDataTableParamsResult<
+  SortKey extends string,
+  Filters extends Record<string, unknown> = Record<string, never>,
+> = {
+  sortField: SortKey;
+  sortOrder: SortOrder;
+  page: number;
+  rowsPerPage: number;
+  setSort: (field: SortKey) => void;
+  setPage: (page: number) => void;
+  setRowsPerPage: (rowsPerPage: number) => void;
+  filters: Filters;
+  setFilter: <K extends keyof Filters>(key: K, value: Filters[K]) => void;
+};
+
+const parseSortField = <K extends string>(
+  value: string | null,
+  sortKeys: readonly K[],
+  defaultKey: K,
+): K => {
+  if (value && (sortKeys as readonly string[]).includes(value)) {
+    return value as K;
+  }
+  return defaultKey;
+};
+
+const parseSortOrder = (
+  value: string | null,
+  fallback: SortOrder,
+): SortOrder => {
+  if (value === 'asc') return 'asc';
+  if (value === 'desc') return 'desc';
+  return fallback;
+};
+
+const parsePage = (value: string | null): number => {
+  if (!value) return 0;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : 0;
+};
+
+const parseRowsPerPage = (
+  value: string | null,
+  defaultRowsPerPage: number,
+  options?: readonly number[],
+): number => {
+  if (!value) return defaultRowsPerPage;
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return defaultRowsPerPage;
+  if (options && !options.includes(parsed)) return defaultRowsPerPage;
+  return parsed;
+};
+
+const computeNextSort = <K extends string>(
+  currentField: K,
+  currentOrder: SortOrder,
+  nextField: K,
+  orderFor: (field: K) => SortOrder,
+): { field: K; order: SortOrder } => {
+  if (currentField === nextField) {
+    return {
+      field: nextField,
+      order: currentOrder === 'asc' ? 'desc' : 'asc',
+    };
+  }
+  return { field: nextField, order: orderFor(nextField) };
+};
+
+// ---------- Hook ----------
+
+export const useDataTableParams = <
+  SortKey extends string,
+  Filters extends Record<string, unknown> = Record<string, never>,
+>({
+  sortKeys,
+  defaultSortKey,
+  defaultSortOrder = 'desc',
+  defaultOrderOverrides,
+  defaultRowsPerPage = 25,
+  rowsPerPageOptions,
+  paramKeys: paramKeysOverride,
+  filters: filtersConfig,
+}: UseDataTableParamsConfig<SortKey, Filters>): UseDataTableParamsResult<
+  SortKey,
+  Filters
+> => {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const paramKeys = useMemo<ParamKeys>(
+    () => ({ ...DEFAULT_PARAM_KEYS, ...paramKeysOverride }),
+    [paramKeysOverride],
+  );
+
+  const orderFor = useCallback(
+    (field: SortKey): SortOrder =>
+      defaultOrderOverrides?.[field] ?? defaultSortOrder,
+    [defaultOrderOverrides, defaultSortOrder],
+  );
+
+  const sortField = useMemo(
+    () =>
+      parseSortField(
+        searchParams.get(paramKeys.sort),
+        sortKeys,
+        defaultSortKey,
+      ),
+    [searchParams, paramKeys.sort, sortKeys, defaultSortKey],
+  );
+
+  const sortOrder = useMemo(
+    () =>
+      parseSortOrder(searchParams.get(paramKeys.order), orderFor(sortField)),
+    [searchParams, paramKeys.order, orderFor, sortField],
+  );
+
+  const page = useMemo(
+    () => parsePage(searchParams.get(paramKeys.page)),
+    [searchParams, paramKeys.page],
+  );
+
+  const rowsPerPage = useMemo(
+    () =>
+      parseRowsPerPage(
+        searchParams.get(paramKeys.rowsPerPage),
+        defaultRowsPerPage,
+        rowsPerPageOptions,
+      ),
+    [
+      searchParams,
+      paramKeys.rowsPerPage,
+      defaultRowsPerPage,
+      rowsPerPageOptions,
+    ],
+  );
+
+  // Re-compute on every render. Parsers may be inline functions (non-stable
+  // refs), so memoising on filtersConfig wouldn't help. The work is cheap —
+  // URLSearchParams reads plus caller-supplied parse calls.
+  const filters = useMemo(() => {
+    const result: Record<string, unknown> = {};
+    if (filtersConfig) {
+      for (const key of Object.keys(filtersConfig) as (keyof Filters)[]) {
+        const config = filtersConfig[key];
+        const paramKey = config.paramKey ?? (key as string);
+        result[key as string] = config.parse(searchParams.get(paramKey));
+      }
+    }
+    return result as Filters;
+  }, [searchParams, filtersConfig]);
+
+  const setSort = useCallback(
+    (nextField: SortKey) => {
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          const currentField = parseSortField(
+            prev.get(paramKeys.sort),
+            sortKeys,
+            defaultSortKey,
+          );
+          const currentOrder = parseSortOrder(
+            prev.get(paramKeys.order),
+            orderFor(currentField),
+          );
+          const nextSort = computeNextSort(
+            currentField,
+            currentOrder,
+            nextField,
+            orderFor,
+          );
+
+          if (nextSort.field === defaultSortKey) next.delete(paramKeys.sort);
+          else next.set(paramKeys.sort, nextSort.field);
+
+          if (nextSort.order === orderFor(nextSort.field))
+            next.delete(paramKeys.order);
+          else next.set(paramKeys.order, nextSort.order);
+
+          // Sort change resets the current page slot.
+          next.delete(paramKeys.page);
+
+          return next;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams, paramKeys, sortKeys, defaultSortKey, orderFor],
+  );
+
+  const setPage = useCallback(
+    (nextPage: number) => {
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          if (nextPage <= 0) next.delete(paramKeys.page);
+          else next.set(paramKeys.page, String(nextPage));
+          return next;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams, paramKeys.page],
+  );
+
+  const setRowsPerPage = useCallback(
+    (nextRowsPerPage: number) => {
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          if (nextRowsPerPage === defaultRowsPerPage)
+            next.delete(paramKeys.rowsPerPage);
+          else next.set(paramKeys.rowsPerPage, String(nextRowsPerPage));
+          // Row size change invalidates the current page index.
+          next.delete(paramKeys.page);
+          return next;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams, paramKeys, defaultRowsPerPage],
+  );
+
+  const setFilter = useCallback(
+    <K extends keyof Filters>(key: K, value: Filters[K]) => {
+      if (!filtersConfig) return;
+      const config = filtersConfig[key];
+      const filterParamKey = config.paramKey ?? (key as string);
+      const resetPage = config.resetPageOnChange ?? true;
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          const serialized = config.serialize(value);
+          if (serialized === null) next.delete(filterParamKey);
+          else next.set(filterParamKey, serialized);
+          if (resetPage) next.delete(paramKeys.page);
+          return next;
+        },
+        { replace: true },
+      );
+    },
+    [filtersConfig, setSearchParams, paramKeys.page],
+  );
+
+  return {
+    sortField,
+    sortOrder,
+    page,
+    rowsPerPage,
+    setSort,
+    setPage,
+    setRowsPerPage,
+    filters,
+    setFilter,
+  };
+};


### PR DESCRIPTION
## Summary

Adds a sortable list view to the Miner Leaderboard and Discoveries pages alongside the existing card grid, and extracts a **shared `DataTable` base component** (+ `useDataTableParams` hook) that `MinersList` is the first consumer of — the foundation for onboarding the remaining bespoke tables in a follow-up PR.

**List view UX (the feature):**

A small icon toggle in the page header switches between card grid and list view. The chosen view is remembered across navigation via `localStorage` (URL params still win when present, so shared links work). The list matches the existing Top Repositories table — same sticky header, cell styles, row hover. Every numeric column is sortable: clicking the active column flips asc/desc, clicking a different column resets to desc. Sort state (`sort`, `dir`) is URL-backed so specific views can be shared.

**Shared `DataTable` + `useDataTableParams` (the refactor):**

- `src/components/common/DataTable.tsx` — generic column-driven table with loading / error / empty states, optional row link, optional controlled sort, bundled MUI pagination config, and `header` / `footer` slots for richer toolbars.
- `src/hooks/useDataTableParams.ts` — URL-param state hook for sort / direction / page / rowsPerPage with per-field default direction overrides and configurable param keys (for pages hosting multiple tables). Pure helpers exported for unit testing without React DOM.
- `MinersList` is rebuilt as a declarative `DataTable` config — first real consumer, validating the API.

## Related Issues

Closes #443

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

[test.webm](https://github.com/user-attachments/assets/9594b592-bff3-48e0-910a-99326eb26d1e)

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
