### PR TITLE
feat: highlight watched miners inside the Live Commit Log

### DIFF
--- a/src/pages/dashboard/views/LiveCommitLog.tsx
+++ b/src/pages/dashboard/views/LiveCommitLog.tsx
@@ -277,12 +277,7 @@ const CommitLogItem: React.FC<{
         >
           <Stack direction="row" alignItems="center" spacing={0.5}>
             {isWatched && (
-              <StarIcon
-                sx={{
-                  fontSize: 12,
-                  color: 'warning.main',
-                }}
-              />
+              <StarIcon sx={{ fontSize: 12, color: 'warning.main' }} />
             )}
             <Typography variant="caption" sx={{ color: 'text.secondary' }}>
               by {entry.author}
@@ -331,21 +326,18 @@ const LiveCommitLog: React.FC = () => {
   const { data, isLoading, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useInfiniteCommitLog({ refetchInterval: 10000 });
 
-  // Commits come from /dash/commits, which only exposes `author` (login).
-  // Watchlist is keyed by numeric githubId, so bridge the two using the
-  // /miners lookup (already cached elsewhere on the dashboard).
+  // Commits expose `author` (login) but not githubId — bridge via /miners.
   const { data: allMiners } = useAllMiners();
   const { isWatched } = useWatchlist();
-  const authorToGithubId = useMemo(() => {
-    const map = new Map<string, string>();
-    if (!Array.isArray(allMiners)) return map;
-    allMiners.forEach((miner) => {
-      if (miner.githubUsername && miner.githubId) {
-        map.set(miner.githubUsername.toLowerCase(), miner.githubId);
-      }
-    });
-    return map;
-  }, [allMiners]);
+  const authorToGithubId = useMemo(
+    () =>
+      new Map(
+        (Array.isArray(allMiners) ? allMiners : [])
+          .filter((m) => m.githubUsername && m.githubId)
+          .map((m) => [m.githubUsername!.toLowerCase(), m.githubId]),
+      ),
+    [allMiners],
+  );
 
   const [statusFilter, setStatusFilter] = useState<CommitStatusFilter>('all');
   const [logEntries, setLogEntries] = useState<CommitLogEntry[]>([]);
@@ -612,20 +604,15 @@ const LiveCommitLog: React.FC = () => {
               <Stack spacing={isMobile ? 1 : isTablet ? 1.25 : 1}>
                 {visibleEntries.map((entry) => {
                   const entryId = getCommitId(entry);
-                  const isNew = newEntryIds.has(entryId);
-                  const authorGithubId = authorToGithubId.get(
+                  const watchedId = authorToGithubId.get(
                     entry.author.toLowerCase(),
                   );
-                  const entryIsWatched = authorGithubId
-                    ? isWatched(authorGithubId)
-                    : false;
-
                   return (
                     <CommitLogItem
                       key={entryId}
                       entry={entry}
-                      isNew={isNew}
-                      isWatched={entryIsWatched}
+                      isNew={newEntryIds.has(entryId)}
+                      isWatched={!!watchedId && isWatched(watchedId)}
                     />
                   );
                 })}

--- a/src/pages/dashboard/views/LiveCommitLog.tsx
+++ b/src/pages/dashboard/views/LiveCommitLog.tsx
@@ -11,9 +11,11 @@ import {
   Avatar,
   Chip,
 } from '@mui/material';
+import StarIcon from '@mui/icons-material/Star';
 import { LinkBox } from '../../../components/common/linkBehavior';
 import theme, { REPO_OWNER_AVATAR_BACKGROUNDS } from '../../../theme';
-import { useInfiniteCommitLog } from '../../../api';
+import { useAllMiners, useInfiniteCommitLog } from '../../../api';
+import { useWatchlist } from '../../../hooks/useWatchlist';
 
 const MONTH_SHORT = [
   'Jan',
@@ -116,8 +118,9 @@ const getScoreColor = (score: string) => {
 const CommitLogItem: React.FC<{
   entry: CommitLogEntry;
   isNew: boolean;
+  isWatched?: boolean;
   innerRef?: React.Ref<HTMLAnchorElement>;
-}> = ({ entry, isNew, innerRef }) => {
+}> = ({ entry, isNew, isWatched = false, innerRef }) => {
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
   const isTablet = useMediaQuery(theme.breakpoints.between('sm', 'md'));
 
@@ -139,6 +142,11 @@ const CommitLogItem: React.FC<{
       href={`/miners/pr?repo=${entry.repository}&number=${entry.pullRequestNumber}`}
       linkState={{ backLabel: 'Back to Dashboard' }}
       ref={innerRef}
+      aria-label={
+        isWatched
+          ? `${entry.pullRequestTitle} by ${entry.author} (watched)`
+          : undefined
+      }
       sx={{
         p: isMobile ? 0.75 : isTablet ? 1.25 : 1,
         borderRadius: 3,
@@ -146,6 +154,9 @@ const CommitLogItem: React.FC<{
         borderColor: isNew
           ? theme.palette.secondary.main
           : theme.palette.border.light,
+        borderLeft: isWatched
+          ? `3px solid ${theme.palette.warning.main}`
+          : undefined,
         backgroundColor: theme.palette.surface.subtle,
         backdropFilter: 'blur(8px)',
         transition: 'all 0.2s cubic-bezier(0.4, 0, 0.2, 1)',
@@ -264,9 +275,19 @@ const CommitLogItem: React.FC<{
             borderTop: `1px solid ${theme.palette.border.subtle}`,
           }}
         >
-          <Typography variant="caption" sx={{ color: 'text.secondary' }}>
-            by {entry.author}
-          </Typography>
+          <Stack direction="row" alignItems="center" spacing={0.5}>
+            {isWatched && (
+              <StarIcon
+                sx={{
+                  fontSize: 12,
+                  color: 'warning.main',
+                }}
+              />
+            )}
+            <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+              by {entry.author}
+            </Typography>
+          </Stack>
           <Stack direction="row" spacing={2}>
             <Stack direction="row" spacing={0.5} alignItems="center">
               <Typography
@@ -309,6 +330,22 @@ const LiveCommitLog: React.FC = () => {
 
   const { data, isLoading, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useInfiniteCommitLog({ refetchInterval: 10000 });
+
+  // Commits come from /dash/commits, which only exposes `author` (login).
+  // Watchlist is keyed by numeric githubId, so bridge the two using the
+  // /miners lookup (already cached elsewhere on the dashboard).
+  const { data: allMiners } = useAllMiners();
+  const { isWatched } = useWatchlist();
+  const authorToGithubId = useMemo(() => {
+    const map = new Map<string, string>();
+    if (!Array.isArray(allMiners)) return map;
+    allMiners.forEach((miner) => {
+      if (miner.githubUsername && miner.githubId) {
+        map.set(miner.githubUsername.toLowerCase(), miner.githubId);
+      }
+    });
+    return map;
+  }, [allMiners]);
 
   const [statusFilter, setStatusFilter] = useState<CommitStatusFilter>('all');
   const [logEntries, setLogEntries] = useState<CommitLogEntry[]>([]);
@@ -576,9 +613,20 @@ const LiveCommitLog: React.FC = () => {
                 {visibleEntries.map((entry) => {
                   const entryId = getCommitId(entry);
                   const isNew = newEntryIds.has(entryId);
+                  const authorGithubId = authorToGithubId.get(
+                    entry.author.toLowerCase(),
+                  );
+                  const entryIsWatched = authorGithubId
+                    ? isWatched(authorGithubId)
+                    : false;
 
                   return (
-                    <CommitLogItem key={entryId} entry={entry} isNew={isNew} />
+                    <CommitLogItem
+                      key={entryId}
+                      entry={entry}
+                      isNew={isNew}
+                      isWatched={entryIsWatched}
+                    />
                   );
                 })}
               </Stack>


### PR DESCRIPTION
## Summary
Closes #528. Watched miners now stand out in the Dashboard's Live Commit Log without disrupting the rhythm of the feed.

- 3px left border in `warning.main` (same gold used by the Watchlist star) on any row authored by a watched miner
- Small filled `StarIcon` (12px) rendered alongside the "by {author}" label
- Row aria-label appended with `(watched)` when active so screen readers get the same signal
- Non-watched rows render exactly as before — the `isNew` pulse animation continues to coexist with the new accent

## Motivation
The Live Commit Log is the dashboard's most engaging surface. The Watchlist is the most personal. Today the two don't know about each other — a pinned miner's PR scrolls by with no visual distinction from hundreds of unrelated rows. This PR wires them together with a subtle, reversible accent so the watchlist starts acting as a live lens on network activity.

## Design notes
- **No schema change.** `CommitLogEntry.author` is already a login string. The bridge into `githubId` happens entirely in the dashboard component via an already-cached `/miners` query.
- **Gentle by design.** The feature brief asked for "a soft highlight color, a thin left border in the watchlist accent, or a small star glyph" — this ships two of the three (border + star) while keeping row height, hover state, and the `isNew` animation untouched.
- **Unknown authors degrade silently.** If the commit log has a row whose `author` isn't in `/miners` (brand-new miner, API lag), `isWatched` is `false` and the row renders as before.

## Type of Change
- [x] Feature / enhancement

## Testing

- [x] `npm run build`
- [x] `npm run test` (37 existing tests pass)
- [x] `npm run format` and `npm run lint:fix`
- [x] Manual:
  - Star a miner on `/top-miners` → navigate to `/dashboard` → rows authored by that miner show the gold left border and star icon.
  - Unstar the miner → the accent is gone on the next render.
  - `localStorage.setItem('gittensor.watchlist.v1', JSON.stringify(['218712309']))` in DevTools → bittoby's PRs immediately highlight across Live Commit Log.
  - New PRs that arrive via the 10s poll still play the `isNew` slide-in animation; both styles coexist.
  - Authors that don't match any miner in `/miners` render normally (no accent, no crash).

## Checklist

- [x] No backend changes
- [x] No new dependencies
- [x] Reuses existing watchlist hook + gold star visual vocabulary (consistent with `WatchlistButton`)
- [x] Accessible: aria-label carries the watched state for screen readers
- [x] Graceful degradation when `/miners` isn't an array yet

## Screenshots

Before:

<img width="1569" height="749" alt="before1" src="https://github.com/user-attachments/assets/53215566-8f09-4e3c-ab7f-03065350f7c5" />

After:

<img width="1817" height="836" alt="after1" src="https://github.com/user-attachments/assets/358fd1ba-9bba-4c71-8c5f-dc8c04251cb6" />
