### PR TITLE
feat: add networkStats and topEarners cards like oss and discoveries pages in watchlist

### DIFF
--- a/src/pages/WatchlistPage.tsx
+++ b/src/pages/WatchlistPage.tsx
@@ -8,13 +8,15 @@ import {
   Dialog,
   DialogTitle,
   DialogActions,
+  useMediaQuery,
 } from '@mui/material';
 import { Link as RouterLink } from 'react-router-dom';
 import { Page } from '../components/layout';
-import { TopMinersTable, SEO } from '../components';
+import { TopMinersTable, LeaderboardSidebar, SEO } from '../components';
 import { useAllMiners } from '../api';
 import { mapAllMinersToStats } from '../utils/minerMapper';
 import { useWatchlist } from '../hooks/useWatchlist';
+import theme, { scrollbarSx } from '../theme';
 
 const WatchlistPage: React.FC = () => {
   const { ids, count, clear } = useWatchlist();
@@ -41,6 +43,14 @@ const WatchlistPage: React.FC = () => {
     setConfirmOpen(false);
   };
 
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+  const isTablet = useMediaQuery(theme.breakpoints.between('sm', 'md'));
+  const isLargeScreen = useMediaQuery(theme.breakpoints.up('xl'));
+  const showSidebarRight = useMediaQuery(theme.breakpoints.up('xl'));
+
+  const sidebarWidth =
+    isMobile || isTablet ? '100%' : isLargeScreen ? '340px' : '300px';
+
   return (
     <Page title="Watchlist">
       <SEO
@@ -50,97 +60,135 @@ const WatchlistPage: React.FC = () => {
       <Box
         sx={{
           width: '100%',
+          height: showSidebarRight ? 'calc(100vh - 64px)' : 'auto',
           display: 'flex',
-          flexDirection: 'column',
-          gap: { xs: 2, sm: 1.5 },
+          flexDirection: showSidebarRight ? 'row' : 'column',
+          gap: { xs: 2, sm: 2, md: 2.5, lg: 3 },
           py: { xs: 2, sm: 2, md: 2.5, lg: 3 },
           px: { xs: 2, sm: 2, md: 2.5, lg: 3 },
+          overflow: 'hidden',
         }}
       >
-        <Stack
-          direction="row"
-          alignItems="center"
-          justifyContent="space-between"
-          spacing={2}
+        {/* Main Content Area */}
+        <Box
+          sx={{
+            flex: 1,
+            display: 'flex',
+            flexDirection: 'column',
+            gap: { xs: 2, sm: 1.5 },
+            minHeight: 0,
+            overflow: showSidebarRight ? 'auto' : 'visible',
+            minWidth: 0,
+            pr: showSidebarRight ? 1 : 0,
+            ...scrollbarSx,
+          }}
         >
-          <Typography
-            sx={{
-              fontSize: '0.8rem',
-              color: (t) => alpha(t.palette.text.primary, 0.5),
-              lineHeight: 1.6,
-            }}
+          <Stack
+            direction="row"
+            alignItems="center"
+            justifyContent="space-between"
+            spacing={2}
           >
-            Your watchlist — {count}{' '}
-            {count === 1 ? 'miner pinned' : 'miners pinned'}. Stored locally in
-            this browser.
-          </Typography>
-          {count > 0 && (
-            <Button
-              size="small"
-              onClick={() => setConfirmOpen(true)}
-              sx={{
-                fontSize: '0.75rem',
-                textTransform: 'none',
-                color: 'text.secondary',
-              }}
-            >
-              Clear watchlist
-            </Button>
-          )}
-        </Stack>
-
-        {isEmpty ? (
-          <Box
-            sx={{
-              py: 8,
-              textAlign: 'center',
-              display: 'flex',
-              flexDirection: 'column',
-              gap: 2,
-              alignItems: 'center',
-              color: 'text.secondary',
-            }}
-          >
-            <Typography
-              sx={{
-                fontSize: '0.95rem',
-              }}
-            >
-              Your watchlist is empty.
-            </Typography>
             <Typography
               sx={{
                 fontSize: '0.8rem',
-                maxWidth: 480,
                 color: (t) => alpha(t.palette.text.primary, 0.5),
+                lineHeight: 1.6,
               }}
             >
-              Browse the leaderboard and star miners you want to track. Pinned
-              miners appear here across reloads and tabs.
+              Your watchlist — {count}{' '}
+              {count === 1 ? 'miner pinned' : 'miners pinned'}. Stored locally
+              in this browser.
             </Typography>
-            <Button
-              component={RouterLink}
-              to="/top-miners"
-              variant="outlined"
-              size="small"
-              sx={{ textTransform: 'none', mt: 1 }}
+            {count > 0 && (
+              <Button
+                size="small"
+                onClick={() => setConfirmOpen(true)}
+                sx={{
+                  fontSize: '0.75rem',
+                  textTransform: 'none',
+                  color: 'text.secondary',
+                }}
+              >
+                Clear watchlist
+              </Button>
+            )}
+          </Stack>
+
+          {isEmpty ? (
+            <Box
+              sx={{
+                py: 8,
+                textAlign: 'center',
+                display: 'flex',
+                flexDirection: 'column',
+                gap: 2,
+                alignItems: 'center',
+                color: 'text.secondary',
+              }}
             >
-              Go to leaderboard
-            </Button>
-          </Box>
-        ) : (
-          <Box sx={{ width: '100%' }}>
-            <TopMinersTable
-              miners={minerStats}
-              isLoading={isLoadingMinerStats}
-              getMinerHref={(m) =>
-                `/miners/details?githubId=${encodeURIComponent(m.githubId)}`
-              }
-              linkState={{ backLabel: 'Back to Watchlist' }}
-              variant="watchlist"
-            />
-          </Box>
-        )}
+              <Typography
+                sx={{
+                  fontSize: '0.95rem',
+                }}
+              >
+                Your watchlist is empty.
+              </Typography>
+              <Typography
+                sx={{
+                  fontSize: '0.8rem',
+                  maxWidth: 480,
+                  color: (t) => alpha(t.palette.text.primary, 0.5),
+                }}
+              >
+                Browse the leaderboard and star miners you want to track. Pinned
+                miners appear here across reloads and tabs.
+              </Typography>
+              <Button
+                component={RouterLink}
+                to="/top-miners"
+                variant="outlined"
+                size="small"
+                sx={{ textTransform: 'none', mt: 1 }}
+              >
+                Go to leaderboard
+              </Button>
+            </Box>
+          ) : (
+            <Box sx={{ width: '100%' }}>
+              <TopMinersTable
+                miners={minerStats}
+                isLoading={isLoadingMinerStats}
+                getMinerHref={(m) =>
+                  `/miners/details?githubId=${encodeURIComponent(m.githubId)}`
+                }
+                linkState={{ backLabel: 'Back to Watchlist' }}
+                variant="watchlist"
+              />
+            </Box>
+          )}
+        </Box>
+
+        {/* Right Sidebar */}
+        <Box
+          sx={{
+            width: showSidebarRight ? sidebarWidth : '100%',
+            height: showSidebarRight ? '100%' : 'auto',
+            maxHeight: showSidebarRight ? '100%' : 'none',
+            flexShrink: 0,
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 2,
+          }}
+        >
+          <LeaderboardSidebar
+            miners={allMinerStats}
+            getMinerHref={(m) =>
+              `/miners/details?githubId=${encodeURIComponent(m.githubId)}`
+            }
+            linkState={{ backLabel: 'Back to Watchlist' }}
+          />
+        </Box>
       </Box>
 
       <Dialog open={confirmOpen} onClose={() => setConfirmOpen(false)}>


### PR DESCRIPTION
## Closes: #445

## Summary

- Add **Network Stats** and **Top Earners** sidebar cards to the Watchlist page, matching the layout pattern already used on the OSS Contributions and Discoveries pages.
- The sidebar reuses the existing `LeaderboardSidebar` component and reflects **full network stats** (all miners), not just the watched subset.
- Clicking a miner in the sidebar navigates to their details page with a "Back to Watchlist" breadcrumb.

## Changes

- `src/pages/WatchlistPage.tsx`
  - Import and render `LeaderboardSidebar` in a right-side panel
  - Add responsive layout: sidebar renders inline on `xl`+ screens, stacks below on smaller screens (same breakpoint logic as `TopMinersPage`)
  - Add `handleSelectMiner` to navigate from sidebar rows to miner detail pages
  - Pass `allMinerStats` (full network list) to the sidebar so stats are network-wide

## Test plan

- [ ] Visit `/watchlist` on a wide screen (`xl`+) — Network Stats and Top Earners cards appear on the right
- [ ] Resize to below `xl` — sidebar stacks below the table
- [ ] Click a miner row in Top Earners / Most Active — navigates to miner details with "Back to Watchlist" back label
- [ ] Watchlist with 0 pinned miners — empty state still renders correctly alongside the sidebar
- [ ] Watchlist with pinned miners — table and sidebar coexist without layout overflow

## Screenshots

<img width="1773" height="874" alt="image" src="https://github.com/user-attachments/assets/cffef89c-1883-4dfb-bf47-89eb3477c71e" />

<img width="1789" height="880" alt="image" src="https://github.com/user-attachments/assets/58aafcb6-acc5-4652-8321-2fbef9326b97" />

