### PR TITLE
Fix Watchlist eligibility ambiguity (OSS vs Discoveries)

### DIFF
--- a/src/components/leaderboard/MinerCard.tsx
+++ b/src/components/leaderboard/MinerCard.tsx
@@ -14,6 +14,7 @@ interface MinerCardProps {
   href: string;
   linkState?: Record<string, unknown>;
   variant?: LeaderboardVariant;
+  showDualEligibilityBadges?: boolean;
 }
 
 const INACTIVE_OPACITY = 0.24;
@@ -53,6 +54,7 @@ export const MinerCard: React.FC<MinerCardProps> = ({
   href,
   linkState,
   variant = 'oss',
+  showDualEligibilityBadges = false,
 }) => {
   const linkProps = useLinkBehavior(href, { state: linkState });
   const isNumericId = (value?: string) => !value || /^\d+$/.test(value);
@@ -70,11 +72,19 @@ export const MinerCard: React.FC<MinerCardProps> = ({
 
   const credibilityPercent = (miner.credibility ?? 0) * 100;
   const issueCredPercent = (miner.issueCredibility ?? 0) * 100;
+  const ossEligible = miner.ossIsEligible ?? miner.isEligible ?? false;
+  const discoveriesEligible =
+    miner.discoveriesIsEligible ??
+    miner.isIssueEligible ??
+    (variant === 'discoveries' ? (miner.isEligible ?? false) : false);
   const isWatchlist = variant === 'watchlist';
   const isDiscoveries = variant === 'discoveries';
+  const baseEligible = miner.isEligible ?? false;
   const isEligible = isWatchlist
-    ? (miner.isEligible ?? false) || (miner.isIssueEligible ?? false)
-    : (miner.isEligible ?? false);
+    ? ossEligible || discoveriesEligible || baseEligible
+    : showDualEligibilityBadges
+      ? ossEligible || discoveriesEligible
+      : baseEligible;
 
   const segments = getSegments(miner, variant);
 
@@ -197,9 +207,64 @@ export const MinerCard: React.FC<MinerCardProps> = ({
             alignItems: 'center',
             gap: 0.5,
             flexShrink: 0,
+            flexWrap: 'wrap',
+            justifyContent: 'flex-end',
           }}
         >
-          {!isEligible && (
+          {showDualEligibilityBadges ? (
+            <>
+              <Typography
+                sx={(theme) => ({
+                  fontFamily: FONTS.mono,
+                  fontSize: '0.65rem',
+                  fontWeight: 700,
+                  textTransform: 'uppercase',
+                  border: `1px solid ${
+                    ossEligible
+                      ? alpha(theme.palette.status.merged, 0.45)
+                      : theme.palette.border.subtle
+                  }`,
+                  borderRadius: 1,
+                  px: 0.75,
+                  py: 0.25,
+                  letterSpacing: '0.06em',
+                  color: ossEligible
+                    ? theme.palette.status.merged
+                    : theme.palette.text.secondary,
+                  backgroundColor: ossEligible
+                    ? alpha(theme.palette.status.merged, 0.08)
+                    : theme.palette.surface.subtle,
+                })}
+              >
+                OSS {ossEligible ? 'Eligible' : 'Ineligible'}
+              </Typography>
+              <Typography
+                sx={(theme) => ({
+                  fontFamily: FONTS.mono,
+                  fontSize: '0.65rem',
+                  fontWeight: 700,
+                  textTransform: 'uppercase',
+                  border: `1px solid ${
+                    discoveriesEligible
+                      ? alpha(theme.palette.status.merged, 0.45)
+                      : theme.palette.border.subtle
+                  }`,
+                  borderRadius: 1,
+                  px: 0.75,
+                  py: 0.25,
+                  letterSpacing: '0.06em',
+                  color: discoveriesEligible
+                    ? theme.palette.status.merged
+                    : theme.palette.text.secondary,
+                  backgroundColor: discoveriesEligible
+                    ? alpha(theme.palette.status.merged, 0.08)
+                    : theme.palette.surface.subtle,
+                })}
+              >
+                Issues {discoveriesEligible ? 'Eligible' : 'Ineligible'}
+              </Typography>
+            </>
+          ) : !isEligible ? (
             <Typography
               sx={(theme) => ({
                 fontFamily: FONTS.mono,
@@ -217,7 +282,7 @@ export const MinerCard: React.FC<MinerCardProps> = ({
             >
               Ineligible
             </Typography>
-          )}
+          ) : null}
           {miner.githubId && (
             <WatchlistButton githubId={miner.githubId} size="small" />
           )}

--- a/src/components/leaderboard/TopMinersTable.tsx
+++ b/src/components/leaderboard/TopMinersTable.tsx
@@ -29,6 +29,7 @@ interface TopMinersTableProps {
   getMinerHref: (miner: MinerStats) => string;
   linkState?: Record<string, unknown>;
   variant?: LeaderboardVariant;
+  showDualEligibilityBadges?: boolean;
 }
 
 const getAllowedSortOptions = (variant: LeaderboardVariant): SortOption[] => {
@@ -74,6 +75,7 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
   getMinerHref,
   linkState,
   variant = 'oss',
+  showDualEligibilityBadges = false,
 }) => {
   const theme = useTheme();
   const [searchParams, setSearchParams] = useSearchParams();
@@ -295,6 +297,7 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
                   variant={variant}
                   href={getMinerHref(miner)}
                   linkState={linkState}
+                  showDualEligibilityBadges={showDualEligibilityBadges}
                 />
               </Grid>
             ))}

--- a/src/components/leaderboard/types.ts
+++ b/src/components/leaderboard/types.ts
@@ -20,6 +20,15 @@ export interface MinerStats {
   uniqueReposCount?: number;
   credibility?: number;
   isEligible?: boolean;
+  /**
+   * Program-specific eligibility flags.
+   *
+   * These allow UI surfaces like Watchlist to disambiguate eligibility between
+   * OSS contributions and Issue Discoveries without changing the default
+   * `isEligible` semantics used across leaderboards.
+   */
+  ossIsEligible?: boolean;
+  discoveriesIsEligible?: boolean;
   usdPerDay?: number;
   totalMergedPrs?: number;
   totalOpenPrs?: number;

--- a/src/pages/DiscoveriesPage.tsx
+++ b/src/pages/DiscoveriesPage.tsx
@@ -41,6 +41,8 @@ const DiscoveriesPage: React.FC = () => {
       uniqueReposCount: parseNumber(stat.uniqueReposCount),
       credibility: parseNumber(stat.issueCredibility),
       isEligible: stat.isIssueEligible ?? false,
+      ossIsEligible: stat.isEligible ?? false,
+      discoveriesIsEligible: stat.isIssueEligible ?? false,
       usdPerDay: parseNumber(stat.usdPerDay),
       totalMergedPrs: parseNumber(stat.totalMergedPrs),
       totalOpenPrs: parseNumber(stat.totalOpenPrs),

--- a/src/pages/WatchlistPage.tsx
+++ b/src/pages/WatchlistPage.tsx
@@ -30,7 +30,15 @@ const WatchlistPage: React.FC = () => {
     [allMinersStats],
   );
   const minerStats = useMemo(
-    () => allMinerStats.filter((m) => watchedSet.has(m.githubId)),
+    () =>
+      allMinerStats
+        .filter((m) => watchedSet.has(m.githubId))
+        .map((m) => ({
+          ...m,
+          // Watchlist cards should be enabled if miner is eligible for either
+          // OSS contributions or Issue Discoveries.
+          isEligible: Boolean(m.ossIsEligible || m.discoveriesIsEligible),
+        })),
     [allMinerStats, watchedSet],
   );
 
@@ -138,6 +146,7 @@ const WatchlistPage: React.FC = () => {
               }
               linkState={{ backLabel: 'Back to Watchlist' }}
               variant="watchlist"
+              showDualEligibilityBadges
             />
           </Box>
         )}

--- a/src/utils/minerMapper.ts
+++ b/src/utils/minerMapper.ts
@@ -26,6 +26,8 @@ export const mapAllMinersToStats = (
     uniqueReposCount: parseNumber(stat.uniqueReposCount),
     credibility: parseNumber(stat.credibility),
     isEligible: stat.isEligible ?? false,
+    ossIsEligible: stat.isEligible ?? false,
+    discoveriesIsEligible: stat.isIssueEligible ?? false,
     usdPerDay: parseNumber(stat.usdPerDay),
     totalMergedPrs: parseNumber(stat.totalMergedPrs),
     totalOpenPrs: parseNumber(stat.totalOpenPrs),


### PR DESCRIPTION
## Summary

This PR fixes misleading “Ineligible” states in the Watchlist when a miner is Discoveries-eligible but OSS-ineligible.

- Adds two explicit eligibility badges on Watchlist miner cards:
 - OSS Eligible / OSS Ineligible
 - Discoveries Eligible / Discoveries Ineligible
- Updates Watchlist card enable/disable logic:
 - Enabled if eligible for either OSS or Discoveries
 - Disabled only if eligible for neither
- Keeps existing leaderboard behavior intact (OSS leaderboard still uses OSS eligibility; Discoveries page still uses Discoveries eligibility)

## Related Issues

close #497 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

<img width="1857" height="961" alt="image" src="https://github.com/user-attachments/assets/f5f69a8a-4bf8-4cfa-8b18-0bea6c0be888" />
