### PR TITLE
repsitory row not center aligned

### DIFF
--- a/src/components/leaderboard/LeaderboardTableSkeleton.tsx
+++ b/src/components/leaderboard/LeaderboardTableSkeleton.tsx
@@ -11,7 +11,7 @@ interface LeaderboardTableSkeletonProps {
 
 const LAYOUTS: Record<
   SkeletonVariant,
-  Array<{ width: string; barWidth: string; align?: 'right' }>
+  Array<{ width: string; barWidth: string; align?: 'right' | 'center' }>
 > = {
   miners: [
     { width: '80px', barWidth: '24px' },
@@ -32,10 +32,10 @@ const LAYOUTS: Record<
   repositories: [
     { width: '60px', barWidth: '24px' },
     { width: '35%', barWidth: '70%' },
-    { width: '12%', barWidth: '50%', align: 'right' },
-    { width: '18%', barWidth: '55%', align: 'right' },
-    { width: '15%', barWidth: '40%', align: 'right' },
-    { width: '15%', barWidth: '40%', align: 'right' },
+    { width: '12%', barWidth: '50%', align: 'center' },
+    { width: '18%', barWidth: '55%', align: 'center' },
+    { width: '15%', barWidth: '40%', align: 'center' },
+    { width: '15%', barWidth: '40%', align: 'center' },
   ],
 };
 
@@ -59,7 +59,8 @@ const LeaderboardTableSkeleton: React.FC<LeaderboardTableSkeletonProps> = ({
                 width={col.barWidth}
                 sx={{
                   bgcolor: 'rgba(255,255,255,0.06)',
-                  ml: col.align === 'right' ? 'auto' : 0,
+                  ...(col.align === 'right' && { ml: 'auto' }),
+                  ...(col.align === 'center' && { mx: 'auto' }),
                 }}
               />
             </TableCell>

--- a/src/components/leaderboard/TopRepositoriesTable.tsx
+++ b/src/components/leaderboard/TopRepositoriesTable.tsx
@@ -307,6 +307,15 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
         shadowBlur: 12,
       },
     }));
+    const positiveSeriesValues = seriesData
+      .map((item) => item.value)
+      .filter((value) => Number.isFinite(value) && value > 0);
+    const minPositiveValue =
+      positiveSeriesValues.length > 0 ? Math.min(...positiveSeriesValues) : 1;
+    const logMin =
+      minPositiveValue < 1
+        ? 10 ** Math.floor(Math.log10(minPositiveValue))
+        : 1;
 
     return {
       backgroundColor: 'transparent',
@@ -401,7 +410,7 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
       },
       yAxis: {
         type: effectiveLogScale ? 'log' : 'value',
-        min: effectiveLogScale ? 1 : 0,
+        min: effectiveLogScale ? logMin : 0,
         logBase: 10,
         name: metric.yAxis,
         nameTextStyle: {
@@ -413,6 +422,12 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
           color: textColor,
           fontSize: 11,
           formatter: (value: number) => {
+            if (sortColumn === 'weight') {
+              if (value >= 1000) return `${(value / 1000).toFixed(1)}k`;
+              if (value >= 10) return value.toFixed(1).replace(/\.0$/, '');
+              if (value >= 1) return value.toFixed(2).replace(/\.?0+$/, '');
+              return value.toFixed(3).replace(/\.?0+$/, '');
+            }
             if (value >= 1000) return `${(value / 1000).toFixed(1)}k`;
             return value.toFixed(0);
           },
@@ -491,7 +506,7 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
   }: {
     column: SortColumn;
     children: React.ReactNode;
-    align?: 'left' | 'right';
+    align?: 'left' | 'right' | 'center';
     sx?: SxProps<Theme>;
   }) => (
     <TableCell
@@ -511,7 +526,12 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
         sx={{
           display: 'flex',
           alignItems: 'center',
-          justifyContent: align === 'right' ? 'flex-end' : 'flex-start',
+          justifyContent:
+            align === 'right'
+              ? 'flex-end'
+              : align === 'center'
+                ? 'center'
+                : 'flex-start',
           gap: 0.5,
         }}
       >
@@ -783,19 +803,23 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
               <TableCell sx={{ ...headerCellStyle, width: '60px' }}>
                 Rank
               </TableCell>
-              <SortableHeader column="repository" sx={{ width: '35%' }}>
+              <SortableHeader
+                column="repository"
+                align="center"
+                sx={{ width: '35%' }}
+              >
                 Repository
               </SortableHeader>
               <SortableHeader
                 column="weight"
-                align="right"
+                align="center"
                 sx={{ width: '12%' }}
               >
                 Weight
               </SortableHeader>
               <SortableHeader
                 column="totalScore"
-                align="right"
+                align="center"
                 sx={{
                   width: '18%',
                 }}
@@ -804,14 +828,14 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
               </SortableHeader>
               <SortableHeader
                 column="totalPRs"
-                align="right"
+                align="center"
                 sx={{ width: '15%' }}
               >
                 PRs
               </SortableHeader>
               <SortableHeader
                 column="contributors"
-                align="right"
+                align="center"
                 sx={{ width: '15%' }}
               >
                 Contributors
@@ -853,12 +877,14 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
                           <RankIcon rank={repo.rank || 0} />
                         </TableCell>
                         <TableCell
+                          align="left"
                           sx={{ ...bodyCellStyle, width: '35%', pl: 1.5 }}
                         >
                           <Box
                             sx={{
                               display: 'flex',
                               alignItems: 'center',
+                              justifyContent: 'flex-start',
                               gap: 1,
                               cursor: 'pointer',
                               '&:hover': {
@@ -906,7 +932,7 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
                           </Box>
                         </TableCell>
                         <TableCell
-                          align="right"
+                          align="center"
                           sx={{ ...bodyCellStyle, width: '12%' }}
                         >
                           <Typography
@@ -921,7 +947,7 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
                           </Typography>
                         </TableCell>
                         <TableCell
-                          align="right"
+                          align="center"
                           sx={{ ...bodyCellStyle, width: '18%' }}
                         >
                           <Typography
@@ -941,7 +967,7 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
                           </Typography>
                         </TableCell>
                         <TableCell
-                          align="right"
+                          align="center"
                           sx={{ ...bodyCellStyle, width: '15%' }}
                         >
                           <Typography
@@ -958,7 +984,7 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
                           </Typography>
                         </TableCell>
                         <TableCell
-                          align="right"
+                          align="center"
                           sx={{ ...bodyCellStyle, width: '15%' }}
                         >
                           <Typography


### PR DESCRIPTION
##Title

Repository Weights Chart Y-Axis Shows Only Zeros for Non-Zero Values

## Summary

The repository weights chart in the repositories panel renders Y-axis labels as `0` even when plotted weight values are greater than `0`. This happens because axis tick formatting rounds fractional values to integers.

## Related Issues

#566 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

- Before: left Y-axis labels display only `0` while bars represent non-zero weights.
- After: Y-axis labels display non-zero decimal values correctly.
- Reference capture: `2026-04-17_11h57_17.mp4`

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [ ] Tested against the test API
- [ ] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
