### PR TITLE
feat(repositories): make repo name link directly to GitHub

### DIFF
--- a/src/components/leaderboard/TopRepositoriesTable.tsx
+++ b/src/components/leaderboard/TopRepositoriesTable.tsx
@@ -934,8 +934,31 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
                           sx={{ ...bodyCellStyle, width: '35%', pl: 1.5 }}
                         >
                           <Box
+                            onClick={(e) => {
+                              e.preventDefault();
+                              e.stopPropagation();
+                              window.open(
+                                `https://github.com/${repo.repository || ''}`,
+                                '_blank',
+                                'noopener,noreferrer',
+                              );
+                            }}
+                            role="link"
+                            tabIndex={0}
+                            onKeyDown={(e) => {
+                              if (e.key === 'Enter' || e.key === ' ') {
+                                e.preventDefault();
+                                e.stopPropagation();
+                                window.open(
+                                  `https://github.com/${repo.repository || ''}`,
+                                  '_blank',
+                                  'noopener,noreferrer',
+                                );
+                              }
+                            }}
+                            aria-label={`Open ${repo.repository || ''} on GitHub`}
                             sx={{
-                              display: 'flex',
+                              display: 'inline-flex',
                               alignItems: 'center',
                               gap: 1,
                               cursor: 'pointer',
@@ -962,7 +985,7 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
                               }}
                             />
                             <Tooltip
-                              title={repo.repository || ''}
+                              title={`Open ${repo.repository || ''} on GitHub`}
                               placement="top"
                             >
                               <Typography


### PR DESCRIPTION
## Summary

On the Repositories page, split the click target per row:

- Click the **repo name** (e.g. `entrius/gittensor`) → opens the repo on GitHub in a new tab.
- Click **anywhere else on the row** → opens the repository details page (unchanged).

Previously, reaching a repo's GitHub URL required opening the (slow-loading) details page first and then clicking "View on GitHub." This makes the common "go to GitHub" action a single click.

## Related Issues

Closes https://github.com/entrius/gittensor-ui/issues/551
<!-- Link to related issues: Fixes #123, Closes #456 -->

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots
https://github.com/user-attachments/assets/bcbb75bb-a7e6-4b18-900e-837b06722428


## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [ ] Responsive/mobile checked
- [ ] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes