### PR TITLE
fix: repository chart unusable when sorted by Weight

### DIFF
--- a/src/components/leaderboard/TopRepositoriesTable.tsx
+++ b/src/components/leaderboard/TopRepositoriesTable.tsx
@@ -273,7 +273,10 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
     };
     const metric = chartMetric[sortColumn] ?? chartMetric.totalScore;
     const effectiveLogScale =
-      useLogScale && sortColumn !== 'totalPRs' && sortColumn !== 'contributors';
+      useLogScale &&
+      sortColumn !== 'weight' &&
+      sortColumn !== 'totalPRs' &&
+      sortColumn !== 'contributors';
 
     const barGradient = {
       type: 'linear',
@@ -414,6 +417,7 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
           fontSize: 11,
           formatter: (value: number) => {
             if (value >= 1000) return `${(value / 1000).toFixed(1)}k`;
+            if (sortColumn === 'weight') return value.toFixed(2);
             return value.toFixed(0);
           },
         },


### PR DESCRIPTION
## Summary

Fixes two composing bugs on the Repositories chart that only surface when the active sort column is **Weight**:

### Bug 1 — Log Scale default hides bars

After #308 the chart's metric follows the active sort column. The existing `effectiveLogScale` expression already auto-disables log scale for `totalPRs` and `contributors` — but not for `weight`. With Log Scale ON (the default), Weight values in `[0, 1]` render against a log y-axis starting at `1`, so every bar falls below the minimum and becomes invisible.

### Bug 2 — Axis labels round decimals to zero

Even when Log Scale is toggled off (linear y-axis 0 → 1), the tick-label formatter used `.toFixed(0)` for every value — so ticks like `0.2`, `0.4`, `0.6`, `0.8` all collapsed to labels `0`, `0`, `0`, `1`. Bars rendered, but the scale was illegible.

## Fix

Two small composing changes:

```diff
     const effectiveLogScale =
-      useLogScale && sortColumn !== 'totalPRs' && sortColumn !== 'contributors';
+      useLogScale &&
+      sortColumn !== 'weight' &&
+      sortColumn !== 'totalPRs' &&
+      sortColumn !== 'contributors';
```

```diff
           formatter: (value: number) => {
             if (value >= 1000) return `${(value / 1000).toFixed(1)}k`;
+            if (sortColumn === 'weight') return value.toFixed(2);
             return value.toFixed(0);
           },
```

Total diff: **+5 / −1 in one file.**

**Log Scale toggle is intentionally preserved** — it remains useful for the Total Score metric (top repos dwarf the rest), so the pattern of auto-disabling per-metric (rather than removing the control) is the correct shape. This PR just fills in the two missing pieces for the `weight` case.

No behavior change for any other sort column.

## Related Issues

Fixes #466

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

### Before
https://github.com/user-attachments/assets/5c3958bc-452f-4b41-828c-291a97871935

### After
https://github.com/user-attachments/assets/959c6e9a-ee1b-4b68-bb57-d0021640881b


## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes