### PR TITLE
fix: polish sidebar hover and watchlist dialog styling

### DIFF
--- a/src/components/leaderboard/LeaderboardSidebar.tsx
+++ b/src/components/leaderboard/LeaderboardSidebar.tsx
@@ -315,10 +315,11 @@ const LeaderboardRow: React.FC<LeaderboardRowProps> = ({
         display: 'flex',
         alignItems: 'center',
         py: 1,
+        px: 2,
+        mx: -2,
         cursor: 'pointer',
         '&:hover': {
           backgroundColor: alpha(theme.palette.text.primary, 0.03),
-          borderRadius: 1,
         },
       })}
     >

--- a/src/components/leaderboard/MinersList.tsx
+++ b/src/components/leaderboard/MinersList.tsx
@@ -119,7 +119,11 @@ export const MinersList: React.FC<MinersListProps> = ({
       cellSx: { p: 0 },
       renderCell: (miner) =>
         miner.githubId ? (
-          <WatchlistButton githubId={miner.githubId} size="small" />
+          <WatchlistButton
+            category="miners"
+            itemKey={miner.githubId}
+            size="small"
+          />
         ) : null,
     },
   ];

--- a/src/pages/WatchlistPage.tsx
+++ b/src/pages/WatchlistPage.tsx
@@ -254,21 +254,63 @@ const WatchlistPage: React.FC = () => {
         )}
       </Box>
 
-      <Dialog open={confirmOpen} onClose={() => setConfirmOpen(false)}>
-        <DialogTitle>
+      <Dialog
+        open={confirmOpen}
+        onClose={() => setConfirmOpen(false)}
+        PaperProps={{
+          sx: (t) => ({
+            backgroundColor: t.palette.background.default,
+            border: `1px solid ${t.palette.border.light}`,
+            borderRadius: 3,
+            backgroundImage: 'none',
+            p: 3,
+          }),
+        }}
+      >
+        <DialogTitle
+          sx={{
+            fontFamily: '"JetBrains Mono", monospace',
+            fontSize: '0.9rem',
+            fontWeight: 600,
+            p: 0,
+            mb: 3,
+          }}
+        >
           Clear all {count} pinned {count === 1 ? noun.single : noun.plural}?
         </DialogTitle>
-        <DialogActions>
+        <DialogActions sx={{ p: 0 }}>
           <Button
             onClick={() => setConfirmOpen(false)}
-            sx={{ textTransform: 'none' }}
+            sx={{
+              fontFamily: '"JetBrains Mono", monospace',
+              textTransform: 'none',
+              fontSize: '0.8rem',
+              color: 'rgba(255, 255, 255, 0.7)',
+              border: '1px solid rgba(255, 255, 255, 0.1)',
+              borderRadius: '8px',
+              px: 2,
+              '&:hover': {
+                color: '#ffffff',
+                borderColor: 'rgba(255, 255, 255, 0.2)',
+              },
+            }}
           >
             Cancel
           </Button>
           <Button
             onClick={handleClear}
-            color="error"
-            sx={{ textTransform: 'none' }}
+            sx={{
+              fontFamily: '"JetBrains Mono", monospace',
+              textTransform: 'none',
+              fontSize: '0.8rem',
+              color: '#ffffff',
+              backgroundColor: 'error.main',
+              borderRadius: '8px',
+              px: 2,
+              '&:hover': {
+                backgroundColor: 'error.dark',
+              },
+            }}
           >
             Clear {noun.plural}
           </Button>

--- a/src/pages/WatchlistPage.tsx
+++ b/src/pages/WatchlistPage.tsx
@@ -269,7 +269,6 @@ const WatchlistPage: React.FC = () => {
       >
         <DialogTitle
           sx={{
-            fontFamily: '"JetBrains Mono", monospace',
             fontSize: '0.9rem',
             fontWeight: 600,
             p: 0,
@@ -282,16 +281,16 @@ const WatchlistPage: React.FC = () => {
           <Button
             onClick={() => setConfirmOpen(false)}
             sx={{
-              fontFamily: '"JetBrains Mono", monospace',
               textTransform: 'none',
               fontSize: '0.8rem',
-              color: 'rgba(255, 255, 255, 0.7)',
-              border: '1px solid rgba(255, 255, 255, 0.1)',
-              borderRadius: '8px',
+              color: (t) => alpha(t.palette.text.primary, 0.7),
+              border: '1px solid',
+              borderColor: 'border.light',
+              borderRadius: 2,
               px: 2,
               '&:hover': {
-                color: '#ffffff',
-                borderColor: 'rgba(255, 255, 255, 0.2)',
+                color: 'text.primary',
+                borderColor: 'border.medium',
               },
             }}
           >
@@ -300,12 +299,11 @@ const WatchlistPage: React.FC = () => {
           <Button
             onClick={handleClear}
             sx={{
-              fontFamily: '"JetBrains Mono", monospace',
               textTransform: 'none',
               fontSize: '0.8rem',
-              color: '#ffffff',
+              color: 'common.white',
               backgroundColor: 'error.main',
-              borderRadius: '8px',
+              borderRadius: 2,
               px: 2,
               '&:hover': {
                 backgroundColor: 'error.dark',


### PR DESCRIPTION
## Summary
- Extend leaderboard row hover background to full width in the sidebar by matching negative margin to parent padding
- Style the watchlist "Clear all pinned miners?" dialog to match the project's dark theme — JetBrains Mono font, `background.default`, `border.light` border, and button styles consistent with the `back` variant

## Test plan
- [x] Open OSS Contributions or Discoveries page — hover sidebar Top Earners / Most Active rows and verify hover covers full width edge-to-edge
- [x] Open Watchlist with pinned miners — click "Clear watchlist" and verify dialog matches dark theme (black background, border, mono font, styled buttons)
- [x] Confirm Cancel and Clear actions still work correctly

<img width="1827" height="693" alt="a" src="https://github.com/user-attachments/assets/d1a6fa29-9f1c-418d-8bc4-f9e18a500dd1" />
<img width="1820" height="693" alt="Screenshot 2026-04-20 085647" src="https://github.com/user-attachments/assets/4bd31598-3521-4d76-849d-abd0e19e9aa8" />


Before
<img width="1816" height="708" alt="before" src="https://github.com/user-attachments/assets/7c5e5653-7113-411e-bd4c-8f7c08163f4d" />
