### PR TITLE
feat(tables): add Excel and PDF export to data tables

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,8 @@
         "echarts": "^6.0.0",
         "echarts-for-react": "^3.0.5",
         "github-markdown-css": "^5.8.1",
+        "jspdf": "^4.2.1",
+        "jspdf-autotable": "^5.0.7",
         "parse-diff": "^0.11.1",
         "react": "^18.3.1",
         "react-activity-calendar": "^3.0.5",
@@ -31,7 +33,8 @@
         "react-syntax-highlighter": "^16.1.0",
         "react-tooltip": "^5.30.0",
         "rehype-raw": "^7.0.0",
-        "remark-gfm": "^4.0.1"
+        "remark-gfm": "^4.0.1",
+        "xlsx": "^0.18.5"
       },
       "devDependencies": {
         "@types/react": "^18.3.3",
@@ -2069,6 +2072,12 @@
       "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
     },
+    "node_modules/@types/pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==",
+      "license": "MIT"
+    },
     "node_modules/@types/parse-json": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
@@ -2086,6 +2095,13 @@
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
       "license": "MIT"
+    },
+    "node_modules/@types/raf": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/react": {
       "version": "18.3.28",
@@ -2124,6 +2140,13 @@
       "peerDependencies": {
         "@types/react": "*"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -2491,6 +2514,15 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/adler-32": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
+      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
@@ -2603,6 +2635,16 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
@@ -2638,6 +2680,26 @@
         "node": ">=6"
       }
     },
+    "node_modules/canvg": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
+      "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/ccount": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
@@ -2646,6 +2708,19 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/cfb": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
+      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "crc-32": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/chai": {
@@ -2730,6 +2805,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/codepage": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
+      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2785,6 +2869,18 @@
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
       "license": "MIT"
     },
+    "node_modules/core-js": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/cosmiconfig": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
@@ -2801,6 +2897,18 @@
         "node": ">=10"
       }
     },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2814,6 +2922,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/csstype": {
@@ -2921,6 +3039,16 @@
       "dependencies": {
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
+      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optional": true,
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/dunder-proto": {
@@ -3372,6 +3500,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-png": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/fast-png/-/fast-png-6.4.0.tgz",
+      "integrity": "sha512-kAqZq1TlgBjZcLr5mcN6NP5Rv4V2f22z00c3g8vRrwkcqjerx7BEhPbOnWCPqaHUl2XWQBJQvOT/FQhdMT7X/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/pako": "^2.0.3",
+        "iobuffer": "^5.3.2",
+        "pako": "^2.1.0"
+      }
+    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -3412,6 +3551,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
@@ -3513,6 +3658,15 @@
       "integrity": "sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==",
       "engines": {
         "node": ">=0.4.x"
+      }
+    },
+    "node_modules/frac": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
+      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/fs.realpath": {
@@ -3929,6 +4083,20 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
@@ -3998,6 +4166,12 @@
       "dependencies": {
         "loose-envify": "^1.0.0"
       }
+    },
+    "node_modules/iobuffer": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz",
+      "integrity": "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==",
+      "license": "MIT"
     },
     "node_modules/is-alphabetical": {
       "version": "2.0.1",
@@ -4173,6 +4347,32 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/jspdf": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.2.1.tgz",
+      "integrity": "sha512-YyAXyvnmjTbR4bHQRLzex3CuINCDlQnBqoSYyjJwTP2x9jDLuKDzy7aKUl0hgx3uhcl7xzg32agn5vlie6HIlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6",
+        "fast-png": "^6.2.0",
+        "fflate": "^0.8.1"
+      },
+      "optionalDependencies": {
+        "canvg": "^3.0.11",
+        "core-js": "^3.6.0",
+        "dompurify": "^3.3.1",
+        "html2canvas": "^1.0.0-rc.5"
+      }
+    },
+    "node_modules/jspdf-autotable": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/jspdf-autotable/-/jspdf-autotable-5.0.7.tgz",
+      "integrity": "sha512-2wr7H6liNDBYNwt25hMQwXkEWFOEopgKIvR1Eukuw6Zmprm/ZcnmLTQEjW7Xx3FCbD3v7pflLcnMAv/h1jFDQw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "jspdf": "^2 || ^3 || ^4"
+      }
     },
     "node_modules/keyv": {
       "version": "4.5.4",
@@ -5286,6 +5486,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -5410,6 +5616,13 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -5557,6 +5770,16 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "performance-now": "^2.1.0"
+      }
     },
     "node_modules/react": {
       "version": "18.3.1",
@@ -5762,6 +5985,13 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/rehype-raw": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/rehype-raw/-/rehype-raw-7.0.0.tgz",
@@ -5881,6 +6111,16 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "license": "MIT OR SEE LICENSE IN FEEL-FREE.md",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8.15"
       }
     },
     "node_modules/rimraf": {
@@ -6062,12 +6302,34 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/ssf": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
+      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "frac": "~1.1.2"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/stackblur-canvas": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.14"
+      }
     },
     "node_modules/std-env": {
       "version": "3.10.0",
@@ -6165,11 +6427,31 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/tabbable": {
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
       "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
       "license": "MIT"
+    },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
     },
     "node_modules/text-table": {
       "version": "0.2.0",
@@ -6396,6 +6678,16 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
       }
     },
     "node_modules/vfile": {
@@ -7174,6 +7466,24 @@
         "node": ">=8"
       }
     },
+    "node_modules/wmf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
+      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/word": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
+      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -7190,6 +7500,27 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/xlsx": {
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
+      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "cfb": "~1.2.1",
+        "codepage": "~1.15.0",
+        "crc-32": "~1.2.1",
+        "ssf": "~0.11.2",
+        "wmf": "~1.0.1",
+        "word": "~0.3.0"
+      },
+      "bin": {
+        "xlsx": "bin/xlsx.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/yaml": {
       "version": "1.10.2",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
     "echarts": "^6.0.0",
     "echarts-for-react": "^3.0.5",
     "github-markdown-css": "^5.8.1",
+    "jspdf": "^4.2.1",
+    "jspdf-autotable": "^5.0.7",
     "parse-diff": "^0.11.1",
     "react": "^18.3.1",
     "react-activity-calendar": "^3.0.5",
@@ -38,7 +40,8 @@
     "react-syntax-highlighter": "^16.1.0",
     "react-tooltip": "^5.30.0",
     "rehype-raw": "^7.0.0",
-    "remark-gfm": "^4.0.1"
+    "remark-gfm": "^4.0.1",
+    "xlsx": "^0.18.5"
   },
   "devDependencies": {
     "@types/react": "^18.3.3",

--- a/src/components/common/ExportMenu.tsx
+++ b/src/components/common/ExportMenu.tsx
@@ -1,0 +1,119 @@
+import React, { useCallback, useState } from 'react';
+import {
+  Button,
+  Menu,
+  MenuItem,
+  ListItemIcon,
+  ListItemText,
+} from '@mui/material';
+import FileDownloadOutlinedIcon from '@mui/icons-material/FileDownloadOutlined';
+import TableChartOutlinedIcon from '@mui/icons-material/TableChartOutlined';
+import PictureAsPdfOutlinedIcon from '@mui/icons-material/PictureAsPdfOutlined';
+import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
+import {
+  type ExportColumn,
+  type ExportOptions,
+  exportRowsToExcel,
+  exportRowsToPdf,
+} from '../../utils';
+
+interface ExportMenuProps<T> {
+  rows: T[];
+  columns: ExportColumn<T>[];
+  options: ExportOptions;
+  label?: string;
+  size?: 'small' | 'medium';
+  disabled?: boolean;
+}
+
+export const ExportMenu = <T,>({
+  rows,
+  columns,
+  options,
+  label = 'Export',
+  size = 'small',
+  disabled,
+}: ExportMenuProps<T>): React.ReactElement => {
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+  const isOpen = Boolean(anchorEl);
+  const isEmpty = rows.length === 0;
+  const isDisabled = disabled || isEmpty;
+
+  const handleOpen = useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      setAnchorEl(event.currentTarget);
+    },
+    [],
+  );
+
+  const handleClose = useCallback(() => {
+    setAnchorEl(null);
+  }, []);
+
+  const handleExportExcel = useCallback(() => {
+    exportRowsToExcel(rows, columns, options);
+    handleClose();
+  }, [rows, columns, options, handleClose]);
+
+  const handleExportPdf = useCallback(() => {
+    exportRowsToPdf(rows, columns, options);
+    handleClose();
+  }, [rows, columns, options, handleClose]);
+
+  return (
+    <>
+      <Button
+        size={size}
+        variant="outlined"
+        onClick={handleOpen}
+        disabled={isDisabled}
+        startIcon={<FileDownloadOutlinedIcon sx={{ fontSize: '1rem' }} />}
+        endIcon={<ArrowDropDownIcon sx={{ fontSize: '1rem' }} />}
+        aria-haspopup="menu"
+        aria-expanded={isOpen}
+        sx={{
+          height: size === 'small' ? 32 : 36,
+          textTransform: 'none',
+          fontSize: '0.75rem',
+          fontWeight: 500,
+          borderColor: 'border.light',
+          color: 'text.primary',
+          backgroundColor: 'background.default',
+          '&:hover': {
+            borderColor: 'border.medium',
+            backgroundColor: 'surface.subtle',
+          },
+        }}
+      >
+        {label}
+      </Button>
+      <Menu
+        anchorEl={anchorEl}
+        open={isOpen}
+        onClose={handleClose}
+        MenuListProps={{ dense: true }}
+      >
+        <MenuItem onClick={handleExportExcel}>
+          <ListItemIcon>
+            <TableChartOutlinedIcon fontSize="small" />
+          </ListItemIcon>
+          <ListItemText
+            primary="Excel (.xlsx)"
+            primaryTypographyProps={{ fontSize: '0.8rem' }}
+          />
+        </MenuItem>
+        <MenuItem onClick={handleExportPdf}>
+          <ListItemIcon>
+            <PictureAsPdfOutlinedIcon fontSize="small" />
+          </ListItemIcon>
+          <ListItemText
+            primary="PDF"
+            primaryTypographyProps={{ fontSize: '0.8rem' }}
+          />
+        </MenuItem>
+      </Menu>
+    </>
+  );
+};
+
+export default ExportMenu;

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -1,3 +1,4 @@
 export * from './RowLink';
 export * from './SearchInput';
 export * from './WatchlistButton';
