### PR TITLE
feat(ui): add local “This is me” identity and row highlighting (#526)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7113,24 +7113,6 @@
         }
       }
     },
-    "node_modules/vitest/node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
-    },
     "node_modules/web-namespaces": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",

--- a/src/components/common/SelfIdentityPanel.tsx
+++ b/src/components/common/SelfIdentityPanel.tsx
@@ -1,0 +1,117 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Box,
+  Button,
+  Stack,
+  TextField,
+  Typography,
+  alpha,
+} from '@mui/material';
+import { useSelfIdentity } from '../../hooks/useSelfIdentity';
+
+/**
+ * Local-only "This is me" setup (GitHub username + optional hotkey).
+ */
+const SelfIdentityPanel: React.FC = () => {
+  const { githubLogin, hotkey, hasConfigured, setIdentity, clear } =
+    useSelfIdentity();
+  const [draftGh, setDraftGh] = useState(githubLogin);
+  const [draftHk, setDraftHk] = useState(hotkey);
+
+  useEffect(() => {
+    setDraftGh(githubLogin);
+    setDraftHk(hotkey);
+  }, [githubLogin, hotkey]);
+
+  const handleSave = () => {
+    setIdentity({ githubLogin: draftGh, hotkey: draftHk });
+  };
+
+  return (
+    <Box
+      sx={{
+        py: 2,
+        px: 0,
+        borderTop: (t) => `1px solid ${t.palette.border.medium}`,
+      }}
+    >
+      <Typography
+        sx={{
+          fontSize: '0.7rem',
+          fontWeight: 600,
+          letterSpacing: '0.06em',
+          textTransform: 'uppercase',
+          color: 'text.secondary',
+          mb: 0.75,
+        }}
+      >
+        This is me
+      </Typography>
+      <Typography
+        sx={{
+          fontSize: '0.65rem',
+          color: (t) => alpha(t.palette.text.primary, 0.45),
+          lineHeight: 1.45,
+          mb: 1.25,
+        }}
+      >
+        Highlight your rows in lists and activity. Stored only in this browser.
+      </Typography>
+      <Stack spacing={1.25}>
+        <TextField
+          size="small"
+          fullWidth
+          label="GitHub username"
+          placeholder="octocat"
+          value={draftGh}
+          onChange={(e) => setDraftGh(e.target.value)}
+          autoComplete="username"
+          inputProps={{ spellCheck: false }}
+          sx={{
+            '& .MuiInputBase-input': { fontSize: '0.8rem' },
+            '& .MuiInputLabel-root': { fontSize: '0.75rem' },
+          }}
+        />
+        <TextField
+          size="small"
+          fullWidth
+          label="Hotkey (optional)"
+          placeholder="Subnet hotkey"
+          value={draftHk}
+          onChange={(e) => setDraftHk(e.target.value)}
+          autoComplete="off"
+          inputProps={{ spellCheck: false }}
+          sx={{
+            '& .MuiInputBase-input': { fontSize: '0.75rem' },
+            '& .MuiInputLabel-root': { fontSize: '0.75rem' },
+          }}
+        />
+        <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap">
+          <Button
+            size="small"
+            variant="outlined"
+            onClick={handleSave}
+            sx={{ textTransform: 'none', fontSize: '0.75rem' }}
+          >
+            Save
+          </Button>
+          {hasConfigured && (
+            <Button
+              size="small"
+              onClick={clear}
+              sx={{
+                textTransform: 'none',
+                fontSize: '0.72rem',
+                color: 'text.secondary',
+              }}
+            >
+              Clear
+            </Button>
+          )}
+        </Stack>
+      </Stack>
+    </Box>
+  );
+};
+
+export default SelfIdentityPanel;

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -1,3 +1,4 @@
 export * from './RowLink';
 export * from './SearchInput';
 export * from './WatchlistButton';
+export { default as SelfIdentityPanel } from './SelfIdentityPanel';

--- a/src/components/issues/IssueSubmissionsTable.tsx
+++ b/src/components/issues/IssueSubmissionsTable.tsx
@@ -19,6 +19,9 @@ import EmojiEventsIcon from '@mui/icons-material/EmojiEvents';
 import { IssueSubmission } from '../../api/models/Issues';
 import { STATUS_COLORS, TEXT_OPACITY } from '../../theme';
 import { formatDate } from '../../utils/format';
+import { useSelfIdentity } from '../../hooks/useSelfIdentity';
+import { submissionMatchesSelf } from '../../utils/selfIdentityMatch';
+import { selfHighlightSx } from '../../utils/selfHighlightSx';
 
 const headerCellSx = {
   fontSize: '0.7rem',
@@ -52,6 +55,7 @@ const IssueSubmissionsTable: React.FC<IssueSubmissionsTableProps> = ({
 }) => {
   const navigate = useNavigate();
   const theme = useTheme();
+  const { prefs } = useSelfIdentity();
 
   return (
     <Card
@@ -112,7 +116,9 @@ const IssueSubmissionsTable: React.FC<IssueSubmissionsTableProps> = ({
               </TableRow>
             </TableHead>
             <TableBody>
-              {submissions.map((submission) => (
+              {submissions.map((submission) => {
+                const isSelf = submissionMatchesSelf(prefs, submission);
+                return (
                 <TableRow
                   key={`${submission.repositoryFullName}-${submission.number}`}
                   onClick={() =>
@@ -127,6 +133,7 @@ const IssueSubmissionsTable: React.FC<IssueSubmissionsTableProps> = ({
                     '&:hover': {
                       backgroundColor: alpha(theme.palette.common.white, 0.03),
                     },
+                    ...selfHighlightSx(theme, isSelf),
                   }}
                 >
                   <TableCell sx={bodyCellSx}>
@@ -236,7 +243,8 @@ const IssueSubmissionsTable: React.FC<IssueSubmissionsTableProps> = ({
                     </Typography>
                   </TableCell>
                 </TableRow>
-              ))}
+              );
+              })}
             </TableBody>
           </Table>
         </TableContainer>

--- a/src/components/issues/IssuesList.tsx
+++ b/src/components/issues/IssuesList.tsx
@@ -25,6 +25,9 @@ import { formatTokenAmount, formatDate } from '../../utils/format';
 import { getIssueStatusMeta } from '../../utils/issueStatus';
 import { STATUS_COLORS, TEXT_OPACITY } from '../../theme';
 import BountyProgress from './BountyProgress';
+import { useSelfIdentity } from '../../hooks/useSelfIdentity';
+import { bountySolverMatchesSelf } from '../../utils/selfIdentityMatch';
+import { selfHighlightSx } from '../../utils/selfHighlightSx';
 
 type ListType = 'available' | 'pending' | 'history';
 type SortDirection = 'asc' | 'desc';
@@ -61,6 +64,7 @@ const IssuesList: React.FC<IssuesListProps> = ({
   onSelectIssue,
 }) => {
   const theme = useTheme();
+  const { prefs } = useSelfIdentity();
   const [sortKey, setSortKey] = useState<SortKey>('id');
   const [sortDirection, setSortDirection] = useState<SortDirection>('desc');
   const { data: dashStats } = useStats();
@@ -372,6 +376,9 @@ const IssuesList: React.FC<IssuesListProps> = ({
             {sortedIssues.map((issue) => {
               const statusBadge = getIssueStatusMeta(issue.status);
               const usdDisplay = toUsd(issue.targetBounty);
+              const isSelfRow =
+                listType === 'history' &&
+                bountySolverMatchesSelf(prefs, issue.solverHotkey);
 
               return (
                 <TableRow
@@ -383,6 +390,7 @@ const IssuesList: React.FC<IssuesListProps> = ({
                     '&:hover': {
                       backgroundColor: alpha(theme.palette.common.white, 0.03),
                     },
+                    ...selfHighlightSx(theme, isSelfRow),
                   }}
                 >
                   {/* Common columns */}

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -9,6 +9,7 @@ import {
 } from '@mui/material';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { useWatchlist } from '../../hooks/useWatchlist';
+import { SelfIdentityPanel } from '../common';
 
 interface SidebarProps {
   onNavigate?: () => void;
@@ -123,6 +124,8 @@ const Sidebar: React.FC<SidebarProps> = ({ onNavigate }) => {
           </Button>
         ))}
       </Stack>
+
+      <SelfIdentityPanel />
 
       {/* Spacer to push footer to bottom */}
       <Box sx={{ flexGrow: 1 }} />

--- a/src/components/leaderboard/LeaderboardSidebar.tsx
+++ b/src/components/leaderboard/LeaderboardSidebar.tsx
@@ -5,6 +5,8 @@ import { SectionCard } from './SectionCard';
 import { STATUS_COLORS } from '../../theme';
 import { getGithubAvatarSrc } from '../../utils/ExplorerUtils';
 import { type MinerStats, FONTS } from './types';
+import { useSelfIdentity } from '../../hooks/useSelfIdentity';
+import { minerMatchesSelf } from '../../utils/selfIdentityMatch';
 
 // Re-export MinerStats for backward compatibility
 export type { MinerStats } from './types';
@@ -299,72 +301,83 @@ const LeaderboardRow: React.FC<LeaderboardRowProps> = ({
   type,
   variant = 'oss',
   onClick,
-}) => (
-  <Box
-    onClick={onClick}
-    sx={(theme) => ({
-      display: 'flex',
-      alignItems: 'center',
-      py: 1,
-      cursor: 'pointer',
-      '&:hover': {
-        backgroundColor: alpha(theme.palette.text.primary, 0.03),
-        borderRadius: 1,
-      },
-    })}
-  >
-    <Typography
-      sx={{
-        fontFamily: FONTS.mono,
-        fontSize: '0.85rem',
-        color: STATUS_COLORS.open,
-        width: 24,
-      }}
-    >
-      {rank}
-    </Typography>
+}) => {
+  const { prefs } = useSelfIdentity();
+  const isSelf = minerMatchesSelf(miner, prefs);
+  return (
     <Box
-      sx={{
+      onClick={onClick}
+      sx={(theme) => ({
         display: 'flex',
         alignItems: 'center',
-        gap: 1,
-        flex: 1,
-        minWidth: 0,
-      }}
+        py: 1,
+        cursor: 'pointer',
+        borderRadius: 1,
+        ...(isSelf
+          ? {
+              borderLeft: `3px solid ${theme.palette.secondary.main}`,
+              backgroundColor: alpha(theme.palette.secondary.main, 0.08),
+            }
+          : {}),
+        '&:hover': {
+          backgroundColor: alpha(theme.palette.text.primary, 0.03),
+          borderRadius: 1,
+        },
+      })}
     >
-      <Avatar
-        src={getGithubAvatarSrc(miner.author || miner.githubId)}
-        sx={{ width: 20, height: 20 }}
-      />
+      <Typography
+        sx={{
+          fontFamily: FONTS.mono,
+          fontSize: '0.85rem',
+          color: STATUS_COLORS.open,
+          width: 24,
+        }}
+      >
+        {rank}
+      </Typography>
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 1,
+          flex: 1,
+          minWidth: 0,
+        }}
+      >
+        <Avatar
+          src={getGithubAvatarSrc(miner.author || miner.githubId)}
+          sx={{ width: 20, height: 20 }}
+        />
+        <Typography
+          sx={(theme) => ({
+            fontFamily: FONTS.mono,
+            fontSize: '0.85rem',
+            color: theme.palette.text.tertiary,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          })}
+        >
+          {miner.author || miner.githubId}
+        </Typography>
+      </Box>
       <Typography
         sx={(theme) => ({
           fontFamily: FONTS.mono,
-          fontSize: '0.85rem',
-          color: theme.palette.text.tertiary,
-          overflow: 'hidden',
-          textOverflow: 'ellipsis',
-          whiteSpace: 'nowrap',
+          fontSize: '0.95rem',
+          color:
+            type === 'earners'
+              ? STATUS_COLORS.merged
+              : theme.palette.text.primary,
+          fontWeight: 600,
         })}
       >
-        {miner.author || miner.githubId}
+        {type === 'earners'
+          ? `$${Math.round(miner.usdPerDay || 0).toLocaleString()}`
+          : variant === 'discoveries'
+            ? miner.totalIssues
+            : miner.totalPRs}
       </Typography>
     </Box>
-    <Typography
-      sx={(theme) => ({
-        fontFamily: FONTS.mono,
-        fontSize: '0.95rem',
-        color:
-          type === 'earners'
-            ? STATUS_COLORS.merged
-            : theme.palette.text.primary,
-        fontWeight: 600,
-      })}
-    >
-      {type === 'earners'
-        ? `$${Math.round(miner.usdPerDay || 0).toLocaleString()}`
-        : variant === 'discoveries'
-          ? miner.totalIssues
-          : miner.totalPRs}
-    </Typography>
-  </Box>
-);
+  );
+};

--- a/src/components/leaderboard/MinerCard.tsx
+++ b/src/components/leaderboard/MinerCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Box, Card, Typography, Avatar } from '@mui/material';
+import { Box, Card, Typography, Avatar, Chip } from '@mui/material';
 import { alpha, useTheme } from '@mui/material/styles';
 import ReactECharts from 'echarts-for-react';
 import { useMinerGithubData, useMinerPRs } from '../../api';
@@ -7,6 +7,9 @@ import { CHART_COLORS, STATUS_COLORS } from '../../theme';
 import { getGithubAvatarSrc } from '../../utils/ExplorerUtils';
 import { RowLink, WatchlistButton } from '../common';
 import { type MinerStats, type LeaderboardVariant, FONTS } from './types';
+import { useSelfIdentity } from '../../hooks/useSelfIdentity';
+import { minerMatchesSelf } from '../../utils/selfIdentityMatch';
+import { selfHighlightSx } from '../../utils/selfHighlightSx';
 
 interface MinerCardProps {
   miner: MinerStats;
@@ -54,6 +57,8 @@ export const MinerCard: React.FC<MinerCardProps> = ({
   variant = 'oss',
 }) => {
   const muiTheme = useTheme();
+  const { prefs } = useSelfIdentity();
+  const isSelf = minerMatchesSelf(miner, prefs);
   const isNumericId = (value?: string) => !value || /^\d+$/.test(value);
   const shouldFetch = !!miner.githubId && isNumericId(miner.author);
   const { data: githubData } = useMinerGithubData(miner.githubId, shouldFetch);
@@ -96,6 +101,7 @@ export const MinerCard: React.FC<MinerCardProps> = ({
           boxShadow: isEligible
             ? `0 2px 8px ${alpha(theme.palette.background.default, 0.1)}`
             : 'none',
+          ...selfHighlightSx(theme, isSelf),
           '&:hover': {
             backgroundColor: isEligible
               ? theme.palette.surface.elevated
@@ -150,22 +156,49 @@ export const MinerCard: React.FC<MinerCardProps> = ({
                 overflow: 'hidden',
               }}
             >
-              <Typography
-                sx={(theme) => ({
-                  fontFamily: FONTS.mono,
-                  fontSize: '1rem',
-                  fontWeight: 700,
-                  color: isEligible
-                    ? theme.palette.text.primary
-                    : theme.palette.text.tertiary,
-                  opacity: isEligible ? 1 : INACTIVE_OPACITY,
-                  overflow: 'hidden',
-                  textOverflow: 'ellipsis',
-                  whiteSpace: 'nowrap',
-                })}
+              <Box
+                sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 0.75,
+                  minWidth: 0,
+                }}
               >
-                {username}
-              </Typography>
+                <Typography
+                  sx={(theme) => ({
+                    fontFamily: FONTS.mono,
+                    fontSize: '1rem',
+                    fontWeight: 700,
+                    color: isEligible
+                      ? theme.palette.text.primary
+                      : theme.palette.text.tertiary,
+                    opacity: isEligible ? 1 : INACTIVE_OPACITY,
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                  })}
+                >
+                  {username}
+                </Typography>
+                {isSelf && (
+                  <Chip
+                    label="you"
+                    size="small"
+                    sx={{
+                      height: 18,
+                      flexShrink: 0,
+                      fontSize: '0.6rem',
+                      fontWeight: 700,
+                      '& .MuiChip-label': { px: 0.75, py: 0 },
+                      borderColor: (t) => alpha(t.palette.secondary.main, 0.45),
+                      color: 'secondary.main',
+                      backgroundColor: (t) =>
+                        alpha(t.palette.secondary.main, 0.12),
+                    }}
+                    variant="outlined"
+                  />
+                )}
+              </Box>
               <Typography
                 sx={(theme) => ({
                   fontFamily: FONTS.mono,

--- a/src/components/miners/MinerPRsTable.tsx
+++ b/src/components/miners/MinerPRsTable.tsx
@@ -33,6 +33,9 @@ import ExplorerFilterButton from './ExplorerFilterButton';
 import TablePagination from './TablePagination';
 import { type MinerStatusFilter } from '../../utils/ExplorerUtils';
 import { headerCellStyle, bodyCellStyle, tooltipSlotProps } from '../../theme';
+import { useSelfIdentity } from '../../hooks/useSelfIdentity';
+import { prAuthorMatchesSelf } from '../../utils/selfIdentityMatch';
+import { selfHighlightSx } from '../../utils/selfHighlightSx';
 
 type PrSortField = 'number' | 'repository' | 'score' | 'lines' | 'date';
 type SortDir = 'asc' | 'desc';
@@ -90,6 +93,7 @@ interface MinerPRsTableProps {
 const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
   const theme = useTheme();
   const navigate = useNavigate();
+  const { prefs } = useSelfIdentity();
   const [searchParams, setSearchParams] = useSearchParams();
   const { data: prs, isLoading } = useMinerPRs(githubId);
   const [selectedAuthor, setSelectedAuthor] = useState<string | null>(null);
@@ -495,6 +499,11 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
               <TableBody>
                 {pagedPRs.map((pr, index) => {
                   const scoreTooltip = getScoreTooltip(pr);
+                  const isSelf = prAuthorMatchesSelf(
+                    prefs,
+                    pr.author,
+                    pr.hotkey,
+                  );
                   return (
                     <TableRow
                       key={`${pr.repository}-${pr.pullRequestNumber}-${index}`}
@@ -514,6 +523,7 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
                           backgroundColor: 'surface.subtle',
                         },
                         transition: 'all 0.2s',
+                        ...selfHighlightSx(theme, isSelf),
                       }}
                     >
                       <TableCell

--- a/src/components/repositories/RepositoryContributorsTable.tsx
+++ b/src/components/repositories/RepositoryContributorsTable.tsx
@@ -13,6 +13,8 @@ import { useAllPrs, useAllMiners } from '../../api';
 import { useNavigate } from 'react-router-dom';
 import { STATUS_COLORS } from '../../theme';
 import { isMergedPr } from '../../utils/prStatus';
+import { useSelfIdentity } from '../../hooks/useSelfIdentity';
+import { contributorRowMatchesSelf } from '../../utils/selfIdentityMatch';
 
 interface RepositoryContributorsTableProps {
   repositoryFullName: string;
@@ -23,6 +25,7 @@ const RepositoryContributorsTable: React.FC<
 > = ({ repositoryFullName }) => {
   const theme = useTheme();
   const navigate = useNavigate();
+  const { prefs } = useSelfIdentity();
   const { data: allPRs, isLoading } = useAllPrs();
   const { data: allMinersStats } = useAllMiners();
 
@@ -181,6 +184,7 @@ const RepositoryContributorsTable: React.FC<
           const minerData = minerDataMap.get(contributor.githubId);
           const minerRank = minerData?.rank;
           const isInactive = !minerData?.isEligible;
+          const isSelf = contributorRowMatchesSelf(prefs, contributor);
 
           return (
             <Box
@@ -197,6 +201,15 @@ const RepositoryContributorsTable: React.FC<
                 alignItems: 'center',
                 minWidth: 0,
                 opacity: isInactive ? 0.5 : 1,
+                ...(isSelf
+                  ? {
+                      borderLeft: `3px solid ${theme.palette.secondary.main}`,
+                      backgroundColor: alpha(
+                        theme.palette.secondary.main,
+                        0.08,
+                      ),
+                    }
+                  : {}),
                 '&:hover': {
                   backgroundColor: alpha(theme.palette.common.white, 0.04),
                   opacity: 1,

--- a/src/components/repositories/RepositoryPRsTable.tsx
+++ b/src/components/repositories/RepositoryPRsTable.tsx
@@ -43,6 +43,9 @@ import {
   isOpenPr,
 } from '../../utils';
 import FilterButton from '../FilterButton';
+import { useSelfIdentity } from '../../hooks/useSelfIdentity';
+import { prAuthorMatchesSelf } from '../../utils/selfIdentityMatch';
+import { selfHighlightSx } from '../../utils/selfHighlightSx';
 
 interface RepositoryPRsTableProps {
   repositoryFullName: string;
@@ -55,6 +58,7 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
 }) => {
   const theme = useTheme();
   const navigate = useNavigate();
+  const { prefs } = useSelfIdentity();
   const [filter, setFilter] = useState<'all' | 'open' | 'closed' | 'merged'>(
     state,
   );
@@ -362,7 +366,9 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
               </TableRow>
             </TableHead>
             <TableBody>
-              {sortedPRs.map((pr) => (
+              {sortedPRs.map((pr) => {
+                const isSelf = prAuthorMatchesSelf(prefs, pr.author, pr.hotkey);
+                return (
                 <TableRow
                   key={`${pr.repository}-${pr.pullRequestNumber}`}
                   onClick={() => {
@@ -377,6 +383,7 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
                       backgroundColor: 'surface.light',
                     },
                     transition: 'background-color 0.2s',
+                    ...selfHighlightSx(theme, isSelf),
                   }}
                 >
                   <TableCell sx={bodyCellStyle}>
@@ -484,7 +491,8 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
                       : '-'}
                   </TableCell>
                 </TableRow>
-              ))}
+              );
+              })}
             </TableBody>
           </Table>
         </TableContainer>

--- a/src/hooks/useSelfIdentity.ts
+++ b/src/hooks/useSelfIdentity.ts
@@ -1,0 +1,104 @@
+import { useCallback, useSyncExternalStore } from 'react';
+import { type SelfIdentityPrefs } from '../utils/selfIdentityMatch';
+
+const STORAGE_KEY = 'gittensor.selfIdentity.v1';
+
+type Listener = () => void;
+const listeners = new Set<Listener>();
+
+const emptyPrefs = (): SelfIdentityPrefs => ({
+  githubLogin: '',
+  hotkey: '',
+});
+
+const readFromStorage = (): SelfIdentityPrefs => {
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return emptyPrefs();
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== 'object') return emptyPrefs();
+    const rec = parsed as Record<string, unknown>;
+    const githubLogin =
+      typeof rec.githubLogin === 'string' ? rec.githubLogin : '';
+    const hotkey = typeof rec.hotkey === 'string' ? rec.hotkey : '';
+    return { githubLogin, hotkey };
+  } catch {
+    return emptyPrefs();
+  }
+};
+
+let snapshot: SelfIdentityPrefs = readFromStorage();
+
+const notify = () => {
+  listeners.forEach((l) => l());
+};
+
+const prefsEqual = (a: SelfIdentityPrefs, b: SelfIdentityPrefs) =>
+  a.githubLogin === b.githubLogin && a.hotkey === b.hotkey;
+
+const setSnapshot = (next: SelfIdentityPrefs) => {
+  if (prefsEqual(next, snapshot)) return;
+  snapshot = next;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+  } catch {
+    // private mode / quota — in-memory still works for the session
+  }
+  notify();
+};
+
+const handleStorageEvent = (e: StorageEvent) => {
+  if (e.key !== STORAGE_KEY) return;
+  snapshot = readFromStorage();
+  notify();
+};
+
+const subscribe = (listener: Listener) => {
+  if (listeners.size === 0) {
+    window.addEventListener('storage', handleStorageEvent);
+  }
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+    if (listeners.size === 0) {
+      window.removeEventListener('storage', handleStorageEvent);
+    }
+  };
+};
+
+const getSnapshot = () => snapshot;
+
+export interface UseSelfIdentity {
+  githubLogin: string;
+  hotkey: string;
+  prefs: SelfIdentityPrefs;
+  hasConfigured: boolean;
+  setIdentity: (next: SelfIdentityPrefs) => void;
+  clear: () => void;
+}
+
+export const useSelfIdentity = (): UseSelfIdentity => {
+  const prefs = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+
+  const hasConfigured = !!(
+    prefs.githubLogin.trim() || prefs.hotkey.trim()
+  );
+
+  const setIdentity = useCallback((next: SelfIdentityPrefs) => {
+    setSnapshot({
+      githubLogin: next.githubLogin.trim(),
+      hotkey: next.hotkey.trim(),
+    });
+  }, []);
+
+  const clear = useCallback(() => setSnapshot(emptyPrefs()), []);
+
+  return {
+    githubLogin: prefs.githubLogin,
+    hotkey: prefs.hotkey,
+    prefs,
+    hasConfigured,
+    setIdentity,
+    clear,
+  };
+};

--- a/src/pages/IssuesPage.tsx
+++ b/src/pages/IssuesPage.tsx
@@ -6,19 +6,38 @@
  * - Pending Issues: Registered issues awaiting funding
  * - History: Completed or cancelled issues
  */
-import React from 'react';
+import React, { useLayoutEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { Box, Tabs, Tab, Stack, Typography, alpha } from '@mui/material';
 import { Page } from '../components/layout';
 import { SEO } from '../components';
 import { IssueStats, IssuesList } from '../components/issues';
 import { useIssuesStats, useIssues } from '../api';
+import { readStoredTab, writeStoredTab } from '../utils/tabPreferences';
 
 const TAB_SLUGS = ['available', 'pending', 'history'] as const;
+
+const BOUNTIES_TAB_STORAGE_KEY = 'gittensor-ui:bounties-last-tab';
 
 const IssuesPage: React.FC = () => {
   const navigate = useNavigate();
   const { tab: tabParam } = useParams<{ tab?: string }>();
+
+  useLayoutEffect(() => {
+    if (
+      tabParam &&
+      TAB_SLUGS.includes(tabParam as (typeof TAB_SLUGS)[number])
+    ) {
+      writeStoredTab(BOUNTIES_TAB_STORAGE_KEY, tabParam);
+      return;
+    }
+    const saved = readStoredTab(BOUNTIES_TAB_STORAGE_KEY);
+    const slug =
+      saved && TAB_SLUGS.includes(saved as (typeof TAB_SLUGS)[number])
+        ? saved
+        : 'available';
+    navigate(`/bounties/${slug}`, { replace: true });
+  }, [tabParam, navigate]);
 
   const tabIndex = Math.max(
     0,
@@ -31,7 +50,9 @@ const IssuesPage: React.FC = () => {
   const historyIssuesQuery = useIssues('completed,cancelled');
 
   const handleTabChange = (_event: React.SyntheticEvent, newValue: number) => {
-    navigate(`/bounties/${TAB_SLUGS[newValue]}`, { replace: true });
+    const slug = TAB_SLUGS[newValue];
+    writeStoredTab(BOUNTIES_TAB_STORAGE_KEY, slug);
+    navigate(`/bounties/${slug}`, { replace: true });
   };
 
   return (

--- a/src/pages/MinerDetailsPage.tsx
+++ b/src/pages/MinerDetailsPage.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useLayoutEffect } from 'react';
 import { Navigate, useSearchParams } from 'react-router-dom';
 import { Box, Tab, Tabs, Typography, alpha } from '@mui/material';
 import { Page } from '../components/layout';
@@ -13,8 +13,12 @@ import {
   SEO,
 } from '../components';
 import { WatchlistButton } from '../components/common';
+import { readStoredTab, writeStoredTab } from '../utils/tabPreferences';
 
 type ViewMode = 'prs' | 'issues';
+
+const minerTabStorageKey = (mode: ViewMode) =>
+  `gittensor-ui:miner-details-tab:${mode}`;
 
 const PR_TABS = [
   'overview',
@@ -45,6 +49,26 @@ const MinerDetailsPage: React.FC = () => {
   const tabs = viewMode === 'issues' ? ISSUE_TABS : PR_TABS;
 
   const tabParam = searchParams.get('tab');
+
+  useLayoutEffect(() => {
+    if (!githubId) {
+      return;
+    }
+    const allowedTabs = viewMode === 'issues' ? ISSUE_TABS : PR_TABS;
+    if (tabParam && (allowedTabs as readonly string[]).includes(tabParam)) {
+      writeStoredTab(minerTabStorageKey(viewMode), tabParam);
+      return;
+    }
+    const saved = readStoredTab(minerTabStorageKey(viewMode));
+    const nextTab: MinerDetailsTab =
+      saved && (allowedTabs as readonly string[]).includes(saved)
+        ? (saved as MinerDetailsTab)
+        : 'overview';
+    const p = new URLSearchParams(searchParams);
+    p.set('tab', nextTab);
+    setSearchParams(p, { replace: true });
+  }, [githubId, viewMode, tabParam, searchParams, setSearchParams]);
+
   const activeTab: MinerDetailsTab =
     tabParam && (tabs as readonly string[]).includes(tabParam)
       ? (tabParam as MinerDetailsTab)
@@ -53,7 +77,13 @@ const MinerDetailsPage: React.FC = () => {
   const handleModeChange = (mode: ViewMode) => {
     const p = new URLSearchParams(searchParams);
     p.set('mode', mode);
-    p.set('tab', 'overview');
+    const nextTabs = mode === 'issues' ? ISSUE_TABS : PR_TABS;
+    const saved = readStoredTab(minerTabStorageKey(mode));
+    const nextTab: MinerDetailsTab =
+      saved && (nextTabs as readonly string[]).includes(saved)
+        ? (saved as MinerDetailsTab)
+        : 'overview';
+    p.set('tab', nextTab);
     setSearchParams(p, { replace: true });
   };
 
@@ -61,6 +91,7 @@ const MinerDetailsPage: React.FC = () => {
     _event: React.SyntheticEvent,
     newValue: MinerDetailsTab,
   ) => {
+    writeStoredTab(minerTabStorageKey(viewMode), newValue);
     const p = new URLSearchParams(searchParams);
     p.set('tab', newValue);
     setSearchParams(p, { replace: true });

--- a/src/pages/PRDetailsPage.tsx
+++ b/src/pages/PRDetailsPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useLayoutEffect, useRef, useState } from 'react';
 import { useSearchParams, useNavigate } from 'react-router-dom';
 import { Box, Tabs, Tab, CircularProgress, Typography } from '@mui/material';
 import { Page } from '../components/layout';
@@ -15,19 +15,68 @@ import { STATUS_COLORS } from '../theme';
 import VisibilityIcon from '@mui/icons-material/Visibility';
 import CodeIcon from '@mui/icons-material/Code';
 import ChatBubbleOutlineIcon from '@mui/icons-material/ChatBubbleOutline';
+import { readStoredTab, writeStoredTab } from '../utils/tabPreferences';
+
+const PR_DETAILS_TAB_STORAGE_KEY = 'gittensor-ui:pr-details-last-tab';
+
+const PR_TAB_SLUGS = ['overview', 'files', 'conversation'] as const;
 
 const PRDetailsPage: React.FC = () => {
-  const [searchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
   const navigate = useNavigate();
   const repository = searchParams.get('repo');
   const pullRequestNumber = searchParams.get('number');
   const [tabValue, setTabValue] = useState(0);
+  const tabInitForPr = useRef<string | null>(null);
 
   // Call hook unconditionally (React rules of hooks)
   const { data: prDetails, isLoading } = usePullRequestDetails(
     repository || '',
     pullRequestNumber ? parseInt(pullRequestNumber) : 0,
   );
+
+  const prRouteKey =
+    repository && pullRequestNumber ? `${repository}#${pullRequestNumber}` : '';
+
+  useLayoutEffect(() => {
+    if (!repository || !pullRequestNumber || !prDetails) {
+      return;
+    }
+    if (tabInitForPr.current === prRouteKey) {
+      return;
+    }
+    tabInitForPr.current = prRouteKey;
+
+    const tabFromUrl = searchParams.get('tab');
+    if (
+      tabFromUrl &&
+      PR_TAB_SLUGS.includes(tabFromUrl as (typeof PR_TAB_SLUGS)[number])
+    ) {
+      const idx = PR_TAB_SLUGS.indexOf(
+        tabFromUrl as (typeof PR_TAB_SLUGS)[number],
+      );
+      setTabValue(idx);
+      writeStoredTab(PR_DETAILS_TAB_STORAGE_KEY, PR_TAB_SLUGS[idx]);
+      return;
+    }
+
+    const saved = readStoredTab(PR_DETAILS_TAB_STORAGE_KEY);
+    const idx =
+      saved && PR_TAB_SLUGS.includes(saved as (typeof PR_TAB_SLUGS)[number])
+        ? PR_TAB_SLUGS.indexOf(saved as (typeof PR_TAB_SLUGS)[number])
+        : 0;
+    setTabValue(idx);
+    const p = new URLSearchParams(searchParams);
+    p.set('tab', PR_TAB_SLUGS[idx]);
+    setSearchParams(p, { replace: true });
+  }, [
+    repository,
+    pullRequestNumber,
+    prDetails,
+    prRouteKey,
+    searchParams,
+    setSearchParams,
+  ]);
 
   // If no repo or PR number is provided, redirect to miners page
   if (!repository || !pullRequestNumber) {
@@ -39,6 +88,11 @@ const PRDetailsPage: React.FC = () => {
 
   const handleTabChange = (_event: React.SyntheticEvent, newValue: number) => {
     setTabValue(newValue);
+    const slug = PR_TAB_SLUGS[newValue];
+    writeStoredTab(PR_DETAILS_TAB_STORAGE_KEY, slug);
+    const p = new URLSearchParams(searchParams);
+    p.set('tab', slug);
+    setSearchParams(p, { replace: true });
   };
 
   return (

--- a/src/pages/dashboard/views/LiveCommitLog.tsx
+++ b/src/pages/dashboard/views/LiveCommitLog.tsx
@@ -14,6 +14,9 @@ import {
 import { useNavigate } from 'react-router-dom';
 import { useInfiniteCommitLog } from '../../../api';
 import theme, { REPO_OWNER_AVATAR_BACKGROUNDS } from '../../../theme';
+import { useSelfIdentity } from '../../../hooks/useSelfIdentity';
+import { prAuthorMatchesSelf } from '../../../utils/selfIdentityMatch';
+import { selfHighlightSx } from '../../../utils/selfHighlightSx';
 
 const MONTH_SHORT = [
   'Jan',
@@ -116,7 +119,8 @@ const getScoreColor = (score: string) => {
 const CommitLogItem: React.FC<{
   entry: CommitLogEntry;
   isNew: boolean;
-}> = ({ entry, isNew }) => {
+  isSelf: boolean;
+}> = ({ entry, isNew, isSelf }) => {
   const navigate = useNavigate();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
   const isTablet = useMediaQuery(theme.breakpoints.between('sm', 'md'));
@@ -142,7 +146,7 @@ const CommitLogItem: React.FC<{
           { state: { backLabel: 'Back to Dashboard' } },
         )
       }
-      sx={{
+      sx={(t) => ({
         p: isMobile ? 0.75 : isTablet ? 1.25 : 1,
         borderRadius: 3,
         border: '1px solid',
@@ -150,6 +154,7 @@ const CommitLogItem: React.FC<{
           ? theme.palette.secondary.main
           : theme.palette.border.light,
         backgroundColor: theme.palette.surface.subtle,
+        ...selfHighlightSx(t, isSelf),
         backdropFilter: 'blur(8px)',
         transition: 'all 0.2s cubic-bezier(0.4, 0, 0.2, 1)',
         animation: isNew ? 'slideIn 0.5s ease-out' : undefined,
@@ -176,7 +181,7 @@ const CommitLogItem: React.FC<{
           from: { opacity: 0, transform: 'translateX(-20px)' },
           to: { opacity: 1, transform: 'translateX(0)' },
         },
-      }}
+      })}
     >
       <Stack
         spacing={isMobile ? 0.5 : isTablet ? 1 : 0.5}
@@ -267,9 +272,27 @@ const CommitLogItem: React.FC<{
             borderTop: `1px solid ${theme.palette.border.subtle}`,
           }}
         >
-          <Typography variant="caption" sx={{ color: 'text.secondary' }}>
-            by {entry.author}
-          </Typography>
+          <Stack direction="row" alignItems="center" spacing={0.75}>
+            <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+              by {entry.author}
+            </Typography>
+            {isSelf && (
+              <Chip
+                label="you"
+                size="small"
+                sx={{
+                  height: 16,
+                  fontSize: '0.55rem',
+                  fontWeight: 700,
+                  '& .MuiChip-label': { px: 0.5, py: 0 },
+                  borderColor: alpha(theme.palette.secondary.main, 0.45),
+                  color: 'secondary.main',
+                  backgroundColor: alpha(theme.palette.secondary.main, 0.12),
+                }}
+                variant="outlined"
+              />
+            )}
+          </Stack>
           <Stack direction="row" spacing={2}>
             <Stack direction="row" spacing={0.5} alignItems="center">
               <Typography
@@ -307,6 +330,7 @@ const CommitLogItem: React.FC<{
 const LiveCommitLog: React.FC = () => {
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
   const isTablet = useMediaQuery(theme.breakpoints.between('sm', 'md'));
+  const { prefs } = useSelfIdentity();
 
   const { data, isLoading, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useInfiniteCommitLog({ refetchInterval: 10000 });
@@ -579,7 +603,16 @@ const LiveCommitLog: React.FC = () => {
                   const isNew = newEntryIds.has(entryId);
 
                   return (
-                    <CommitLogItem key={entryId} entry={entry} isNew={isNew} />
+                    <CommitLogItem
+                      key={entryId}
+                      entry={entry}
+                      isNew={isNew}
+                      isSelf={prAuthorMatchesSelf(
+                        prefs,
+                        entry.author,
+                        entry.hotkey,
+                      )}
+                    />
                   );
                 })}
               </Stack>

--- a/src/tests/selfIdentityMatch.test.ts
+++ b/src/tests/selfIdentityMatch.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+import {
+  bountySolverMatchesSelf,
+  githubLoginMatches,
+  hotkeyMatches,
+  minerMatchesSelf,
+  normalizeGithubLogin,
+  prAuthorMatchesSelf,
+  submissionMatchesSelf,
+} from '../utils/selfIdentityMatch';
+
+describe('normalizeGithubLogin', () => {
+  it('trims and lowercases and strips @', () => {
+    expect(normalizeGithubLogin('  @OctoCat ')).toBe('octocat');
+  });
+});
+
+describe('githubLoginMatches', () => {
+  const prefs = { githubLogin: 'alice', hotkey: '' };
+  it('matches case-insensitively', () => {
+    expect(githubLoginMatches(prefs, 'Alice')).toBe(true);
+  });
+  it('returns false when prefs empty', () => {
+    expect(githubLoginMatches({ githubLogin: '', hotkey: '' }, 'bob')).toBe(
+      false,
+    );
+  });
+});
+
+describe('hotkeyMatches', () => {
+  const prefs = { githubLogin: '', hotkey: '5ABCdef' };
+  it('matches case-insensitively', () => {
+    expect(hotkeyMatches(prefs, '5abcdef')).toBe(true);
+  });
+});
+
+describe('minerMatchesSelf', () => {
+  it('matches author login', () => {
+    expect(
+      minerMatchesSelf(
+        { githubId: '99', author: 'carol', hotkey: 'hk1' },
+        { githubLogin: 'Carol', hotkey: '' },
+      ),
+    ).toBe(true);
+  });
+  it('matches non-numeric githubId as login', () => {
+    expect(
+      minerMatchesSelf(
+        { githubId: 'dave', author: '12345', hotkey: '' },
+        { githubLogin: 'Dave', hotkey: '' },
+      ),
+    ).toBe(true);
+  });
+  it('matches hotkey', () => {
+    expect(
+      minerMatchesSelf(
+        { githubId: '1', author: 'x', hotkey: 'SAME' },
+        { githubLogin: '', hotkey: 'same' },
+      ),
+    ).toBe(true);
+  });
+  it('does not treat numeric githubId as login', () => {
+    expect(
+      minerMatchesSelf(
+        { githubId: '12345', author: '999', hotkey: '' },
+        { githubLogin: '12345', hotkey: '' },
+      ),
+    ).toBe(false);
+  });
+});
+
+describe('prAuthorMatchesSelf', () => {
+  it('matches author or hotkey', () => {
+    const prefs = { githubLogin: 'bob', hotkey: 'hk99' };
+    expect(prAuthorMatchesSelf(prefs, 'Bob', null)).toBe(true);
+    expect(prAuthorMatchesSelf(prefs, 'other', 'HK99')).toBe(true);
+    expect(prAuthorMatchesSelf(prefs, 'other', null)).toBe(false);
+  });
+});
+
+describe('bountySolverMatchesSelf', () => {
+  it('uses hotkey only', () => {
+    expect(
+      bountySolverMatchesSelf(
+        { githubLogin: 'a', hotkey: 'solver' },
+        'Solver',
+      ),
+    ).toBe(true);
+  });
+});
+
+describe('submissionMatchesSelf', () => {
+  it('matches login or submission hotkey', () => {
+    expect(
+      submissionMatchesSelf(
+        { githubLogin: 'pat', hotkey: '' },
+        { authorLogin: 'Pat', hotkey: null },
+      ),
+    ).toBe(true);
+    expect(
+      submissionMatchesSelf(
+        { githubLogin: '', hotkey: 'hk' },
+        { authorLogin: 'x', hotkey: 'HK' },
+      ),
+    ).toBe(true);
+  });
+});

--- a/src/utils/selfHighlightSx.ts
+++ b/src/utils/selfHighlightSx.ts
@@ -1,0 +1,10 @@
+import { alpha, type Theme } from '@mui/material/styles';
+
+/** Subtle accent for rows/cards that belong to the configured identity. */
+export const selfHighlightSx = (theme: Theme, active: boolean) => {
+  if (!active) return {};
+  return {
+    borderLeft: `3px solid ${theme.palette.secondary.main}`,
+    backgroundColor: alpha(theme.palette.secondary.main, 0.08),
+  };
+};

--- a/src/utils/selfIdentityMatch.ts
+++ b/src/utils/selfIdentityMatch.ts
@@ -1,0 +1,94 @@
+/**
+ * Pure helpers for "This is me" highlighting (issue #526).
+ * Matching is case-insensitive. GitHub logins ignore leading @.
+ */
+
+export type SelfIdentityPrefs = {
+  githubLogin: string;
+  hotkey: string;
+};
+
+export const normalizeGithubLogin = (value: string | null | undefined): string =>
+  (value ?? '')
+    .trim()
+    .replace(/^@+/, '')
+    .toLowerCase();
+
+export const normalizeHotkey = (value: string | null | undefined): string =>
+  (value ?? '').trim().toLowerCase();
+
+export const githubLoginMatches = (
+  prefs: SelfIdentityPrefs,
+  candidate: string | null | undefined,
+): boolean => {
+  const self = normalizeGithubLogin(prefs.githubLogin);
+  if (!self) return false;
+  const other = normalizeGithubLogin(candidate);
+  return !!other && self === other;
+};
+
+export const hotkeyMatches = (
+  prefs: SelfIdentityPrefs,
+  candidate: string | null | undefined,
+): boolean => {
+  const self = normalizeHotkey(prefs.hotkey);
+  if (!self) return false;
+  const other = normalizeHotkey(candidate);
+  return !!other && self === other;
+};
+
+export type MinerSelfMatchInput = {
+  githubId: string;
+  author?: string;
+  hotkey: string;
+};
+
+/**
+ * Leaderboard miner cards: GitHub handle against `author` or non-numeric
+ * `githubId`, plus optional hotkey match against the miner's subnet hotkey.
+ */
+export const minerMatchesSelf = (
+  miner: MinerSelfMatchInput,
+  prefs: SelfIdentityPrefs,
+): boolean => {
+  if (hotkeyMatches(prefs, miner.hotkey)) return true;
+  if (githubLoginMatches(prefs, miner.author)) return true;
+  if (miner.githubId && !/^\d+$/.test(miner.githubId)) {
+    if (githubLoginMatches(prefs, miner.githubId)) return true;
+  }
+  return false;
+};
+
+export const prAuthorMatchesSelf = (
+  prefs: SelfIdentityPrefs,
+  author: string | null | undefined,
+  prHotkey?: string | null,
+): boolean =>
+  githubLoginMatches(prefs, author) || hotkeyMatches(prefs, prHotkey);
+
+export const bountySolverMatchesSelf = (
+  prefs: SelfIdentityPrefs,
+  solverHotkey: string | null | undefined,
+): boolean => hotkeyMatches(prefs, solverHotkey);
+
+export const contributorRowMatchesSelf = (
+  prefs: SelfIdentityPrefs,
+  contributor: { author: string; githubId: string },
+): boolean => {
+  if (githubLoginMatches(prefs, contributor.author)) return true;
+  if (
+    contributor.githubId &&
+    !/^\d+$/.test(contributor.githubId) &&
+    githubLoginMatches(prefs, contributor.githubId)
+  ) {
+    return true;
+  }
+  return false;
+};
+
+export const submissionMatchesSelf = (
+  prefs: SelfIdentityPrefs,
+  submission: { authorLogin: string; hotkey: string | null },
+): boolean =>
+  githubLoginMatches(prefs, submission.authorLogin) ||
+  hotkeyMatches(prefs, submission.hotkey);

--- a/src/utils/tabPreferences.ts
+++ b/src/utils/tabPreferences.ts
@@ -1,0 +1,26 @@
+/**
+ * Persist last-selected UI tabs in localStorage (per browser profile).
+ * Used when the URL does not specify a tab.
+ */
+
+export function readStoredTab(storageKey: string): string | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+  try {
+    return window.localStorage.getItem(storageKey);
+  } catch {
+    return null;
+  }
+}
+
+export function writeStoredTab(storageKey: string, value: string): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  try {
+    window.localStorage.setItem(storageKey, value);
+  } catch {
+    // ignore quota / private mode
+  }
+}


### PR DESCRIPTION
## Summary
Adds “This is me”: save a GitHub username and optional subnet hotkey in the browser, sync it across tabs, and highlight matching miners, PRs, live commits, bounty history, submissions, and repo contributors so your own rows are easy to spot.

## Problem
Leaderboards, PR tables, the live feed, and bounty views are crowded. Your rows looked like everyone else’s, so finding yourself meant repeated manual scanning after every visit.

## Solution
Persist identity in localStorage (per profile), with cross-tab sync (same pattern as the watchlist).
Sidebar UI to set values, Save, and Clear.
Subtle treatment: left accent + tinted background, plus a small “you” chip where it fits (e.g. miner cards, live commits).
Matching is case-insensitive; @ is stripped from GitHub handles. URLs are unchanged—this is optional local UI state.

## What changed
useSelfIdentity — storage key gittensor.selfIdentity.v1, useSyncExternalStore + storage listener.
SelfIdentityPanel + Sidebar — entry point for identity and clear.
selfIdentityMatch.ts + selfHighlightSx.ts — shared match logic and row/card sx helper.
Surfaces wired up: MinerCard, LeaderboardSidebar, LiveCommitLog, RepositoryPRsTable, MinerPRsTable, IssuesList (bounty history), IssueSubmissionsTable, RepositoryContributorsTable.
Tests: src/tests/selfIdentityMatch.test.ts (Vitest).

## How to test
Sidebar → This is me → username (optional hotkey) → Save.
Check leaderboard, dashboard live activity, repo/miner PR tables, bounties history, bounty detail submissions, repo contributors.
Open another tab; change or Clear and confirm behavior stays in sync.

## Checklist
[x] npm run test
[x] npm run build
[x] npm run lint
