### PR TITLE
Watchlist: dual eligibility cards, improved layout, and performance

### DIFF
--- a/src/components/common/SearchInput.tsx
+++ b/src/components/common/SearchInput.tsx
@@ -8,6 +8,9 @@ interface SearchInputProps {
   onChange: (value: string) => void;
   width?: number | string;
   placeholder?: string;
+  inputRef?: React.Ref<HTMLInputElement>;
+  autoFocus?: boolean;
+  onBlur?: React.FocusEventHandler<HTMLInputElement>;
 }
 
 export const SearchInput: React.FC<SearchInputProps> = ({
@@ -15,12 +18,18 @@ export const SearchInput: React.FC<SearchInputProps> = ({
   onChange,
   width = 180,
   placeholder = 'Search...',
+  inputRef,
+  autoFocus = false,
+  onBlur,
 }) => (
   <TextField
+    inputRef={inputRef}
+    autoFocus={autoFocus}
     placeholder={placeholder}
     size="small"
     value={value}
     onChange={(e) => onChange(e.target.value)}
+    onBlur={onBlur}
     InputProps={{
       startAdornment: (
         <InputAdornment position="start">

--- a/src/components/leaderboard/MinerCard.tsx
+++ b/src/components/leaderboard/MinerCard.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { Box, Card, Typography, Avatar } from '@mui/material';
 import { alpha, useTheme } from '@mui/material/styles';
 import ReactECharts from 'echarts-for-react';
@@ -49,6 +49,8 @@ const getSegments = (
 ): Segment[] =>
   variant === 'discoveries' ? getIssueSegments(miner) : getPrSegments(miner);
 
+const isNumericGithubAuthor = (value?: string) => !value || /^\d+$/.test(value);
+
 export const MinerCard: React.FC<MinerCardProps> = ({
   miner,
   href,
@@ -57,15 +59,14 @@ export const MinerCard: React.FC<MinerCardProps> = ({
   showDualEligibilityBadges = false,
 }) => {
   const linkProps = useLinkBehavior(href, { state: linkState });
-  const isNumericId = (value?: string) => !value || /^\d+$/.test(value);
-  const shouldFetch = !!miner.githubId && isNumericId(miner.author);
+  const shouldFetch = !!miner.githubId && isNumericGithubAuthor(miner.author);
   const { data: githubData } = useMinerGithubData(miner.githubId, shouldFetch);
   const { data: prs } = useMinerPRs(miner.githubId, shouldFetch);
 
   const username =
     githubData?.login ||
     prs?.[0]?.author ||
-    (!isNumericId(miner.author) ? miner.author : miner.githubId) ||
+    (!isNumericGithubAuthor(miner.author) ? miner.author : miner.githubId) ||
     miner.githubId ||
     '';
   const avatarSrc = githubData?.avatarUrl || getGithubAvatarSrc(username);
@@ -87,6 +88,136 @@ export const MinerCard: React.FC<MinerCardProps> = ({
       : baseEligible;
 
   const segments = getSegments(miner, variant);
+
+  const minerIdentity = (
+    <Box
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 1.5,
+        minWidth: 0,
+        flex: { sm: '1 1 0%' },
+      }}
+    >
+      <Avatar
+        src={avatarSrc}
+        sx={(theme) => ({
+          width: 36,
+          height: 36,
+          border: '2px solid',
+          borderColor: isEligible
+            ? alpha(theme.palette.status.merged, 0.3)
+            : theme.palette.border.subtle,
+          filter: isEligible ? 'none' : 'grayscale(100%)',
+          opacity: isEligible ? 1 : INACTIVE_OPACITY,
+          flexShrink: 0,
+        })}
+      />
+      <Box
+        sx={{
+          minWidth: 0,
+          minHeight: 36,
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'space-between',
+          overflow: 'hidden',
+        }}
+      >
+        <Typography
+          sx={(theme) => ({
+            fontFamily: FONTS.mono,
+            fontSize: '1rem',
+            fontWeight: 700,
+            color: isEligible
+              ? theme.palette.text.primary
+              : theme.palette.text.tertiary,
+            opacity: isEligible ? 1 : INACTIVE_OPACITY,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          })}
+        >
+          {username}
+        </Typography>
+        <Typography
+          sx={(theme) => ({
+            fontFamily: FONTS.mono,
+            fontSize: '0.72rem',
+            fontWeight: 700,
+            color: isEligible
+              ? theme.palette.status.merged
+              : theme.palette.text.tertiary,
+            opacity: isEligible ? 1 : INACTIVE_OPACITY,
+            lineHeight: 1,
+            mt: 0.1,
+          })}
+        >
+          #{miner.rank}
+        </Typography>
+      </Box>
+    </Box>
+  );
+
+  const dualEligibilityPills = (
+    <>
+      <Typography
+        sx={(theme) => ({
+          fontFamily: FONTS.mono,
+          fontSize: { xs: '0.6rem', sm: '0.65rem' },
+          fontWeight: 700,
+          textTransform: 'uppercase',
+          border: `1px solid ${
+            ossEligible
+              ? alpha(theme.palette.status.merged, 0.45)
+              : theme.palette.border.subtle
+          }`,
+          borderRadius: 1,
+          px: { xs: 0.65, sm: 0.75 },
+          py: 0.35,
+          letterSpacing: { xs: '0.04em', sm: '0.06em' },
+          color: ossEligible
+            ? theme.palette.status.merged
+            : theme.palette.text.secondary,
+          backgroundColor: ossEligible
+            ? alpha(theme.palette.status.merged, 0.08)
+            : theme.palette.surface.subtle,
+          lineHeight: 1.2,
+          flexShrink: 0,
+          whiteSpace: 'nowrap',
+        })}
+      >
+        OSS {ossEligible ? 'Eligible' : 'Ineligible'}
+      </Typography>
+      <Typography
+        sx={(theme) => ({
+          fontFamily: FONTS.mono,
+          fontSize: { xs: '0.6rem', sm: '0.65rem' },
+          fontWeight: 700,
+          textTransform: 'uppercase',
+          border: `1px solid ${
+            discoveriesEligible
+              ? alpha(theme.palette.status.merged, 0.45)
+              : theme.palette.border.subtle
+          }`,
+          borderRadius: 1,
+          px: { xs: 0.65, sm: 0.75 },
+          py: 0.35,
+          letterSpacing: { xs: '0.04em', sm: '0.06em' },
+          color: discoveriesEligible
+            ? theme.palette.status.merged
+            : theme.palette.text.secondary,
+          backgroundColor: discoveriesEligible
+            ? alpha(theme.palette.status.merged, 0.08)
+            : theme.palette.surface.subtle,
+          lineHeight: 1.2,
+          flexShrink: 0,
+          whiteSpace: 'nowrap',
+        })}
+      >
+        Issues {discoveriesEligible ? 'Eligible' : 'Ineligible'}
+      </Typography>
+    </>
+  );
 
   return (
     <Card
@@ -129,165 +260,127 @@ export const MinerCard: React.FC<MinerCardProps> = ({
       })}
       elevation={0}
     >
-      <Box
-        sx={{
-          display: 'flex',
-          justifyContent: 'space-between',
-          alignItems: 'flex-start',
-        }}
-      >
-        <Box
-          sx={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: 1.5,
-            minWidth: 0,
-          }}
-        >
-          <Avatar
-            src={avatarSrc}
-            sx={(theme) => ({
-              width: 36,
-              height: 36,
-              border: '2px solid',
-              borderColor: isEligible
-                ? alpha(theme.palette.status.merged, 0.3)
-                : theme.palette.border.subtle,
-              filter: isEligible ? 'none' : 'grayscale(100%)',
-              opacity: isEligible ? 1 : INACTIVE_OPACITY,
-              flexShrink: 0,
-            })}
-          />
+      {showDualEligibilityBadges ? (
+        <>
           <Box
             sx={{
-              minWidth: 0,
-              minHeight: 36,
-              display: 'flex',
+              display: { xs: 'flex', sm: 'none' },
               flexDirection: 'column',
-              justifyContent: 'space-between',
-              overflow: 'hidden',
+              gap: 1,
             }}
           >
-            <Typography
-              sx={(theme) => ({
-                fontFamily: FONTS.mono,
-                fontSize: '1rem',
-                fontWeight: 700,
-                color: isEligible
-                  ? theme.palette.text.primary
-                  : theme.palette.text.tertiary,
-                opacity: isEligible ? 1 : INACTIVE_OPACITY,
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
-                whiteSpace: 'nowrap',
-              })}
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                gap: 1,
+                minWidth: 0,
+              }}
             >
-              {username}
-            </Typography>
-            <Typography
-              sx={(theme) => ({
-                fontFamily: FONTS.mono,
-                fontSize: '0.72rem',
-                fontWeight: 700,
-                color: isEligible
-                  ? theme.palette.status.merged
-                  : theme.palette.text.tertiary,
-                opacity: isEligible ? 1 : INACTIVE_OPACITY,
-                lineHeight: 1,
-                mt: 0.1,
-              })}
+              {minerIdentity}
+              {miner.githubId && (
+                <WatchlistButton githubId={miner.githubId} size="small" />
+              )}
+            </Box>
+            <Box
+              sx={{
+                display: 'flex',
+                flexWrap: 'wrap',
+                alignItems: 'center',
+                columnGap: 0.75,
+                rowGap: 0.75,
+              }}
             >
-              #{miner.rank}
-            </Typography>
+              {dualEligibilityPills}
+            </Box>
           </Box>
-        </Box>
+          <Box
+            sx={{
+              display: { xs: 'none', sm: 'flex' },
+              justifyContent: 'space-between',
+              alignItems: 'center',
+              gap: 1,
+              width: '100%',
+              minWidth: 0,
+            }}
+          >
+            {minerIdentity}
+            <Box
+              sx={{
+                display: 'flex',
+                flexDirection: 'row',
+                alignItems: 'center',
+                justifyContent: 'flex-end',
+                gap: { sm: 0.5, md: 0.75 },
+                flexShrink: 0,
+                flexWrap: 'nowrap',
+                minWidth: 0,
+              }}
+            >
+              <Box
+                sx={{
+                  display: 'flex',
+                  flexDirection: 'row',
+                  alignItems: 'center',
+                  gap: { sm: 0.45, md: 0.5 },
+                  flexWrap: 'nowrap',
+                  flexShrink: 0,
+                }}
+              >
+                {dualEligibilityPills}
+              </Box>
+              {miner.githubId && (
+                <WatchlistButton githubId={miner.githubId} size="small" />
+              )}
+            </Box>
+          </Box>
+        </>
+      ) : (
         <Box
           sx={{
             display: 'flex',
-            alignItems: 'center',
-            gap: 0.5,
-            flexShrink: 0,
-            flexWrap: 'wrap',
-            justifyContent: 'flex-end',
+            justifyContent: 'space-between',
+            alignItems: 'flex-start',
+            gap: 1,
           }}
         >
-          {showDualEligibilityBadges ? (
-            <>
+          {minerIdentity}
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 0.5,
+              flexShrink: 0,
+              flexWrap: 'wrap',
+              justifyContent: 'flex-end',
+            }}
+          >
+            {!isEligible ? (
               <Typography
                 sx={(theme) => ({
                   fontFamily: FONTS.mono,
                   fontSize: '0.65rem',
                   fontWeight: 700,
+                  color: theme.palette.text.secondary,
                   textTransform: 'uppercase',
-                  border: `1px solid ${
-                    ossEligible
-                      ? alpha(theme.palette.status.merged, 0.45)
-                      : theme.palette.border.subtle
-                  }`,
+                  border: `1px solid ${theme.palette.border.subtle}`,
                   borderRadius: 1,
                   px: 0.75,
                   py: 0.25,
                   letterSpacing: '0.06em',
-                  color: ossEligible
-                    ? theme.palette.status.merged
-                    : theme.palette.text.secondary,
-                  backgroundColor: ossEligible
-                    ? alpha(theme.palette.status.merged, 0.08)
-                    : theme.palette.surface.subtle,
+                  backgroundColor: theme.palette.surface.subtle,
                 })}
               >
-                OSS {ossEligible ? 'Eligible' : 'Ineligible'}
+                Ineligible
               </Typography>
-              <Typography
-                sx={(theme) => ({
-                  fontFamily: FONTS.mono,
-                  fontSize: '0.65rem',
-                  fontWeight: 700,
-                  textTransform: 'uppercase',
-                  border: `1px solid ${
-                    discoveriesEligible
-                      ? alpha(theme.palette.status.merged, 0.45)
-                      : theme.palette.border.subtle
-                  }`,
-                  borderRadius: 1,
-                  px: 0.75,
-                  py: 0.25,
-                  letterSpacing: '0.06em',
-                  color: discoveriesEligible
-                    ? theme.palette.status.merged
-                    : theme.palette.text.secondary,
-                  backgroundColor: discoveriesEligible
-                    ? alpha(theme.palette.status.merged, 0.08)
-                    : theme.palette.surface.subtle,
-                })}
-              >
-                Issues {discoveriesEligible ? 'Eligible' : 'Ineligible'}
-              </Typography>
-            </>
-          ) : !isEligible ? (
-            <Typography
-              sx={(theme) => ({
-                fontFamily: FONTS.mono,
-                fontSize: '0.65rem',
-                fontWeight: 700,
-                color: theme.palette.text.secondary,
-                textTransform: 'uppercase',
-                border: `1px solid ${theme.palette.border.subtle}`,
-                borderRadius: 1,
-                px: 0.75,
-                py: 0.25,
-                letterSpacing: '0.06em',
-                backgroundColor: theme.palette.surface.subtle,
-              })}
-            >
-              Ineligible
-            </Typography>
-          ) : null}
-          {miner.githubId && (
-            <WatchlistButton githubId={miner.githubId} size="small" />
-          )}
+            ) : null}
+            {miner.githubId && (
+              <WatchlistButton githubId={miner.githubId} size="small" />
+            )}
+          </Box>
         </Box>
-      </Box>
+      )}
 
       <Box
         sx={{
@@ -597,6 +690,38 @@ const CredDonut: React.FC<CredDonutProps> = ({
   size = 48,
 }) => {
   const muiTheme = useTheme();
+  const segmentFingerprint = segments.map((s) => s.value).join(',');
+
+  const chartOption = useMemo(() => {
+    const values =
+      segmentFingerprint === ''
+        ? []
+        : segmentFingerprint.split(',').map((v) => Number(v));
+
+    return {
+      backgroundColor: 'transparent',
+      series: [
+        {
+          type: 'pie' as const,
+          radius: ['65%', '90%'],
+          silent: true,
+          label: { show: false },
+          itemStyle: { borderRadius: 3, borderWidth: 0 },
+          data: values.map((value, i) => ({
+            value,
+            itemStyle: {
+              color: isEligible
+                ? CHART_SEGMENT_COLORS[i]
+                : alpha(
+                    muiTheme.palette.text.secondary,
+                    INACTIVE_OPACITY * CHART_INACTIVE_RATIOS[i],
+                  ),
+            },
+          })),
+        },
+      ],
+    };
+  }, [segmentFingerprint, isEligible, muiTheme]);
 
   return (
     <Box
@@ -616,31 +741,10 @@ const CredDonut: React.FC<CredDonutProps> = ({
         }}
       >
         <ReactECharts
-          option={{
-            backgroundColor: 'transparent',
-            series: [
-              {
-                type: 'pie',
-                radius: ['65%', '90%'],
-                silent: true,
-                label: { show: false },
-                itemStyle: { borderRadius: 3, borderWidth: 0 },
-                data: segments.map((segment, i) => ({
-                  value: segment.value,
-                  itemStyle: {
-                    color: isEligible
-                      ? CHART_SEGMENT_COLORS[i]
-                      : alpha(
-                          muiTheme.palette.text.secondary,
-                          INACTIVE_OPACITY * CHART_INACTIVE_RATIOS[i],
-                        ),
-                  },
-                })),
-              },
-            ],
-          }}
+          option={chartOption}
           style={{ width: '100%', height: '100%' }}
           opts={{ renderer: 'svg' }}
+          lazyUpdate
         />
         <Box
           sx={{

--- a/src/components/leaderboard/TopMinersTable.tsx
+++ b/src/components/leaderboard/TopMinersTable.tsx
@@ -1,6 +1,20 @@
-import React, { useCallback, useEffect, useMemo } from 'react';
-import { Box, Typography, CircularProgress, Grid } from '@mui/material';
-import { alpha, type Theme } from '@mui/material/styles';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import SearchIcon from '@mui/icons-material/Search';
+import {
+  Box,
+  Typography,
+  CircularProgress,
+  Grid,
+  IconButton,
+  useMediaQuery,
+} from '@mui/material';
+import { alpha, useTheme, type Theme } from '@mui/material/styles';
 import { useSearchParams } from 'react-router-dom';
 import { SectionCard } from './SectionCard';
 import { MinerCard } from './MinerCard';
@@ -78,6 +92,25 @@ const getVisibleCountFromQuery = (value: string | null): number => {
   return parsed;
 };
 
+/** Stable sort helper — avoids recreating closures on every TopMinersTable render. */
+const sortMinersList = (list: MinerStats[], option: SortOption): MinerStats[] =>
+  [...list].sort((a, b) => {
+    switch (option) {
+      case 'totalScore':
+        return b.totalScore - a.totalScore;
+      case 'usdPerDay':
+        return (b.usdPerDay ?? 0) - (a.usdPerDay ?? 0);
+      case 'totalPRs':
+        return b.totalPRs - a.totalPRs;
+      case 'totalIssues':
+        return (b.totalIssues ?? 0) - (a.totalIssues ?? 0);
+      case 'credibility':
+        return (b.credibility ?? 0) - (a.credibility ?? 0);
+      default:
+        return 0;
+    }
+  });
+
 const TopMinersTable: React.FC<TopMinersTableProps> = ({
   miners,
   isLoading,
@@ -101,6 +134,15 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
     () => getVisibleCountFromQuery(searchParams.get(VISIBLE_QUERY_PARAM)),
     [searchParams],
   );
+
+  const theme = useTheme();
+  const isSmUp = useMediaQuery(theme.breakpoints.up('sm'));
+  const [mobileSearchOpen, setMobileSearchOpen] = useState(false);
+  const mobileSearchInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (isSmUp) setMobileSearchOpen(false);
+  }, [isSmUp]);
 
   const handleSortChange = useCallback(
     (nextSortOption: SortOption) => {
@@ -150,28 +192,19 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
     [setSearchParams],
   );
 
-  // Helper to sort a list of miners
-  const sortMinersList = (list: MinerStats[], option: SortOption) =>
-    [...list].sort((a, b) => {
-      switch (option) {
-        case 'totalScore':
-          return b.totalScore - a.totalScore;
-        case 'usdPerDay':
-          return (b.usdPerDay ?? 0) - (a.usdPerDay ?? 0);
-        case 'totalPRs':
-          return b.totalPRs - a.totalPRs;
-        case 'totalIssues':
-          return (b.totalIssues ?? 0) - (a.totalIssues ?? 0);
-        case 'credibility':
-          return (b.credibility ?? 0) - (a.credibility ?? 0);
-        default:
-          return 0;
-      }
-    });
+  const minersAfterEligibilityOnly = useMemo(() => {
+    let result = [...miners];
+    if (eligibilityFilter === 'eligible') {
+      result = result.filter((m) => m.isEligible);
+    } else if (eligibilityFilter === 'ineligible') {
+      result = result.filter((m) => !m.isEligible);
+    }
+    return result;
+  }, [miners, eligibilityFilter]);
 
   // Process and filter miners
   const filteredMiners = useMemo(() => {
-    let result = [...miners];
+    let result = [...minersAfterEligibilityOnly];
 
     if (searchQuery) {
       const lowerQuery = searchQuery.toLowerCase();
@@ -182,17 +215,11 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
       );
     }
 
-    if (eligibilityFilter === 'eligible') {
-      result = result.filter((m) => m.isEligible);
-    } else if (eligibilityFilter === 'ineligible') {
-      result = result.filter((m) => !m.isEligible);
-    }
-
     return sortMinersList(result, sortOption).map((miner, index) => ({
       ...miner,
       rank: index + 1,
     }));
-  }, [miners, searchQuery, eligibilityFilter, sortOption]);
+  }, [minersAfterEligibilityOnly, searchQuery, sortOption]);
 
   useEffect(() => {
     if (visibleCount <= filteredMiners.length) return;
@@ -210,12 +237,21 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
     );
   }, [filteredMiners.length, setSearchParams, visibleCount]);
 
+  const handleMobileSearchBlur = useCallback(() => {
+    if (!isSmUp && !searchQuery.trim()) {
+      setMobileSearchOpen(false);
+    }
+  }, [isSmUp, searchQuery]);
+
   const handleSearchChange = useCallback(
     (nextQuery: string) => {
+      const normalizedQuery = nextQuery.trim();
+      if (!normalizedQuery && !isSmUp) {
+        setMobileSearchOpen(false);
+      }
       setSearchParams(
         (previousParams) => {
           const nextSearchParams = new URLSearchParams(previousParams);
-          const normalizedQuery = nextQuery.trim();
 
           if (normalizedQuery) {
             nextSearchParams.set(SEARCH_QUERY_PARAM, normalizedQuery);
@@ -231,7 +267,7 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
         { replace: true },
       );
     },
-    [setSearchParams],
+    [isSmUp, setSearchParams],
   );
 
   const visibleMiners = useMemo(
@@ -244,6 +280,13 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
     filteredMiners.length - visibleMiners.length,
   );
 
+  const searchActive = searchQuery.trim().length > 0;
+  const minersTitle = searchActive
+    ? `Miners (${filteredMiners.length}/${minersAfterEligibilityOnly.length})`
+    : `Miners (${filteredMiners.length})`;
+
+  const showMobileSearchField = isSmUp || mobileSearchOpen || searchActive;
+
   if (isLoading) {
     return (
       <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
@@ -253,7 +296,7 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
   }
 
   return (
-    <Box sx={{ p: 2 }}>
+    <Box sx={{ p: { xs: 0, sm: 2 } }}>
       {/* Header Card — two-row toolbar */}
       <SectionCard
         sx={{
@@ -269,31 +312,78 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
           boxShadow: 'none',
         }}
       >
-        <Box sx={{ p: 2, display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+        <Box
+          sx={{
+            p: { xs: 1.25, sm: 2 },
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 1.5,
+          }}
+        >
           {/* Row 1: Title + Search */}
           <Box
             sx={{
               display: 'flex',
               alignItems: 'center',
-              gap: 2,
-              flexWrap: { xs: 'wrap', sm: 'nowrap' },
+              gap: { xs: 1, sm: 2 },
+              flexWrap: 'nowrap',
+              width: '100%',
+              minWidth: 0,
             }}
           >
             <Typography
               variant="h6"
-              sx={{ fontSize: '1.25rem', fontWeight: 600, flexShrink: 0 }}
+              sx={{
+                fontSize: { xs: '1.05rem', sm: '1.25rem' },
+                fontWeight: 600,
+                flexShrink: 0,
+                minWidth: 0,
+              }}
             >
-              Miners ({filteredMiners.length})
+              {minersTitle}
             </Typography>
             <Box
-              sx={{ flex: 1, minWidth: 0, width: { xs: '100%', sm: 'auto' } }}
+              sx={{
+                flex: 1,
+                minWidth: 0,
+                display: 'flex',
+                justifyContent: { xs: 'flex-end', sm: 'stretch' },
+                alignItems: 'center',
+              }}
             >
-              <SearchInput
-                value={searchQuery}
-                onChange={handleSearchChange}
-                width="100%"
-                placeholder="Search miners..."
-              />
+              {showMobileSearchField ? (
+                <Box sx={{ width: '100%', maxWidth: { sm: 'none' } }}>
+                  <SearchInput
+                    value={searchQuery}
+                    onChange={handleSearchChange}
+                    width="100%"
+                    placeholder="Search miners..."
+                    inputRef={mobileSearchInputRef}
+                    autoFocus={!isSmUp && mobileSearchOpen}
+                    onBlur={handleMobileSearchBlur}
+                  />
+                </Box>
+              ) : (
+                <IconButton
+                  type="button"
+                  size="small"
+                  aria-label="Search miners"
+                  onClick={() => {
+                    setMobileSearchOpen(true);
+                    requestAnimationFrame(() => {
+                      mobileSearchInputRef.current?.focus();
+                    });
+                  }}
+                  sx={(t) => ({
+                    color: t.palette.text.secondary,
+                    border: `1px solid ${t.palette.border.light}`,
+                    borderRadius: 2,
+                    p: 0.75,
+                  })}
+                >
+                  <SearchIcon sx={{ fontSize: '1.15rem' }} />
+                </IconButton>
+              )}
             </Box>
           </Box>
 
@@ -301,10 +391,10 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
           <Box
             sx={{
               display: 'flex',
-              alignItems: 'center',
+              flexDirection: { xs: 'column', lg: 'row' },
+              alignItems: { xs: 'stretch', lg: 'center' },
               justifyContent: 'space-between',
-              gap: 1,
-              flexWrap: 'wrap',
+              gap: { xs: 1.25, lg: 1 },
             }}
           >
             <SortButtons
@@ -312,10 +402,18 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
               onSortChange={handleSortChange}
               variant={variant}
             />
-            <EligibilityToggle
-              value={eligibilityFilter}
-              onChange={handleEligibilityChange}
-            />
+            <Box
+              sx={{
+                display: 'flex',
+                justifyContent: { xs: 'center', lg: 'flex-end' },
+                flexShrink: 0,
+              }}
+            >
+              <EligibilityToggle
+                value={eligibilityFilter}
+                onChange={handleEligibilityChange}
+              />
+            </Box>
           </Box>
         </Box>
       </SectionCard>
@@ -324,7 +422,7 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
         {filteredMiners.length > 0 && (
           <Grid container spacing={2}>
             {visibleMiners.map((miner) => (
-              <Grid item xs={12} sm={12} md={6} lg={4} xl={4} key={miner.id}>
+              <Grid item xs={12} sm={12} md={6} lg={6} xl={4} key={miner.id}>
                 <MinerCard
                   miner={miner}
                   variant={variant}
@@ -431,8 +529,16 @@ const SortButtons: React.FC<SortButtonsProps> = ({
     sx={{
       display: 'flex',
       gap: 0.5,
-      flexWrap: 'wrap',
-      justifyContent: 'center',
+      flexWrap: 'nowrap',
+      justifyContent: { xs: 'flex-start', lg: 'center' },
+      width: { xs: '100%', lg: 'auto' },
+      minWidth: 0,
+      overflowX: 'auto',
+      pb: 0.25,
+      mx: { xs: -0.25, sm: 0 },
+      px: { xs: 0.25, sm: 0 },
+      WebkitOverflowScrolling: 'touch',
+      scrollbarWidth: 'thin',
     }}
   >
     {[
@@ -451,9 +557,12 @@ const SortButtons: React.FC<SortButtonsProps> = ({
         onClick={() => onSortChange(option.value as SortOption)}
         sx={(theme) => ({
           px: 1.5,
-          height: 32,
+          py: { xs: 0.75, sm: 0 },
+          minHeight: { xs: 40, sm: 32 },
+          height: { xs: 'auto', sm: 32 },
           display: 'flex',
           alignItems: 'center',
+          flexShrink: 0,
           borderRadius: 2,
           cursor: 'pointer',
           backgroundColor:
@@ -479,8 +588,9 @@ const SortButtons: React.FC<SortButtonsProps> = ({
         <Typography
           sx={{
             fontFamily: FONTS.mono,
-            fontSize: '0.75rem',
+            fontSize: { xs: '0.72rem', sm: '0.75rem' },
             fontWeight: 600,
+            whiteSpace: 'nowrap',
           }}
         >
           {option.label}
@@ -508,11 +618,15 @@ const EligibilityToggle: React.FC<EligibilityToggleProps> = ({
 }) => (
   <Box
     sx={(theme) => ({
-      display: 'inline-flex',
+      display: 'flex',
+      flexWrap: { xs: 'wrap', sm: 'nowrap' },
+      justifyContent: 'center',
       gap: 0.5,
       p: 0.5,
       borderRadius: 2,
       backgroundColor: theme.palette.surface.light,
+      width: { xs: '100%', sm: 'auto' },
+      maxWidth: { xs: 420, sm: 'none' },
     })}
   >
     {ELIGIBILITY_OPTIONS.map((option) => {
@@ -526,9 +640,12 @@ const EligibilityToggle: React.FC<EligibilityToggleProps> = ({
           onClick={() => onChange(option.value)}
           sx={(theme) => ({
             px: 1.5,
-            height: 24,
+            minHeight: { xs: 36, sm: 24 },
+            height: { xs: 'auto', sm: 24 },
+            flex: { xs: '1 1 auto', sm: '0 0 auto' },
             display: 'flex',
             alignItems: 'center',
+            justifyContent: 'center',
             border: 0,
             borderRadius: 1.5,
             backgroundColor: isActive


### PR DESCRIPTION
## Summary

Adds a **Watchlist leaderboard** with dual eligibility (OSS + Issues), improving clarity of miner performance and insights.

- Introduces `watchlist` variant in `TopMinersTable` with search, sort, filters, and sticky header  
- Enhances `MinerCard` with **dual eligibility pills** and **two CredDonuts (PR vs Issues)**  
- Improves **responsive layout**, mobile UX, and rendering performance (memoization, hoisted helpers)

## Type of Change

- [x] Bug fix
- [x] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Other (CI, dev tooling)

## Screenshots

**Before**
<img width="338" height="694" alt="before" src="https://github.com/user-attachments/assets/42f3bad0-e837-4ee5-9847-9ed07dae5c15" />


[gorec-2026-04-22-03-24-18.webm](https://github.com/user-attachments/assets/d8d56a54-5389-4ff0-8205-5c5117cabc5b)


**After**

<img width="360" height="740" alt="image" src="https://github.com/user-attachments/assets/43228ac5-623f-4153-bc50-a6fa2e1c9f0b" />

[gorec-2026-04-22-03-24-49.webm](https://github.com/user-attachments/assets/2c6ea7de-0f68-4771-98f8-e5831ce64f5e)

## Checklist

- [x] Components are modular and well-structured
- [x] Uses theme (no hardcoded styles)
- [x] Responsive/mobile tested
- [x] Tested against API
- [x] `npm run format` and `npm run lint:fix` run
- [x] `npm run build` passes
- [x] Screenshots added