### PR TITLE
fix:Onboard: align SEO title, description, and canonical URL with the active tab

### DIFF
--- a/src/pages/OnboardPage.tsx
+++ b/src/pages/OnboardPage.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Box, Tabs, Tab, Card, CardContent } from '@mui/material';
 import { Page } from '../components/layout';
 import { SEO } from '../components';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams, useLocation } from 'react-router-dom';
 import { AboutContent } from '../components/onboard/AboutContent';
 import { FAQContent } from '../components/onboard/FAQContent';
 
@@ -10,8 +10,42 @@ import { GettingStarted } from '../components/onboard/GettingStarted';
 import { Scoring } from '../components/onboard/Scoring';
 import { LanguageWeightsTable } from '../components/repositories';
 
+const ONBOARD_TAB_SEO: Record<
+  'about' | 'getting-started' | 'scoring' | 'languages' | 'faq',
+  { title: string; description: string }
+> = {
+  about: {
+    title: 'About',
+    description:
+      'What Gittensor is, how incentives work, and how open-source miners earn rewards.',
+  },
+  'getting-started': {
+    title: 'Getting Started',
+    description:
+      'Start mining on Gittensor. Setup guide, documentation, and resources.',
+  },
+  scoring: {
+    title: 'Scoring',
+    description:
+      'How miner scores work: OSS contributions, PR merges, code quality, discovery bonuses, and credibility requirements.',
+  },
+  languages: {
+    title: 'Languages',
+    description:
+      'Programming language weights used when scoring contributions across tracked repositories.',
+  },
+  faq: {
+    title: 'FAQ',
+    description:
+      'Answers to common questions about subnets, incentives, staking, and Gittensor.',
+  },
+};
+
+type OnboardTabKey = keyof typeof ONBOARD_TAB_SEO;
+
 const OnboardPage: React.FC = () => {
   const [searchParams, setSearchParams] = useSearchParams();
+  const location = useLocation();
 
   // Determine active tab from URL query param or default to 0
   const tabParam = searchParams.get('tab');
@@ -23,7 +57,7 @@ const OnboardPage: React.FC = () => {
     faq: 4,
   };
 
-  const indexToTabName: Record<number, string> = {
+  const indexToTabName: Record<number, OnboardTabKey> = {
     0: 'about',
     1: 'getting-started',
     2: 'scoring',
@@ -42,12 +76,17 @@ const OnboardPage: React.FC = () => {
     setSearchParams(newParams, { replace: true });
   };
 
+  const activeTabKey = indexToTabName[activeTab];
+  const { title: seoTitle, description: seoDescription } =
+    ONBOARD_TAB_SEO[activeTabKey];
+  const seoUrl =
+    typeof window !== 'undefined'
+      ? `${window.location.origin}${location.pathname}${location.search}`
+      : undefined;
+
   return (
     <Page title="Onboard">
-      <SEO
-        title="Getting Started - Gittensor"
-        description="Start mining on Gittensor. Setup guide, documentation, and resources."
-      />
+      <SEO title={seoTitle} description={seoDescription} url={seoUrl} />
       <Box
         sx={{
           display: 'flex',


### PR DESCRIPTION
## Summary

`OnboardPage` uses URL query `tab` to show About, Getting Started, Scoring, Languages, or FAQ, but `<SEO>` was hardcoded to Getting Started only. Browser titles, meta descriptions, and social previews for routes like `/onboard?tab=faq` therefore misrepresented the visible content.

This change maps the active tab to per-tab `title` and `description` via a small `ONBOARD_TAB_SEO` table and passes an explicit `url` into `SEO` (from `useLocation()` plus `window.location.origin`) so `<link rel="canonical">`, `og:url`, and related tags stay in sync with the current `tab` when sharing or bookmarking.

**Scope:** `src/pages/OnboardPage.tsx` only (frontend).

## Related Issues

Fixes #565

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

Before:

https://github.com/user-attachments/assets/99bf0e63-3b94-4f20-b7b7-a31af061e90a

After:

https://github.com/user-attachments/assets/3cc1f2dc-7b4b-431c-9681-9ece466ffb37

<!-- Include before/after screenshots for every UI/visual change. Remove this section if not applicable. -->

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [ ] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
