### PR TITLE
change mobile layout of miner detail page

### DIFF
--- a/src/components/miners/MinerInsightsCard.tsx
+++ b/src/components/miners/MinerInsightsCard.tsx
@@ -380,45 +380,56 @@ const MinerInsightsCard: React.FC<MinerInsightsCardProps> = ({
                 py: 1.2,
                 border: `1px solid ${style.border}`,
                 backgroundColor: style.background,
-                display: 'flex',
-                alignItems: 'flex-start',
-                gap: 1.1,
               }}
             >
-              <Box sx={{ color: style.color, mt: 0.15 }}>{style.icon}</Box>
-              <Box sx={{ flexGrow: 1 }}>
-                <Typography
-                  sx={{
-                    color: style.color,
-                    fontSize: '0.83rem',
-                    fontWeight: 600,
-                  }}
-                >
-                  {insight.title}
-                </Typography>
-                <Typography
-                  sx={{
-                    color: (t) => alpha(t.palette.text.primary, 0.68),
-                    fontSize: '0.8rem',
-                    mt: 0.4,
-                    lineHeight: 1.45,
-                  }}
-                >
-                  {insight.description}
-                </Typography>
-              </Box>
-              <Chip
-                size="small"
-                label={insight.type}
+              <Box
                 sx={{
-                  textTransform: 'uppercase',
-                  fontSize: '0.62rem',
-                  color: style.color,
-                  backgroundColor: alpha(style.color, 0.12),
-                  border: `1px solid ${alpha(style.color, 0.35)}`,
-                  height: 22,
+                  display: 'flex',
+                  alignItems: 'flex-start',
+                  justifyContent: 'space-between',
+                  gap: 1.1,
+                  mb: 0.75,
                 }}
-              />
+              >
+                <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1.1, minWidth: 0, flex: 1 }}>
+                  <Box sx={{ color: style.color, mt: 0.15, flexShrink: 0 }}>
+                    {style.icon}
+                  </Box>
+                  <Typography
+                    sx={{
+                      color: style.color,
+                      fontSize: '0.83rem',
+                      fontWeight: 600,
+                      lineHeight: 1.35,
+                    }}
+                  >
+                    {insight.title}
+                  </Typography>
+                </Box>
+                <Chip
+                  size="small"
+                  label={insight.type}
+                  sx={{
+                    flexShrink: 0,
+                    textTransform: 'uppercase',
+                    fontSize: '0.62rem',
+                    color: style.color,
+                    backgroundColor: alpha(style.color, 0.12),
+                    border: `1px solid ${alpha(style.color, 0.35)}`,
+                    height: 22,
+                  }}
+                />
+              </Box>
+              <Typography
+                sx={{
+                  color: (t) => alpha(t.palette.text.primary, 0.68),
+                  fontSize: '0.8rem',
+                  lineHeight: 1.45,
+                  width: '100%',
+                }}
+              >
+                {insight.description}
+              </Typography>
             </Box>
           );
         })}
@@ -427,7 +438,7 @@ const MinerInsightsCard: React.FC<MinerInsightsCardProps> = ({
       <Typography
         sx={{
           mt: 2,
-          textAlign: 'right',
+          textAlign: { xs: 'center', sm: 'right' },
           fontSize: '0.72rem',
           color: (t) => alpha(t.palette.text.primary, 0.35),
         }}

--- a/src/components/miners/MinerInsightsCard.tsx
+++ b/src/components/miners/MinerInsightsCard.tsx
@@ -391,7 +391,15 @@ const MinerInsightsCard: React.FC<MinerInsightsCardProps> = ({
                   mb: 0.75,
                 }}
               >
-                <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1.1, minWidth: 0, flex: 1 }}>
+                <Box
+                  sx={{
+                    display: 'flex',
+                    alignItems: 'flex-start',
+                    gap: 1.1,
+                    minWidth: 0,
+                    flex: 1,
+                  }}
+                >
                   <Box sx={{ color: style.color, mt: 0.15, flexShrink: 0 }}>
                     {style.icon}
                   </Box>

--- a/src/pages/MinerDetailsPage.tsx
+++ b/src/pages/MinerDetailsPage.tsx
@@ -26,13 +26,23 @@ const PR_TABS = [
 const ISSUE_TABS = ['overview', 'activity', 'repositories'] as const;
 type MinerDetailsTab = (typeof PR_TABS)[number] | (typeof ISSUE_TABS)[number];
 
-const tabSx = {
+/**
+ * Align first tab label with Card body content (MinerInsightsCard `p: 3` — same edge as
+ * "Insights & Next Actions" and insight row borders, not inner `px: 1.5` text).
+ * Padding lives on the tab flex row, not the scroll buttons: with scroll arrows, the
+ * first tab was shifted right by the left arrow width.
+ */
+const tabsAlignSx = {
+  '& .MuiTabs-flexContainer': {
+    pl: 3,
+  },
   '& .MuiTab-root': {
     color: 'text.secondary',
     textTransform: 'none' as const,
     fontSize: '0.83rem',
     fontWeight: 500,
     '&.Mui-selected': { color: 'primary.main' },
+    '&:first-of-type': { pl: 0 },
   },
 };
 
@@ -167,9 +177,8 @@ const MinerDetailsPage: React.FC = () => {
               value={activeTab}
               onChange={handleTabChange}
               variant="scrollable"
-              scrollButtons="auto"
-              allowScrollButtonsMobile
-              sx={tabSx}
+              scrollButtons={false}
+              sx={tabsAlignSx}
             >
               <Tab value="overview" label="Overview" />
               <Tab value="activity" label="Activity" />


### PR DESCRIPTION
## Summary

- Adjust the "Overview" tab to the same line of "Insights & Next Actions" so that it looks like clean.
- Make text of Collateral and Credibility section as wide as box so that it looks like clean.
- Put the "Learn more about scoring in the docs" text on the center of box.

## Related Issues

Fixes #580.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

- before

<img width="448" height="657" alt="issue1" src="https://github.com/user-attachments/assets/15720546-1975-4ef1-8952-7a7ba2559001" />
<br/><br/>
<img width="447" height="587" alt="issue2" src="https://github.com/user-attachments/assets/b6d5a954-b457-4e79-ab10-ab25517a7b75" />

- after

<img width="444" height="685" alt="issue1-2_fix" src="https://github.com/user-attachments/assets/8bffc5f5-ab56-4766-a3e4-b23883eb94fd" />

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [] Tested against the test API
- [] `npm run format` and `npm run lint:fix` have been run
- [ ] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
