### PR TITLE
fix: persist status filter in URL query params

### DIFF
--- a/src/components/repositories/RepositoryPRsTable.tsx
+++ b/src/components/repositories/RepositoryPRsTable.tsx
@@ -28,6 +28,7 @@ type PrSortField =
   | 'mergedAt';
 type SortOrder = 'asc' | 'desc';
 import { useAllPrs } from '../../api';
+import { useSearchParams } from 'react-router-dom';
 import { LinkTableRow } from '../common/linkBehavior';
 import theme, {
   TEXT_OPACITY,
@@ -43,13 +44,42 @@ interface RepositoryPRsTableProps {
   state?: 'open' | 'closed' | 'merged' | 'all';
 }
 
+const PR_STATUS_FILTERS: readonly PrStatusFilter[] = [
+  'all',
+  'open',
+  'merged',
+  'closed',
+];
+
+const isPrStatusFilter = (value: string | null): value is PrStatusFilter =>
+  value !== null && (PR_STATUS_FILTERS as readonly string[]).includes(value);
+
 const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
   repositoryFullName,
   state = 'all',
 }) => {
-  const [filter, setFilter] = useState<PrStatusFilter>(state);
+  const [searchParams, setSearchParams] = useSearchParams();
+  const prStatusParam = searchParams.get('prStatus');
+  const filter: PrStatusFilter = isPrStatusFilter(prStatusParam)
+    ? prStatusParam
+    : state;
   const [sortField, setSortField] = useState<PrSortField>('score');
   const [sortOrder, setSortOrder] = useState<SortOrder>('desc');
+
+  const setStatusFilter = (next: PrStatusFilter) => {
+    setSearchParams(
+      (prev) => {
+        const params = new URLSearchParams(prev);
+        if (next === 'all') {
+          params.delete('prStatus');
+        } else {
+          params.set('prStatus', next);
+        }
+        return params;
+      },
+      { replace: true },
+    );
+  };
 
   const handleSort = (field: PrSortField) => {
     if (sortField === field) {
@@ -148,28 +178,28 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
             <FilterButton
               label="All"
               isActive={filter === 'all'}
-              onClick={() => setFilter('all')}
+              onClick={() => setStatusFilter('all')}
               count={counts.all}
               color={theme.palette.status.neutral}
             />
             <FilterButton
               label="Open"
               isActive={filter === 'open'}
-              onClick={() => setFilter('open')}
+              onClick={() => setStatusFilter('open')}
               count={counts.open}
               color={theme.palette.status.open}
             />
             <FilterButton
               label="Merged"
               isActive={filter === 'merged'}
-              onClick={() => setFilter('merged')}
+              onClick={() => setStatusFilter('merged')}
               count={counts.merged}
               color={theme.palette.status.merged}
             />
             <FilterButton
               label="Closed"
               isActive={filter === 'closed'}
-              onClick={() => setFilter('closed')}
+              onClick={() => setStatusFilter('closed')}
               count={counts.closed}
               color={theme.palette.status.closed}
             />
@@ -219,28 +249,28 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
           <FilterButton
             label="All"
             isActive={filter === 'all'}
-            onClick={() => setFilter('all')}
+            onClick={() => setStatusFilter('all')}
             count={counts.all}
             color={theme.palette.status.neutral}
           />
           <FilterButton
             label="Open"
             isActive={filter === 'open'}
-            onClick={() => setFilter('open')}
+            onClick={() => setStatusFilter('open')}
             count={counts.open}
             color={theme.palette.status.open}
           />
           <FilterButton
             label="Merged"
             isActive={filter === 'merged'}
-            onClick={() => setFilter('merged')}
+            onClick={() => setStatusFilter('merged')}
             count={counts.merged}
             color={theme.palette.status.merged}
           />
           <FilterButton
             label="Closed"
             isActive={filter === 'closed'}
-            onClick={() => setFilter('closed')}
+            onClick={() => setStatusFilter('closed')}
             count={counts.closed}
             color={theme.palette.status.closed}
           />


### PR DESCRIPTION
## Summary

The repository PR status filter was stored only in local component state.
This PR syncs filter state to URL query params (prStatus) so selected filters persist across refresh/navigation and can be shared.
Invalid prStatus values now safely fall back to default (all).

## Related Issues

Closes #484 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

<img width="1484" height="495" alt="image" src="https://github.com/user-attachments/assets/ff71cfc1-0ec7-4a2a-b9a4-b2d06990848c" />
<img width="1526" height="532" alt="image" src="https://github.com/user-attachments/assets/6e3c295f-e908-4205-a478-fa2906f1d1c6" />
<img width="1498" height="502" alt="image" src="https://github.com/user-attachments/assets/cbac9bc4-8cbd-4e81-9df5-e184bd4eb36c" />

## Checklist

- [ ] New components are modularized/separated where sensible
- [ ] Uses predefined theme (e.g. no hardcoded colors)
- [ ] Responsive/mobile checked
- [ ] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
