### PR TITLE
fix: capitalize sidebar navigation labels

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -29,17 +29,17 @@ const Sidebar: React.FC<SidebarProps> = ({ onNavigate }) => {
     path: string;
     badge?: string | number;
   }> = [
-    { label: 'dashboard', path: '/dashboard' },
-    { label: 'oss contributions', path: '/top-miners' },
-    { label: 'discoveries', path: '/discoveries', badge: 'new' },
+    { label: 'Dashboard', path: '/dashboard' },
+    { label: 'OSS Contributions', path: '/top-miners' },
+    { label: 'Discoveries', path: '/discoveries', badge: 'New' },
     {
-      label: 'watchlist',
+      label: 'Watchlist',
       path: '/watchlist',
       badge: watchlistCount > 0 ? watchlistCount : undefined,
     },
-    { label: 'bounties', path: '/bounties' },
-    { label: 'repositories', path: '/repositories' },
-    { label: 'onboard', path: '/onboard' },
+    { label: 'Bounties', path: '/bounties' },
+    { label: 'Repositories', path: '/repositories' },
+    { label: 'Onboard', path: '/onboard' },
   ];
 
   return (


### PR DESCRIPTION
## Summary

Capitalizes all primary sidebar navigation labels from lowercase to title case, fixing the presentation inconsistency described in #447.

### Changes
- `dashboard` → `Dashboard`
- `oss contributions` → `OSS Contributions`
- `discoveries` → `Discoveries`
- `watchlist` → `Watchlist`
- `bounties` → `Bounties`
- `repositories` → `Repositories`
- `onboard` → `Onboard`
- Discoveries badge `new` → `New`

The sidebar buttons already have `textTransform: 'none'` set, so MUI does not auto-capitalize — the labels render exactly as written. This change makes them consistent with common UI copy conventions and improves scanability.

### File changed
- `src/components/layout/Sidebar.tsx` — updated nav item label strings

Closes #447