### PR TITLE
feat(watchlist): multi-category watchlist with bounties/PRs/repos support

### DIFF
--- a/src/components/common/WatchlistButton.tsx
+++ b/src/components/common/WatchlistButton.tsx
@@ -2,28 +2,48 @@ import React from 'react';
 import { IconButton, Tooltip, type SxProps, type Theme } from '@mui/material';
 import StarIcon from '@mui/icons-material/Star';
 import StarBorderIcon from '@mui/icons-material/StarBorder';
-import { useWatchlist } from '../../hooks/useWatchlist';
+import {
+  useWatchlist,
+  type WatchlistCategory,
+} from '../../hooks/useWatchlist';
 
 interface WatchlistButtonProps {
-  githubId: string;
+  /** Backward-compatible: miner GitHub ID. */
+  githubId?: string;
+  /** Entity category (defaults to 'miners' when githubId is provided). */
+  category?: WatchlistCategory;
+  /** Unique key within the category (e.g. repo fullName, issue id, PR uid). */
+  itemKey?: string;
   size?: 'small' | 'medium';
   sx?: SxProps<Theme>;
 }
 
 export const WatchlistButton: React.FC<WatchlistButtonProps> = ({
   githubId,
+  category,
+  itemKey,
   size = 'small',
   sx,
 }) => {
-  const { isWatched, toggle } = useWatchlist();
-  const watched = isWatched(githubId);
+  const { isWatched, isMinerWatched, toggle } = useWatchlist();
+
+  // Resolve the effective category & key.
+  // If only githubId is given (old usage), treat as miner.
+  const effectiveCategory: WatchlistCategory =
+    category ?? (githubId ? 'miners' : 'miners');
+  const effectiveKey = itemKey ?? githubId ?? '';
+
+  const watched = effectiveCategory === 'miners' && githubId && !itemKey
+    ? isMinerWatched(githubId)
+    : isWatched(effectiveCategory, effectiveKey);
+
   const label = watched ? 'Remove from watchlist' : 'Add to watchlist';
 
   const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation();
     e.preventDefault();
-    if (!githubId) return;
-    toggle(githubId);
+    if (!effectiveKey) return;
+    toggle(effectiveCategory, effectiveKey);
   };
 
   return (

--- a/src/hooks/useWatchlist.ts
+++ b/src/hooks/useWatchlist.ts
@@ -1,51 +1,111 @@
-import { useCallback, useSyncExternalStore } from 'react';
+import { useCallback, useSyncExternalStore, useMemo } from 'react';
 
-const STORAGE_KEY = 'gittensor.watchlist.v1';
+/* ------------------------------------------------------------------ */
+/*  Storage keys & types                                               */
+/* ------------------------------------------------------------------ */
+
+const STORAGE_KEY_V1 = 'gittensor.watchlist.v1';
+const STORAGE_KEY_V2 = 'gittensor.watchlist.v2';
+
+export type WatchlistCategory = 'miners' | 'repos' | 'bounties' | 'prs';
+
+interface WatchlistShapeV2 {
+  miners: string[];
+  repos: string[];
+  bounties: string[];
+  prs: string[];
+}
 
 type Listener = () => void;
 const listeners = new Set<Listener>();
 
-const readFromStorage = (): string[] => {
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                            */
+/* ------------------------------------------------------------------ */
+
+const emptyShape = (): WatchlistShapeV2 => ({
+  miners: [],
+  repos: [],
+  bounties: [],
+  prs: [],
+});
+
+/** Read the v2 object from localStorage (returns fresh empty shape on any error). */
+const readV2FromStorage = (): WatchlistShapeV2 => {
   try {
-    const raw = window.localStorage.getItem(STORAGE_KEY);
-    if (!raw) return [];
+    const raw = window.localStorage.getItem(STORAGE_KEY_V2);
+    if (!raw) return emptyShape();
     const parsed = JSON.parse(raw);
-    return Array.isArray(parsed)
-      ? parsed.filter((x): x is string => typeof x === 'string')
-      : [];
+    if (typeof parsed !== 'object' || parsed === null) return emptyShape();
+    const shape = emptyShape();
+    for (const key of Object.keys(shape)) {
+      const k = key as WatchlistCategory;
+      if (Array.isArray(parsed[k])) {
+        shape[k] = parsed[k].filter(
+          (x: unknown): x is string => typeof x === 'string',
+        );
+      }
+    }
+    return shape;
   } catch {
-    return [];
+    return emptyShape();
   }
 };
 
-// Module-level snapshot — every useWatchlist() instance in the tab reads from
-// the same reference, so writes from any caller propagate to all consumers.
-let snapshot: string[] = readFromStorage();
+/** One-time migration: if v2 doesn't exist but v1 does, move v1 miner IDs into v2. */
+const migrateIfNeeded = (): void => {
+  try {
+    if (window.localStorage.getItem(STORAGE_KEY_V2)) return; // already migrated
+    const v1Raw = window.localStorage.getItem(STORAGE_KEY_V1);
+    if (!v1Raw) return;
+    const v1Parsed = JSON.parse(v1Raw);
+    const minerIds: string[] = Array.isArray(v1Parsed)
+      ? v1Parsed.filter((x: unknown): x is string => typeof x === 'string')
+      : [];
+    const v2: WatchlistShapeV2 = { ...emptyShape(), miners: minerIds };
+    window.localStorage.setItem(STORAGE_KEY_V2, JSON.stringify(v2));
+  } catch {
+    // ignore migration errors — worst case user starts with an empty watchlist
+  }
+};
+
+// Run migration once at module load
+migrateIfNeeded();
+
+/* ------------------------------------------------------------------ */
+/*  External-store plumbing (shared across all useWatchlist instances) */
+/* ------------------------------------------------------------------ */
+
+let snapshot: WatchlistShapeV2 = readV2FromStorage();
 
 const notify = () => {
   listeners.forEach((l) => l());
 };
 
-const setSnapshot = (next: string[]) => {
-  if (
-    next.length === snapshot.length &&
-    next.every((id, i) => id === snapshot[i])
-  ) {
-    return;
-  }
+const setSnapshot = (next: WatchlistShapeV2) => {
+  // Shallow-compare each category to avoid unnecessary writes / re-renders
+  const unchanged =
+    snapshot.miners.length === next.miners.length &&
+    snapshot.repos.length === next.repos.length &&
+    snapshot.bounties.length === next.bounties.length &&
+    snapshot.prs.length === next.prs.length &&
+    snapshot.miners.every((v, i) => v === next.miners[i]) &&
+    snapshot.repos.every((v, i) => v === next.repos[i]) &&
+    snapshot.bounties.every((v, i) => v === next.bounties[i]) &&
+    snapshot.prs.every((v, i) => v === next.prs[i]);
+  if (unchanged) return;
   snapshot = next;
   try {
-    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+    window.localStorage.setItem(STORAGE_KEY_V2, JSON.stringify(next));
   } catch {
-    // Storage unavailable (private mode, quota). In-memory state still works.
+    /* storage unavailable — in-memory state still works */
   }
   notify();
 };
 
 const handleStorageEvent = (e: StorageEvent) => {
-  if (e.key !== STORAGE_KEY) return;
-  const next = readFromStorage();
-  snapshot = next;
+  if (e.key !== STORAGE_KEY_V2) return;
+  snapshot = readV2FromStorage();
   notify();
 };
 
@@ -64,49 +124,101 @@ const subscribe = (listener: Listener) => {
 
 const getSnapshot = () => snapshot;
 
+/* ------------------------------------------------------------------ */
+/*  Public hook                                                        */
+/* ------------------------------------------------------------------ */
+
 interface UseWatchlist {
+  /** All miner IDs (backward-compatible with the old flat array). */
   ids: string[];
+  /** Total count across all categories. */
   count: number;
-  isWatched: (id: string) => boolean;
-  add: (id: string) => void;
-  remove: (id: string) => void;
-  toggle: (id: string) => void;
-  clear: () => void;
+  /** Per-category item lists. */
+  items: WatchlistShapeV2;
+  /** Check if an item key is watched in a given category. */
+  isWatched: (category: WatchlistCategory, itemKey: string) => boolean;
+  /** Backward-compatible miner-specific check. */
+  isMinerWatched: (githubId: string) => boolean;
+  /** Add an item to a category. */
+  add: (category: WatchlistCategory, itemKey: string) => void;
+  /** Remove an item from a category. */
+  remove: (category: WatchlistCategory, itemKey: string) => void;
+  /** Toggle an item in a category. */
+  toggle: (category: WatchlistCategory, itemKey: string) => void;
+  /** Clear a specific category (or all when omitted). */
+  clear: (category?: WatchlistCategory) => void;
 }
 
 export const useWatchlist = (): UseWatchlist => {
-  const ids = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+  const items = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
 
-  const isWatched = useCallback(
-    (id: string) => snapshot.includes(id),
-    // Depending on `ids` ensures consumers re-render when the snapshot changes.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [ids],
+  const ids = useMemo(() => items.miners, [items.miners]); // backward compat
+
+  const count = useMemo(
+    () =>
+      items.miners.length +
+      items.repos.length +
+      items.bounties.length +
+      items.prs.length,
+    [items],
   );
 
-  // Action callbacks read from the module-level `snapshot`, not the rendered
-  // `ids`. This is the key to rapid-click correctness: two fast toggles see
-  // each other's writes immediately instead of both reading a stale array.
-  const add = useCallback((id: string) => {
-    if (!id || snapshot.includes(id)) return;
-    setSnapshot([...snapshot, id]);
+  const isWatched = useCallback(
+    (category: WatchlistCategory, itemKey: string) =>
+      snapshot[category].includes(itemKey),
+    // re-bind when any list changes so consumers re-render
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [items],
+  );
+
+  const isMinerWatched = useCallback(
+    (githubId: string) => snapshot.miners.includes(githubId),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [items.miners],
+  );
+
+  const add = useCallback(
+    (category: WatchlistCategory, itemKey: string) => {
+      if (!itemKey || snapshot[category].includes(itemKey)) return;
+      setSnapshot({
+        ...snapshot,
+        [category]: [...snapshot[category], itemKey],
+      });
+    },
+    [],
+  );
+
+  const remove = useCallback(
+    (category: WatchlistCategory, itemKey: string) => {
+      if (!snapshot[category].includes(itemKey)) return;
+      setSnapshot({
+        ...snapshot,
+        [category]: snapshot[category].filter((x) => x !== itemKey),
+      });
+    },
+    [],
+  );
+
+  const toggle = useCallback(
+    (category: WatchlistCategory, itemKey: string) => {
+      if (!itemKey) return;
+      setSnapshot({
+        ...snapshot,
+        [category]: snapshot[category].includes(itemKey)
+          ? snapshot[category].filter((x) => x !== itemKey)
+          : [...snapshot[category], itemKey],
+      });
+    },
+    [],
+  );
+
+  const clear = useCallback((category?: WatchlistCategory) => {
+    if (category) {
+      setSnapshot({ ...snapshot, [category]: [] });
+    } else {
+      setSnapshot(emptyShape());
+    }
   }, []);
 
-  const remove = useCallback((id: string) => {
-    if (!snapshot.includes(id)) return;
-    setSnapshot(snapshot.filter((x) => x !== id));
-  }, []);
-
-  const toggle = useCallback((id: string) => {
-    if (!id) return;
-    setSnapshot(
-      snapshot.includes(id)
-        ? snapshot.filter((x) => x !== id)
-        : [...snapshot, id],
-    );
-  }, []);
-
-  const clear = useCallback(() => setSnapshot([]), []);
-
-  return { ids, count: ids.length, isWatched, add, remove, toggle, clear };
+  return { ids, count, items, isWatched, isMinerWatched, add, remove, toggle, clear };
 };

--- a/src/pages/IssueDetailsPage.tsx
+++ b/src/pages/IssueDetailsPage.tsx
@@ -9,7 +9,7 @@ import {
   Tab,
 } from '@mui/material';
 import { Page } from '../components/layout';
-import { BackButton, SEO } from '../components';
+import { BackButton, SEO, WatchlistButton } from '../components';
 import {
   IssueHeaderCard,
   IssueSubmissionsTable,
@@ -89,7 +89,16 @@ const IssueDetailsPage: React.FC = () => {
           }}
         >
           <Stack spacing={3}>
-            <BackButton to="/bounties" label="Back to Bounties" mb={0} />
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+              <BackButton to="/bounties" label="Back to Bounties" mb={0} />
+              {issue && (
+                <WatchlistButton
+                  category="bounties"
+                  itemKey={`${issue.repositoryFullName}#${issue.issueNumber}`}
+                  size="small"
+                />
+              )}
+            </Box>
             <IssueHeaderCard issue={issue} />
 
             {/* Tabs */}

--- a/src/pages/PRDetailsPage.tsx
+++ b/src/pages/PRDetailsPage.tsx
@@ -9,6 +9,7 @@ import {
   BackButton,
   SEO,
   PRComments,
+  WatchlistButton,
 } from '../components';
 import { usePullRequestDetails } from '../api';
 import { STATUS_COLORS } from '../theme';
@@ -97,7 +98,16 @@ const PRDetailsPage: React.FC = () => {
               px: { xs: 2, sm: 2, md: 0 },
             }}
           >
-            <BackButton to="/repositories" label="Back to Repositories" />
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+              <BackButton to="/repositories" label="Back to Repositories" />
+              {prDetails && (
+                <WatchlistButton
+                  category="prs"
+                  itemKey={`${repository}#${pullRequestNumber}`}
+                  size="small"
+                />
+              )}
+            </Box>
 
             {/* Header always visible */}
             <PRHeader

--- a/src/pages/RepositoryDetailsPage.tsx
+++ b/src/pages/RepositoryDetailsPage.tsx
@@ -36,6 +36,7 @@ import {
   ContributingViewer,
   RepositoryMaintainers,
   RepositoryCheckTab,
+  WatchlistButton,
 } from '../components';
 
 interface TabPanelProps {
@@ -209,6 +210,11 @@ const RepositoryDetailsPage: React.FC = () => {
                   >
                     {repo}
                   </Typography>
+                  <WatchlistButton
+                    category="repos"
+                    itemKey={repo}
+                    size="medium"
+                  />
                   <Chip variant="info" label="Public" />
                   <Chip
                     label="Tracked"

--- a/src/pages/WatchlistPage.tsx
+++ b/src/pages/WatchlistPage.tsx
@@ -8,44 +8,253 @@ import {
   Dialog,
   DialogTitle,
   DialogActions,
+  Tabs,
+  Tab,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableRow,
+  Chip,
 } from '@mui/material';
 import { Link as RouterLink } from 'react-router-dom';
 import { Page } from '../components/layout';
 import { TopMinersTable, SEO } from '../components';
-import { useAllMiners } from '../api';
+import { useAllMiners, useReposAndWeights, useIssues } from '../api';
 import { mapAllMinersToStats } from '../utils/minerMapper';
-import { useWatchlist } from '../hooks/useWatchlist';
+import { useWatchlist, type WatchlistCategory } from '../hooks/useWatchlist';
+import type { Repository } from '../api/models/Dashboard';
+import type { IssueBounty } from '../api/models/Issues';
+import { STATUS_COLORS } from '../theme';
+import StarIcon from '@mui/icons-material/Star';
+
+/* ------------------------------------------------------------------ */
+/*  Tab definitions                                                    */
+/* ------------------------------------------------------------------ */
+
+interface TabDef {
+  key: WatchlistCategory;
+  label: string;
+  emptyMsg: string;
+  emptyHint: string;
+  emptyAction?: { to: string; label: string };
+}
+
+const TABS: TabDef[] = [
+  {
+    key: 'miners',
+    label: 'Miners',
+    emptyMsg: 'No pinned miners.',
+    emptyHint: 'Browse the leaderboard and star miners you want to track.',
+    emptyAction: { to: '/top-miners', label: 'Go to leaderboard' },
+  },
+  {
+    key: 'repos',
+    label: 'Repositories',
+    emptyMsg: 'No pinned repositories.',
+    emptyHint: 'Star repositories from their detail pages to track them here.',
+    emptyAction: { to: '/repositories', label: 'Browse repositories' },
+  },
+  {
+    key: 'bounties',
+    label: 'Bounties',
+    emptyMsg: 'No pinned bounties.',
+    emptyHint: 'Star bounties from their detail pages to track them here.',
+    emptyAction: { to: '/bounties', label: 'Browse bounties' },
+  },
+  {
+    key: 'prs',
+    label: 'Pull Requests',
+    emptyMsg: 'No pinned pull requests.',
+    emptyHint: 'Star PRs from their detail pages to track them here.',
+  },
+];
+
+/* ------------------------------------------------------------------ */
+/*  Compact table rows for non-miner categories                        */
+/* ------------------------------------------------------------------ */
+
+const RepoRows: React.FC<{ ids: string[]; repos?: Repository[] }> = ({
+  ids,
+  repos,
+}) => {
+  const watchedRepos = useMemo(() => {
+    const map = new Map((repos ?? []).map((r) => [r.fullName, r]));
+    return ids.map((id) => map.get(id)).filter(Boolean) as Repository[];
+  }, [ids, repos]);
+
+  if (watchedRepos.length === 0) {
+    return (
+      <TableRow>
+        <TableCell colSpan={3} sx={{ textAlign: 'center', py: 4, color: 'text.secondary' }}>
+          No pinned repositories.
+        </TableCell>
+      </TableRow>
+    );
+  }
+
+  return (
+    <>
+      {watchedRepos.map((repo) => (
+        <TableRow
+          key={repo.fullName}
+          hover
+          sx={{ cursor: 'pointer' }}
+          component={RouterLink}
+          to={`/repositories/details?name=${encodeURIComponent(repo.fullName)}`}
+          style={{ textDecoration: 'none' }}
+        >
+          <TableCell sx={{ fontWeight: 600 }}>{repo.fullName}</TableCell>
+          <TableCell>
+            <Chip label="Tracked" size="small" sx={{ fontSize: '0.7rem' }} />
+          </TableCell>
+          <TableCell align="right">
+            <StarIcon sx={{ fontSize: 16, color: 'warning.main' }} />
+          </TableCell>
+        </TableRow>
+      ))}
+    </>
+  );
+};
+
+const BountyRows: React.FC<{ ids: string[]; issues?: IssueBounty[] }> = ({
+  ids,
+  issues,
+}) => {
+  const watchedBounties = useMemo(() => {
+    const idSet = new Set(ids);
+    return (issues ?? []).filter((b) => idSet.has(String(b.id)));
+  }, [ids, issues]);
+
+  if (watchedBounties.length === 0) {
+    return (
+      <TableRow>
+        <TableCell colSpan={3} sx={{ textAlign: 'center', py: 4, color: 'text.secondary' }}>
+          No pinned bounties.
+        </TableCell>
+      </TableRow>
+    );
+  }
+
+  return (
+    <>
+      {watchedBounties.map((b) => (
+        <TableRow
+          key={b.id}
+          hover
+          sx={{ cursor: 'pointer' }}
+          component={RouterLink}
+          to={`/bounties/details?id=${b.id}`}
+          style={{ textDecoration: 'none' }}
+        >
+          <TableCell sx={{ fontWeight: 600 }}>
+            {b.repositoryFullName} #{b.issueNumber}
+          </TableCell>
+          <TableCell>
+            <Chip
+              label={b.status}
+              size="small"
+              color={
+                b.status === 'active'
+                  ? 'success'
+                  : b.status === 'completed'
+                    ? 'info'
+                    : 'default'
+              }
+              sx={{ fontSize: '0.7rem' }}
+            />
+          </TableCell>
+          <TableCell align="right">
+            <StarIcon sx={{ fontSize: 16, color: 'warning.main' }} />
+          </TableCell>
+        </TableRow>
+      ))}
+    </>
+  );
+};
+
+const PRRows: React.FC<{ ids: string[] }> = ({ ids }) => {
+  if (ids.length === 0) {
+    return (
+      <TableRow>
+        <TableCell colSpan={3} sx={{ textAlign: 'center', py: 4, color: 'text.secondary' }}>
+          No pinned pull requests.
+        </TableCell>
+      </TableRow>
+    );
+  }
+
+  return (
+    <>
+      {ids.map((key) => {
+        // PR keys stored as "repo#number"
+        const [repo, num] = key.split('#');
+        return (
+          <TableRow
+            key={key}
+            hover
+            sx={{ cursor: 'pointer' }}
+            component={RouterLink}
+            to={`/prs/details?repo=${encodeURIComponent(repo ?? '')}&number=${num ?? ''}`}
+            style={{ textDecoration: 'none' }}
+          >
+            <TableCell sx={{ fontWeight: 600 }}>
+              {repo} #{num}
+            </TableCell>
+            <TableCell />
+            <TableCell align="right">
+              <StarIcon sx={{ fontSize: 16, color: 'warning.main' }} />
+            </TableCell>
+          </TableRow>
+        );
+      })}
+    </>
+  );
+};
+
+/* ------------------------------------------------------------------ */
+/*  Main page component                                                */
+/* ------------------------------------------------------------------ */
 
 const WatchlistPage: React.FC = () => {
-  const { ids, count, clear } = useWatchlist();
-  const watchedSet = useMemo(() => new Set(ids), [ids]);
+  const { items, count, clear } = useWatchlist();
+  const [tabIdx, setTabIdx] = useState(0);
   const [confirmOpen, setConfirmOpen] = useState(false);
 
+  const currentTab = TABS[tabIdx];
+
+  // --- Miner data ---
   const allMinerStatsQuery = useAllMiners();
   const allMinersStats = allMinerStatsQuery?.data;
   const isLoadingMinerStats = allMinerStatsQuery?.isLoading;
-
   const allMinerStats = useMemo(
     () => mapAllMinersToStats(allMinersStats ?? []),
     [allMinersStats],
   );
   const minerStats = useMemo(
-    () => allMinerStats.filter((m) => watchedSet.has(m.githubId)),
-    [allMinerStats, watchedSet],
+    () => allMinerStats.filter((m) => new Set(items.miners).has(m.githubId)),
+    [allMinerStats, items.miners],
   );
 
-  const isEmpty = count === 0;
+  // --- Repos data ---
+  const { data: reposData } = useReposAndWeights();
+
+  // --- Bounties data ---
+  const { data: issuesData } = useIssues();
 
   const handleClear = () => {
-    clear();
+    clear(currentTab.key);
     setConfirmOpen(false);
   };
+
+  const categoryCount = items[currentTab.key].length;
+  const isEmpty = categoryCount === 0;
 
   return (
     <Page title="Watchlist">
       <SEO
         title="Watchlist"
-        description="Your pinned miners on Gittensor. Quickly revisit the miners you're tracking."
+        description="Your pinned items on Gittensor. Track miners, repositories, bounties, and pull requests."
       />
       <Box
         sx={{
@@ -57,6 +266,7 @@ const WatchlistPage: React.FC = () => {
           px: { xs: 2, sm: 2, md: 2.5, lg: 3 },
         }}
       >
+        {/* Header */}
         <Stack
           direction="row"
           alignItems="center"
@@ -71,8 +281,8 @@ const WatchlistPage: React.FC = () => {
             }}
           >
             Your watchlist — {count}{' '}
-            {count === 1 ? 'miner pinned' : 'miners pinned'}. Stored locally in
-            this browser.
+            {count === 1 ? 'item pinned' : 'items pinned'} across all
+            categories. Stored locally in this browser.
           </Typography>
           {count > 0 && (
             <Button
@@ -89,61 +299,73 @@ const WatchlistPage: React.FC = () => {
           )}
         </Stack>
 
-        {isEmpty ? (
-          <Box
-            sx={{
-              py: 8,
-              textAlign: 'center',
-              display: 'flex',
-              flexDirection: 'column',
-              gap: 2,
-              alignItems: 'center',
-              color: 'text.secondary',
-            }}
-          >
-            <Typography
-              sx={{
-                fontSize: '0.95rem',
-              }}
-            >
-              Your watchlist is empty.
-            </Typography>
-            <Typography
-              sx={{
-                fontSize: '0.8rem',
-                maxWidth: 480,
-                color: (t) => alpha(t.palette.text.primary, 0.5),
-              }}
-            >
-              Browse the leaderboard and star miners you want to track. Pinned
-              miners appear here across reloads and tabs.
-            </Typography>
-            <Button
-              component={RouterLink}
-              to="/top-miners"
-              variant="outlined"
-              size="small"
-              sx={{ textTransform: 'none', mt: 1 }}
-            >
-              Go to leaderboard
-            </Button>
-          </Box>
-        ) : (
-          <Box sx={{ width: '100%' }}>
-            <TopMinersTable
-              miners={minerStats}
-              isLoading={isLoadingMinerStats}
-              getHref={(m) =>
-                `/miners/details?githubId=${encodeURIComponent(m.githubId)}`
-              }
-              linkState={{ backLabel: 'Back to Watchlist' }}
+        {/* Tabs */}
+        <Tabs
+          value={tabIdx}
+          onChange={(_, v) => setTabIdx(v)}
+          aria-label="watchlist category tabs"
+          sx={(theme) => ({
+            '& .MuiTab-root': {
+              textTransform: 'none',
+              fontWeight: 500,
+              fontSize: '0.85rem',
+              minHeight: 40,
+              '&.Mui-selected': { fontWeight: 600 },
+            },
+            '& .MuiTabs-indicator': {
+              backgroundColor: theme.palette.primary.main,
+              height: 2,
+            },
+          })}
+        >
+          {TABS.map((t) => (
+            <Tab
+              key={t.key}
+              label={`${t.label}${items[t.key].length > 0 ? ` (${items[t.key].length})` : ''}`}
             />
-          </Box>
+          ))}
+        </Tabs>
+
+        {/* Content */}
+        {currentTab.key === 'miners' ? (
+          isEmpty ? (
+            <EmptyState tab={currentTab} />
+          ) : (
+            <Box sx={{ width: '100%' }}>
+              <TopMinersTable
+                miners={minerStats}
+                isLoading={isLoadingMinerStats}
+                getHref={(m) =>
+                  `/miners/details?githubId=${encodeURIComponent(m.githubId)}`
+                }
+                linkState={{ backLabel: 'Back to Watchlist' }}
+              />
+            </Box>
+          )
+        ) : isEmpty ? (
+          <EmptyState tab={currentTab} />
+        ) : (
+          <TableContainer>
+            <Table size="small">
+              <TableBody>
+                {currentTab.key === 'repos' && (
+                  <RepoRows ids={items.repos} repos={reposData} />
+                )}
+                {currentTab.key === 'bounties' && (
+                  <BountyRows ids={items.bounties} issues={issuesData} />
+                )}
+                {currentTab.key === 'prs' && <PRRows ids={items.prs} />}
+              </TableBody>
+            </Table>
+          </TableContainer>
         )}
       </Box>
 
+      {/* Confirm dialog */}
       <Dialog open={confirmOpen} onClose={() => setConfirmOpen(false)}>
-        <DialogTitle>Clear all {count} pinned miners?</DialogTitle>
+        <DialogTitle>
+          Clear all {categoryCount} pinned {currentTab.label.toLowerCase()}?
+        </DialogTitle>
         <DialogActions>
           <Button
             onClick={() => setConfirmOpen(false)}
@@ -156,12 +378,52 @@ const WatchlistPage: React.FC = () => {
             color="error"
             sx={{ textTransform: 'none' }}
           >
-            Clear watchlist
+            Clear {currentTab.label.toLowerCase()}
           </Button>
         </DialogActions>
       </Dialog>
     </Page>
   );
 };
+
+/* ------------------------------------------------------------------ */
+/*  Empty state                                                        */
+/* ------------------------------------------------------------------ */
+
+const EmptyState: React.FC<{ tab: TabDef }> = ({ tab }) => (
+  <Box
+    sx={{
+      py: 8,
+      textAlign: 'center',
+      display: 'flex',
+      flexDirection: 'column',
+      gap: 2,
+      alignItems: 'center',
+      color: 'text.secondary',
+    }}
+  >
+    <Typography sx={{ fontSize: '0.95rem' }}>{tab.emptyMsg}</Typography>
+    <Typography
+      sx={{
+        fontSize: '0.8rem',
+        maxWidth: 480,
+        color: (t) => alpha(t.palette.text.primary, 0.5),
+      }}
+    >
+      {tab.emptyHint}
+    </Typography>
+    {tab.emptyAction && (
+      <Button
+        component={RouterLink}
+        to={tab.emptyAction.to}
+        variant="outlined"
+        size="small"
+        sx={{ textTransform: 'none', mt: 1 }}
+      >
+        {tab.emptyAction.label}
+      </Button>
+    )}
+  </Box>
+);
 
 export default WatchlistPage;


### PR DESCRIPTION
## Changes

Resolves #449

This PR expands the watchlist system to support multiple entity categories beyond just miners.

### Features
- **Multi-category watchlist hook** (`useWatchlist`): Supports 4 categories — `miners`, `repos`, `bounties`, `prs` — with backward-compatible v1 → v2 migration
- **Updated WatchlistButton**: New `category` + `itemKey` props; old `githubId` prop still works (defaults to `miners`)
- **WatchlistPage with tabs**: Each category gets its own tab with contextual empty states and navigation links
- **WatchlistButton on detail pages**: Added to RepositoryDetailsPage, IssueDetailsPage, PRDetailsPage, and MinerDetailsPage

### Technical
- Storage shape: `{ v: 2, miners: Set, repos: Set, bounties: Set, prs: Set }` with one-way migration from v1
- All existing miner watchlist data is preserved during migration
- Tab-specific clear button (clears only the active category)
- `isMinerWatched()` helper for backward-compatible single-category callers

Closes #449