### PR TITLE
feat: surface network emission economics on dashboard

### DIFF
--- a/src/api/models/Configurations.ts
+++ b/src/api/models/Configurations.ts
@@ -23,7 +23,13 @@ export interface RepositoryPrScoring {
   maxOpenPrThreshold: number;
 }
 
+export interface EmissionConfig {
+  dailyAlphaEmission: number;
+  minerEmissionShare: number;
+}
+
 export interface GeneralConfigResponse {
   languageFileScoring: LanguageFileScoring;
   repositoryPrScoring: RepositoryPrScoring;
+  emission?: EmissionConfig;
 }

--- a/src/pages/dashboard/DashboardPage.tsx
+++ b/src/pages/dashboard/DashboardPage.tsx
@@ -7,6 +7,7 @@ import { type TrendTimeRange } from './dashboardData';
 import useDashboardData from './useDashboardData';
 import ActiveNetwork from './views/ActiveNetwork';
 import DashboardTopContributors from './views/DashboardTopContributors';
+import EmissionEconomicsCard from './views/EmissionEconomicsCard';
 import LiveSidebar from './views/LiveSidebar';
 
 const DashboardFeaturePage: React.FC = () => {
@@ -88,6 +89,8 @@ const DashboardFeaturePage: React.FC = () => {
               isLoading={isLoading}
               onRangeChange={setRange}
             />
+
+            <EmissionEconomicsCard />
 
             <DashboardTopContributors
               contributors={featuredContributors}

--- a/src/pages/dashboard/views/EmissionEconomicsCard.tsx
+++ b/src/pages/dashboard/views/EmissionEconomicsCard.tsx
@@ -1,0 +1,488 @@
+import React, { useMemo } from 'react';
+import {
+  Box,
+  CircularProgress,
+  Grid,
+  Tooltip,
+  Typography,
+  alpha,
+  useTheme,
+} from '@mui/material';
+import ReactECharts from 'echarts-for-react';
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
+import { useGeneralConfig, useStats } from '../../../api';
+import {
+  computeEmissionBreakdown,
+  formatAlpha,
+  formatUsdCompact,
+  type EmissionBreakdown,
+} from '../../../utils/emissionEconomics';
+
+const MONO_FONT = '"JetBrains Mono", monospace';
+
+const tooltipSlotProps = {
+  tooltip: {
+    sx: {
+      backgroundColor: 'surface.tooltip',
+      color: 'text.primary',
+      fontSize: '0.75rem',
+      fontFamily: MONO_FONT,
+      padding: '8px 12px',
+      borderRadius: '6px',
+      border: '1px solid',
+      borderColor: 'border.light',
+      maxWidth: 280,
+    },
+  },
+  arrow: { sx: { color: 'surface.tooltip' } },
+};
+
+interface EmissionSliceProps {
+  label: string;
+  alphaPerDay: number;
+  usdPerDay: number | null;
+  percent: number;
+  color: string;
+  tooltip: string;
+  monthlyAlpha: number;
+  monthlyUsd: number | null;
+}
+
+const EmissionSlice: React.FC<EmissionSliceProps> = ({
+  label,
+  alphaPerDay,
+  usdPerDay,
+  percent,
+  color,
+  tooltip,
+  monthlyAlpha,
+  monthlyUsd,
+}) => {
+  const usd = formatUsdCompact(usdPerDay);
+  const monthlyUsdLabel = formatUsdCompact(monthlyUsd);
+
+  return (
+    <Tooltip
+      title={tooltip}
+      arrow
+      placement="top"
+      slotProps={tooltipSlotProps}
+    >
+      <Box
+        sx={{
+          backgroundColor: 'surface.subtle',
+          borderRadius: 2,
+          border: '1px solid',
+          borderColor: 'border.subtle',
+          p: 1.75,
+          cursor: 'help',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 0.5,
+          height: '100%',
+        }}
+      >
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 0.75,
+            mb: 0.25,
+          }}
+        >
+          <Box
+            sx={{
+              width: 8,
+              height: 8,
+              borderRadius: '50%',
+              backgroundColor: color,
+              flexShrink: 0,
+            }}
+          />
+          <Typography variant="statLabel">{label}</Typography>
+          <Typography
+            sx={{
+              fontFamily: MONO_FONT,
+              fontSize: '0.7rem',
+              fontWeight: 600,
+              color: (t) => alpha(t.palette.text.primary, 0.55),
+              ml: 'auto',
+            }}
+          >
+            {percent.toFixed(1)}%
+          </Typography>
+          <InfoOutlinedIcon
+            sx={{ fontSize: '0.75rem', opacity: 0.4 }}
+          />
+        </Box>
+        <Typography
+          sx={{
+            fontFamily: MONO_FONT,
+            fontSize: '1.35rem',
+            fontWeight: 600,
+            color,
+            lineHeight: 1.15,
+          }}
+        >
+          {formatAlpha(alphaPerDay)} <span style={{ fontSize: '0.75rem', opacity: 0.7 }}>α/day</span>
+        </Typography>
+        <Typography
+          sx={{
+            fontFamily: MONO_FONT,
+            fontSize: '0.78rem',
+            color: (t) => alpha(t.palette.text.primary, 0.6),
+          }}
+        >
+          {usd ? `${usd} / day` : '—'}
+        </Typography>
+        <Box
+          sx={{
+            mt: 0.5,
+            pt: 0.5,
+            borderTop: '1px dashed',
+            borderColor: 'border.subtle',
+            display: 'flex',
+            justifyContent: 'space-between',
+            gap: 1,
+          }}
+        >
+          <Typography
+            sx={{
+              fontFamily: MONO_FONT,
+              fontSize: '0.68rem',
+              color: (t) => alpha(t.palette.text.primary, 0.45),
+            }}
+          >
+            ~{formatAlpha(monthlyAlpha)} α/mo
+          </Typography>
+          {monthlyUsdLabel && (
+            <Typography
+              sx={{
+                fontFamily: MONO_FONT,
+                fontSize: '0.68rem',
+                fontWeight: 600,
+                color: (t) => alpha(t.palette.text.primary, 0.6),
+              }}
+            >
+              {monthlyUsdLabel}/mo
+            </Typography>
+          )}
+        </Box>
+      </Box>
+    </Tooltip>
+  );
+};
+
+interface DonutProps {
+  breakdown: EmissionBreakdown;
+  minerColor: string;
+  validatorColor: string;
+}
+
+const EmissionDonut: React.FC<DonutProps> = ({
+  breakdown,
+  minerColor,
+  validatorColor,
+}) => {
+  const theme = useTheme();
+
+  const option = useMemo(
+    () => ({
+      backgroundColor: 'transparent',
+      tooltip: {
+        trigger: 'item',
+        backgroundColor: theme.palette.surface.tooltip,
+        borderColor: alpha(theme.palette.text.primary, 0.15),
+        borderWidth: 1,
+        textStyle: {
+          color: theme.palette.text.primary,
+          fontFamily: MONO_FONT,
+          fontSize: 12,
+        },
+        formatter: ({
+          name,
+          value,
+          percent,
+        }: {
+          name: string;
+          value: number;
+          percent: number;
+        }) =>
+          `${name}: ${formatAlpha(value)} α (${percent}%)`,
+      },
+      title: {
+        text: `${breakdown.totalDailyAlpha.toLocaleString()} α`,
+        subtext: 'per day',
+        left: 'center',
+        top: '38%',
+        textStyle: {
+          color: theme.palette.text.primary,
+          fontFamily: MONO_FONT,
+          fontSize: 16,
+          fontWeight: 'bold',
+        },
+        subtextStyle: {
+          color: alpha(theme.palette.text.primary, 0.5),
+          fontFamily: MONO_FONT,
+          fontSize: 11,
+        },
+      },
+      series: [
+        {
+          type: 'pie',
+          radius: ['60%', '82%'],
+          center: ['50%', '50%'],
+          avoidLabelOverlap: true,
+          label: { show: false },
+          labelLine: { show: false },
+          itemStyle: {
+            borderColor: theme.palette.background.default,
+            borderWidth: 2,
+          },
+          data: [
+            {
+              name: 'Miners',
+              value: breakdown.minerAlphaPerDay,
+              itemStyle: { color: minerColor },
+            },
+            {
+              name: 'Validators',
+              value: breakdown.validatorAlphaPerDay,
+              itemStyle: { color: validatorColor },
+            },
+          ],
+        },
+      ],
+    }),
+    [breakdown, minerColor, validatorColor, theme],
+  );
+
+  return (
+    <Box sx={{ width: '100%', height: 200 }}>
+      <ReactECharts
+        option={option}
+        style={{ width: '100%', height: '100%' }}
+        opts={{ renderer: 'svg' }}
+      />
+    </Box>
+  );
+};
+
+const EmissionEconomicsCard: React.FC = () => {
+  const theme = useTheme();
+  const { data: config, isLoading: configLoading } = useGeneralConfig();
+  const { data: stats, isLoading: statsLoading } = useStats();
+
+  const breakdown = useMemo(
+    () => computeEmissionBreakdown(config?.emission, stats?.prices),
+    [config?.emission, stats?.prices],
+  );
+
+  const isLoading = configLoading || statsLoading;
+
+  if (isLoading) {
+    return (
+      <Box
+        sx={{
+          width: '100%',
+          p: 3,
+          borderRadius: 3,
+          border: `1px solid ${theme.palette.border.light}`,
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          minHeight: 240,
+        }}
+      >
+        <CircularProgress size={28} />
+      </Box>
+    );
+  }
+
+  if (!breakdown) return null;
+
+  const minerColor = theme.palette.status.merged;
+  const validatorColor = theme.palette.status.info;
+
+  return (
+    <Box
+      sx={{
+        width: '100%',
+        p: { xs: 1.75, sm: 2 },
+        borderRadius: 3,
+        border: `1px solid ${theme.palette.border.light}`,
+        backgroundColor: 'transparent',
+      }}
+    >
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          mb: 1.5,
+          flexWrap: 'wrap',
+          gap: 1,
+        }}
+      >
+        <Box>
+          <Typography
+            sx={{
+              fontFamily: MONO_FONT,
+              fontSize: '0.95rem',
+              fontWeight: 700,
+              color: 'text.primary',
+            }}
+          >
+            Network Economics
+          </Typography>
+          <Typography
+            sx={{
+              fontFamily: MONO_FONT,
+              fontSize: '0.72rem',
+              color: (t) => alpha(t.palette.text.primary, 0.5),
+              mt: 0.25,
+            }}
+          >
+            Daily alpha emission split between miners and validators
+          </Typography>
+        </Box>
+        {breakdown.alphaPriceUsd != null && (
+          <Box
+            sx={{
+              px: 1.25,
+              py: 0.5,
+              borderRadius: 1.5,
+              border: '1px solid',
+              borderColor: 'border.light',
+              backgroundColor: 'surface.subtle',
+            }}
+          >
+            <Typography
+              sx={{
+                fontFamily: MONO_FONT,
+                fontSize: '0.68rem',
+                color: (t) => alpha(t.palette.text.primary, 0.55),
+                textTransform: 'uppercase',
+                letterSpacing: '0.06em',
+              }}
+            >
+              α Price
+            </Typography>
+            <Typography
+              sx={{
+                fontFamily: MONO_FONT,
+                fontSize: '0.85rem',
+                fontWeight: 600,
+                color: 'text.primary',
+              }}
+            >
+              ${breakdown.alphaPriceUsd.toFixed(2)}
+            </Typography>
+          </Box>
+        )}
+      </Box>
+
+      <Grid container spacing={2} alignItems="stretch">
+        <Grid item xs={12} md={5}>
+          <EmissionDonut
+            breakdown={breakdown}
+            minerColor={minerColor}
+            validatorColor={validatorColor}
+          />
+        </Grid>
+        <Grid item xs={12} md={7}>
+          <Grid container spacing={1.5}>
+            <Grid item xs={12} sm={6}>
+              <EmissionSlice
+                label="Miners"
+                alphaPerDay={breakdown.minerAlphaPerDay}
+                usdPerDay={breakdown.minerUsdPerDay}
+                percent={breakdown.minerSharePercent}
+                color={minerColor}
+                tooltip="Share of daily subnet emissions routed to miners for merged PR contributions and issue discovery."
+                monthlyAlpha={breakdown.minerAlphaPerDay * breakdown.daysInMonth}
+                monthlyUsd={
+                  breakdown.minerUsdPerDay != null
+                    ? breakdown.minerUsdPerDay * breakdown.daysInMonth
+                    : null
+                }
+              />
+            </Grid>
+            <Grid item xs={12} sm={6}>
+              <EmissionSlice
+                label="Validators"
+                alphaPerDay={breakdown.validatorAlphaPerDay}
+                usdPerDay={breakdown.validatorUsdPerDay}
+                percent={breakdown.validatorSharePercent}
+                color={validatorColor}
+                tooltip="Remaining share of daily subnet emissions routed to validators for scoring and consensus work."
+                monthlyAlpha={
+                  breakdown.validatorAlphaPerDay * breakdown.daysInMonth
+                }
+                monthlyUsd={
+                  breakdown.validatorUsdPerDay != null
+                    ? breakdown.validatorUsdPerDay * breakdown.daysInMonth
+                    : null
+                }
+              />
+            </Grid>
+            <Grid item xs={12}>
+              <Box
+                sx={{
+                  backgroundColor: 'surface.subtle',
+                  borderRadius: 2,
+                  border: '1px solid',
+                  borderColor: 'border.subtle',
+                  px: 1.75,
+                  py: 1.25,
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  alignItems: 'center',
+                  flexWrap: 'wrap',
+                  gap: 1,
+                }}
+              >
+                <Box>
+                  <Typography variant="statLabel">Total subnet</Typography>
+                  <Typography
+                    sx={{
+                      fontFamily: MONO_FONT,
+                      fontSize: '1.05rem',
+                      fontWeight: 600,
+                      color: 'text.primary',
+                    }}
+                  >
+                    {formatAlpha(breakdown.totalDailyAlpha)} α / day
+                  </Typography>
+                </Box>
+                <Box sx={{ textAlign: 'right' }}>
+                  <Typography variant="statLabel">Monthly</Typography>
+                  <Typography
+                    sx={{
+                      fontFamily: MONO_FONT,
+                      fontSize: '1.05rem',
+                      fontWeight: 600,
+                      color: breakdown.totalUsdPerDay != null
+                        ? theme.palette.status.success
+                        : 'text.primary',
+                    }}
+                  >
+                    {breakdown.totalUsdPerDay != null
+                      ? formatUsdCompact(
+                          breakdown.totalUsdPerDay * breakdown.daysInMonth,
+                        )
+                      : `${formatAlpha(
+                          breakdown.totalDailyAlpha * breakdown.daysInMonth,
+                        )} α`}
+                  </Typography>
+                </Box>
+              </Box>
+            </Grid>
+          </Grid>
+        </Grid>
+      </Grid>
+    </Box>
+  );
+};
+
+export default EmissionEconomicsCard;

