### PR TITLE
feat: add retry/timeout logic to ApiUtils

### DIFF
--- a/src/api/ApiUtils.ts
+++ b/src/api/ApiUtils.ts
@@ -1,6 +1,25 @@
 import { useQuery } from '@tanstack/react-query';
 import axios, { type AxiosError } from 'axios';
 
+const REQUEST_TIMEOUT_MS = 15_000;
+export const MAX_RETRIES = 3;
+
+const isRetryableStatus = (status: number): boolean =>
+  status === 429 || status >= 500;
+
+export const shouldRetry = (
+  failureCount: number,
+  error: AxiosError,
+): boolean => {
+  if (failureCount >= MAX_RETRIES) return false;
+  const status = error?.response?.status;
+  if (status === undefined) return true; // network error or timeout — no HTTP response
+  return isRetryableStatus(status);
+};
+
+export const getRetryDelay = (attempt: number): number =>
+  Math.min(1_000 * 2 ** attempt, 30_000);
+
 export const useApiQuery = <TResponse = void, TSelect = TResponse>(
   queryName: string,
   url: string,
@@ -14,10 +33,14 @@ export const useApiQuery = <TResponse = void, TSelect = TResponse>(
     queryKey: [queryName, url, queryParams],
     queryFn: async () => {
       const requestUrl = baseUrl ? `${baseUrl}${url}` : url;
-      const { data } = await axios.get(requestUrl, { params: queryParams });
+      const { data } = await axios.get(requestUrl, {
+        params: queryParams,
+        timeout: REQUEST_TIMEOUT_MS,
+      });
       return data;
     },
-    retry: false,
+    retry: shouldRetry,
+    retryDelay: getRetryDelay,
     enabled: enabled ?? true,
     refetchInterval,
   });

--- a/src/tests/ApiUtils.test.ts
+++ b/src/tests/ApiUtils.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+import { type AxiosError } from 'axios';
+
+import { MAX_RETRIES, getRetryDelay, shouldRetry } from '../api/ApiUtils';
+
+const makeError = (status?: number): AxiosError =>
+  ({
+    response: status !== undefined ? { status } : undefined,
+  }) as AxiosError;
+
+// ─── shouldRetry ────────────────────────────────────────────────────────────
+
+describe('shouldRetry', () => {
+  describe('retryable status codes', () => {
+    it('retries on 429 Too Many Requests', () => {
+      expect(shouldRetry(0, makeError(429))).toBe(true);
+    });
+
+    it('retries on 500 Internal Server Error', () => {
+      expect(shouldRetry(0, makeError(500))).toBe(true);
+    });
+
+    it('retries on 502 Bad Gateway', () => {
+      expect(shouldRetry(0, makeError(502))).toBe(true);
+    });
+
+    it('retries on 503 Service Unavailable', () => {
+      expect(shouldRetry(0, makeError(503))).toBe(true);
+    });
+
+    it('retries on 504 Gateway Timeout', () => {
+      expect(shouldRetry(0, makeError(504))).toBe(true);
+    });
+
+    it('retries when there is no HTTP response (network error / timeout)', () => {
+      expect(shouldRetry(0, makeError(undefined))).toBe(true);
+    });
+  });
+
+  describe('non-retryable status codes', () => {
+    it('does not retry on 400 Bad Request', () => {
+      expect(shouldRetry(0, makeError(400))).toBe(false);
+    });
+
+    it('does not retry on 401 Unauthorized', () => {
+      expect(shouldRetry(0, makeError(401))).toBe(false);
+    });
+
+    it('does not retry on 403 Forbidden', () => {
+      expect(shouldRetry(0, makeError(403))).toBe(false);
+    });
+
+    it('does not retry on 404 Not Found', () => {
+      expect(shouldRetry(0, makeError(404))).toBe(false);
+    });
+
+    it('does not retry on 422 Unprocessable Entity', () => {
+      expect(shouldRetry(0, makeError(422))).toBe(false);
+    });
+  });
+
+  describe('max retries enforcement', () => {
+    it('stops retrying once MAX_RETRIES is reached on a 5xx', () => {
+      expect(shouldRetry(MAX_RETRIES, makeError(500))).toBe(false);
+    });
+
+    it('stops retrying once MAX_RETRIES is reached on a 429', () => {
+      expect(shouldRetry(MAX_RETRIES, makeError(429))).toBe(false);
+    });
+
+    it('stops retrying once MAX_RETRIES is reached on a network error', () => {
+      expect(shouldRetry(MAX_RETRIES, makeError(undefined))).toBe(false);
+    });
+
+    it('still retries one attempt before the limit', () => {
+      expect(shouldRetry(MAX_RETRIES - 1, makeError(500))).toBe(true);
+    });
+  });
+});
+
+// ─── getRetryDelay ──────────────────────────────────────────────────────────
+
+describe('getRetryDelay', () => {
+  it('returns 1 s on first retry (attempt 0)', () => {
+    expect(getRetryDelay(0)).toBe(1_000);
+  });
+
+  it('returns 2 s on second retry (attempt 1)', () => {
+    expect(getRetryDelay(1)).toBe(2_000);
+  });
+
+  it('returns 4 s on third retry (attempt 2)', () => {
+    expect(getRetryDelay(2)).toBe(4_000);
+  });
+
+  it('caps delay at 30 s for large attempt numbers', () => {
+    expect(getRetryDelay(10)).toBe(30_000);
+    expect(getRetryDelay(100)).toBe(30_000);
+  });
+
+  it('delay grows exponentially between attempts', () => {
+    const d0 = getRetryDelay(0);
+    const d1 = getRetryDelay(1);
+    const d2 = getRetryDelay(2);
+    expect(d1).toBe(d0 * 2);
+    expect(d2).toBe(d1 * 2);
+  });
+});


### PR DESCRIPTION
## Closes: #477 

## Summary

- Adds `REQUEST_TIMEOUT_MS = 15_000` (15 s) to all Axios requests via `useApiQuery`
- Adds `shouldRetry` — retries on 429, 5xx, and network errors; stops after `MAX_RETRIES = 3`; never retries 4xx client errors
- Adds `getRetryDelay` — exponential backoff capped at 30 s: 1 s → 2 s → 4 s → … → 30 s
- Wires `retry` and `retryDelay` into React Query options in `useApiQuery`
- Adds 20 unit tests in `src/tests/ApiUtils.test.ts` (vitest)

## Test plan

- [x] `npx vitest run` — 57/57 tests pass (no regressions)
- [x] TypeScript — zero type errors
- [x] ESLint — no warnings
- [x] Prettier — formatted correctly