### PR TITLE
fix: improve the FAQ expressions and add a new entry for issue discoveries

### DIFF
--- a/src/components/onboard/AboutContent.tsx
+++ b/src/components/onboard/AboutContent.tsx
@@ -160,8 +160,8 @@ export const AboutContent: React.FC = () => {
                         minimumFractionDigits: 2,
                         maximumFractionDigits: 2,
                       },
-                    )} monthly reward pool by making open source contributions.`
-                  : 'Stop coding for free. Get paid in TAO for your open source contributions.',
+                    )} monthly reward pool through OSS contributions or Issue Discovery.`
+                  : 'Stop coding for free. Earn alpha tokens through two tracks: merge PRs to OSS repositories or discover issues for others to solve.',
               },
               {
                 icon: <VerifiedUserIcon fontSize="large" />,

--- a/src/components/onboard/FAQContent.tsx
+++ b/src/components/onboard/FAQContent.tsx
@@ -65,11 +65,10 @@ export const FAQContent: React.FC = () => (
           <>
             To start mining, you need to make pull requests to recognized OSS
             repositories on GitHub. Once your code is merged into the production
-            branch, you'll be eligible for emissions based on factors like the
-            repository weight, AST token-based code scoring, language weights,
-            and multipliers such as time decay, review quality, and labels.
-            Check out our GitHub repository for detailed setup instructions.
-            Feel free to join the{' '}
+            branch, you'll be eligible for emissions based on factors like PR
+            size, files affected, repository popularity, and more. Check out our
+            GitHub repository for detailed setup instructions. Feel free to join
+            the{' '}
             <a
               href="https://discord.com/invite/bittensor"
               target="_blank"
@@ -87,14 +86,11 @@ export const FAQContent: React.FC = () => (
         answer={
           <>
             Your rewards are determined by the weight of the repository you
-            contribute to, the quality of your code changes (measured by AST
+            contribute to, the quality of your code changes (measured by
             token-based scoring), and multipliers like time decay, review
-            quality, label type (e.g. feature: 1.5×, bug: 1.25×), and issue
-            bonuses. We also factor in your credibility, which is the ratio of
-            your merged PRs to your total PR attempts — with one closed PR
-            forgiven (mulligan) before the ratio is calculated. The earliest
-            contributor to a repository also earns pioneer dividends from later
-            contributors' scores. See the{' '}
+            quality, and issue bonuses. We also factor in your 'credibility',
+            which is the ratio of your merged PRs to your total PR attempts
+            (merged + closed). See the{' '}
             <a
               href="https://docs.gittensor.io/oss-contributions.html"
               target="_blank"
@@ -132,8 +128,8 @@ export const FAQContent: React.FC = () => (
           <>
             You must contribute to an incentivized repository listed in our
             master list. To become eligible for rewards, you need at least 5
-            merged PRs with a token score of 5 or higher and 80% credibility
-            (with one closed PR forgiven). Check the{' '}
+            merged PRs with a token score of 5 or higher and 80% credibility.
+            Check the{' '}
             <a
               href="https://docs.gittensor.io/oss-contributions.html"
               target="_blank"
@@ -143,29 +139,6 @@ export const FAQContent: React.FC = () => (
               Scoring documentation
             </a>{' '}
             for full eligibility details.
-          </>
-        }
-      />
-      <FAQ
-        question="What is Issue Discovery?"
-        answer={
-          <>
-            Issue Discovery is a separate earning track within Gittensor where
-            miners are rewarded for finding and reporting valid bugs or
-            improvement opportunities in recognized repositories. Discovered
-            issues are evaluated and scored by validators. To become eligible,
-            you need at least 7 valid solved issues and 80% issue credibility.
-            Issue Discovery accounts for 30% of total subnet emissions — the
-            same share as OSS contributions. See the{' '}
-            <a
-              href="https://docs.gittensor.io/issue-discovery.html"
-              target="_blank"
-              rel="noopener noreferrer"
-              style={{ color: 'inherit', textDecoration: 'underline' }}
-            >
-              Issue Discovery documentation
-            </a>{' '}
-            for full details.
           </>
         }
       />

--- a/src/components/onboard/FAQContent.tsx
+++ b/src/components/onboard/FAQContent.tsx
@@ -65,10 +65,11 @@ export const FAQContent: React.FC = () => (
           <>
             To start mining, you need to make pull requests to recognized OSS
             repositories on GitHub. Once your code is merged into the production
-            branch, you'll be eligible for emissions based on factors like PR
-            size, files affected, repository popularity, and more. Check out our
-            GitHub repository for detailed setup instructions. Feel free to join
-            the{' '}
+            branch, you'll be eligible for emissions based on factors like the
+            repository weight, AST token-based code scoring, language weights,
+            and multipliers such as time decay, review quality, and labels. Check
+            out our GitHub repository for detailed setup instructions. Feel free
+            to join the{' '}
             <a
               href="https://discord.com/invite/bittensor"
               target="_blank"
@@ -87,10 +88,13 @@ export const FAQContent: React.FC = () => (
           <>
             Your rewards are determined by the weight of the repository you
             contribute to, the quality of your code changes (measured by
-            token-based scoring), and multipliers like time decay, review
-            quality, and issue bonuses. We also factor in your 'credibility',
-            which is the ratio of your merged PRs to your total PR attempts
-            (merged + closed). See the{' '}
+            AST token-based scoring), and multipliers like time decay, review
+            quality, label type (e.g. feature: 1.5×, bug: 1.25×), and issue
+            bonuses. We also factor in your credibility, which is the ratio of
+            your merged PRs to your total PR attempts — with one closed PR
+            forgiven (mulligan) before the ratio is calculated. The earliest
+            contributor to a repository also earns pioneer dividends from later
+            contributors' scores. See the{' '}
             <a
               href="https://docs.gittensor.io/oss-contributions.html"
               target="_blank"
@@ -128,8 +132,8 @@ export const FAQContent: React.FC = () => (
           <>
             You must contribute to an incentivized repository listed in our
             master list. To become eligible for rewards, you need at least 5
-            merged PRs with a token score of 5 or higher, 80% credibility, and a
-            GitHub account that is at least 180 days old. Check the{' '}
+            merged PRs with a token score of 5 or higher and 80% credibility
+            (with one closed PR forgiven). Check the{' '}
             <a
               href="https://docs.gittensor.io/oss-contributions.html"
               target="_blank"
@@ -139,6 +143,29 @@ export const FAQContent: React.FC = () => (
               Scoring documentation
             </a>{' '}
             for full eligibility details.
+          </>
+        }
+      />
+      <FAQ
+        question="What is Issue Discovery?"
+        answer={
+          <>
+            Issue Discovery is a separate earning track within Gittensor where
+            miners are rewarded for finding and reporting valid bugs or
+            improvement opportunities in recognized repositories. Discovered
+            issues are evaluated and scored by validators. To become eligible,
+            you need at least 7 valid solved issues and 80% issue credibility.
+            Issue Discovery accounts for 30% of total subnet emissions — the
+            same share as OSS contributions. See the{' '}
+            <a
+              href="https://docs.gittensor.io/issue-discovery.html"
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{ color: 'inherit', textDecoration: 'underline' }}
+            >
+              Issue Discovery documentation
+            </a>{' '}
+            for full details.
           </>
         }
       />

--- a/src/components/onboard/FAQContent.tsx
+++ b/src/components/onboard/FAQContent.tsx
@@ -67,9 +67,9 @@ export const FAQContent: React.FC = () => (
             repositories on GitHub. Once your code is merged into the production
             branch, you'll be eligible for emissions based on factors like the
             repository weight, AST token-based code scoring, language weights,
-            and multipliers such as time decay, review quality, and labels. Check
-            out our GitHub repository for detailed setup instructions. Feel free
-            to join the{' '}
+            and multipliers such as time decay, review quality, and labels.
+            Check out our GitHub repository for detailed setup instructions.
+            Feel free to join the{' '}
             <a
               href="https://discord.com/invite/bittensor"
               target="_blank"
@@ -87,8 +87,8 @@ export const FAQContent: React.FC = () => (
         answer={
           <>
             Your rewards are determined by the weight of the repository you
-            contribute to, the quality of your code changes (measured by
-            AST token-based scoring), and multipliers like time decay, review
+            contribute to, the quality of your code changes (measured by AST
+            token-based scoring), and multipliers like time decay, review
             quality, label type (e.g. feature: 1.5×, bug: 1.25×), and issue
             bonuses. We also factor in your credibility, which is the ratio of
             your merged PRs to your total PR attempts — with one closed PR


### PR DESCRIPTION

## Closes: #470 

## Summary

- Fix incorrect GitHub account age requirement (180 days) — this check does not exist in the codebase
- Correct credibility description to include the 1-PR mulligan in the calculation
- Replace inaccurate mining factors ("PR size, files affected") with accurate AST token-based scoring description
- Add label multipliers (feature 1.5×, bug 1.25×) and pioneer dividends to rewards explanation
- Add new Issue Discovery FAQ entry covering eligibility gates, emissions share, and link to docs
- Fix "Get paid in TAO" fallback copy — rewards are alpha tokens, not TAO
- Update "Direct Incentives" card to surface Issue Discovery as a second earning track alongside OSS contributions

## Motivation

Several onboarding content entries were out of sync with the current scoring logic and mechanics in the validator:
- `MIN_VALID_MERGED_PRS`, `MIN_CREDIBILITY`, and `CREDIBILITY_MULLIGAN_COUNT` in `constants.py` / `credibility.py` were not accurately reflected
- The Issue Discovery track (`MIN_VALID_SOLVED_ISSUES = 7`, 30% emissions share) had no FAQ coverage and was absent from the "Why Become a Miner?" section
- No GitHub account age constant exists anywhere in the codebase; the 180-day claim was stale/incorrect
- Rewards are distributed as alpha tokens, not TAO

## Changes

- `src/components/onboard/FAQContent.tsx` — updated 3 existing FAQ entries, added 1 new Issue Discovery entry
- `src/components/onboard/AboutContent.tsx` — updated "Direct Incentives" card copy in the "Why Become a Miner?" section

## Screenshots

Before

https://github.com/user-attachments/assets/27789a44-9197-4106-99d6-6ce807cf651a

After

https://github.com/user-attachments/assets/10e8728d-bcd3-458d-bdf2-74ce0b0205bf



