### PR TITLE
Leaderboard: show network summary first on mobile and compact miner paging

### DIFF
--- a/src/components/leaderboard/LeaderboardSidebar.tsx
+++ b/src/components/leaderboard/LeaderboardSidebar.tsx
@@ -67,7 +67,14 @@ export const LeaderboardSidebar: React.FC<LeaderboardSidebarProps> = ({
       sx={{ height: '100%', overflow: 'auto', pr: 1, ...scrollbarSx }}
     >
       {/* CARD 1: Network Stats */}
-      <SectionCard title="Network Stats" sx={{ flexShrink: 0 }}>
+      <SectionCard
+        id="leaderboard-network-stats"
+        title="Network Stats"
+        sx={{
+          flexShrink: 0,
+          scrollMarginTop: { xs: 72, sm: 80 },
+        }}
+      >
         <Box
           sx={{
             pt: 1,

--- a/src/components/leaderboard/SectionCard.tsx
+++ b/src/components/leaderboard/SectionCard.tsx
@@ -15,12 +15,14 @@ export const SectionCard: React.FC<{
   title?: string;
   action?: React.ReactNode;
   centerContent?: React.ReactNode;
-}> = ({ children, sx, title, action, centerContent }) => {
+  id?: string;
+}> = ({ children, sx, title, action, centerContent, id }) => {
   const hasAction = !!action;
   const hasCenter = !!centerContent;
 
   return (
     <Card
+      id={id}
       sx={{
         borderRadius: 3,
         border: '1px solid',

--- a/src/components/leaderboard/TopMinersTable.tsx
+++ b/src/components/leaderboard/TopMinersTable.tsx
@@ -1,6 +1,12 @@
 import React, { useCallback, useEffect, useMemo } from 'react';
-import { Box, Typography, CircularProgress, Grid } from '@mui/material';
-import { alpha, type Theme } from '@mui/material/styles';
+import {
+  Box,
+  Typography,
+  CircularProgress,
+  Grid,
+  useMediaQuery,
+} from '@mui/material';
+import { alpha, useTheme, type Theme } from '@mui/material/styles';
 import { useSearchParams } from 'react-router-dom';
 import { SectionCard } from './SectionCard';
 import { MinerCard } from './MinerCard';
@@ -16,7 +22,11 @@ import {
 // Re-export MinerStats for backward compatibility
 export type { MinerStats } from './types';
 
+/** Desktop: initial load and each “Show more” step */
 const MINERS_PAGE_SIZE = 60;
+/** Viewports below `xl`: shorter first page and load-more step */
+const COMPACT_VISIBLE_INITIAL = 6;
+const COMPACT_VISIBLE_STEP = 12;
 const SORT_QUERY_PARAM = 'sort';
 const ELIGIBLE_QUERY_PARAM = 'eligible';
 const SEARCH_QUERY_PARAM = 'search';
@@ -67,17 +77,6 @@ const getEligibilityFilterFromQuery = (
   return 'all';
 };
 
-const getVisibleCountFromQuery = (value: string | null): number => {
-  if (!value) return MINERS_PAGE_SIZE;
-
-  const parsed = Number.parseInt(value, 10);
-  if (!Number.isFinite(parsed) || parsed < MINERS_PAGE_SIZE) {
-    return MINERS_PAGE_SIZE;
-  }
-
-  return parsed;
-};
-
 const TopMinersTable: React.FC<TopMinersTableProps> = ({
   miners,
   isLoading,
@@ -86,6 +85,15 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
   variant = 'oss',
   showDualEligibilityBadges = false,
 }) => {
+  const theme = useTheme();
+  const useCompactPaging = useMediaQuery(theme.breakpoints.down('xl'));
+  const initialChunk = useCompactPaging
+    ? COMPACT_VISIBLE_INITIAL
+    : MINERS_PAGE_SIZE;
+  const loadMoreChunk = useCompactPaging
+    ? COMPACT_VISIBLE_STEP
+    : MINERS_PAGE_SIZE;
+
   const [searchParams, setSearchParams] = useSearchParams();
   const searchQuery = searchParams.get(SEARCH_QUERY_PARAM) ?? '';
   const sortParamValue = searchParams.get(SORT_QUERY_PARAM);
@@ -97,10 +105,13 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
     () => getEligibilityFilterFromQuery(searchParams.get(ELIGIBLE_QUERY_PARAM)),
     [searchParams],
   );
-  const visibleCount = useMemo(
-    () => getVisibleCountFromQuery(searchParams.get(VISIBLE_QUERY_PARAM)),
-    [searchParams],
-  );
+  const visibleCount = useMemo(() => {
+    const raw = searchParams.get(VISIBLE_QUERY_PARAM);
+    if (!raw) return initialChunk;
+    const parsed = Number.parseInt(raw, 10);
+    if (!Number.isFinite(parsed) || parsed < initialChunk) return initialChunk;
+    return parsed;
+  }, [searchParams, initialChunk]);
 
   const handleSortChange = useCallback(
     (nextSortOption: SortOption) => {
@@ -279,12 +290,39 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
               flexWrap: { xs: 'wrap', sm: 'nowrap' },
             }}
           >
-            <Typography
-              variant="h6"
-              sx={{ fontSize: '1.25rem', fontWeight: 600, flexShrink: 0 }}
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 1.5,
+                flexWrap: 'wrap',
+                flexShrink: 0,
+              }}
             >
-              Miners ({filteredMiners.length})
-            </Typography>
+              <Typography
+                variant="h6"
+                sx={{ fontSize: '1.25rem', fontWeight: 600 }}
+              >
+                Miners ({filteredMiners.length})
+              </Typography>
+              {useCompactPaging && variant !== 'watchlist' && (
+                <Typography
+                  component="a"
+                  href="#leaderboard-network-stats"
+                  sx={{
+                    fontFamily: FONTS.mono,
+                    fontSize: '0.72rem',
+                    fontWeight: 600,
+                    color: 'primary.main',
+                    textDecoration: 'none',
+                    letterSpacing: '0.04em',
+                    '&:hover': { textDecoration: 'underline' },
+                  }}
+                >
+                  Network summary
+                </Typography>
+              )}
+            </Box>
             <Box
               sx={{ flex: 1, minWidth: 0, width: { xs: '100%', sm: 'auto' } }}
             >
@@ -341,7 +379,7 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
           <Box
             onClick={() => {
               const nextVisibleCount = Math.min(
-                visibleCount + MINERS_PAGE_SIZE,
+                visibleCount + loadMoreChunk,
                 filteredMiners.length,
               );
 
@@ -349,7 +387,7 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
                 (previousParams) => {
                   const nextSearchParams = new URLSearchParams(previousParams);
 
-                  if (nextVisibleCount > MINERS_PAGE_SIZE) {
+                  if (nextVisibleCount > initialChunk) {
                     nextSearchParams.set(
                       VISIBLE_QUERY_PARAM,
                       String(nextVisibleCount),
@@ -393,7 +431,7 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
                 letterSpacing: '0.06em',
               }}
             >
-              Show {Math.min(MINERS_PAGE_SIZE, remainingMiners)} More
+              Show {Math.min(loadMoreChunk, remainingMiners)} More
             </Typography>
           </Box>
         )}

--- a/src/pages/DiscoveriesPage.tsx
+++ b/src/pages/DiscoveriesPage.tsx
@@ -98,6 +98,7 @@ const DiscoveriesPage: React.FC = () => {
             overflow: showSidebarRight ? 'auto' : 'visible',
             minWidth: 0,
             pr: showSidebarRight ? 1 : 0,
+            order: showSidebarRight ? 1 : 2,
             ...scrollbarSx,
           }}
         >
@@ -132,6 +133,7 @@ const DiscoveriesPage: React.FC = () => {
             display: 'flex',
             flexDirection: 'column',
             gap: 2,
+            order: showSidebarRight ? 2 : 1,
           }}
         >
           <LeaderboardSidebar

--- a/src/pages/TopMinersPage.tsx
+++ b/src/pages/TopMinersPage.tsx
@@ -65,6 +65,7 @@ const TopMinersPage: React.FC = () => {
             overflow: showSidebarRight ? 'auto' : 'visible',
             minWidth: 0,
             pr: showSidebarRight ? 1 : 0,
+            order: showSidebarRight ? 1 : 2,
             ...scrollbarSx,
           }}
         >
@@ -99,6 +100,7 @@ const TopMinersPage: React.FC = () => {
             display: 'flex',
             flexDirection: 'column',
             gap: 2, // Add gap for spacing when stacked
+            order: showSidebarRight ? 2 : 1,
           }}
         >
           {/* Render extracted Sidebar Content here */}


### PR DESCRIPTION


## Summary

On viewports **below `xl`**, the miner leaderboard used to stack **Network Stats** and **Top Earners** **below** a long grid of miner cards, so mobile users had to scroll a lot before seeing the summary. This change:

- Uses flex **`order`** so the **sidebar (Network Stats + Top Earners / Most Active)** renders **above** the intro + miner table when the layout is stacked (`TopMinersPage`, `DiscoveriesPage`).
- Uses **smaller paging** below `xl`: **6** miners initially and **12** per “Show more” (desktop remains **60** / **60**).
- Adds **`id="leaderboard-network-stats"`** with **`scrollMarginTop`** on the Network Stats card, optional **`id`** on **`SectionCard`**, and a **“Network summary”** link in the miner toolbar on compact layouts (not on watchlist).

---

## Related Issues




## Type of Change

- [ ] Bug fix  
- [x] New feature  
- [ ] Refactor  
- [ ] Documentation  
- [ ] Other (describe below)

*(If your team treats this as UX polish on existing pages, you can check **Bug fix** instead.)*



## Screenshots

<img width="789" height="814" alt="2026-04-17_15h03_08" src="https://github.com/user-attachments/assets/7a175666-db75-4bf5-b86f-a84854f5fd8e" />

<img width="790" height="808" alt="2026-04-17_15h19_19" src="https://github.com/user-attachments/assets/e0290c74-670b-4b42-8dd9-a722ce4273f4" />





## Checklist

- [x] New components are modularized/separated where sensible *(changes stay in existing pages/components)*  
- [x] Uses predefined theme (e.g. no hardcoded colors)  
- [x] Responsive/mobile checked *(confirm on a real device or devtools)*  
- [ ] Tested against the test API  
- [x] `npm run format` and `npm run lint:fix` have been run  
- [x] `npm run build` passes  
- [x] Screenshots included for any UI/visual changes  

Check the last five items after you run commands and capture screenshots.