### PR TITLE
fix: add Issue Discovery FAQ entry to onboard page

### DIFF
--- a/src/components/onboard/FAQContent.tsx
+++ b/src/components/onboard/FAQContent.tsx
@@ -142,6 +142,29 @@ export const FAQContent: React.FC = () => (
           </>
         }
       />
+      <FAQ
+        question="How does Issue Discovery work?"
+        answer={
+          <>
+            File GitHub issues on Gittensor-tracked repositories. When someone
+            else's merged PR resolves your issue, you earn a discovery score
+            based on the solving PR's code quality (token score). Eligibility
+            requires 7 or more valid solved issues (each with a token score of
+            at least 5) and 80%+ issue credibility. Credibility is calculated as{' '}
+            <em>solved / (solved + max(0, closed − 1))</em> — one closed issue
+            is forgiven. See the{' '}
+            <a
+              href="https://docs.gittensor.io/issue-discovery.html"
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{ color: 'inherit', textDecoration: 'underline' }}
+            >
+              Issue Discovery documentation
+            </a>{' '}
+            for the full scoring breakdown.
+          </>
+        }
+      />
     </Stack>
   </Box>
 );


### PR DESCRIPTION
## Summary
Fixes #498. Adds a new FAQ entry explaining Issue Discovery - how it works, eligibility requirements, the credibility formula (including the one-issue mulligan), and a link to the full documentation. Issue Discovery accounts for 30% of emissions but had no representation in the FAQ.

## What changed
`src/components/onboard/FAQContent.tsx` - added one new `<FAQ>` entry after the existing 8 entries:

**Q:** "How does Issue Discovery work?"
**A:** Covers the issue filing → solving → scoring flow, the 7-valid-issues eligibility threshold, the 80%+ credibility requirement, the `solved / (solved + max(0, closed − 1))` formula with mulligan explanation, and a link to `https://docs.gittensor.io/issue-discovery.html`.

Follows the existing pattern: same `<FAQ>` component, same link styling (`color: 'inherit', textDecoration: 'underline'`), same `target="_blank" rel="noopener noreferrer"`.

## Type of Change
- [x] Bug fix (missing content - 30% of emissions undocumented in onboarding)

## Testing
- [ ] `npm run build`
- [ ] `npm run lint:fix`
- [ ] Manual: `/onboard?tab=faq` → 9 entries now visible, last one is "How does Issue Discovery work?"
- [ ] Click the "Issue Discovery documentation" link → opens `https://docs.gittensor.io/issue-discovery.html` in new tab

## Checklist
- [x] No behavior change to existing FAQ entries
- [x] No new dependencies
- [x] Single file touched
- [x] Link styling matches existing FAQ entries

## Video to upload

https://github.com/user-attachments/assets/b31954e8-f6f3-4000-b2a3-b5484a8e959e

