### PR TITLE
feature: place oss eligibility badge below miner name consistently

### DIFF
--- a/src/components/miners/MinerScoreCard.tsx
+++ b/src/components/miners/MinerScoreCard.tsx
@@ -386,6 +386,16 @@ const MinerScoreCard: React.FC<MinerScoreCardProps> = ({
           }}
         />
         <Box sx={{ minWidth: 0, flex: 1 }}>
+          <Typography
+            sx={{
+              fontSize: { xs: '1.15rem', sm: '1.35rem' },
+              fontWeight: 700,
+              color: 'text.primary',
+              mb: 0.5,
+            }}
+          >
+            {githubData?.name || username}
+          </Typography>
           <Box
             sx={{
               display: 'flex',
@@ -395,15 +405,6 @@ const MinerScoreCard: React.FC<MinerScoreCardProps> = ({
               mb: 0.5,
             }}
           >
-            <Typography
-              sx={{
-                fontSize: { xs: '1.15rem', sm: '1.35rem' },
-                fontWeight: 700,
-                color: 'text.primary',
-              }}
-            >
-              {githubData?.name || username}
-            </Typography>
             <Tooltip
               title="Requires 5+ merged PRs with token score >= 5 and 80%+ credibility"
               arrow


### PR DESCRIPTION
## Summary

Adjusted the miner details header layout to keep miner name and eligibility badges on separate rows.
OSS Eligible/Ineligible now consistently appears below the miner name for both short and long names, improving visual consistency across profiles and mobile widths.

## Related Issues

Fixes #520 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

- Before: short names could render OSS Eligible inline with the name while long names wrapped it below.

<img width="402" height="421" alt="oss_eligible_issue" src="https://github.com/user-attachments/assets/76ed0267-78f5-426e-99ca-4f64f6f58e67" />

- After: OSS Eligible/Ineligible always renders on a dedicated line under the miner name.

<img width="464" height="725" alt="oss_eligible_issue_fix" src="https://github.com/user-attachments/assets/f46e7831-63ad-45cd-b4cd-da8065990fbb" />

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [ ] Tested against the test API
- [ ] `npm run format` and `npm run lint:fix` have been run
- [ ] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
