### PR TITLE
fix(repositories): persist PR status filter in URL

### DIFF
--- a/src/components/repositories/RepositoryPRsTable.tsx
+++ b/src/components/repositories/RepositoryPRsTable.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import {
   Card,
   Typography,
@@ -29,7 +29,7 @@ type PrSortField =
   | 'mergedAt';
 type SortOrder = 'asc' | 'desc';
 import { useAllPrs } from '../../api';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import {
   TEXT_OPACITY,
   scrollbarSx,
@@ -38,6 +38,16 @@ import {
 } from '../../theme';
 import { filterPrs, getPrStatusCounts, type PrStatusFilter } from '../../utils';
 import FilterButton from '../FilterButton';
+
+const PR_STATUS_FILTERS: readonly PrStatusFilter[] = [
+  'all',
+  'open',
+  'merged',
+  'closed',
+];
+
+const isPrStatusFilter = (value: string | null): value is PrStatusFilter =>
+  value !== null && (PR_STATUS_FILTERS as readonly string[]).includes(value);
 
 interface RepositoryPRsTableProps {
   repositoryFullName: string;
@@ -50,7 +60,27 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
 }) => {
   const theme = useTheme();
   const navigate = useNavigate();
-  const [filter, setFilter] = useState<PrStatusFilter>(state);
+  const [searchParams, setSearchParams] = useSearchParams();
+  const prStatusParam = searchParams.get('prStatus');
+  const filter: PrStatusFilter = isPrStatusFilter(prStatusParam)
+    ? prStatusParam
+    : state;
+
+  const setFilter = useCallback(
+    (next: PrStatusFilter) => {
+      setSearchParams(
+        (prev) => {
+          const nextParams = new URLSearchParams(prev);
+          if (next === 'all') nextParams.delete('prStatus');
+          else nextParams.set('prStatus', next);
+          return nextParams;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
+  );
+
   const [sortField, setSortField] = useState<PrSortField>('score');
   const [sortOrder, setSortOrder] = useState<SortOrder>('desc');
 


### PR DESCRIPTION
## Summary

In `RepositoryPRsTable` (rendered on the Repository Details → Pull Requests tab), the status filter (All / Open / Merged / Closed) was managed only in local React state. Refreshing the page or copying the URL dropped the selection and fell back to the default filter.

Fix syncs the selection to the `prStatus` URL search param on click and reads it back on mount — the same pattern already used by `MinerPRsTable` and previously approved by the maintainer in #198, #201, and #299.

- URL param name `prStatus` matches the existing convention in `MinerPRsTable`
- `isPrStatusFilter` type-guard rejects stale/invalid values so malformed URLs fall back to the component's `state` prop default
- `setSearchParams` uses `{ replace: true }` (approved pattern from #312)
- `prStatus=all` is omitted from the URL when filter is `'all'` to keep the URL clean

No behavior change on mount when the URL has no `prStatus` — `filter` still falls through to the `state` prop default, so any parent that passes `state="open"` or similar is unaffected.

## Related Issues

Fixes #484

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

<!-- TODO: attach short clip/screenshot: select "Merged" → URL shows ?prStatus=merged → refresh → filter still Merged → share URL in new tab → filter is Merged -->

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [ ] Screenshots included for any UI/visual changes