### PR TITLE
fix(discoveries): remove duplicate issue stats row from miner cards

### DIFF
--- a/src/components/leaderboard/MinerCard.tsx
+++ b/src/components/leaderboard/MinerCard.tsx
@@ -397,7 +397,7 @@ const MinerCardFooter: React.FC<MinerCardFooterProps> = ({
         </Box>
       </Box>
 
-      {(variant === 'discoveries' || variant === 'watchlist') && (
+      {variant === 'watchlist' && (
         <Box
           sx={(theme) => ({
             pt: 0.35,

--- a/src/pages/DiscoveriesPage.tsx
+++ b/src/pages/DiscoveriesPage.tsx
@@ -39,7 +39,7 @@ const DiscoveriesPage: React.FC = () => {
       linesDeleted: parseNumber(stat.totalDeletions),
       hotkey: stat.hotkey || 'N/A',
       uniqueReposCount: parseNumber(stat.uniqueReposCount),
-      credibility: parseNumber(stat.issueCredibility),
+      issueCredibility: parseNumber(stat.issueCredibility),
       isEligible: stat.isIssueEligible ?? false,
       usdPerDay: parseNumber(stat.usdPerDay),
       totalMergedPrs: parseNumber(stat.totalMergedPrs),


### PR DESCRIPTION
## Summary

- Remove the duplicate row of issue stats (Solved / Open / Closed) on Discoveries miner cards by gating the "Issues" footer panel to `variant === 'watchlist'` only. Restores PR #292's single-row layout while preserving PR #380's watchlist behavior.
- The donut chart in each Discoveries card displays `0%` on almost every card - including `bitloi #1` which is the only *eligible* discoverer. A donut showing `0%` on a card that has solved 13 / 19 issues is misleading.

## Related Issues

Closes https://github.com/entrius/gittensor-ui/issues/517
Closes https://github.com/entrius/gittensor-ui/issues/553

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots
**Before**
<img width="1337" height="358" alt="image" src="https://github.com/user-attachments/assets/a142e1d4-ba13-48d0-a795-94e80ac3a2d5" />

**After**
Discoveries
<img width="1376" height="520" alt="image" src="https://github.com/user-attachments/assets/9d0e73f4-6b9c-48f9-bc98-42c155bf5ae2" />
Watchlist
<img width="1445" height="438" alt="image" src="https://github.com/user-attachments/assets/bf19c79a-94d9-429e-9e6c-cd670c6d35ba" />

<!-- before: two identical Solved/Open/Closed rows in the card footer; after: single row -->

## Checklist

- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes