### PR TITLE
feat: add rightSideBar that shows new info for the miners in watchlis…

### DIFF
--- a/src/components/leaderboard/ActivitySidebarCards.tsx
+++ b/src/components/leaderboard/ActivitySidebarCards.tsx
@@ -3,13 +3,14 @@ import { Box, Stack, Typography } from '@mui/material';
 import { alpha } from '@mui/material/styles';
 import { SectionCard } from './SectionCard';
 import { STATUS_COLORS, DIFF_COLORS, CREDIBILITY_COLORS } from '../../theme';
+import { credibilityColor } from '../../utils/format';
 import { type MinerStats, FONTS } from './types';
 
-interface WatchlistSidebarProps {
+interface ActivitySidebarCardsProps {
   miners: MinerStats[];
 }
 
-export const WatchlistSidebar: React.FC<WatchlistSidebarProps> = ({
+export const ActivitySidebarCards: React.FC<ActivitySidebarCardsProps> = ({
   miners,
 }) => {
   const ossUsdPerDay = useMemo(
@@ -90,23 +91,11 @@ export const WatchlistSidebar: React.FC<WatchlistSidebarProps> = ({
         ? CREDIBILITY_COLORS.moderate
         : STATUS_COLORS.closed;
 
-  const credibilityColor =
-    codeStats.avgCredibility >= 90
-      ? CREDIBILITY_COLORS.excellent
-      : codeStats.avgCredibility >= 70
-        ? CREDIBILITY_COLORS.good
-        : codeStats.avgCredibility >= 50
-          ? CREDIBILITY_COLORS.moderate
-          : codeStats.avgCredibility >= 30
-            ? CREDIBILITY_COLORS.low
-            : CREDIBILITY_COLORS.poor;
-
   return (
-    <Stack spacing={2} sx={{ height: '100%', overflow: 'auto', pr: 1 }}>
+    <>
       {/* CARD 1: PR Activity */}
       <SectionCard title="PR Activity" sx={{ flexShrink: 0 }}>
         <Box sx={{ px: 2, pt: 1, pb: 2 }}>
-          {/* Three-column PR breakdown */}
           <Box
             sx={(theme) => ({
               display: 'grid',
@@ -134,7 +123,6 @@ export const WatchlistSidebar: React.FC<WatchlistSidebarProps> = ({
             />
           </Box>
 
-          {/* Merge Rate */}
           <Box
             sx={{
               display: 'flex',
@@ -152,7 +140,7 @@ export const WatchlistSidebar: React.FC<WatchlistSidebarProps> = ({
               Merge Rate
             </Typography>
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
-              <MergeRateBar rate={prStats.mergeRate} color={mergeRateColor} />
+              <RateBar rate={prStats.mergeRate} color={mergeRateColor} />
               <Typography
                 sx={{
                   fontFamily: FONTS.mono,
@@ -168,8 +156,7 @@ export const WatchlistSidebar: React.FC<WatchlistSidebarProps> = ({
             </Box>
           </Box>
 
-          {/* Total $/day */}
-          <ImpactRow
+          <StatRow
             label="Total $/day"
             value={`$${Math.round(ossUsdPerDay).toLocaleString()}`}
             valueColor={STATUS_COLORS.merged}
@@ -207,7 +194,6 @@ export const WatchlistSidebar: React.FC<WatchlistSidebarProps> = ({
             />
           </Box>
 
-          {/* Solve Rate */}
           <Box
             sx={{
               display: 'flex',
@@ -225,10 +211,7 @@ export const WatchlistSidebar: React.FC<WatchlistSidebarProps> = ({
               Solve Rate
             </Typography>
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
-              <MergeRateBar
-                rate={issueStats.solveRate}
-                color={solveRateColor}
-              />
+              <RateBar rate={issueStats.solveRate} color={solveRateColor} />
               <Typography
                 sx={{
                   fontFamily: FONTS.mono,
@@ -244,8 +227,7 @@ export const WatchlistSidebar: React.FC<WatchlistSidebarProps> = ({
             </Box>
           </Box>
 
-          {/* Total $/day */}
-          <ImpactRow
+          <StatRow
             label="Total $/day"
             value={`$${Math.round(issueUsdPerDay).toLocaleString()}`}
             valueColor={STATUS_COLORS.merged}
@@ -265,17 +247,17 @@ export const WatchlistSidebar: React.FC<WatchlistSidebarProps> = ({
             gap: 2,
           }}
         >
-          <ImpactRow
+          <StatRow
             label="Lines Added"
-            value={`+${prStats.merged === 0 && codeStats.linesAdded === 0 ? '0' : codeStats.linesAdded.toLocaleString()}`}
+            value={`+${codeStats.linesAdded.toLocaleString()}`}
             valueColor={DIFF_COLORS.additions}
           />
-          <ImpactRow
+          <StatRow
             label="Lines Deleted"
             value={`-${codeStats.linesDeleted.toLocaleString()}`}
             valueColor={DIFF_COLORS.deletions}
           />
-          <ImpactRow
+          <StatRow
             label="Repos Touched"
             value={codeStats.reposTouched.toLocaleString()}
           />
@@ -296,16 +278,16 @@ export const WatchlistSidebar: React.FC<WatchlistSidebarProps> = ({
               Avg Credibility
             </Typography>
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
-              <MergeRateBar
+              <RateBar
                 rate={codeStats.avgCredibility}
-                color={credibilityColor}
+                color={credibilityColor(codeStats.avgCredibility / 100)}
               />
               <Typography
                 sx={{
                   fontFamily: FONTS.mono,
                   fontWeight: 600,
                   fontSize: '1.1rem',
-                  color: credibilityColor,
+                  color: credibilityColor(codeStats.avgCredibility / 100),
                   minWidth: 40,
                   textAlign: 'right',
                 }}
@@ -316,11 +298,51 @@ export const WatchlistSidebar: React.FC<WatchlistSidebarProps> = ({
           </Box>
         </Box>
       </SectionCard>
-    </Stack>
+    </>
   );
 };
 
-// ── Sub-components ──────────────────────────────────────────────
+// ── Shared sub-components ────────────────────────────────────────
+
+export interface StatRowProps {
+  label: string;
+  value: number | string;
+  valueColor?: string;
+}
+
+export const StatRow: React.FC<StatRowProps> = ({
+  label,
+  value,
+  valueColor,
+}) => (
+  <Box
+    sx={{
+      display: 'flex',
+      justifyContent: 'space-between',
+      alignItems: 'center',
+    }}
+  >
+    <Typography
+      sx={{
+        fontFamily: FONTS.mono,
+        fontSize: '0.85rem',
+        color: STATUS_COLORS.open,
+      }}
+    >
+      {label}
+    </Typography>
+    <Typography
+      sx={(theme) => ({
+        fontFamily: FONTS.mono,
+        fontWeight: 600,
+        fontSize: '1.1rem',
+        color: valueColor ?? theme.palette.text.primary,
+      })}
+    >
+      {value}
+    </Typography>
+  </Box>
+);
 
 interface PRColumnProps {
   label: string;
@@ -360,12 +382,12 @@ const PRColumn: React.FC<PRColumnProps> = ({ label, value, color }) => (
   </Box>
 );
 
-interface MergeRateBarProps {
+interface RateBarProps {
   rate: number;
   color: string;
 }
 
-const MergeRateBar: React.FC<MergeRateBarProps> = ({ rate, color }) => (
+const RateBar: React.FC<RateBarProps> = ({ rate, color }) => (
   <Box
     sx={(theme) => ({
       width: 64,
@@ -384,41 +406,5 @@ const MergeRateBar: React.FC<MergeRateBarProps> = ({ rate, color }) => (
         transition: 'width 0.4s ease',
       }}
     />
-  </Box>
-);
-
-interface ImpactRowProps {
-  label: string;
-  value: string;
-  valueColor?: string;
-}
-
-const ImpactRow: React.FC<ImpactRowProps> = ({ label, value, valueColor }) => (
-  <Box
-    sx={{
-      display: 'flex',
-      justifyContent: 'space-between',
-      alignItems: 'center',
-    }}
-  >
-    <Typography
-      sx={{
-        fontFamily: FONTS.mono,
-        fontSize: '0.85rem',
-        color: STATUS_COLORS.open,
-      }}
-    >
-      {label}
-    </Typography>
-    <Typography
-      sx={(theme) => ({
-        fontFamily: FONTS.mono,
-        fontWeight: 600,
-        fontSize: '1.1rem',
-        color: valueColor ?? theme.palette.text.primary,
-      })}
-    >
-      {value}
-    </Typography>
   </Box>
 );

--- a/src/components/leaderboard/ActivitySidebarCards.tsx
+++ b/src/components/leaderboard/ActivitySidebarCards.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { Box, Stack, Typography } from '@mui/material';
+import { Box, Typography } from '@mui/material';
 import { alpha } from '@mui/material/styles';
 import { SectionCard } from './SectionCard';
 import { STATUS_COLORS, DIFF_COLORS, CREDIBILITY_COLORS } from '../../theme';

--- a/src/components/leaderboard/LeaderboardSidebar.tsx
+++ b/src/components/leaderboard/LeaderboardSidebar.tsx
@@ -6,6 +6,7 @@ import { STATUS_COLORS, scrollbarSx } from '../../theme';
 import { getGithubAvatarSrc } from '../../utils/ExplorerUtils';
 import { LinkBox } from '../common/linkBehavior';
 import { type MinerStats, FONTS } from './types';
+import { ActivitySidebarCards } from './ActivitySidebarCards';
 
 // Re-export MinerStats for backward compatibility
 export type { MinerStats } from './types';
@@ -49,57 +50,15 @@ export const LeaderboardSidebar: React.FC<LeaderboardSidebarProps> = ({
     [miners, variant],
   );
 
-  // Network Stats Data
-  const networkStats = useMemo(
-    () => ({
-      totalMiners: miners.length,
-      eligible: miners.filter((m) => m.isEligible).length,
-      totalPRs: miners.reduce((acc, m) => acc + (m.totalPRs || 0), 0),
-      totalIssues: miners.reduce((acc, m) => acc + (m.totalIssues || 0), 0),
-      dailyPool: miners.reduce((acc, m) => acc + (m.usdPerDay || 0), 0),
-    }),
-    [miners],
-  );
-
   return (
     <Stack
       spacing={2}
       sx={{ height: '100%', overflow: 'auto', pr: 1, ...scrollbarSx }}
     >
-      {/* CARD 1: Network Stats */}
-      <SectionCard title="Network Stats" sx={{ flexShrink: 0 }}>
-        <Box
-          sx={{
-            pt: 1,
-            px: 2,
-            pb: 2,
-            display: 'flex',
-            flexDirection: 'column',
-            gap: 2,
-          }}
-        >
-          <StatRow label="Total Miners" value={networkStats.totalMiners} />
-          <StatRow
-            label={variant === 'discoveries' ? 'Issues Eligible' : 'Eligible'}
-            value={networkStats.eligible}
-          />
-          <StatRow
-            label={variant === 'discoveries' ? 'Total Issues' : 'Total PRs'}
-            value={
-              variant === 'discoveries'
-                ? networkStats.totalIssues
-                : networkStats.totalPRs
-            }
-          />
-          <StatRow
-            label="Daily Pool"
-            value={`$${networkStats.dailyPool.toLocaleString()}`}
-            valueColor={STATUS_COLORS.merged}
-          />
-        </Box>
-      </SectionCard>
+      {/* Activity Cards: PR Activity, Issue Activity, Code Impact */}
+      <ActivitySidebarCards miners={miners} />
 
-      {/* CARD 2: Leaderboard Lists (Tabs) */}
+      {/* Leaderboard Lists (Tabs) */}
       <SectionCard
         title={leaderboardType === 'earners' ? 'Top Earners' : 'Most Active'}
         action={
@@ -131,42 +90,6 @@ export const LeaderboardSidebar: React.FC<LeaderboardSidebarProps> = ({
     </Stack>
   );
 };
-
-interface StatRowProps {
-  label: string;
-  value: number | string;
-  valueColor?: string;
-}
-
-const StatRow: React.FC<StatRowProps> = ({ label, value, valueColor }) => (
-  <Box
-    sx={{
-      display: 'flex',
-      justifyContent: 'space-between',
-      alignItems: 'center',
-    }}
-  >
-    <Typography
-      sx={{
-        fontFamily: FONTS.mono,
-        fontSize: '0.85rem',
-        color: STATUS_COLORS.open,
-      }}
-    >
-      {label}
-    </Typography>
-    <Typography
-      sx={(theme) => ({
-        fontFamily: FONTS.mono,
-        fontWeight: 600,
-        fontSize: '1.1rem',
-        color: valueColor ?? theme.palette.text.primary,
-      })}
-    >
-      {value}
-    </Typography>
-  </Box>
-);
 
 interface LeaderboardTabsProps {
   activeTab: 'earners' | 'active';

--- a/src/components/leaderboard/MinersList.tsx
+++ b/src/components/leaderboard/MinersList.tsx
@@ -119,7 +119,11 @@ export const MinersList: React.FC<MinersListProps> = ({
       cellSx: { p: 0 },
       renderCell: (miner) =>
         miner.githubId ? (
-          <WatchlistButton githubId={miner.githubId} size="small" />
+          <WatchlistButton
+            category="miners"
+            itemKey={miner.githubId}
+            size="small"
+          />
         ) : null,
     },
   ];

--- a/src/components/leaderboard/WatchlistSidebar.tsx
+++ b/src/components/leaderboard/WatchlistSidebar.tsx
@@ -2,11 +2,7 @@ import React, { useMemo } from 'react';
 import { Box, Stack, Typography } from '@mui/material';
 import { alpha } from '@mui/material/styles';
 import { SectionCard } from './SectionCard';
-import {
-  STATUS_COLORS,
-  DIFF_COLORS,
-  CREDIBILITY_COLORS,
-} from '../../theme';
+import { STATUS_COLORS, DIFF_COLORS, CREDIBILITY_COLORS } from '../../theme';
 import { type MinerStats, FONTS } from './types';
 
 interface WatchlistSidebarProps {
@@ -33,15 +29,9 @@ export const WatchlistSidebar: React.FC<WatchlistSidebarProps> = ({
   );
 
   const prStats = useMemo(() => {
-    const merged = miners.reduce(
-      (acc, m) => acc + (m.totalMergedPrs || 0),
-      0,
-    );
+    const merged = miners.reduce((acc, m) => acc + (m.totalMergedPrs || 0), 0);
     const open = miners.reduce((acc, m) => acc + (m.totalOpenPrs || 0), 0);
-    const closed = miners.reduce(
-      (acc, m) => acc + (m.totalClosedPrs || 0),
-      0,
-    );
+    const closed = miners.reduce((acc, m) => acc + (m.totalClosedPrs || 0), 0);
     const total = merged + open + closed;
     const mergeRate = total > 0 ? Math.round((merged / total) * 100) : 0;
     return { merged, open, closed, mergeRate };
@@ -52,10 +42,7 @@ export const WatchlistSidebar: React.FC<WatchlistSidebarProps> = ({
       (acc, m) => acc + (m.totalSolvedIssues || 0),
       0,
     );
-    const open = miners.reduce(
-      (acc, m) => acc + (m.totalOpenIssues || 0),
-      0,
-    );
+    const open = miners.reduce((acc, m) => acc + (m.totalOpenIssues || 0), 0);
     const closed = miners.reduce(
       (acc, m) => acc + (m.totalClosedIssues || 0),
       0,
@@ -66,10 +53,7 @@ export const WatchlistSidebar: React.FC<WatchlistSidebarProps> = ({
   }, [miners]);
 
   const codeStats = useMemo(() => {
-    const linesAdded = miners.reduce(
-      (acc, m) => acc + (m.linesAdded || 0),
-      0,
-    );
+    const linesAdded = miners.reduce((acc, m) => acc + (m.linesAdded || 0), 0);
     const linesDeleted = miners.reduce(
       (acc, m) => acc + (m.linesDeleted || 0),
       0,
@@ -241,7 +225,10 @@ export const WatchlistSidebar: React.FC<WatchlistSidebarProps> = ({
               Solve Rate
             </Typography>
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
-              <MergeRateBar rate={issueStats.solveRate} color={solveRateColor} />
+              <MergeRateBar
+                rate={issueStats.solveRate}
+                color={solveRateColor}
+              />
               <Typography
                 sx={{
                   fontFamily: FONTS.mono,
@@ -309,7 +296,10 @@ export const WatchlistSidebar: React.FC<WatchlistSidebarProps> = ({
               Avg Credibility
             </Typography>
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
-              <MergeRateBar rate={codeStats.avgCredibility} color={credibilityColor} />
+              <MergeRateBar
+                rate={codeStats.avgCredibility}
+                color={credibilityColor}
+              />
               <Typography
                 sx={{
                   fontFamily: FONTS.mono,
@@ -339,7 +329,14 @@ interface PRColumnProps {
 }
 
 const PRColumn: React.FC<PRColumnProps> = ({ label, value, color }) => (
-  <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 0.5 }}>
+  <Box
+    sx={{
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+      gap: 0.5,
+    }}
+  >
     <Typography
       sx={{
         fontFamily: FONTS.mono,

--- a/src/components/leaderboard/WatchlistSidebar.tsx
+++ b/src/components/leaderboard/WatchlistSidebar.tsx
@@ -1,0 +1,427 @@
+import React, { useMemo } from 'react';
+import { Box, Stack, Typography } from '@mui/material';
+import { alpha } from '@mui/material/styles';
+import { SectionCard } from './SectionCard';
+import {
+  STATUS_COLORS,
+  DIFF_COLORS,
+  CREDIBILITY_COLORS,
+} from '../../theme';
+import { type MinerStats, FONTS } from './types';
+
+interface WatchlistSidebarProps {
+  miners: MinerStats[];
+}
+
+export const WatchlistSidebar: React.FC<WatchlistSidebarProps> = ({
+  miners,
+}) => {
+  const ossUsdPerDay = useMemo(
+    () =>
+      miners
+        .filter((m) => m.ossIsEligible)
+        .reduce((acc, m) => acc + (m.usdPerDay || 0), 0),
+    [miners],
+  );
+
+  const issueUsdPerDay = useMemo(
+    () =>
+      miners
+        .filter((m) => m.discoveriesIsEligible)
+        .reduce((acc, m) => acc + (m.usdPerDay || 0), 0),
+    [miners],
+  );
+
+  const prStats = useMemo(() => {
+    const merged = miners.reduce(
+      (acc, m) => acc + (m.totalMergedPrs || 0),
+      0,
+    );
+    const open = miners.reduce((acc, m) => acc + (m.totalOpenPrs || 0), 0);
+    const closed = miners.reduce(
+      (acc, m) => acc + (m.totalClosedPrs || 0),
+      0,
+    );
+    const total = merged + open + closed;
+    const mergeRate = total > 0 ? Math.round((merged / total) * 100) : 0;
+    return { merged, open, closed, mergeRate };
+  }, [miners]);
+
+  const issueStats = useMemo(() => {
+    const solved = miners.reduce(
+      (acc, m) => acc + (m.totalSolvedIssues || 0),
+      0,
+    );
+    const open = miners.reduce(
+      (acc, m) => acc + (m.totalOpenIssues || 0),
+      0,
+    );
+    const closed = miners.reduce(
+      (acc, m) => acc + (m.totalClosedIssues || 0),
+      0,
+    );
+    const total = solved + open + closed;
+    const solveRate = total > 0 ? Math.round((solved / total) * 100) : 0;
+    return { solved, open, closed, solveRate };
+  }, [miners]);
+
+  const codeStats = useMemo(() => {
+    const linesAdded = miners.reduce(
+      (acc, m) => acc + (m.linesAdded || 0),
+      0,
+    );
+    const linesDeleted = miners.reduce(
+      (acc, m) => acc + (m.linesDeleted || 0),
+      0,
+    );
+    const reposTouched = miners.reduce(
+      (acc, m) => acc + (m.uniqueReposCount || 0),
+      0,
+    );
+    const credibilityValues = miners
+      .map((m) => m.credibility)
+      .filter((c): c is number => typeof c === 'number');
+    const avgCredibility =
+      credibilityValues.length > 0
+        ? Math.round(
+            (credibilityValues.reduce((acc, c) => acc + c, 0) /
+              credibilityValues.length) *
+              100,
+          )
+        : 0;
+    return { linesAdded, linesDeleted, reposTouched, avgCredibility };
+  }, [miners]);
+
+  const solveRateColor =
+    issueStats.solveRate >= 80
+      ? CREDIBILITY_COLORS.excellent
+      : issueStats.solveRate >= 50
+        ? CREDIBILITY_COLORS.moderate
+        : STATUS_COLORS.closed;
+
+  const mergeRateColor =
+    prStats.mergeRate >= 80
+      ? CREDIBILITY_COLORS.excellent
+      : prStats.mergeRate >= 50
+        ? CREDIBILITY_COLORS.moderate
+        : STATUS_COLORS.closed;
+
+  const credibilityColor =
+    codeStats.avgCredibility >= 90
+      ? CREDIBILITY_COLORS.excellent
+      : codeStats.avgCredibility >= 70
+        ? CREDIBILITY_COLORS.good
+        : codeStats.avgCredibility >= 50
+          ? CREDIBILITY_COLORS.moderate
+          : codeStats.avgCredibility >= 30
+            ? CREDIBILITY_COLORS.low
+            : CREDIBILITY_COLORS.poor;
+
+  return (
+    <Stack spacing={2} sx={{ height: '100%', overflow: 'auto', pr: 1 }}>
+      {/* CARD 1: PR Activity */}
+      <SectionCard title="PR Activity" sx={{ flexShrink: 0 }}>
+        <Box sx={{ px: 2, pt: 1, pb: 2 }}>
+          {/* Three-column PR breakdown */}
+          <Box
+            sx={(theme) => ({
+              display: 'grid',
+              gridTemplateColumns: '1fr 1fr 1fr',
+              gap: 1,
+              mb: 2,
+              pb: 2,
+              borderBottom: `1px solid ${theme.palette.border.light}`,
+            })}
+          >
+            <PRColumn
+              label="Merged"
+              value={prStats.merged}
+              color={STATUS_COLORS.merged}
+            />
+            <PRColumn
+              label="Open"
+              value={prStats.open}
+              color={STATUS_COLORS.open}
+            />
+            <PRColumn
+              label="Closed"
+              value={prStats.closed}
+              color={STATUS_COLORS.closed}
+            />
+          </Box>
+
+          {/* Merge Rate */}
+          <Box
+            sx={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              alignItems: 'center',
+            }}
+          >
+            <Typography
+              sx={{
+                fontFamily: FONTS.mono,
+                fontSize: '0.85rem',
+                color: STATUS_COLORS.open,
+              }}
+            >
+              Merge Rate
+            </Typography>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
+              <MergeRateBar rate={prStats.mergeRate} color={mergeRateColor} />
+              <Typography
+                sx={{
+                  fontFamily: FONTS.mono,
+                  fontWeight: 600,
+                  fontSize: '1.1rem',
+                  color: mergeRateColor,
+                  minWidth: 40,
+                  textAlign: 'right',
+                }}
+              >
+                {prStats.mergeRate}%
+              </Typography>
+            </Box>
+          </Box>
+
+          {/* Total $/day */}
+          <ImpactRow
+            label="Total $/day"
+            value={`$${Math.round(ossUsdPerDay).toLocaleString()}`}
+            valueColor={STATUS_COLORS.merged}
+          />
+        </Box>
+      </SectionCard>
+
+      {/* CARD 2: Issue Activity */}
+      <SectionCard title="Issue Activity" sx={{ flexShrink: 0 }}>
+        <Box sx={{ px: 2, pt: 1, pb: 2 }}>
+          <Box
+            sx={(theme) => ({
+              display: 'grid',
+              gridTemplateColumns: '1fr 1fr 1fr',
+              gap: 1,
+              mb: 2,
+              pb: 2,
+              borderBottom: `1px solid ${theme.palette.border.light}`,
+            })}
+          >
+            <PRColumn
+              label="Solved"
+              value={issueStats.solved}
+              color={STATUS_COLORS.merged}
+            />
+            <PRColumn
+              label="Open"
+              value={issueStats.open}
+              color={STATUS_COLORS.open}
+            />
+            <PRColumn
+              label="Closed"
+              value={issueStats.closed}
+              color={STATUS_COLORS.closed}
+            />
+          </Box>
+
+          {/* Solve Rate */}
+          <Box
+            sx={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              alignItems: 'center',
+            }}
+          >
+            <Typography
+              sx={{
+                fontFamily: FONTS.mono,
+                fontSize: '0.85rem',
+                color: STATUS_COLORS.open,
+              }}
+            >
+              Solve Rate
+            </Typography>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
+              <MergeRateBar rate={issueStats.solveRate} color={solveRateColor} />
+              <Typography
+                sx={{
+                  fontFamily: FONTS.mono,
+                  fontWeight: 600,
+                  fontSize: '1.1rem',
+                  color: solveRateColor,
+                  minWidth: 40,
+                  textAlign: 'right',
+                }}
+              >
+                {issueStats.solveRate}%
+              </Typography>
+            </Box>
+          </Box>
+
+          {/* Total $/day */}
+          <ImpactRow
+            label="Total $/day"
+            value={`$${Math.round(issueUsdPerDay).toLocaleString()}`}
+            valueColor={STATUS_COLORS.merged}
+          />
+        </Box>
+      </SectionCard>
+
+      {/* CARD 3: Code Impact */}
+      <SectionCard title="Code Impact" sx={{ flexShrink: 0 }}>
+        <Box
+          sx={{
+            px: 2,
+            pt: 1,
+            pb: 2,
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 2,
+          }}
+        >
+          <ImpactRow
+            label="Lines Added"
+            value={`+${prStats.merged === 0 && codeStats.linesAdded === 0 ? '0' : codeStats.linesAdded.toLocaleString()}`}
+            valueColor={DIFF_COLORS.additions}
+          />
+          <ImpactRow
+            label="Lines Deleted"
+            value={`-${codeStats.linesDeleted.toLocaleString()}`}
+            valueColor={DIFF_COLORS.deletions}
+          />
+          <ImpactRow
+            label="Repos Touched"
+            value={codeStats.reposTouched.toLocaleString()}
+          />
+          <Box
+            sx={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              alignItems: 'center',
+            }}
+          >
+            <Typography
+              sx={{
+                fontFamily: FONTS.mono,
+                fontSize: '0.85rem',
+                color: STATUS_COLORS.open,
+              }}
+            >
+              Avg Credibility
+            </Typography>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
+              <MergeRateBar rate={codeStats.avgCredibility} color={credibilityColor} />
+              <Typography
+                sx={{
+                  fontFamily: FONTS.mono,
+                  fontWeight: 600,
+                  fontSize: '1.1rem',
+                  color: credibilityColor,
+                  minWidth: 40,
+                  textAlign: 'right',
+                }}
+              >
+                {codeStats.avgCredibility}%
+              </Typography>
+            </Box>
+          </Box>
+        </Box>
+      </SectionCard>
+    </Stack>
+  );
+};
+
+// ── Sub-components ──────────────────────────────────────────────
+
+interface PRColumnProps {
+  label: string;
+  value: number;
+  color: string;
+}
+
+const PRColumn: React.FC<PRColumnProps> = ({ label, value, color }) => (
+  <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 0.5 }}>
+    <Typography
+      sx={{
+        fontFamily: FONTS.mono,
+        fontSize: '0.7rem',
+        color: STATUS_COLORS.open,
+        textTransform: 'uppercase',
+      }}
+    >
+      {label}
+    </Typography>
+    <Typography
+      sx={{
+        fontFamily: FONTS.mono,
+        fontSize: '1.1rem',
+        fontWeight: 600,
+        color,
+      }}
+    >
+      {value.toLocaleString()}
+    </Typography>
+  </Box>
+);
+
+interface MergeRateBarProps {
+  rate: number;
+  color: string;
+}
+
+const MergeRateBar: React.FC<MergeRateBarProps> = ({ rate, color }) => (
+  <Box
+    sx={(theme) => ({
+      width: 64,
+      height: 6,
+      borderRadius: 3,
+      backgroundColor: alpha(theme.palette.text.primary, 0.1),
+      overflow: 'hidden',
+    })}
+  >
+    <Box
+      sx={{
+        width: `${rate}%`,
+        height: '100%',
+        borderRadius: 3,
+        backgroundColor: color,
+        transition: 'width 0.4s ease',
+      }}
+    />
+  </Box>
+);
+
+interface ImpactRowProps {
+  label: string;
+  value: string;
+  valueColor?: string;
+}
+
+const ImpactRow: React.FC<ImpactRowProps> = ({ label, value, valueColor }) => (
+  <Box
+    sx={{
+      display: 'flex',
+      justifyContent: 'space-between',
+      alignItems: 'center',
+    }}
+  >
+    <Typography
+      sx={{
+        fontFamily: FONTS.mono,
+        fontSize: '0.85rem',
+        color: STATUS_COLORS.open,
+      }}
+    >
+      {label}
+    </Typography>
+    <Typography
+      sx={(theme) => ({
+        fontFamily: FONTS.mono,
+        fontWeight: 600,
+        fontSize: '1.1rem',
+        color: valueColor ?? theme.palette.text.primary,
+      })}
+    >
+      {value}
+    </Typography>
+  </Box>
+);

--- a/src/components/leaderboard/index.ts
+++ b/src/components/leaderboard/index.ts
@@ -2,7 +2,7 @@
 export { default as TopMinersTable } from './TopMinersTable';
 export { default as TopRepositoriesTable } from './TopRepositoriesTable';
 export { LeaderboardSidebar } from './LeaderboardSidebar';
-export { WatchlistSidebar } from './WatchlistSidebar';
+export { ActivitySidebarCards, StatRow } from './ActivitySidebarCards';
 export { MinerCard } from './MinerCard';
 export { MinersList } from './MinersList';
 export { RankIcon } from './RankIcon';

--- a/src/components/leaderboard/index.ts
+++ b/src/components/leaderboard/index.ts
@@ -2,6 +2,7 @@
 export { default as TopMinersTable } from './TopMinersTable';
 export { default as TopRepositoriesTable } from './TopRepositoriesTable';
 export { LeaderboardSidebar } from './LeaderboardSidebar';
+export { WatchlistSidebar } from './WatchlistSidebar';
 export { MinerCard } from './MinerCard';
 export { MinersList } from './MinersList';
 export { RankIcon } from './RankIcon';

--- a/src/pages/WatchlistPage.tsx
+++ b/src/pages/WatchlistPage.tsx
@@ -11,10 +11,16 @@ import {
   Tab,
   Tabs,
   Badge,
+  useMediaQuery,
 } from '@mui/material';
 import { Link as RouterLink, useSearchParams } from 'react-router-dom';
 import { Page } from '../components/layout';
-import { TopMinersTable, SEO, WatchlistButton } from '../components';
+import {
+  TopMinersTable,
+  WatchlistSidebar,
+  SEO,
+  WatchlistButton,
+} from '../components';
 import { LinkBox } from '../components/common/linkBehavior';
 import { useAllMiners, useAllPrs, useReposAndWeights, useIssues } from '../api';
 import { mapAllMinersToStats } from '../utils/minerMapper';
@@ -27,7 +33,7 @@ import {
 import { isMergedPr, isClosedUnmergedPr } from '../utils/prStatus';
 import { getIssueStatusMeta } from '../utils/issueStatus';
 import { formatTokenAmount } from '../utils/format';
-import { STATUS_COLORS } from '../theme';
+import theme, { STATUS_COLORS, scrollbarSx } from '../theme';
 
 const TAB_ORDER: readonly WatchlistCategory[] = [
   'miners',
@@ -96,6 +102,25 @@ const WatchlistPage: React.FC = () => {
   const noun = TAB_NOUN[activeTab];
   const discovery = TAB_DISCOVERY[activeTab];
 
+  const isLargeScreen = useMediaQuery(theme.breakpoints.up('xl'));
+  const showSidebarRight = !isEmpty && isLargeScreen;
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+  const isTablet = useMediaQuery(theme.breakpoints.between('sm', 'md'));
+  const sidebarWidth =
+    isMobile || isTablet ? '100%' : isLargeScreen ? '340px' : '300px';
+
+  const { ids: minerIds } = useWatchlist('miners');
+  const { data: allMinersData } = useAllMiners();
+  const minerStats = useMemo(() => {
+    const watchedSet = new Set(minerIds);
+    return mapAllMinersToStats(allMinersData ?? [])
+      .filter((m) => watchedSet.has(m.githubId))
+      .map((m) => ({
+        ...m,
+        isEligible: Boolean(m.ossIsEligible || m.discoveriesIsEligible),
+      }));
+  }, [allMinersData, minerIds]);
+
   const handleClear = () => {
     clear();
     setConfirmOpen(false);
@@ -126,131 +151,166 @@ const WatchlistPage: React.FC = () => {
       <Box
         sx={{
           width: '100%',
+          height: showSidebarRight ? 'calc(100vh - 64px)' : 'auto',
           display: 'flex',
-          flexDirection: 'column',
-          gap: { xs: 2, sm: 1.5 },
+          flexDirection: showSidebarRight ? 'row' : 'column',
+          gap: { xs: 2, sm: 2, md: 2.5, lg: 3 },
           py: { xs: 2, sm: 2, md: 2.5, lg: 3 },
           px: { xs: 2, sm: 2, md: 2.5, lg: 3 },
+          overflow: 'hidden',
         }}
       >
-        <Stack
-          direction="row"
-          alignItems="center"
-          justifyContent="space-between"
-          spacing={2}
+        {/* Main Content Area */}
+        <Box
+          sx={{
+            flex: 1,
+            display: 'flex',
+            flexDirection: 'column',
+            gap: { xs: 2, sm: 1.5 },
+            minHeight: 0,
+            overflow: showSidebarRight ? 'auto' : 'visible',
+            minWidth: 0,
+            pr: showSidebarRight ? 1 : 0,
+            ...scrollbarSx,
+          }}
         >
-          <Typography
-            sx={{
-              fontSize: '0.8rem',
-              color: (t) => alpha(t.palette.text.primary, 0.5),
-              lineHeight: 1.6,
-            }}
+          <Stack
+            direction="row"
+            alignItems="center"
+            justifyContent="space-between"
+            spacing={2}
           >
-            Your watchlist — {count}{' '}
-            {count === 1 ? `${noun.single} pinned` : `${noun.plural} pinned`}.
-            Stored locally in this browser.
-          </Typography>
-          {count > 0 && (
-            <Button
-              size="small"
-              onClick={() => setConfirmOpen(true)}
-              sx={{
-                fontSize: '0.75rem',
-                textTransform: 'none',
-                color: 'text.secondary',
-              }}
-            >
-              Clear {noun.plural}
-            </Button>
-          )}
-        </Stack>
-
-        <Box sx={{ borderBottom: '1px solid', borderColor: 'border.light' }}>
-          <Tabs
-            value={activeTab}
-            onChange={handleTabChange}
-            variant="scrollable"
-            scrollButtons="auto"
-            sx={{
-              minHeight: 40,
-              '& .MuiTab-root': {
-                minHeight: 40,
-                fontSize: '0.83rem',
-                fontWeight: 500,
-                textTransform: 'none',
-                color: 'text.secondary',
-                '&.Mui-selected': { color: 'primary.main' },
-              },
-            }}
-          >
-            {TAB_ORDER.map((cat) => (
-              <Tab
-                key={cat}
-                value={cat}
-                label={
-                  <Badge
-                    badgeContent={counts[cat]}
-                    color="primary"
-                    sx={{
-                      '& .MuiBadge-badge': {
-                        fontSize: '0.65rem',
-                        minWidth: 18,
-                        height: 18,
-                      },
-                    }}
-                  >
-                    <Box sx={{ pr: counts[cat] > 0 ? 1.5 : 0 }}>
-                      {TAB_LABELS[cat]}
-                    </Box>
-                  </Badge>
-                }
-              />
-            ))}
-          </Tabs>
-        </Box>
-
-        {isEmpty ? (
-          <Box
-            sx={{
-              py: 8,
-              textAlign: 'center',
-              display: 'flex',
-              flexDirection: 'column',
-              gap: 2,
-              alignItems: 'center',
-              color: 'text.secondary',
-            }}
-          >
-            <Typography sx={{ fontSize: '0.95rem' }}>
-              No watched {noun.plural} yet.
-            </Typography>
             <Typography
               sx={{
                 fontSize: '0.8rem',
-                maxWidth: 480,
                 color: (t) => alpha(t.palette.text.primary, 0.5),
+                lineHeight: 1.6,
               }}
             >
-              {discovery.hint} Pinned items appear here across reloads and tabs.
+              Your watchlist — {count}{' '}
+              {count === 1 ? `${noun.single} pinned` : `${noun.plural} pinned`}.
+              Stored locally in this browser.
             </Typography>
-            <Button
-              component={RouterLink}
-              to={discovery.path}
-              variant="outlined"
-              size="small"
-              sx={{ textTransform: 'none', mt: 1 }}
+            {count > 0 && (
+              <Button
+                size="small"
+                onClick={() => setConfirmOpen(true)}
+                sx={{
+                  fontSize: '0.75rem',
+                  textTransform: 'none',
+                  color: 'text.secondary',
+                }}
+              >
+                Clear {noun.plural}
+              </Button>
+            )}
+          </Stack>
+
+          <Box sx={{ borderBottom: '1px solid', borderColor: 'border.light' }}>
+            <Tabs
+              value={activeTab}
+              onChange={handleTabChange}
+              variant="scrollable"
+              scrollButtons="auto"
+              sx={{
+                minHeight: 40,
+                '& .MuiTab-root': {
+                  minHeight: 40,
+                  fontSize: '0.83rem',
+                  fontWeight: 500,
+                  textTransform: 'none',
+                  color: 'text.secondary',
+                  '&.Mui-selected': { color: 'primary.main' },
+                },
+              }}
             >
-              Go to {discovery.label}
-            </Button>
+              {TAB_ORDER.map((cat) => (
+                <Tab
+                  key={cat}
+                  value={cat}
+                  label={
+                    <Badge
+                      badgeContent={counts[cat]}
+                      color="primary"
+                      sx={{
+                        '& .MuiBadge-badge': {
+                          fontSize: '0.65rem',
+                          minWidth: 18,
+                          height: 18,
+                        },
+                      }}
+                    >
+                      <Box sx={{ pr: counts[cat] > 0 ? 1.5 : 0 }}>
+                        {TAB_LABELS[cat]}
+                      </Box>
+                    </Badge>
+                  }
+                />
+              ))}
+            </Tabs>
           </Box>
-        ) : activeTab === 'miners' ? (
-          <MinersList itemKeys={ids} />
-        ) : activeTab === 'repos' ? (
-          <ReposList itemKeys={ids} />
-        ) : activeTab === 'bounties' ? (
-          <BountiesList itemKeys={ids} />
-        ) : (
-          <PRsList itemKeys={ids} />
+
+          {isEmpty ? (
+            <Box
+              sx={{
+                py: 8,
+                textAlign: 'center',
+                display: 'flex',
+                flexDirection: 'column',
+                gap: 2,
+                alignItems: 'center',
+                color: 'text.secondary',
+              }}
+            >
+              <Typography sx={{ fontSize: '0.95rem' }}>
+                No watched {noun.plural} yet.
+              </Typography>
+              <Typography
+                sx={{
+                  fontSize: '0.8rem',
+                  color: (t) => alpha(t.palette.text.primary, 0.5),
+                  lineHeight: 1.6,
+                }}
+              >
+                {discovery.hint} Pinned items appear here across reloads and
+                tabs.
+              </Typography>
+              <Button
+                component={RouterLink}
+                to={discovery.path}
+                variant="outlined"
+                size="small"
+                sx={{ textTransform: 'none', mt: 1 }}
+              >
+                Go to {discovery.label}
+              </Button>
+            </Box>
+          ) : activeTab === 'miners' ? (
+            <MinersList itemKeys={ids} />
+          ) : activeTab === 'repos' ? (
+            <ReposList itemKeys={ids} />
+          ) : activeTab === 'bounties' ? (
+            <BountiesList itemKeys={ids} />
+          ) : (
+            <PRsList itemKeys={ids} />
+          )}
+        </Box>
+
+        {/* Right Sidebar — new activities */}
+        {!isEmpty && (
+          <Box
+            sx={{
+              width: showSidebarRight ? sidebarWidth : '100%',
+              height: showSidebarRight ? '100%' : 'auto',
+              maxHeight: showSidebarRight ? '100%' : 'none',
+              flexShrink: 0,
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 2,
+            }}
+          >
+            <WatchlistSidebar miners={minerStats} />
+          </Box>
         )}
       </Box>
 

--- a/src/pages/WatchlistPage.tsx
+++ b/src/pages/WatchlistPage.tsx
@@ -17,7 +17,7 @@ import { Link as RouterLink, useSearchParams } from 'react-router-dom';
 import { Page } from '../components/layout';
 import {
   TopMinersTable,
-  WatchlistSidebar,
+  ActivitySidebarCards,
   SEO,
   WatchlistButton,
 } from '../components';
@@ -309,7 +309,7 @@ const WatchlistPage: React.FC = () => {
               gap: 2,
             }}
           >
-            <WatchlistSidebar miners={minerStats} />
+            <ActivitySidebarCards miners={minerStats} />
           </Box>
         )}
       </Box>


### PR DESCRIPTION
## Closes: #562 

## Summary

- Add a new `WatchlistSidebar` component to the watchlist page with three purpose-built cards: **PR Activity**, **Issue Activity**, and **Code Impact**
- PR Activity and Issue Activity cards each show a Merged/Solved · Open · Closed breakdown, a rate progress bar (Merge Rate / Solve Rate), and pool-specific total $/day earnings
- Code Impact card shows Lines Added, Lines Deleted, Repos Touched, and Avg Credibility with a color-coded progress bar
- Sidebar renders only when the watchlist is non-empty; responsive layout matches the existing TopMinersPage pattern (right column on `xl`, stacked below on smaller screens)

## Details

- `WatchlistSidebar` is a standalone component — `LeaderboardSidebar` is untouched
- All data is derived from existing `MinerStats` fields (`totalMergedPrs`, `totalOpenPrs`, `totalClosedPrs`, `totalSolvedIssues`, `totalOpenIssues`, `totalClosedIssues`, `linesAdded`, `linesDeleted`, `uniqueReposCount`, `credibility`) — no backend changes required
- Pool earnings are split correctly: OSS pool total filters by `isEligible`, issue discovery pool total filters by `isIssueEligible`
- `credibility` is stored as a `0–1` float and is multiplied by 100 before display, consistent with the rest of the codebase
- All design tokens (`fontSize`, `fontWeight`, `STATUS_COLORS`, `FONTS.mono`, card padding) match the existing `LeaderboardSidebar` / `StatRow` design system

## Test plan

- [ ] Navigate to `/watchlist` with an empty watchlist — single-column layout, no sidebar visible
- [ ] Pin several miners from the leaderboard, return to `/watchlist` on an `xl` screen — sidebar appears on the right
- [ ] Verify PR Activity shows Merged (green) · Open (white) · Closed (red) counts with Merge Rate bar and OSS pool total $/day
- [ ] Verify Issue Activity shows Solved (green) · Open (white) · Closed (red) counts with Solve Rate bar and issue discovery pool total $/day
- [ ] Confirm PR Activity and Issue Activity show **different** $/day totals reflecting separate pools
- [ ] Verify Code Impact shows Lines Added (green `+N`), Lines Deleted (red `-N`), Repos Touched, and Avg Credibility with progress bar
- [ ] Confirm Avg Credibility displays as a percentage (e.g. `87%`) not a decimal
- [ ] Resize below `xl` — sidebar stacks below the table at full width
- [ ] Verify OSS Contributions page (`/top-miners`) is unchanged

<img width="1787" height="880" alt="image" src="https://github.com/user-attachments/assets/0781f53a-f6f3-441c-8dfa-d0442e5a6524" />
