### PR TITLE
feat(layout): add collapsible sidebar with show/hide toggle

### DIFF
--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -191,7 +191,7 @@ const AppLayout: React.FC = () => {
               top: 12,
               left: SIDEBAR_WIDTH - 36,
               zIndex: 1300,
-              cursor: 'w-resize',
+              cursor: 'pointer',
               color: theme.palette.text.secondary,
               '&:hover': { color: theme.palette.text.primary },
             }}
@@ -228,7 +228,7 @@ const AppLayout: React.FC = () => {
               '& .sidebar-toggle-logo': { display: 'flex' },
               '& .sidebar-toggle-chevron': { display: 'none' },
               '&:hover': {
-                cursor: 'e-resize',
+                cursor: 'pointer',
                 backgroundColor: alpha(theme.palette.text.primary, 0.08),
                 color: theme.palette.text.primary,
                 '& .sidebar-toggle-logo': { display: 'none' },

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense, useRef, useState } from 'react';
+import React, { Suspense, useEffect, useRef, useState } from 'react';
 import {
   Box,
   useMediaQuery,
@@ -6,6 +6,7 @@ import {
   IconButton,
   AppBar,
   Toolbar,
+  Tooltip,
   alpha,
 } from '@mui/material';
 import { Outlet, useLocation } from 'react-router-dom';
@@ -18,18 +19,66 @@ import GlobalSearchBar from './GlobalSearchBar';
 import theme, { scrollbarSx } from '../../theme';
 import { getRouteForPathname } from '../../routes';
 
+const SIDEBAR_OPEN_STORAGE_KEY = 'gittensor.sidebar.open';
+const SIDEBAR_WIDTH = 240;
+
+const PanelLeftIcon: React.FC<{ size?: number }> = ({ size = 20 }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <rect width="18" height="18" x="3" y="3" rx="2" />
+    <path d="M9 3v18" />
+  </svg>
+);
+
+const readStoredSidebarOpen = (): boolean => {
+  try {
+    const raw = window.localStorage.getItem(SIDEBAR_OPEN_STORAGE_KEY);
+    return raw === null ? true : raw === 'true';
+  } catch {
+    return true;
+  }
+};
+
 const AppLayout: React.FC = () => {
   const mainRef = useRef<HTMLElement>(null);
   const location = useLocation();
   useOnNavigate(() => mainRef.current?.scrollTo(0, 0));
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
   const [mobileOpen, setMobileOpen] = useState(false);
+  const [sidebarOpen, setSidebarOpen] = useState<boolean>(
+    readStoredSidebarOpen,
+  );
   const shouldShowGlobalSearch = Boolean(
     getRouteForPathname(location.pathname)?.showGlobalSearch,
   );
 
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(
+        SIDEBAR_OPEN_STORAGE_KEY,
+        sidebarOpen ? 'true' : 'false',
+      );
+    } catch {
+      // storage unavailable (private mode) — toggle still works in-memory
+    }
+  }, [sidebarOpen]);
+
   const handleDrawerToggle = () => {
     setMobileOpen(!mobileOpen);
+  };
+
+  const handleSidebarToggle = () => {
+    setSidebarOpen((prev) => !prev);
   };
 
   return (
@@ -104,18 +153,126 @@ const AppLayout: React.FC = () => {
         </Drawer>
       )}
 