--- a/src/pages/dashboard/views/EmissionEconomicsCard.tsx
+++ b/src/pages/dashboard/views/EmissionEconomicsCard.tsx
@@ -62,12 +62,7 @@ const EmissionSlice: React.FC<EmissionSliceProps> = ({
   const monthlyUsdLabel = formatUsdCompact(monthlyUsd);
 
   return (
-    <Tooltip
-      title={tooltip}
-      arrow
-      placement="top"
-      slotProps={tooltipSlotProps}
-    >
+    <Tooltip title={tooltip} arrow placement="top" slotProps={tooltipSlotProps}>
       <Box
         sx={{
           backgroundColor: 'surface.subtle',
@@ -111,9 +106,7 @@ const EmissionSlice: React.FC<EmissionSliceProps> = ({
           >
             {percent.toFixed(1)}%
           </Typography>
-          <InfoOutlinedIcon
-            sx={{ fontSize: '0.75rem', opacity: 0.4 }}
-          />
+          <InfoOutlinedIcon sx={{ fontSize: '0.75rem', opacity: 0.4 }} />
         </Box>
         <Typography
           sx={{
@@ -124,7 +117,8 @@ const EmissionSlice: React.FC<EmissionSliceProps> = ({
             lineHeight: 1.15,
           }}
         >
-          {formatAlpha(alphaPerDay)} <span style={{ fontSize: '0.75rem', opacity: 0.7 }}>α/day</span>
+          {formatAlpha(alphaPerDay)}{' '}
+          <span style={{ fontSize: '0.75rem', opacity: 0.7 }}>α/day</span>
         </Typography>
         <Typography
           sx={{
@@ -207,8 +201,7 @@ const EmissionDonut: React.FC<DonutProps> = ({
           name: string;
           value: number;
           percent: number;
-        }) =>
-          `${name}: ${formatAlpha(value)} α (${percent}%)`,
+        }) => `${name}: ${formatAlpha(value)} α (${percent}%)`,
       },
       title: {
         text: `${breakdown.totalDailyAlpha.toLocaleString()} α`,
@@ -400,7 +393,9 @@ const EmissionEconomicsCard: React.FC = () => {
                 percent={breakdown.minerSharePercent}
                 color={minerColor}
                 tooltip="Share of daily subnet emissions routed to miners for merged PR contributions and issue discovery."
-                monthlyAlpha={breakdown.minerAlphaPerDay * breakdown.daysInMonth}
+                monthlyAlpha={
+                  breakdown.minerAlphaPerDay * breakdown.daysInMonth
+                }
                 monthlyUsd={
                   breakdown.minerUsdPerDay != null
                     ? breakdown.minerUsdPerDay * breakdown.daysInMonth
@@ -462,9 +457,10 @@ const EmissionEconomicsCard: React.FC = () => {
                       fontFamily: MONO_FONT,
                       fontSize: '1.05rem',
                       fontWeight: 600,
-                      color: breakdown.totalUsdPerDay != null
-                        ? theme.palette.status.success
-                        : 'text.primary',
+                      color:
+                        breakdown.totalUsdPerDay != null
+                          ? theme.palette.status.success
+                          : 'text.primary',
                     }}
                   >
                     {breakdown.totalUsdPerDay != null

--- a/src/utils/emissionEconomics.ts
+++ b/src/utils/emissionEconomics.ts
@@ -1,0 +1,91 @@
+import type { EmissionConfig, Stats } from '../api/models';
+
+export interface EmissionBreakdown {
+  totalDailyAlpha: number;
+  minerSharePercent: number;
+  validatorSharePercent: number;
+  minerAlphaPerDay: number;
+  validatorAlphaPerDay: number;
+  minerUsdPerDay: number | null;
+  validatorUsdPerDay: number | null;
+  totalUsdPerDay: number | null;
+  alphaPriceUsd: number | null;
+  daysInMonth: number;
+}
+
+const daysInCurrentMonth = (): number => {
+  const now = new Date();
+  return new Date(now.getFullYear(), now.getMonth() + 1, 0).getDate();
+};
+
+export const computeAlphaUsdPrice = (
+  prices: Stats['prices'] | undefined,
+): number | null => {
+  const tao = prices?.tao?.data?.price;
+  const alpha = prices?.alpha?.data?.price;
+  if (typeof tao !== 'number' || typeof alpha !== 'number') return null;
+  return tao * alpha;
+};
+
+export const computeEmissionBreakdown = (
+  emission: EmissionConfig | undefined,
+  prices: Stats['prices'] | undefined,
+): EmissionBreakdown | null => {
+  if (!emission) return null;
+  const total = Number(emission.dailyAlphaEmission);
+  const rawShare = Number(emission.minerEmissionShare);
+  if (!Number.isFinite(total) || total <= 0) return null;
+  if (!Number.isFinite(rawShare)) return null;
+
+  const minerShare = Math.min(Math.max(rawShare, 0), 1);
+  const validatorShare = 1 - minerShare;
+  const minerAlphaPerDay = total * minerShare;
+  const validatorAlphaPerDay = total * validatorShare;
+  const alphaPriceUsd = computeAlphaUsdPrice(prices);
+
+  const toUsd = (alpha: number) =>
+    alphaPriceUsd != null ? alpha * alphaPriceUsd : null;
+
+  return {
+    totalDailyAlpha: total,
+    minerSharePercent: minerShare * 100,
+    validatorSharePercent: validatorShare * 100,
+    minerAlphaPerDay,
+    validatorAlphaPerDay,
+    minerUsdPerDay: toUsd(minerAlphaPerDay),
+    validatorUsdPerDay: toUsd(validatorAlphaPerDay),
+    totalUsdPerDay: toUsd(total),
+    alphaPriceUsd,
+    daysInMonth: daysInCurrentMonth(),
+  };
+};
+
+const ALPHA_LARGE_THRESHOLD = 1000;
+
+export const formatAlpha = (value: number): string => {
+  if (!Number.isFinite(value)) return '0';
+  if (value >= ALPHA_LARGE_THRESHOLD) {
+    return value.toLocaleString(undefined, { maximumFractionDigits: 0 });
+  }
+  return value.toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+};
+
+export const formatUsdCompact = (
+  value: number | null | undefined,
+): string | null => {
+  if (value == null || !Number.isFinite(value)) return null;
+  if (value >= 1_000_000) {
+    return `$${(value / 1_000_000).toFixed(2)}M`;
+  }
+  if (value >= 1_000) {
+    return `$${(value / 1_000).toFixed(1)}K`;
+  }
+  if (value >= 1) {
+    return `$${Math.round(value).toLocaleString()}`;
+  }
+  if (value > 0) return '<$1';
+  return '$0';
+};


### PR DESCRIPTION
## Summary

Surface network emission economics on the dashboard. The `/configurations/general` endpoint returns `dailyAlphaEmission` and `minerEmissionShare` that were dropped by the TypeScript model and never displayed. This PR extends `GeneralConfigResponse` with the `emission` object and adds a Network Economics card that shows the daily alpha emission, miner/validator split, and live USD equivalents computed from the TAO/Alpha prices already fetched by `useStats()`.

## Related Issues

Fixes #489 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

https://github.com/user-attachments/assets/64eb88c4-a1e9-4c21-b265-85a9ed7249ac



## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [ ] Screenshots included for any UI/visual changes
