### PR TITLE
fix: add initials fallback to Avatar components across the app

### DIFF
--- a/src/components/issues/IssuesList.tsx
+++ b/src/components/issues/IssuesList.tsx
@@ -21,7 +21,7 @@ import {
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import { IssueBounty } from '../../api/models/Issues';
 import { useStats } from '../../api';
-import { formatTokenAmount, formatDate } from '../../utils/format';
+import { formatTokenAmount, formatDate, getInitials } from '../../utils/format';
 import { getIssueStatusMeta } from '../../utils/issueStatus';
 import { STATUS_COLORS, TEXT_OPACITY, scrollbarSx } from '../../theme';
 import BountyProgress from './BountyProgress';
@@ -402,8 +402,15 @@ const IssuesList: React.FC<IssuesListProps> = ({
                     >
                       <Avatar
                         src={`https://avatars.githubusercontent.com/${issue.repositoryFullName.split('/')[0]}`}
-                        sx={{ width: 24, height: 24, borderRadius: 1 }}
-                      />
+                        sx={{
+                          width: 24,
+                          height: 24,
+                          borderRadius: 1,
+                          fontSize: '0.65rem',
+                        }}
+                      >
+                        {getInitials(issue.repositoryFullName.split('/')[0])}
+                      </Avatar>
                       <Typography
                         sx={{
                           fontSize: '0.85rem',

--- a/src/components/leaderboard/LeaderboardSidebar.tsx
+++ b/src/components/leaderboard/LeaderboardSidebar.tsx
@@ -4,6 +4,7 @@ import { alpha } from '@mui/material/styles';
 import { SectionCard } from './SectionCard';
 import { STATUS_COLORS, scrollbarSx } from '../../theme';
 import { getGithubAvatarSrc } from '../../utils/ExplorerUtils';
+import { getInitials } from '../../utils/format';
 import { LinkBox } from '../common/linkBehavior';
 import { type MinerStats, FONTS } from './types';
 
@@ -343,8 +344,10 @@ const LeaderboardRow: React.FC<LeaderboardRowProps> = ({
       >
         <Avatar
           src={getGithubAvatarSrc(miner.author || miner.githubId)}
-          sx={{ width: 20, height: 20 }}
-        />
+          sx={{ width: 20, height: 20, fontSize: '0.65rem' }}
+        >
+          {getInitials(miner.author || miner.githubId)}
+        </Avatar>
         <Typography
           sx={(theme) => ({
             fontFamily: FONTS.mono,

--- a/src/components/miners/MinerScoreCard.tsx
+++ b/src/components/miners/MinerScoreCard.tsx
@@ -40,7 +40,7 @@ import {
   calculateOpenIssueThreshold,
   parseNumber,
 } from '../../utils/ExplorerUtils';
-import { credibilityColor } from '../../utils/format';
+import { credibilityColor, getInitials } from '../../utils/format';
 
 const formatTimeAgo = (date: Date): string => {
   const now = new Date();
@@ -384,7 +384,9 @@ const MinerScoreCard: React.FC<MinerScoreCardProps> = ({
             border: '2px solid',
             borderColor: 'border.light',
           }}
-        />
+        >
+          {getInitials(username)}
+        </Avatar>
         <Box sx={{ minWidth: 0, flex: 1 }}>
           <Box
             sx={{

--- a/src/components/prs/PRDetailsCard.tsx
+++ b/src/components/prs/PRDetailsCard.tsx
@@ -13,6 +13,7 @@ import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import { usePullRequestDetails } from '../../api';
 import { linkResetSx, useLinkBehavior } from '../common/linkBehavior';
 import theme, { RANK_COLORS, STATUS_COLORS, TEXT_OPACITY } from '../../theme';
+import { getInitials } from '../../utils/format';
 import { buildMultiplierGrid } from '../../utils/multiplierDefs';
 
 interface PRDetailsCardProps {
@@ -599,7 +600,9 @@ const PRDetailsCard: React.FC<PRDetailsCardProps> = ({
                 src={`https://avatars.githubusercontent.com/${prDetails.authorLogin}`}
                 alt={prDetails.authorLogin}
                 sx={{ width: 32, height: 32 }}
-              />
+              >
+                {getInitials(prDetails.authorLogin)}
+              </Avatar>
               <Typography
                 sx={{
                   color: 'text.primary',

--- a/src/components/repositories/RepositoryCodeBrowser.tsx
+++ b/src/components/repositories/RepositoryCodeBrowser.tsx
@@ -16,6 +16,7 @@ import {
 } from '@mui/material';
 import axios from 'axios';
 import { STATUS_COLORS } from '../../theme';
+import { getInitials } from '../../utils/format';
 import { formatDistanceToNow } from 'date-fns';
 import FolderIcon from '@mui/icons-material/Folder';
 import InsertDriveFileIcon from '@mui/icons-material/InsertDriveFile';
@@ -375,8 +376,10 @@ const RepositoryCodeBrowser: React.FC<RepositoryCodeBrowserProps> = ({
               >
                 <Avatar
                   src={currentCommit.avatarUrl}
-                  sx={{ width: 20, height: 20 }}
-                />
+                  sx={{ width: 20, height: 20, fontSize: '0.65rem' }}
+                >
+                  {getInitials(currentCommit.committerLogin)}
+                </Avatar>
                 <Typography
                   sx={{
                     fontSize: '13px',

--- a/src/components/repositories/RepositoryContributorsTable.tsx
+++ b/src/components/repositories/RepositoryContributorsTable.tsx
@@ -12,6 +12,7 @@ import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
 import { useAllPrs, useAllMiners } from '../../api';
 import { LinkBox } from '../common/linkBehavior';
 import { STATUS_COLORS } from '../../theme';
+import { getInitials } from '../../utils/format';
 import { isMergedPr } from '../../utils/prStatus';
 
 interface RepositoryContributorsTableProps {
@@ -237,9 +238,12 @@ const RepositoryContributorsTable: React.FC<
                   sx={{
                     width: 20,
                     height: 20,
+                    fontSize: '0.65rem',
                     border: `1px solid ${theme.palette.border.light}`,
                   }}
-                />
+                >
+                  {getInitials(contributor.author)}
+                </Avatar>
                 <Box
                   sx={{
                     display: 'flex',

--- a/src/components/repositories/RepositoryPRsTable.tsx
+++ b/src/components/repositories/RepositoryPRsTable.tsx
@@ -36,6 +36,7 @@ import theme, {
   bodyCellStyle,
 } from '../../theme';
 import { filterPrs, getPrStatusCounts, type PrStatusFilter } from '../../utils';
+import { getInitials } from '../../utils/format';
 import FilterButton from '../FilterButton';
 
 interface RepositoryPRsTableProps {
@@ -400,8 +401,10 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
                       <Avatar
                         src={`https://avatars.githubusercontent.com/${pr.author}`}
                         alt={pr.author}
-                        sx={{ width: 20, height: 20 }}
-                      />
+                        sx={{ width: 20, height: 20, fontSize: '0.65rem' }}
+                      >
+                        {getInitials(pr.author)}
+                      </Avatar>
                       {pr.author}
                     </Box>
                   </TableCell>

--- a/src/pages/RepositoriesPage.tsx
+++ b/src/pages/RepositoriesPage.tsx
@@ -8,6 +8,7 @@ import { Page } from '../components/layout';
 import { TopRepositoriesTable, SEO } from '../components';
 import { useAllPrs, useReposAndWeights } from '../api';
 import { type CommitLog } from '../api/models/Dashboard';
+import { getInitials } from '../utils/format';
 
 const FONTS = { mono: '"JetBrains Mono", monospace' } as const;
 
@@ -56,10 +57,13 @@ const HighlightRow: React.FC<{
             width: 24,
             height: 24,
             flexShrink: 0,
+            fontSize: '0.65rem',
             border: '1px solid rgba(255,255,255,0.1)',
             backgroundColor: avatarBg,
           }}
-        />
+        >
+          {getInitials(typeof label === 'string' ? label : undefined)}
+        </Avatar>
         {label}
       </Box>
       {right}

--- a/src/pages/dashboard/views/DashboardTopContributors.tsx
+++ b/src/pages/dashboard/views/DashboardTopContributors.tsx
@@ -9,20 +9,13 @@ import {
 import { alpha, useTheme } from '@mui/material/styles';
 import { useNavigate } from 'react-router-dom';
 import { getGithubAvatarSrc } from '../../../utils';
+import { getInitials } from '../../../utils/format';
 import { type DashboardFeaturedContributor } from '../dashboardData';
 
 interface DashboardTopContributorsProps {
   contributors: DashboardFeaturedContributor[];
   isLoading?: boolean;
 }
-
-const getInitials = (name: string) =>
-  name
-    .split(' ')
-    .map((part) => part[0])
-    .join('')
-    .slice(0, 2)
-    .toUpperCase();
 
 const DashboardTopContributors: React.FC<DashboardTopContributorsProps> = ({
   contributors,

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -63,6 +63,21 @@ export const formatUsdEstimate = (
   return showZero ? `${prefix}$0` : null;
 };
 
+/**
+ * Return up to two uppercase initials from a display name or username.
+ * Falls back to "?" for empty/undefined input.
+ */
+export const getInitials = (name: string | undefined | null): string => {
+  if (!name) return '?';
+  return (
+    name
+      .split(/[\s/]+/)
+      .map((part) => part[0]?.toUpperCase() ?? '')
+      .join('')
+      .slice(0, 2) || '?'
+  );
+};
+
 export const credibilityColor = (cred: number): string => {
   if (cred >= 0.9) return CREDIBILITY_COLORS.excellent;
   if (cred >= 0.7) return CREDIBILITY_COLORS.good;


### PR DESCRIPTION
## Closes: #550

## Summary

- Extract `getInitials` helper into `src/utils/format.ts` so every file can share one implementation
- Add initials children to all 8 self-closing `<Avatar />` instances that showed blank/broken icons when GitHub avatar requests fail (e.g. rate-limited or blocked)
- Remove the duplicate local `getInitials` in `DashboardTopContributors.tsx` in favor of the shared one

## Changes

### Shared utility
- `src/utils/format.ts` — added `getInitials`

### Avatar fallback added (8 files)
- `src/pages/RepositoriesPage.tsx`
- `src/components/leaderboard/LeaderboardSidebar.tsx`
- `src/components/miners/MinerScoreCard.tsx`
- `src/components/prs/PRDetailsCard.tsx`
- `src/components/repositories/RepositoryCodeBrowser.tsx`
- `src/components/repositories/RepositoryContributorsTable.tsx`
- `src/components/repositories/RepositoryPRsTable.tsx`
- `src/components/issues/IssuesList.tsx`

### Dedup
- `src/pages/dashboard/views/DashboardTopContributors.tsx` — removed local getInitials, uses shared version

## Screenshots

Block `avatars.githubusercontent.com` in DevTools → avatars render initials instead of broken/blank circles. Without the fix they show MUI's default grey person icon.