### PR TITLE
Repository Weights Chart Y-Axis Shows Only Zeros for Non-Zero Values

### DIFF
--- a/src/components/leaderboard/TopRepositoriesTable.tsx
+++ b/src/components/leaderboard/TopRepositoriesTable.tsx
@@ -313,9 +313,7 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
     const minPositiveValue =
       positiveSeriesValues.length > 0 ? Math.min(...positiveSeriesValues) : 1;
     const logMin =
-      minPositiveValue < 1
-        ? 10 ** Math.floor(Math.log10(minPositiveValue))
-        : 1;
+      minPositiveValue < 1 ? 10 ** Math.floor(Math.log10(minPositiveValue)) : 1;
 
     return {
       backgroundColor: 'transparent',

--- a/src/components/leaderboard/TopRepositoriesTable.tsx
+++ b/src/components/leaderboard/TopRepositoriesTable.tsx
@@ -307,6 +307,15 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
         shadowBlur: 12,
       },
     }));
+    const positiveSeriesValues = seriesData
+      .map((item) => item.value)
+      .filter((value) => Number.isFinite(value) && value > 0);
+    const minPositiveValue =
+      positiveSeriesValues.length > 0 ? Math.min(...positiveSeriesValues) : 1;
+    const logMin =
+      minPositiveValue < 1
+        ? 10 ** Math.floor(Math.log10(minPositiveValue))
+        : 1;
 
     return {
       backgroundColor: 'transparent',
@@ -401,7 +410,7 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
       },
       yAxis: {
         type: effectiveLogScale ? 'log' : 'value',
-        min: effectiveLogScale ? 1 : 0,
+        min: effectiveLogScale ? logMin : 0,
         logBase: 10,
         name: metric.yAxis,
         nameTextStyle: {
@@ -413,6 +422,12 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
           color: textColor,
           fontSize: 11,
           formatter: (value: number) => {
+            if (sortColumn === 'weight') {
+              if (value >= 1000) return `${(value / 1000).toFixed(1)}k`;
+              if (value >= 10) return value.toFixed(1).replace(/\.0$/, '');
+              if (value >= 1) return value.toFixed(2).replace(/\.?0+$/, '');
+              return value.toFixed(3).replace(/\.?0+$/, '');
+            }
             if (value >= 1000) return `${(value / 1000).toFixed(1)}k`;
             return value.toFixed(0);
           },


### PR DESCRIPTION
## Summary

The repository weights chart in the repositories panel renders Y-axis labels as `0` even when plotted weight values are greater than `0`. This happens because axis tick formatting rounds fractional values to integers.

## Related Issues

#532 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

- Before: left Y-axis labels display only `0` while bars represent non-zero weights.
- After: Y-axis labels display non-zero decimal values correctly.

https://github.com/user-attachments/assets/29439c40-cf0d-4181-a607-6201b46d7493



## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [ ] Tested against the test API
- [ ] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
