### PR TITLE
fix(dashboard): track closed PRs/issues and use miner aggregates for issue totals

### DIFF
--- a/src/pages/dashboard/dashboardData.ts
+++ b/src/pages/dashboard/dashboardData.ts
@@ -9,11 +9,7 @@
  */
 import { type CommitLog, type MinerEvaluation } from '../../api';
 import { type IssueBounty } from '../../api/models/Issues';
-import {
-  getIssueStatusLabel,
-  getPrStatusLabel,
-  parseNumber,
-} from '../../utils';
+import { getPrStatusLabel, parseNumber } from '../../utils';
 
 export type PresetTimeRange = '1d' | '7d' | '35d';
 export type TrendTimeRange = PresetTimeRange | 'all';
@@ -295,7 +291,12 @@ const getPrOverviewMetrics = (prs: CommitLog[], window: WindowBounds) => {
     const normalizedState = getPrStatusLabel(pr);
     const createdInWindow = isWithinWindow(toTimestamp(pr.prCreatedAt), window);
     const mergedInWindow = isWithinWindow(toTimestamp(pr.mergedAt), window);
-    const closedInWindow = isWithinWindow(toTimestamp(pr.closedAt), window);
+    // API does not currently return closedAt for PRs — fall back to
+    // prCreatedAt so closed PRs are still tracked within the window.
+    const closedInWindow = isWithinWindow(
+      toTimestamp(pr.closedAt ?? pr.prCreatedAt),
+      window,
+    );
 
     if (createdInWindow) {
       statusCounts.open += 1;
@@ -321,50 +322,24 @@ const getPrOverviewMetrics = (prs: CommitLog[], window: WindowBounds) => {
   };
 };
 
-const getIssueOverviewMetrics = (
-  issues: IssueBounty[],
-  window: WindowBounds,
-) => {
-  const statusCounts = {
-    total: 0,
-    solved: 0,
-    open: 0,
-    closed: 0,
-  };
-
-  issues.forEach((issue) => {
-    const normalizedStatus = getIssueStatusLabel(issue);
-    const createdInWindow = isWithinWindow(
-      toTimestamp(issue.createdAt),
-      window,
-    );
-    const solvedInWindow = isWithinWindow(
-      toTimestamp(issue.completedAt),
-      window,
-    );
-    const closedInWindow = isWithinWindow(toTimestamp(issue.closedAt), window);
-
-    if (createdInWindow) {
-      statusCounts.open += 1;
-      statusCounts.total += 1;
-    }
-
-    if (normalizedStatus === 'Solved' && solvedInWindow) {
-      statusCounts.solved += 1;
-      statusCounts.total += 1;
-    }
-
-    if (normalizedStatus === 'Closed' && closedInWindow) {
-      statusCounts.closed += 1;
-      statusCounts.total += 1;
-    }
+// Issue discovery metrics are sourced from per-miner aggregates (which
+// reflect every discovered issue) rather than the /issues endpoint (which
+// only returns bounty-backed issues — far fewer). Aggregates are all-time
+// totals, so the Issue Discoveries card is not windowed by the range filter.
+const getIssueOverviewMetricsFromMiners = (miners: MinerEvaluation[]) => {
+  let solved = 0;
+  let closed = 0;
+  let open = 0;
+  miners.forEach((miner) => {
+    solved += miner.totalSolvedIssues ?? 0;
+    closed += miner.totalClosedIssues ?? 0;
+    open += miner.totalOpenIssues ?? 0;
   });
-
   return {
-    total: statusCounts.total,
-    solved: statusCounts.solved,
-    open: statusCounts.open,
-    closed: statusCounts.closed,
+    total: solved + open + closed,
+    solved,
+    open,
+    closed,
   };
 };
 
@@ -375,7 +350,7 @@ const formatCenterPercent = (resolved: number, total: number) => {
 
 export const buildDashboardOverview = (
   prs: CommitLog[],
-  issues: IssueBounty[],
+  miners: MinerEvaluation[],
   range: TrendTimeRange,
   now = new Date(),
 ): DashboardOverviewSection[] => {
@@ -386,10 +361,7 @@ export const buildDashboardOverview = (
   const previousPrMetrics = previousWindow
     ? getPrOverviewMetrics(prs, previousWindow)
     : null;
-  const currentIssueMetrics = getIssueOverviewMetrics(issues, currentWindow);
-  const previousIssueMetrics = previousWindow
-    ? getIssueOverviewMetrics(issues, previousWindow)
-    : null;
+  const currentIssueMetrics = getIssueOverviewMetricsFromMiners(miners);
   const getMetricDelta = (currentValue: number, previousValue?: number) =>
     range === 'all' || previousValue === undefined
       ? '0%'
@@ -405,7 +377,7 @@ export const buildDashboardOverview = (
       ],
       chartCenterLabel: formatCenterPercent(
         currentPrMetrics.merged,
-        currentPrMetrics.total,
+        currentPrMetrics.merged + currentPrMetrics.closed,
       ),
       metrics: [
         {
@@ -448,40 +420,30 @@ export const buildDashboardOverview = (
       ],
       chartCenterLabel: formatCenterPercent(
         currentIssueMetrics.solved,
-        currentIssueMetrics.total,
+        currentIssueMetrics.solved + currentIssueMetrics.closed,
       ),
+      // Issue metrics come from per-miner aggregates (all-time totals), so
+      // there is no previous-window comparison available — deltas are '0%'.
       metrics: [
         {
           label: 'Total',
           value: currentIssueMetrics.total,
-          delta: getMetricDelta(
-            currentIssueMetrics.total,
-            previousIssueMetrics?.total,
-          ),
+          delta: '0%',
         },
         {
           label: 'Solved',
           value: currentIssueMetrics.solved,
-          delta: getMetricDelta(
-            currentIssueMetrics.solved,
-            previousIssueMetrics?.solved,
-          ),
+          delta: '0%',
         },
         {
           label: 'Open',
           value: currentIssueMetrics.open,
-          delta: getMetricDelta(
-            currentIssueMetrics.open,
-            previousIssueMetrics?.open,
-          ),
+          delta: '0%',
         },
         {
           label: 'Closed',
           value: currentIssueMetrics.closed,
-          delta: getMetricDelta(
-            currentIssueMetrics.closed,
-            previousIssueMetrics?.closed,
-          ),
+          delta: '0%',
         },
       ],
     },

--- a/src/pages/dashboard/useDashboardData.ts
+++ b/src/pages/dashboard/useDashboardData.ts
@@ -54,8 +54,8 @@ export const useDashboardData = (range: TrendTimeRange) => {
 
   const overview = useMemo(
     () =>
-      buildDashboardOverview(datasets.prs.data, datasets.issues.data, range),
-    [datasets.issues.data, datasets.prs.data, range],
+      buildDashboardOverview(datasets.prs.data, datasets.miners.data, range),
+    [datasets.miners.data, datasets.prs.data, range],
   );
 
   const trendData = useMemo(


### PR DESCRIPTION
Summary

- **Closed PRs weren't counted.** The `/prs` API doesn't return `closedAt` (verified: all 504 `CLOSED` PRs have no `closedAt`), so the `closedInWindow` check was always false. Falls back to `prCreatedAt` when `closedAt` is missing; real `closedAt` is still preferred if the backend adds it.
- **Donut percentage wrongly factored in "Open".** Changed the center percentage to `merged / (merged + closed)` for OSS Contributions and `solved / (solved + closed)` for Issue Discoveries, per the issue spec.
- **Issue totals were way off (18 vs 1000+).** The `/issues` endpoint only returns bounty-backed issues (31 total), not all discovered issues (~2700+). The Issue Discoveries card now aggregates `totalSolvedIssues / totalClosedIssues / totalOpenIssues` across all miners — the same source the leaderboard uses.

## Related Issues
Closes #700

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

<!-- Include before/after screenshots of the OSS Contributions and Issue Discoveries donut cards. -->
Before
<img width="1060" height="390" alt="image" src="https://github.com/user-attachments/assets/2d90a36a-99be-44cc-b6dd-e3c9664bb1bb" />
After
<img width="1137" height="380" alt="image" src="https://github.com/user-attachments/assets/2c9dca38-d28b-4f18-a736-6dd367314356" />


## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [ ] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes