### PR TITLE
fix: guard against non-array API responses crashing .map() calls

### DIFF
--- a/src/api/SearchApi.ts
+++ b/src/api/SearchApi.ts
@@ -44,7 +44,11 @@ const useCachedSearchDataset = <T>(
   );
 
   return {
-    data: datasetQuery.data ?? cachedData ?? [],
+    data: Array.isArray(datasetQuery.data)
+      ? datasetQuery.data
+      : Array.isArray(cachedData)
+        ? cachedData
+        : [],
     isLoading: isDatasetLoading(
       shouldFetch,
       cachedData,

--- a/src/pages/IssuesPage.tsx
+++ b/src/pages/IssuesPage.tsx
@@ -119,7 +119,11 @@ const IssuesPage: React.FC = () => {
           <Box sx={{ minHeight: 400 }}>
             {tabIndex === 0 && (
               <IssuesList
-                issues={activeIssuesQuery.data || []}
+                issues={
+                  Array.isArray(activeIssuesQuery.data)
+                    ? activeIssuesQuery.data
+                    : []
+                }
                 isLoading={activeIssuesQuery.isLoading}
                 listType="available"
                 onSelectIssue={(id) =>
@@ -131,7 +135,11 @@ const IssuesPage: React.FC = () => {
             )}
             {tabIndex === 1 && (
               <IssuesList
-                issues={registeredIssuesQuery.data || []}
+                issues={
+                  Array.isArray(registeredIssuesQuery.data)
+                    ? registeredIssuesQuery.data
+                    : []
+                }
                 isLoading={registeredIssuesQuery.isLoading}
                 listType="pending"
                 onSelectIssue={(id) =>
@@ -143,7 +151,11 @@ const IssuesPage: React.FC = () => {
             )}
             {tabIndex === 2 && (
               <IssuesList
-                issues={historyIssuesQuery.data || []}
+                issues={
+                  Array.isArray(historyIssuesQuery.data)
+                    ? historyIssuesQuery.data
+                    : []
+                }
                 isLoading={historyIssuesQuery.isLoading}
                 listType="history"
                 onSelectIssue={(id) =>

--- a/src/pages/dashboard/useDashboardData.ts
+++ b/src/pages/dashboard/useDashboardData.ts
@@ -36,17 +36,17 @@ export const useDashboardData = (range: TrendTimeRange) => {
 
   const datasets: DashboardDatasets = {
     prs: {
-      data: prsQuery.data ?? [],
+      data: Array.isArray(prsQuery.data) ? prsQuery.data : [],
       isLoading: prsQuery.isLoading,
       isError: prsQuery.isError,
     },
     miners: {
-      data: minersQuery.data ?? [],
+      data: Array.isArray(minersQuery.data) ? minersQuery.data : [],
       isLoading: minersQuery.isLoading,
       isError: minersQuery.isError,
     },
     issues: {
-      data: issuesQuery.data ?? [],
+      data: Array.isArray(issuesQuery.data) ? issuesQuery.data : [],
       isLoading: issuesQuery.isLoading,
       isError: issuesQuery.isError,
     },


### PR DESCRIPTION
## Closes: #454 

## Summary

Replaces `data || []` and `data ?? []` fallbacks with `Array.isArray()` guards in three locations. These patterns silently pass a truthy non-array object through unchanged, causing `TypeError: .map is not a function` and triggering the error boundary.

**Affected files:**
- `src/pages/IssuesPage.tsx` — 3 `data || []` guards on issues query results
- `src/pages/dashboard/useDashboardData.ts` — 3 `data ?? []` guards for prs/miners/issues
- `src/api/SearchApi.ts` — chained `datasetQuery.data ?? cachedData ?? []` guard

## Test plan
- [ ] Navigate to `/bounties` — issues list renders normally
- [ ] Open global search bar while miners data is loading — no crash
- [ ] Dashboard renders with all three datasets loading

## Screenshots (After fix)

<img width="1799" height="883" alt="image" src="https://github.com/user-attachments/assets/c8f62306-8fd3-4d43-99fd-8532e369d6be" />
