### PR TITLE
fix:Onboard → Getting Started: align stepper connector with circle centers at narrow desktop widths

### DIFF
--- a/src/components/onboard/GettingStarted.tsx
+++ b/src/components/onboard/GettingStarted.tsx
@@ -1,13 +1,5 @@
 import React, { useState } from 'react';
-import {
-  Box,
-  Typography,
-  Stack,
-  Button,
-  Tabs,
-  Tab,
-  Tooltip,
-} from '@mui/material';
+import { Box, Typography, Button, Tabs, Tab, Tooltip } from '@mui/material';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import CheckIcon from '@mui/icons-material/Check';
@@ -443,8 +435,8 @@ export const GettingStarted: React.FC = () => {
           sx={{
             position: 'absolute',
             top: 24,
-            left: '3%',
-            right: '3%',
+            left: { xs: 0, md: 'calc(100% / 14)' },
+            width: { xs: '100%', md: 'calc(100% * 6 / 7)' },
             height: 2,
             background: (theme) =>
               `linear-gradient(90deg, ${theme.palette.border.subtle} 0%, ${theme.palette.border.medium} 50%, ${theme.palette.border.subtle} 100%)`,
@@ -453,12 +445,16 @@ export const GettingStarted: React.FC = () => {
           }}
         />
 
-        <Stack
-          direction={{ xs: 'column', md: 'row' }}
-          spacing={{ xs: 2, md: 0 }}
-          justifyContent="space-between"
-          alignItems={{ xs: 'flex-start', md: 'flex-start' }}
-          sx={{ position: 'relative', zIndex: 1 }}
+        <Box
+          sx={{
+            display: { xs: 'flex', md: 'grid' },
+            flexDirection: { xs: 'column' },
+            gap: { xs: 2, md: 0 },
+            gridTemplateColumns: { md: 'repeat(7, minmax(0, 1fr))' },
+            alignItems: { xs: 'flex-start', md: 'flex-start' },
+            position: 'relative',
+            zIndex: 1,
+          }}
         >
           {steps.map((item, index) => (
             <Box
@@ -469,7 +465,8 @@ export const GettingStarted: React.FC = () => {
                 flexDirection: { xs: 'row', md: 'column' },
                 alignItems: 'center',
                 gap: { xs: 1.5, md: 1 },
-                width: { xs: '100%', md: 'auto' },
+                width: { xs: '100%', md: '100%' },
+                minWidth: 0,
                 cursor: 'pointer',
                 '&:hover .step-circle': {
                   borderColor: 'border.medium',
@@ -550,7 +547,7 @@ export const GettingStarted: React.FC = () => {
               </Box>
             </Box>
           ))}
-        </Stack>
+        </Box>
       </Box>
 
       <Box


### PR DESCRIPTION
## Summary

On **Miner Setup** (`GettingStarted`), the desktop horizontal connector used **`left: 3%` / `right: 3%`** while the seven steps sat in a **`Stack`** with **`space-between`** and variable-width columns. The bar and the circles did not share one layout, so at some **`md`** widths a short line segment appeared **to the left of the step 1 ring**.

This change lays out the step row as a **seven-column CSS grid** on **`md+`** (`repeat(7, minmax(0, 1fr))`) so each circle sits on a column midline. The connector is repositioned with **`left: calc(100% / 14)`** and **`width: calc(100% * 6 / 7)`** so it runs from the first column center to the last, matching the circles. The existing gradient and **`xs`** column layout (flex + vertical gap) are unchanged.

## Related Issues

Fixes #571

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

Before:

https://github.com/user-attachments/assets/d014fa02-b788-42ff-a302-69c672f8915a

After:

https://github.com/user-attachments/assets/3851f61f-d5bc-486c-892a-140d0963fc4a


<!-- Include before/after screenshots for every UI/visual change. Remove this section if not applicable. -->

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [ ] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
