### PR TITLE
fix: cancel pending setTimeout on unmount across 4 components

### DIFF
--- a/src/components/layout/GlobalSearchBar.tsx
+++ b/src/components/layout/GlobalSearchBar.tsx
@@ -204,6 +204,15 @@ const GlobalSearchBar: React.FC = () => {
   const rowRefs = useRef<Record<string, HTMLButtonElement | null>>({});
   const blurTimerRef = useRef<number | null>(null);
 
+  useEffect(
+    () => () => {
+      if (blurTimerRef.current !== null) {
+        window.clearTimeout(blurTimerRef.current);
+      }
+    },
+    [],
+  );
+
   // Activate dataset loading after first interaction (or immediately on /search).
   const [isSearchActivated, setIsSearchActivated] = useState(isSearchPage);
 

--- a/src/components/onboard/GettingStarted.tsx
+++ b/src/components/onboard/GettingStarted.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Box, Typography, Stack, Button, Tabs, Tab } from '@mui/material';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
@@ -50,11 +50,27 @@ const CodeBlock: React.FC<{
   label?: string;
 }> = ({ children, label }) => {
   const [copied, setCopied] = useState(false);
+  const copyTimerRef = useRef<number | null>(null);
+
+  useEffect(
+    () => () => {
+      if (copyTimerRef.current !== null) {
+        window.clearTimeout(copyTimerRef.current);
+      }
+    },
+    [],
+  );
 
   const handleCopy = () => {
     navigator.clipboard.writeText(children.trim());
     setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
+    if (copyTimerRef.current !== null) {
+      window.clearTimeout(copyTimerRef.current);
+    }
+    copyTimerRef.current = window.setTimeout(() => {
+      setCopied(false);
+      copyTimerRef.current = null;
+    }, 2000);
   };
 
   return (

--- a/src/components/prs/PRFilesChanged.tsx
+++ b/src/components/prs/PRFilesChanged.tsx
@@ -1088,12 +1088,28 @@ const PRFileDiffViewer: React.FC<{
 
   const [copied, setCopied] = useState(false);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const copyTimerRef = useRef<number | null>(null);
+
+  useEffect(
+    () => () => {
+      if (copyTimerRef.current !== null) {
+        window.clearTimeout(copyTimerRef.current);
+      }
+    },
+    [],
+  );
 
   const handleCopyPath = (e: React.MouseEvent) => {
     e.stopPropagation();
     navigator.clipboard.writeText(file.filename);
     setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
+    if (copyTimerRef.current !== null) {
+      window.clearTimeout(copyTimerRef.current);
+    }
+    copyTimerRef.current = window.setTimeout(() => {
+      setCopied(false);
+      copyTimerRef.current = null;
+    }, 2000);
   };
 
   if (!file.patch) {

--- a/src/pages/dashboard/views/LiveCommitLog.tsx
+++ b/src/pages/dashboard/views/LiveCommitLog.tsx
@@ -319,6 +319,16 @@ const LiveCommitLog: React.FC = () => {
   const [newEntryIds, setNewEntryIds] = useState<Set<string>>(new Set());
   const logContainerRef = useRef<HTMLDivElement>(null);
   const loadMoreRef = useRef<HTMLDivElement>(null);
+  const newEntryTimerRef = useRef<number | null>(null);
+
+  useEffect(
+    () => () => {
+      if (newEntryTimerRef.current !== null) {
+        window.clearTimeout(newEntryTimerRef.current);
+      }
+    },
+    [],
+  );
 
   const apiCommits = useMemo<CommitLogEntry[]>(
     () => data?.pages.flat() ?? [],
@@ -352,7 +362,13 @@ const LiveCommitLog: React.FC = () => {
 
       if (isHeadUpdate) {
         setNewEntryIds(new Set(novelItems.map(getCommitId)));
-        setTimeout(() => setNewEntryIds(new Set()), 2000);
+        if (newEntryTimerRef.current !== null) {
+          window.clearTimeout(newEntryTimerRef.current);
+        }
+        newEntryTimerRef.current = window.setTimeout(() => {
+          setNewEntryIds(new Set());
+          newEntryTimerRef.current = null;
+        }, 2000);
         return [...novelItems, ...updatedLog];
       }
 


### PR DESCRIPTION
## Summary
- Four components scheduled a `setTimeout` that calls `setState` but never cleared the timer on unmount: `LiveCommitLog`, `PRFileDiffViewer`, onboarding `CodeBlock`, and `GlobalSearchBar`.
- Unmounting within the pending window produced a "state update on unmounted component" warning and leaked the callback closure.
- Each site now tracks the timer in a `useRef`, clears any in-flight timer before scheduling a new one, and clears it in an empty-dep `useEffect` cleanup — matching the existing pattern in [MinerScoreCard.tsx:209-235](src/components/miners/MinerScoreCard.tsx#L209-L235).

## Changes
- [src/pages/dashboard/views/LiveCommitLog.tsx](src/pages/dashboard/views/LiveCommitLog.tsx) — 2s "new entry" highlight timer
- [src/components/prs/PRFilesChanged.tsx](src/components/prs/PRFilesChanged.tsx) — copy-path "copied!" reset timer
- [src/components/onboard/GettingStarted.tsx](src/components/onboard/GettingStarted.tsx) — code block copy-button reset timer
- [src/components/layout/GlobalSearchBar.tsx](src/components/layout/GlobalSearchBar.tsx) — blur-close timer (ref already existed; added unmount cleanup)

## Test plan
- [ ] Open `/dashboard` live commit log, trigger a head update, navigate away within 2s — no React warning in console
- [ ] Open a PR file diff, click copy-path, navigate away within 2s — no warning
- [ ] On onboarding page, click a code-block copy button, navigate away within 2s — no warning
- [ ] Focus global search, blur and navigate away immediately — no warning
- [ ] `npm run typecheck` passes