-      {/* Desktop Sidebar - Hidden on mobile, visible on larger screens */}
+      {/* Desktop Sidebar - Hidden on mobile, visible on larger screens.
+          Slides to 0 width when collapsed; a chevron button on its right
+          edge toggles the state (persisted to localStorage). */}
       {!isMobile && (
         <Box
           sx={{
             flexShrink: 0,
-            width: '240px',
-            minWidth: '240px',
-            borderRight: `1px solid ${theme.palette.border.light}`,
+            width: sidebarOpen ? `${SIDEBAR_WIDTH}px` : 0,
+            minWidth: sidebarOpen ? `${SIDEBAR_WIDTH}px` : 0,
+            borderRight: sidebarOpen
+              ? `1px solid ${theme.palette.border.light}`
+              : 'none',
+            overflow: 'hidden',
+            transition: 'width 0.2s ease, min-width 0.2s ease',
           }}
         >
           <Sidebar />
         </Box>
+      )}
+
+      {/* Sidebar open/close toggle (desktop only).
+          - Open: a plain panel-left IconButton tucked into the sidebar's
+            top-right corner.
+          - Closed: shows the Gittensor logo at the top-left; on hover the
+            logo swaps to the panel-left icon so the user sees what clicking
+            does (ChatGPT-style affordance). */}
+      {!isMobile && sidebarOpen && (
+        <Tooltip title="Collapse sidebar" placement="right" arrow>
+          <IconButton
+            size="small"
+            onClick={handleSidebarToggle}
+            aria-label="Collapse sidebar"
+            aria-expanded
+            sx={{
+              position: 'fixed',
+              top: 12,
+              left: SIDEBAR_WIDTH - 36,
+              zIndex: 1300,
+              cursor: 'w-resize',
+              color: theme.palette.text.secondary,
+              '&:hover': { color: theme.palette.text.primary },
+            }}
+          >
+            <PanelLeftIcon size={18} />
+          </IconButton>
+        </Tooltip>
+      )}
+      {!isMobile && !sidebarOpen && (
+        <Tooltip title="Expand sidebar" placement="right" arrow>
+          <Box
+            component="button"
+            type="button"
+            onClick={handleSidebarToggle}
+            aria-label="Expand sidebar"
+            aria-expanded={false}
+            sx={{
+              position: 'fixed',
+              top: 12,
+              left: 12,
+              zIndex: 1300,
+              width: 32,
+              height: 32,
+              p: 0,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              cursor: 'pointer',
+              backgroundColor: 'transparent',
+              border: 'none',
+              borderRadius: 1,
+              color: theme.palette.text.secondary,
+              transition: 'background-color 0.15s ease, color 0.15s ease',
+              '& .sidebar-toggle-logo': { display: 'flex' },
+              '& .sidebar-toggle-chevron': { display: 'none' },
+              '&:hover': {
+                cursor: 'e-resize',
+                backgroundColor: alpha(theme.palette.text.primary, 0.08),
+                color: theme.palette.text.primary,
+                '& .sidebar-toggle-logo': { display: 'none' },
+                '& .sidebar-toggle-chevron': { display: 'flex' },
+              },
+              '&:focus-visible': {
+                outline: `2px solid ${theme.palette.primary.main}`,
+                outlineOffset: 2,
+              },
+            }}
+          >
+            <Box
+              className="sidebar-toggle-logo"
+              sx={{
+                alignItems: 'center',
+                justifyContent: 'center',
+                width: '100%',
+                height: '100%',
+              }}
+            >
+              <img
+                src="/gt-logo.svg"
+                alt=""
+                aria-hidden="true"
+                style={{
+                  width: '70%',
+                  height: '70%',
+                  filter: `brightness(0) invert(1) drop-shadow(0 0 4px ${alpha(theme.palette.common.white, 0.6)})`,
+                }}
+              />
+            </Box>
+            <Box
+              className="sidebar-toggle-chevron"
+              sx={{
+                alignItems: 'center',
+                justifyContent: 'center',
+                width: '100%',
+                height: '100%',
+              }}
+            >
+              <PanelLeftIcon size={18} />
+            </Box>
+          </Box>
+        </Tooltip>
       )}
 
       {/* Main Content Area - Constrained for ultra-wide screens */}


### PR DESCRIPTION
## Summary

Adds a show/hide toggle for the desktop sidebar so users can reclaim horizontal space on smaller desktop windows without switching to mobile mode. The sidebar slides to 0 width when collapsed, and the toggle state is persisted to `localStorage` so it sticks across page loads and reloads.

- **Open state:** A plain `panel-left` IconButton sits at the top-right of the sidebar. Clicking it collapses the sidebar. Cursor on hover: `w-resize` (left-pointing arrow, signaling the collapse direction).
- **Collapsed state:** A small flat button appears at the top-left showing the Gittensor logo by default. On hover it swaps to the same `panel-left` icon with a subtle background highlight, and the cursor switches to `e-resize` (right-pointing arrow). Clicking it re-opens the sidebar.
- **Persistence:** Stored under the key `gittensor.sidebar.open`, matching the project's existing `namespace.key` convention.
- **Scope:** Desktop only. Mobile continues to use the existing temporary `Drawer` hamburger flow - untouched.

## Related Issues
Closes https://github.com/entrius/gittensor-ui/issues/509

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

https://github.com/user-attachments/assets/13c5f7bc-274b-45fc-8822-e2d58d569cc2

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked (mobile drawer unchanged)
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes