### PR TITLE
feat: add miner issues tab for discovery mode

### DIFF
--- a/src/api/MinerApi.ts
+++ b/src/api/MinerApi.ts
@@ -1,5 +1,6 @@
 // Miner API hooks - uses /miners endpoints
 import { useApiQuery } from './ApiUtils';
+import { type IssueBounty } from './models';
 import {
   type GithubMinerData,
   type MinerEvaluation,
@@ -52,6 +53,20 @@ export const useMinerPRs = (githubId: string, enabled?: boolean) =>
   useMinersQuery<CommitLog[]>(
     'useMinerPRs',
     `/${githubId}/prs`,
+    undefined,
+    undefined,
+    enabled,
+  );
+
+/**
+ * Get all discovered issues created by a specific miner
+ * @param githubId - Numeric GitHub ID (e.g., "583231"), NOT username
+ * @param enabled - Optional flag to enable/disable the query
+ */
+export const useMinerIssues = (githubId: string, enabled?: boolean) =>
+  useMinersQuery<IssueBounty[]>(
+    'useMinerIssues',
+    `/${githubId}/issues`,
     undefined,
     undefined,
     enabled,

--- a/src/components/miners/MinerIssuesTable.tsx
+++ b/src/components/miners/MinerIssuesTable.tsx
@@ -35,7 +35,8 @@ const MinerIssuesTable: React.FC<MinerIssuesTableProps> = ({ githubId }) => {
 
   const minerIssues = useMemo(() => {
     return [...issues].sort(
-      (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+      (a, b) =>
+        new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
     );
   }, [issues]);
 
@@ -51,7 +52,8 @@ const MinerIssuesTable: React.FC<MinerIssuesTableProps> = ({ githubId }) => {
     () => ({
       total: minerIssues.length,
       open: minerIssues.filter((issue) => issue.status !== 'completed').length,
-      solved: minerIssues.filter((issue) => issue.status === 'completed').length,
+      solved: minerIssues.filter((issue) => issue.status === 'completed')
+        .length,
     }),
     [minerIssues],
   );
@@ -94,7 +96,9 @@ const MinerIssuesTable: React.FC<MinerIssuesTableProps> = ({ githubId }) => {
           gap: 1.5,
         }}
       >
-        <Typography sx={{ fontSize: '1rem', fontWeight: 600, color: 'text.primary' }}>
+        <Typography
+          sx={{ fontSize: '1rem', fontWeight: 600, color: 'text.primary' }}
+        >
           Issues Opened ({counts.total})
         </Typography>
         <Box sx={{ display: 'flex', gap: 1 }}>
@@ -137,7 +141,9 @@ const MinerIssuesTable: React.FC<MinerIssuesTableProps> = ({ githubId }) => {
           </Typography>
         </Box>
       ) : (
-        <TableContainer sx={{ maxHeight: 560, overflow: 'auto', ...scrollbarSx }}>
+        <TableContainer
+          sx={{ maxHeight: 560, overflow: 'auto', ...scrollbarSx }}
+        >
           <Table stickyHeader>
             <TableHead>
               <TableRow>
@@ -164,7 +170,9 @@ const MinerIssuesTable: React.FC<MinerIssuesTableProps> = ({ githubId }) => {
                 return (
                   <TableRow
                     key={issue.id}
-                    onClick={() => window.open(getIssueUrl(issue.githubUrl), '_blank')}
+                    onClick={() =>
+                      window.open(getIssueUrl(issue.githubUrl), '_blank')
+                    }
                     sx={{
                       cursor: 'pointer',
                       '&:hover': { backgroundColor: 'surface.light' },
@@ -186,7 +194,9 @@ const MinerIssuesTable: React.FC<MinerIssuesTableProps> = ({ githubId }) => {
                       </a>{' '}
                       {issue.title ? `- ${issue.title}` : ''}
                     </TableCell>
-                    <TableCell sx={bodyCellStyle}>{issue.repositoryFullName}</TableCell>
+                    <TableCell sx={bodyCellStyle}>
+                      {issue.repositoryFullName}
+                    </TableCell>
                     <TableCell sx={bodyCellStyle}>
                       <Chip
                         label={isSolved ? 'SOLVED' : 'OPEN'}

--- a/src/components/miners/MinerIssuesTable.tsx
+++ b/src/components/miners/MinerIssuesTable.tsx
@@ -1,0 +1,232 @@
+import React, { useMemo, useState } from 'react';
+import {
+  Box,
+  Card,
+  Chip,
+  CircularProgress,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography,
+  alpha,
+  useTheme,
+} from '@mui/material';
+import { useMinerIssues } from '../../api';
+import { bodyCellStyle, headerCellStyle, scrollbarSx } from '../../theme';
+import FilterButton from '../FilterButton';
+import { formatTokenAmount } from '../../utils/format';
+
+interface MinerIssuesTableProps {
+  githubId: string;
+}
+
+type IssueFilter = 'all' | 'open' | 'solved';
+
+const getIssueUrl = (githubUrl: string) => githubUrl;
+
+const MinerIssuesTable: React.FC<MinerIssuesTableProps> = ({ githubId }) => {
+  const theme = useTheme();
+  const { data: issues = [], isLoading: isLoadingIssues } =
+    useMinerIssues(githubId);
+  const [filter, setFilter] = useState<IssueFilter>('all');
+
+  const minerIssues = useMemo(() => {
+    return [...issues].sort(
+      (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+    );
+  }, [issues]);
+
+  const filteredIssues = useMemo(() => {
+    if (filter === 'open')
+      return minerIssues.filter((issue) => issue.status !== 'completed');
+    if (filter === 'solved')
+      return minerIssues.filter((issue) => issue.status === 'completed');
+    return minerIssues;
+  }, [minerIssues, filter]);
+
+  const counts = useMemo(
+    () => ({
+      total: minerIssues.length,
+      open: minerIssues.filter((issue) => issue.status !== 'completed').length,
+      solved: minerIssues.filter((issue) => issue.status === 'completed').length,
+    }),
+    [minerIssues],
+  );
+
+  if (isLoadingIssues) {
+    return (
+      <Card
+        sx={{
+          borderRadius: 3,
+          border: `1px solid ${theme.palette.border.light}`,
+          backgroundColor: 'transparent',
+          p: 4,
+          textAlign: 'center',
+        }}
+        elevation={0}
+      >
+        <CircularProgress size={36} sx={{ color: 'primary.main' }} />
+      </Card>
+    );
+  }
+
+  return (
+    <Card
+      sx={{
+        borderRadius: 3,
+        border: `1px solid ${theme.palette.border.light}`,
+        backgroundColor: 'transparent',
+        overflow: 'hidden',
+      }}
+      elevation={0}
+    >
+      <Box
+        sx={{
+          p: 3,
+          borderBottom: `1px solid ${theme.palette.border.light}`,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          flexWrap: 'wrap',
+          gap: 1.5,
+        }}
+      >
+        <Typography sx={{ fontSize: '1rem', fontWeight: 600, color: 'text.primary' }}>
+          Issues Opened ({counts.total})
+        </Typography>
+        <Box sx={{ display: 'flex', gap: 1 }}>
+          <FilterButton
+            label="All"
+            isActive={filter === 'all'}
+            onClick={() => setFilter('all')}
+            count={counts.total}
+            color={theme.palette.text.secondary}
+            activeTextColor="text.primary"
+          />
+          <FilterButton
+            label="Open"
+            isActive={filter === 'open'}
+            onClick={() => setFilter('open')}
+            count={counts.open}
+            color={theme.palette.info.main}
+            activeTextColor="text.primary"
+          />
+          <FilterButton
+            label="Solved"
+            isActive={filter === 'solved'}
+            onClick={() => setFilter('solved')}
+            count={counts.solved}
+            color={theme.palette.success.main}
+            activeTextColor="text.primary"
+          />
+        </Box>
+      </Box>
+
+      {filteredIssues.length === 0 ? (
+        <Box sx={{ p: 4, textAlign: 'center' }}>
+          <Typography
+            sx={{
+              color: alpha(theme.palette.common.white, 0.55),
+              fontSize: '0.9rem',
+            }}
+          >
+            No issue discoveries found for this miner.
+          </Typography>
+        </Box>
+      ) : (
+        <TableContainer sx={{ maxHeight: 560, overflow: 'auto', ...scrollbarSx }}>
+          <Table stickyHeader>
+            <TableHead>
+              <TableRow>
+                <TableCell sx={headerCellStyle}>Issue</TableCell>
+                <TableCell sx={headerCellStyle}>Repository</TableCell>
+                <TableCell sx={headerCellStyle}>Status</TableCell>
+                <TableCell align="right" sx={headerCellStyle}>
+                  Created
+                </TableCell>
+                <TableCell align="right" sx={headerCellStyle}>
+                  Solved Date
+                </TableCell>
+                <TableCell align="right" sx={headerCellStyle}>
+                  Target
+                </TableCell>
+                <TableCell align="right" sx={headerCellStyle}>
+                  Paid
+                </TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {filteredIssues.map((issue) => {
+                const isSolved = issue.status === 'completed';
+                return (
+                  <TableRow
+                    key={issue.id}
+                    onClick={() => window.open(getIssueUrl(issue.githubUrl), '_blank')}
+                    sx={{
+                      cursor: 'pointer',
+                      '&:hover': { backgroundColor: 'surface.light' },
+                    }}
+                  >
+                    <TableCell sx={bodyCellStyle}>
+                      <a
+                        href={getIssueUrl(issue.githubUrl)}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        style={{
+                          color: 'inherit',
+                          textDecoration: 'none',
+                          fontWeight: 500,
+                        }}
+                        onClick={(e) => e.stopPropagation()}
+                      >
+                        #{issue.issueNumber}
+                      </a>{' '}
+                      {issue.title ? `- ${issue.title}` : ''}
+                    </TableCell>
+                    <TableCell sx={bodyCellStyle}>{issue.repositoryFullName}</TableCell>
+                    <TableCell sx={bodyCellStyle}>
+                      <Chip
+                        label={isSolved ? 'SOLVED' : 'OPEN'}
+                        size="small"
+                        sx={{
+                          color: isSolved
+                            ? theme.palette.success.main
+                            : theme.palette.info.main,
+                          border: '1px solid',
+                          borderColor: isSolved
+                            ? alpha(theme.palette.success.main, 0.45)
+                            : alpha(theme.palette.info.main, 0.45),
+                          backgroundColor: 'transparent',
+                          fontWeight: 700,
+                        }}
+                      />
+                    </TableCell>
+                    <TableCell align="right" sx={bodyCellStyle}>
+                      {new Date(issue.createdAt).toLocaleDateString()}
+                    </TableCell>
+                    <TableCell align="right" sx={bodyCellStyle}>
+                      {issue.completedAt
+                        ? new Date(issue.completedAt).toLocaleDateString()
+                        : '-'}
+                    </TableCell>
+                    <TableCell align="right" sx={bodyCellStyle}>
+                      {formatTokenAmount(issue.targetBounty)} ل
+                    </TableCell>
+                    <TableCell align="right" sx={bodyCellStyle}>
+                      {formatTokenAmount(issue.bountyAmount)} ل
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      )}
+    </Card>
+  );
+};
+
+export default MinerIssuesTable;

--- a/src/components/miners/index.ts
+++ b/src/components/miners/index.ts
@@ -3,6 +3,7 @@ export { default as EmptyStateMessage } from './EmptyStateMessage';
 export { default as ExplorerFilterButton } from './ExplorerFilterButton';
 export { default as MinerActivity } from './MinerActivity';
 export { default as MinerInsightsCard } from './MinerInsightsCard';
+export { default as MinerIssuesTable } from './MinerIssuesTable';
 export { default as MinerPRsTable } from './MinerPRsTable';
 export { default as MinerRepositoriesTable } from './MinerRepositoriesTable';
 export { default as MinerScoreBreakdown } from './MinerScoreBreakdown';

--- a/src/pages/MinerDetailsPage.tsx
+++ b/src/pages/MinerDetailsPage.tsx
@@ -6,6 +6,7 @@ import {
   BackButton,
   MinerActivity,
   MinerInsightsCard,
+  MinerIssuesTable,
   MinerPRsTable,
   MinerRepositoriesTable,
   MinerScoreBreakdown,
@@ -22,7 +23,7 @@ const PR_TABS = [
   'pull-requests',
   'repositories',
 ] as const;
-const ISSUE_TABS = ['overview', 'activity', 'repositories'] as const;
+const ISSUE_TABS = ['overview', 'activity', 'issues', 'repositories'] as const;
 type MinerDetailsTab = (typeof PR_TABS)[number] | (typeof ISSUE_TABS)[number];
 
 const tabSx = {
@@ -170,6 +171,7 @@ const MinerDetailsPage: React.FC = () => {
             >
               <Tab value="overview" label="Overview" />
               <Tab value="activity" label="Activity" />
+              {viewMode === 'issues' && <Tab value="issues" label="Issues" />}
               {viewMode === 'prs' && (
                 <Tab value="pull-requests" label="Pull Requests" />
               )}
@@ -187,6 +189,9 @@ const MinerDetailsPage: React.FC = () => {
 
             {activeTab === 'activity' && (
               <MinerActivity githubId={githubId} viewMode={viewMode} />
+            )}
+            {activeTab === 'issues' && viewMode === 'issues' && (
+              <MinerIssuesTable githubId={githubId} />
             )}
             {activeTab === 'pull-requests' && (
               <MinerPRsTable githubId={githubId} />


### PR DESCRIPTION
Closes #524

## Summary
- add a dedicated `Issues` tab to miner details when viewing issue discovery mode
- fetch miner issue discoveries from `/miners/{githubId}/issues` via a new `useMinerIssues` API hook
- render an issues table with open/solved filters, solved date, and bounty target/paid values for quick status visibility

## Test plan
- [x] Open `/miners/details?githubId=<id>&mode=issues` and verify `Issues` tab appears alongside Overview, Activity, and Repositories
- [x] Open the `Issues` tab and confirm rows populate from miner-specific issues endpoint
- [x] Validate `All`, `Open`, and `Solved` filters update row counts and table contents
- [x] Click an issue row and verify it opens the GitHub issue URL in a new tab
- [x] Run lint diagnostics on updated files and confirm no new errors

## Screenshot


https://github.com/user-attachments/assets/8a310749-1ee0-493f-9278-29362ceab76c

