### PR TITLE
fix: add external-link icon to bounties docs hint

### DIFF
--- a/src/pages/IssuesPage.tsx
+++ b/src/pages/IssuesPage.tsx
@@ -9,6 +9,7 @@
 import React from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { Box, Tabs, Tab, Stack, Typography, alpha } from '@mui/material';
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import { Page } from '../components/layout';
 import { SEO } from '../components';
 import { IssueStats, IssuesList } from '../components/issues';
@@ -106,6 +107,7 @@ const IssuesPage: React.FC = () => {
                   fontSize: '0.72rem',
                   color: (t) => alpha(t.palette.text.primary, 0.35),
                   pr: 1,
+                  mt: { xs: 0.5, md: 0 },
                   mb: { xs: 1, md: 0 },
                   textAlign: { xs: 'left', md: 'right' },
                 }}
@@ -121,10 +123,17 @@ const IssuesPage: React.FC = () => {
                     fontSize: 'inherit',
                     fontFamily: 'inherit',
                     textDecoration: 'none',
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    gap: 0.25,
                     '&:hover': { textDecoration: 'underline' },
                   }}
                 >
                   docs
+                  <OpenInNewIcon
+                    sx={{ fontSize: '0.85em' }}
+                    aria-hidden="true"
+                  />
                 </Typography>
               </Typography>
             </Box>


### PR DESCRIPTION
Fixes #533
## Summary
Adds the external-link icon that the issue calls for next to the "docs" anchor on the Bounties page. The earlier right-alignment and spacing trim from a previous effort are already in place; this completes the remaining acceptance criterion.

## What changed
- `src/pages/IssuesPage.tsx` — the docs anchor now renders as an inline-flex with `OpenInNewIcon` (sized `0.85em`, marked `aria-hidden`) beside the "docs" label. Small top-margin adjustment on xs for rhythm.

## Type of Change
- [x] Bug fix (UX polish)

## Testing
- [ ] `npm run build`
- [ ] `npm run lint:fix`
- [ ] Manual: `/bounties` → confirm external-link icon appears after "docs"; confirms right-alignment at ≥ md; confirm the icon doesn't visually break the baseline.

## Screenshot
<img width="1423" height="802" alt="image" src="https://github.com/user-attachments/assets/3f85a640-c2a4-4d55-81e7-cb06a8e5f891" />