+export * from './ExportMenu';

--- a/src/components/issues/IssuesList.tsx
+++ b/src/components/issues/IssuesList.tsx
@@ -23,8 +23,10 @@ import { IssueBounty } from '../../api/models/Issues';
 import { useStats } from '../../api';
 import { formatTokenAmount, formatDate } from '../../utils/format';
 import { getIssueStatusMeta } from '../../utils/issueStatus';
+import type { ExportColumn } from '../../utils';
 import { STATUS_COLORS, TEXT_OPACITY } from '../../theme';
 import BountyProgress from './BountyProgress';
+import { ExportMenu } from '../common/ExportMenu';
 
 type ListType = 'available' | 'pending' | 'history';
 type SortDirection = 'asc' | 'desc';
@@ -200,6 +202,97 @@ const IssuesList: React.FC<IssuesListProps> = ({
     return decorated.map((item) => item.issue);
   }, [issues, sortDirection, sortKey]);
 
+  const exportColumns = useMemo<ExportColumn<IssueBounty>[]>(() => {
+    const commonColumns: ExportColumn<IssueBounty>[] = [
+      { label: 'ID', accessor: (issue) => issue.id, width: 6 },
+      {
+        label: 'Repository',
+        accessor: (issue) => issue.repositoryFullName,
+        width: 28,
+      },
+      {
+        label: 'Issue',
+        accessor: (issue) =>
+          issue.title
+            ? `#${issue.issueNumber} — ${issue.title}`
+            : `#${issue.issueNumber}`,
+        width: 60,
+      },
+    ];
+
+    const statusColumn: ExportColumn<IssueBounty> = {
+      label: 'Status',
+      accessor: (issue) => getIssueStatusMeta(issue.status).text,
+      width: 12,
+    };
+
+    if (listType === 'available') {
+      return [
+        ...commonColumns,
+        {
+          label: 'Bounty (α)',
+          accessor: (issue) => parseAmount(issue.targetBounty),
+          width: 12,
+        },
+        statusColumn,
+      ];
+    }
+
+    if (listType === 'pending') {
+      return [
+        ...commonColumns,
+        {
+          label: 'Target Bounty (α)',
+          accessor: (issue) => parseAmount(issue.targetBounty),
+          width: 14,
+        },
+        {
+          label: 'Funding %',
+          accessor: (issue) => {
+            const target = parseAmount(issue.targetBounty);
+            if (target <= 0) return 0;
+            return Number(
+              ((parseAmount(issue.bountyAmount) / target) * 100).toFixed(2),
+            );
+          },
+          width: 10,
+        },
+        statusColumn,
+      ];
+    }
+
+    return [
+      ...commonColumns,
+      {
+        label: 'Payout (α)',
+        accessor: (issue) => parseAmount(issue.targetBounty),
+        width: 12,
+      },
+      {
+        label: 'Solver',
+        accessor: (issue) => issue.solverHotkey ?? '',
+        width: 20,
+      },
+      statusColumn,
+      {
+        label: 'Date',
+        accessor: (issue) =>
+          issue.completedAt
+            ? formatDate(issue.completedAt)
+            : formatDate(issue.updatedAt),
+        width: 14,
+      },
+    ];
+  }, [listType]);
+
+  const exportOptions = useMemo(
+    () => ({
+      slug: `bounties-${listType}`,
+      title: `Bounties — ${listType.charAt(0).toUpperCase()}${listType.slice(1)}`,
+    }),
+    [listType],
+  );
+
   const renderSortableHeader = useCallback(
     (
       label: string,
@@ -322,6 +415,33 @@ const IssuesList: React.FC<IssuesListProps> = ({
       }}
       elevation={0}
     >
+      <Box
+        sx={{
+          px: 2,
+          py: 1.5,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          borderBottom: '1px solid',
+          borderColor: 'border.light',
+          gap: 2,
+        }}
+      >
+        <Typography
+          sx={{
+            fontSize: '0.75rem',
+            color: 'text.secondary',
+            fontFamily: '"JetBrains Mono", monospace',
+          }}
+        >
+          {issues.length} {issues.length === 1 ? 'issue' : 'issues'}
+        </Typography>
+        <ExportMenu
+          rows={sortedIssues}
+          columns={exportColumns}
+          options={exportOptions}
+        />
+      </Box>
       <TableContainer>
         <Table size="small">
           <TableHead>

--- a/src/components/leaderboard/TopMinersTable.tsx
+++ b/src/components/leaderboard/TopMinersTable.tsx
@@ -5,8 +5,10 @@ import { useSearchParams } from 'react-router-dom';
 import { SectionCard } from './SectionCard';
 import { MinerCard } from './MinerCard';
 import { SearchInput } from '../common/SearchInput';
+import { ExportMenu } from '../common/ExportMenu';
 import FilterButton from '../FilterButton';
 import { STATUS_COLORS } from '../../theme';
+import type { ExportColumn } from '../../utils';
 import {
   type MinerStats,
   type SortOption,
@@ -212,6 +214,57 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
     [filteredMiners, visibleCount],
   );
 
+  const exportColumns = useMemo<ExportColumn<MinerStats>[]>(() => {
+    const activityColumn: ExportColumn<MinerStats> =
+      variant === 'discoveries'
+        ? {
+            label: 'Issues',
+            accessor: (miner) => miner.totalIssues ?? 0,
+            width: 8,
+          }
+        : { label: 'PRs', accessor: (miner) => miner.totalPRs, width: 8 };
+
+    return [
+      { label: 'Rank', accessor: (miner) => miner.rank ?? null, width: 6 },
+      { label: 'Miner', accessor: (miner) => miner.author ?? miner.githubId },
+      { label: 'Hotkey', accessor: (miner) => miner.hotkey, width: 20 },
+      {
+        label: 'Total Score',
+        accessor: (miner) => Number(miner.totalScore.toFixed(4)),
+        width: 12,
+      },
+      {
+        label: 'USD / Day',
+        accessor: (miner) =>
+          miner.usdPerDay != null ? Number(miner.usdPerDay.toFixed(2)) : null,
+        width: 10,
+      },
+      activityColumn,
+      {
+        label: 'Credibility',
+        accessor: (miner) =>
+          miner.credibility != null
+            ? Number(miner.credibility.toFixed(4))
+            : null,
+        width: 12,
+      },
+      {
+        label: 'Eligible',
+        accessor: (miner) => (miner.isEligible ? 'Yes' : 'No'),
+        width: 8,
+      },
+    ];
+  }, [variant]);
+
+  const exportOptions = useMemo(
+    () => ({
+      slug: variant === 'discoveries' ? 'top-miners-discoveries' : 'top-miners',
+      title:
+        variant === 'discoveries' ? 'Top Miners (Discoveries)' : 'Top Miners',
+    }),
+    [variant],
+  );
+
   const remainingMiners = Math.max(
     0,
     filteredMiners.length - visibleMiners.length,
@@ -250,6 +303,11 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
               isActive={showEligibleOnly}
               onClick={handleToggleEligible}
               color={theme.palette.status.merged}
+            />
+            <ExportMenu
+              rows={filteredMiners}
+              columns={exportColumns}
+              options={exportOptions}
             />
           </Box>
         }

--- a/src/components/leaderboard/TopRepositoriesTable.tsx
+++ b/src/components/leaderboard/TopRepositoriesTable.tsx
@@ -39,9 +39,10 @@ import FilterButton from '../FilterButton';
 import ReactECharts from 'echarts-for-react';
 import type { TooltipComponentFormatterCallbackParams } from 'echarts';
 import { useSearchParams } from 'react-router-dom';
-import { truncateText } from '../../utils';
+import { truncateText, type ExportColumn } from '../../utils';
 import { RankIcon } from './RankIcon';
 import LeaderboardTableSkeleton from './LeaderboardTableSkeleton';
+import { ExportMenu } from '../common/ExportMenu';
 import {
   getRepositoryOwnerAvatarBackground,
   headerCellStyle,
@@ -216,6 +217,40 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
 
     return filtered;
   }, [rankedRepositories, statusFilter, searchQuery]);
+
+  const exportColumns = useMemo<ExportColumn<RepoStats>[]>(
+    () => [
+      { label: 'Rank', accessor: (repo) => repo.rank ?? null, width: 6 },
+      { label: 'Repository', accessor: (repo) => repo.repository, width: 40 },
+      {
+        label: 'Weight',
+        accessor: (repo) => Number(repo.weight.toFixed(6)),
+        width: 12,
+      },
+      {
+        label: 'Total Score',
+        accessor: (repo) => Number(repo.totalScore.toFixed(4)),
+        width: 14,
+      },
+      { label: 'PRs', accessor: (repo) => repo.totalPRs, width: 8 },
+      {
+        label: 'Contributors',
+        accessor: (repo) => repo.uniqueMiners.size,
+        width: 12,
+      },
+      {
+        label: 'Status',
+        accessor: (repo) => (repo.inactiveAt ? 'Inactive' : 'Active'),
+        width: 10,
+      },
+    ],
+    [],
+  );
+
+  const exportOptions = useMemo(
+    () => ({ slug: 'top-repositories', title: 'Top Repositories' }),
+    [],
+  );
 
   const getChartOption = () => {
     const chartData = filteredRepositories.slice(
@@ -744,6 +779,13 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
                   '&.Mui-focused fieldset': { borderColor: 'primary.main' },
                 },
               }}
+            />
+
+            <ExportMenu
+              rows={filteredRepositories}
+              columns={exportColumns}
+              options={exportOptions}
+              size="medium"
             />
           </Box>
         </Box>

--- a/src/components/miners/MinerPRsTable.tsx
+++ b/src/components/miners/MinerPRsTable.tsx
@@ -27,10 +27,12 @@ import {
   getPrStatusCounts,
   paginateItems,
   type PrStatusFilter,
+  type ExportColumn,
 } from '../../utils';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import ExplorerFilterButton from './ExplorerFilterButton';
 import TablePagination from './TablePagination';
+import { ExportMenu } from '../common/ExportMenu';
 import { headerCellStyle, bodyCellStyle, tooltipSlotProps } from '../../theme';
 
 type PrSortField = 'number' | 'repository' | 'score' | 'lines' | 'date';
@@ -204,6 +206,45 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
     return getPrStatusCounts(prs);
   }, [prs]);
 
+  const exportColumns = useMemo<ExportColumn<CommitLog>[]>(
+    () => [
+      {
+        label: 'PR #',
+        accessor: (pr) => pr.pullRequestNumber,
+        width: 8,
+      },
+      { label: 'Title', accessor: (pr) => pr.pullRequestTitle, width: 60 },
+      { label: 'Repository', accessor: (pr) => pr.repository, width: 28 },
+      { label: 'Additions', accessor: (pr) => pr.additions, width: 10 },
+      { label: 'Deletions', accessor: (pr) => pr.deletions, width: 10 },
+      {
+        label: 'Score',
+        accessor: (pr) => Number(getEffectiveScore(pr).toFixed(4)),
+        width: 10,
+      },
+      {
+        label: 'Status',
+        accessor: (pr) =>
+          pr.mergedAt ? 'Merged' : pr.prState === 'CLOSED' ? 'Closed' : 'Open',
+        width: 8,
+      },
+      {
+        label: 'Date',
+        accessor: (pr) => pr.mergedAt ?? pr.prCreatedAt ?? '',
+        width: 20,
+      },
+    ],
+    [],
+  );
+
+  const exportOptions = useMemo(
+    () => ({
+      slug: `miner-prs-${githubId}`,
+      title: `Miner PRs (${githubId})`,
+    }),
+    [githubId],
+  );
+
   if (isLoading) {
     return (
       <Card sx={{ p: 4, textAlign: 'center' }} elevation={0}>
@@ -322,6 +363,11 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
                 }}
               />
             </Box>
+            <ExportMenu
+              rows={sortedPRs}
+              columns={exportColumns}
+              options={exportOptions}
+            />
           </Box>
         </Box>
 

--- a/src/utils/export.ts
+++ b/src/utils/export.ts
@@ -1,0 +1,111 @@
+import { format } from 'date-fns';
+import * as XLSX from 'xlsx';
+import { jsPDF } from 'jspdf';
+import autoTable from 'jspdf-autotable';
+
+export type ExportCellValue = string | number | null | undefined;
+
+export interface ExportColumn<T> {
+  label: string;
+  accessor: (row: T) => ExportCellValue;
+  width?: number;
+}
+
+export interface ExportOptions {
+  slug: string;
+  title: string;
+}
+
+const SHEET_NAME_MAX = 31;
+
+const PDF_HEADER_FILL: [number, number, number] = [30, 30, 30];
+const PDF_ALT_ROW_FILL: [number, number, number] = [245, 245, 245];
+const PDF_HEADER_TEXT = 255;
+const PDF_MUTED_TEXT = 120;
+const PDF_PRIMARY_TEXT = 0;
+
+const sanitizeSheetName = (title: string): string =>
+  title.replace(/[\\/?*[\]:]/g, '').slice(0, SHEET_NAME_MAX) || 'Sheet1';
+
+export const buildExportFilename = (slug: string, extension: string): string =>
+  `gittensor-${slug}-${format(new Date(), 'yyyy-MM-dd')}.${extension}`;
+
+const buildHeaderRow = <T>(columns: ExportColumn<T>[]): string[] =>
+  columns.map((column) => column.label);
+
+const rowsToMatrix = <T>(
+  rows: T[],
+  columns: ExportColumn<T>[],
+): ExportCellValue[][] =>
+  rows.map((row) => columns.map((column) => column.accessor(row)));
+
+const stringifyCell = (cell: ExportCellValue): string =>
+  cell === null || cell === undefined ? '' : String(cell);
+
+const renderPdfHeader = (
+  doc: jsPDF,
+  title: string,
+  exportedAt: string,
+): void => {
+  doc.setFont('helvetica', 'bold');
+  doc.setFontSize(14);
+  doc.text('Gittensor', 40, 40);
+  doc.setFont('helvetica', 'normal');
+  doc.setFontSize(12);
+  doc.text(title, 40, 58);
+  doc.setFontSize(9);
+  doc.setTextColor(PDF_MUTED_TEXT);
+  doc.text(`Exported ${exportedAt}`, 40, 74);
+  doc.setTextColor(PDF_PRIMARY_TEXT);
+};
+
+const buildColumnWidths = <T>(columns: ExportColumn<T>[]): { wch: number }[] =>
+  columns.map((column) => ({
+    wch: Math.max(column.width ?? column.label.length, column.label.length) + 2,
+  }));
+
+export const exportRowsToExcel = <T>(
+  rows: T[],
+  columns: ExportColumn<T>[],
+  options: ExportOptions,
+): void => {
+  const worksheet = XLSX.utils.aoa_to_sheet([
+    buildHeaderRow(columns),
+    ...rowsToMatrix(rows, columns),
+  ]);
+  worksheet['!cols'] = buildColumnWidths(columns);
+
+  const workbook = XLSX.utils.book_new();
+  XLSX.utils.book_append_sheet(
+    workbook,
+    worksheet,
+    sanitizeSheetName(options.title),
+  );
+  XLSX.writeFile(workbook, buildExportFilename(options.slug, 'xlsx'));
+};
+
+export const exportRowsToPdf = <T>(
+  rows: T[],
+  columns: ExportColumn<T>[],
+  options: ExportOptions,
+): void => {
+  const doc = new jsPDF({ orientation: 'landscape', unit: 'pt', format: 'a4' });
+  const exportedAt = format(new Date(), "yyyy-MM-dd HH:mm 'UTC'xxx");
+  renderPdfHeader(doc, options.title, exportedAt);
+
+  const body = rowsToMatrix(rows, columns).map((cells) =>
+    cells.map(stringifyCell),
+  );
+
+  autoTable(doc, {
+    head: [buildHeaderRow(columns)],
+    body,
+    startY: 90,
+    styles: { fontSize: 8, cellPadding: 4 },
+    headStyles: { fillColor: PDF_HEADER_FILL, textColor: PDF_HEADER_TEXT },
+    alternateRowStyles: { fillColor: PDF_ALT_ROW_FILL },
+    margin: { left: 40, right: 40 },
+  });
+
+  doc.save(buildExportFilename(options.slug, 'pdf'));
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -4,3 +4,4 @@ export * from './prStatus';
 export * from './prTable';
 export * from './issueStatus';
 export * from './multiplierDefs';
+export * from './export';


### PR DESCRIPTION
## Summary

Adds an **Export** dropdown (Excel `.xlsx` / PDF) to the four data tables that hold their full dataset client-side:

- `TopMinersTable` — leaderboard miners (OSS + Discoveries variants export variant-aware columns)
- `MinerPRsTable` — a miner's individual pull requests
- `IssuesList` — bounties across Available / Pending / History tabs (per-tab column sets)
- `TopRepositoriesTable` — repository weights and stats

Exports respect the **currently visible rows**: active filters (status/eligibility), search query, and sort order all carry through. Numeric columns (scores, bounties, PR counts, credibility) serialize as real numbers in Excel. Filenames are timestamped — e.g. `gittensor-top-miners-2026-04-17.xlsx`, `gittensor-bounties-available-2026-04-17.pdf`.

Implementation:

- Shared generic helpers in `src/utils/export.ts` (`ExportColumn<T>`, `exportRowsToExcel`, `exportRowsToPdf`) built on `xlsx` + `jspdf` + `jspdf-autotable`.
- Reusable `ExportMenu` in `src/components/common/ExportMenu.tsx` — each table declares its own column schema and passes the filtered dataset.
- PDF documents render a Gittensor header, title, and export timestamp via a shared `renderPdfHeader`.

## Related Issues

Closes #475

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

### UI
<img width="1248" height="680" alt="Screenshot 2026-04-17 014121" src="https://github.com/user-attachments/assets/72504da7-14f3-4922-9085-6ce3b3c88ba2" />

### PDF
<img width="1614" height="983" alt="Screenshot 2026-04-17 014134" src="https://github.com/user-attachments/assets/1201db53-95a7-4f6d-b915-809a269ee2b7" />

### Word
<img width="1044" height="787" alt="Screenshot 2026-04-17 014145" src="https://github.com/user-attachments/assets/6686d503-bfdd-42d5-8e6d-4ba5fb100d05" />

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes