### PR TITLE
Move repository distribution chart into the Repositories highlight column

### DIFF
--- a/src/components/leaderboard/TopRepositoriesTable.tsx
+++ b/src/components/leaderboard/TopRepositoriesTable.tsx
@@ -5,6 +5,7 @@ import React, {
   useCallback,
   useRef,
 } from 'react';
+import { createPortal } from 'react-dom';
 import {
   Box,
   Card,
@@ -20,7 +21,6 @@ import {
   InputAdornment,
   Tooltip,
   IconButton,
-  Collapse,
   TablePagination,
   Select,
   MenuItem,
@@ -36,8 +36,6 @@ import {
   type Theme,
 } from '@mui/material';
 import SearchIcon from '@mui/icons-material/Search';
-import BarChartIcon from '@mui/icons-material/BarChart';
-import TableChartIcon from '@mui/icons-material/TableChart';
 import FilterButton from '../FilterButton';
 import ReactECharts from 'echarts-for-react';
 import type { TooltipComponentFormatterCallbackParams } from 'echarts';
@@ -83,6 +81,8 @@ interface TopRepositoriesTableProps {
   isLoading?: boolean;
   getRepositoryHref: (repositoryFullName: string) => string;
   linkState?: Record<string, unknown>;
+  /** When set, the bar chart is rendered into this element (e.g. highlight column on Repositories page). */
+  chartPortalHost?: HTMLElement | null;
 }
 
 const VALID_SORT_COLUMNS: SortColumn[] = [
@@ -100,6 +100,7 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
   isLoading,
   getRepositoryHref,
   linkState,
+  chartPortalHost,
 }) => {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
@@ -124,7 +125,6 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
       ? urlStatusFilter
       : 'all',
   );
-  const [showChart, setShowChart] = useState(false);
   const [page, setPage] = useState(urlPage >= 0 ? urlPage : 0);
   const [rowsPerPage, setRowsPerPage] = useState(
     VALID_ROWS.includes(urlRows) ? urlRows : 10,
@@ -325,21 +325,23 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
 
     return {
       backgroundColor: 'transparent',
-      title: {
-        text: metric.title,
-        subtext: 'Values match the current table sort and page',
-        left: 'center',
-        top: 20,
-        textStyle: {
-          color: primaryColor,
-          fontSize: 18,
-          fontWeight: 600,
-        },
-        subtextStyle: {
-          color: alpha(white, TEXT_OPACITY.tertiary),
-          fontSize: 12,
-        },
-      },
+      title: chartPortalHost
+        ? { show: false }
+        : {
+            text: metric.title,
+            subtext: 'Values match the current table sort and page',
+            left: 'center',
+            top: 20,
+            textStyle: {
+              color: primaryColor,
+              fontSize: 18,
+              fontWeight: 600,
+            },
+            subtextStyle: {
+              color: alpha(white, TEXT_OPACITY.tertiary),
+              fontSize: 12,
+            },
+          },
       tooltip: {
         trigger: 'axis',
         axisPointer: {
@@ -379,8 +381,8 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
       grid: {
         left: '3%',
         right: '3%',
-        bottom: '18%',
-        top: '18%',
+        bottom: chartPortalHost ? '14%' : '18%',
+        top: chartPortalHost ? '8%' : '18%',
         containLabel: true,
       },
       dataZoom: [
@@ -708,60 +710,6 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
                 }}
               />
             </Box>
-            <Tooltip title={showChart ? 'Hide Chart' : 'Show Chart'}>
-              <IconButton
-                onClick={() => setShowChart(!showChart)}
-                size="small"
-                sx={{
-                  color: showChart ? 'text.primary' : 'text.tertiary',
-                  border: '1px solid',
-                  borderColor: 'border.light',
-                  borderRadius: 2,
-                  padding: '6px',
-                  '&:hover': {
-                    backgroundColor: 'surface.light',
-                    borderColor: 'border.medium',
-                  },
-                }}
-              >
-                {showChart ? (
-                  <TableChartIcon fontSize="small" />
-                ) : (
-                  <BarChartIcon fontSize="small" />
-                )}
-              </IconButton>
-            </Tooltip>
-
-            {showChart && (
-              <FormControlLabel
-                control={
-                  <Switch
-                    checked={useLogScale}
-                    onChange={(e) => setUseLogScale(e.target.checked)}
-                    size="small"
-                    sx={{
-                      '& .MuiSwitch-switchBase.Mui-checked': {
-                        color: 'primary.main',
-                      },
-                      '& .MuiSwitch-track': {
-                        backgroundColor: 'border.medium',
-                      },
-                    }}
-                  />
-                }
-                label={
-                  <Typography
-                    variant="body2"
-                    sx={{
-                      fontSize: '0.8rem',
-                      color: 'text.secondary',
-                    }}
-                  >
-                    Log Scale
-                  </Typography>
-                }
-              />
-            )}
 
             <FormControl size="small">
               <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
@@ -831,25 +779,6 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
           </Box>
         </Box>
       </Box>
-
-      <Collapse in={showChart}>
-        <Box
-          sx={{
-            p: 2,
-            borderBottom: '1px solid',
-            borderColor: 'border.light',
-            height: '500px',
-            backgroundColor: 'surface.subtle',
-          }}
-        >
-          {showChart && filteredRepositories.length > 0 && (
-            <ReactECharts
-              option={getChartOption()}
-              style={{ height: '100%', width: '100%' }}
-            />
-          )}
-        </Box>
-      </Collapse>
 
       <TableContainer
         sx={{
@@ -1126,6 +1055,86 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
           '.MuiTablePagination-displayedRows': {},
         }}
       />
+      {chartPortalHost &&
+        createPortal(
+          <Box
+            sx={{
+              height: '100%',
+              width: '100%',
+              display: 'flex',
+              flexDirection: 'column',
+              minHeight: 0,
+              boxSizing: 'border-box',
+            }}
+          >
+            <Box
+              sx={{
+                display: 'flex',
+                justifyContent: 'flex-end',
+                alignItems: 'center',
+                flexShrink: 0,
+                pb: 0.5,
+              }}
+            >
+              <FormControlLabel
+                control={
+                  <Switch
+                    checked={useLogScale}
+                    onChange={(e) => setUseLogScale(e.target.checked)}
+                    size="small"
+                    sx={{
+                      '& .MuiSwitch-switchBase.Mui-checked': {
+                        color: 'primary.main',
+                      },
+                      '& .MuiSwitch-track': {
+                        backgroundColor: 'border.medium',
+                      },
+                    }}
+                  />
+                }
+                label={
+                  <Typography
+                    variant="body2"
+                    sx={{
+                      fontSize: '0.75rem',
+                      color: 'text.secondary',
+                    }}
+                  >
+                    Log scale
+                  </Typography>
+                }
+              />
+            </Box>
+            <Box
+              sx={{
+                flex: 1,
+                minHeight: 200,
+                position: 'relative',
+                borderRadius: 1,
+                overflow: 'hidden',
+              }}
+            >
+              {filteredRepositories.length > 0 ? (
+                <ReactECharts
+                  option={getChartOption()}
+                  style={{ height: '100%', width: '100%', minHeight: 220 }}
+                />
+              ) : (
+                <Typography
+                  sx={{
+                    p: 2,
+                    color: 'text.secondary',
+                    fontSize: '0.8rem',
+                    textAlign: 'center',
+                  }}
+                >
+                  No repositories match the current filters.
+                </Typography>
+              )}
+            </Box>
+          </Box>,
+          chartPortalHost,
+        )}
     </Card>
   );
 };

--- a/src/pages/RepositoriesPage.tsx
+++ b/src/pages/RepositoriesPage.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 
 import { Avatar, Box, Card, Tooltip, Typography } from '@mui/material';
 import { alpha, type Theme } from '@mui/material/styles';
@@ -120,6 +120,13 @@ const getPrHref = (name: string, number: number) =>
   `/miners/pr?repo=${encodeURIComponent(name)}&number=${number}`;
 
 const RepositoriesPage: React.FC = () => {
+  const [chartPortalHost, setChartPortalHost] = useState<HTMLElement | null>(
+    null,
+  );
+  const chartHostRef = useCallback((node: HTMLElement | null) => {
+    setChartPortalHost(node);
+  }, []);
+
   const formatRelativeTime = (date: Date) => {
     const now = new Date();
     if (date > now) return 'just now';
@@ -476,94 +483,115 @@ const RepositoriesPage: React.FC = () => {
             ) : null}
           </Card>
 
-          {/* Recent PRs */}
-          <Card sx={cardSx}>
-            {isLoading || recentPrs.length > 0 ? (
-              <>
-                <SectionHeader>Recent Pull Requests</SectionHeader>
-                <Box sx={{ display: 'flex', flexDirection: 'column' }}>
-                  {recentPrs.length === 0 && !isLoading ? (
-                    <Typography
-                      sx={(theme) => ({
-                        color: alpha(theme.palette.text.primary, 0.3),
-                        fontSize: '0.8rem',
-                        fontStyle: 'italic',
-                        p: 1,
-                      })}
-                    >
-                      No data available
-                    </Typography>
-                  ) : (
-                    recentPrs.map((pr) => (
-                      <HighlightRow
-                        key={`${pr.name}-${pr.number}`}
-                        href={getPrHref(pr.name, pr.number)}
-                        linkState={REPO_LINK_STATE}
-                        avatar={`https://avatars.githubusercontent.com/${pr.name.split('/')[0]}`}
-                        avatarBg={getAvatarBg(pr.name)}
-                        label={
-                          <Box
-                            sx={{
-                              minWidth: 0,
-                              display: 'flex',
-                              flexDirection: 'column',
-                              justifyContent: 'center',
-                            }}
-                          >
-                            <Tooltip title={pr.name} arrow placement="top">
-                              <Typography
-                                sx={{
-                                  fontFamily: FONTS.mono,
-                                  fontSize: '0.68rem',
-                                  color: 'text.tertiary',
-                                  overflow: 'hidden',
-                                  textOverflow: 'ellipsis',
-                                  whiteSpace: 'nowrap',
-                                  lineHeight: 1.2,
-                                }}
-                              >
-                                {pr.name}
-                              </Typography>
-                            </Tooltip>
-                            <Tooltip title={pr.title} arrow placement="top">
-                              <Typography
-                                sx={{
-                                  fontFamily: FONTS.mono,
-                                  fontSize: '0.78rem',
-                                  color: 'text.primary',
-                                  overflow: 'hidden',
-                                  textOverflow: 'ellipsis',
-                                  whiteSpace: 'nowrap',
-                                  lineHeight: 1.3,
-                                }}
-                              >
-                                {pr.title}
-                              </Typography>
-                            </Tooltip>
-                          </Box>
-                        }
-                        right={
-                          <Typography
-                            sx={(theme) => ({
-                              fontFamily: FONTS.mono,
-                              fontSize: '0.68rem',
-                              color: alpha(theme.palette.text.primary, 0.35),
-                              flexShrink: 0,
-                              whiteSpace: 'nowrap',
-                              ml: 1,
-                            })}
-                          >
-                            {formatRelativeTime(pr.createdAt)}
-                          </Typography>
-                        }
-                      />
-                    ))
-                  )}
-                </Box>
-              </>
-            ) : null}
+          {/* Bar chart for current table page (rendered via portal from TopRepositoriesTable) */}
+          <Card
+            sx={{
+              ...cardSx,
+              display: 'flex',
+              flexDirection: 'column',
+              minHeight: { xs: 300, lg: '100%' },
+            }}
+          >
+            <SectionHeader>Repository distribution</SectionHeader>
+            <Box
+              ref={chartHostRef}
+              sx={{
+                flex: 1,
+                minHeight: { xs: 240, lg: 260 },
+                display: 'flex',
+                flexDirection: 'column',
+              }}
+            />
           </Card>
         </Box>
+
+        {/* Recent PRs — below highlight grid */}
+        <Card sx={{ ...cardSx, mb: 3, width: '100%' }}>
+          {isLoading || recentPrs.length > 0 ? (
+            <>
+              <SectionHeader>Recent Pull Requests</SectionHeader>
+              <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+                {recentPrs.length === 0 && !isLoading ? (
+                  <Typography
+                    sx={(theme) => ({
+                      color: alpha(theme.palette.text.primary, 0.3),
+                      fontSize: '0.8rem',
+                      fontStyle: 'italic',
+                      p: 1,
+                    })}
+                  >
+                    No data available
+                  </Typography>
+                ) : (
+                  recentPrs.map((pr) => (
+                    <HighlightRow
+                      key={`${pr.name}-${pr.number}`}
+                      href={getPrHref(pr.name, pr.number)}
+                      linkState={REPO_LINK_STATE}
+                      avatar={`https://avatars.githubusercontent.com/${pr.name.split('/')[0]}`}
+                      avatarBg={getAvatarBg(pr.name)}
+                      label={
+                        <Box
+                          sx={{
+                            minWidth: 0,
+                            display: 'flex',
+                            flexDirection: 'column',
+                            justifyContent: 'center',
+                          }}
+                        >
+                          <Tooltip title={pr.name} arrow placement="top">
+                            <Typography
+                              sx={{
+                                fontFamily: FONTS.mono,
+                                fontSize: '0.68rem',
+                                color: 'text.tertiary',
+                                overflow: 'hidden',
+                                textOverflow: 'ellipsis',
+                                whiteSpace: 'nowrap',
+                                lineHeight: 1.2,
+                              }}
+                            >
+                              {pr.name}
+                            </Typography>
+                          </Tooltip>
+                          <Tooltip title={pr.title} arrow placement="top">
+                            <Typography
+                              sx={{
+                                fontFamily: FONTS.mono,
+                                fontSize: '0.78rem',
+                                color: 'text.primary',
+                                overflow: 'hidden',
+                                textOverflow: 'ellipsis',
+                                whiteSpace: 'nowrap',
+                                lineHeight: 1.3,
+                              }}
+                            >
+                              {pr.title}
+                            </Typography>
+                          </Tooltip>
+                        </Box>
+                      }
+                      right={
+                        <Typography
+                          sx={(theme) => ({
+                            fontFamily: FONTS.mono,
+                            fontSize: '0.68rem',
+                            color: alpha(theme.palette.text.primary, 0.35),
+                            flexShrink: 0,
+                            whiteSpace: 'nowrap',
+                            ml: 1,
+                          })}
+                        >
+                          {formatRelativeTime(pr.createdAt)}
+                        </Typography>
+                      }
+                    />
+                  ))
+                )}
+              </Box>
+            </>
+          ) : null}
+        </Card>
 
         {/* ── Main Table ────────────────────────────────────────────── */}
         <Card
@@ -581,6 +609,7 @@ const RepositoriesPage: React.FC = () => {
             isLoading={isLoading}
             getRepositoryHref={getRepoHref}
             linkState={REPO_LINK_STATE}
+            chartPortalHost={chartPortalHost}
           />
         </Card>
       </Box>


### PR DESCRIPTION

## Summary

- Renders the **repository bar chart** (ECharts) in the **third top card** (“Repository distribution”) instead of behind a **toolbar toggle** above the table.
- Uses **`createPortal`** from `TopRepositoriesTable` into a `chartPortalHost` element on **`RepositoriesPage`**, so the chart stays tied to the same **sort, pagination, status filters, and search** as the table.
- Removes the **chart icon** and **inline collapsed chart** from the table toolbar; keeps a **Log scale** control **above the chart** in the highlight card.
- Moves **Recent Pull Requests** from the third column to a **full-width card** below the three-column highlight grid (above the main table).

## Related Issues



## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

<img width="1868" height="898" alt="2026-04-17_19h21_09" src="https://github.com/user-attachments/assets/7e0e28e6-834e-4fa6-a5c1-857fc805d733" />
<img width="1882" height="902" alt="2026-04-17_19h32_06" src="https://github.com/user-attachments/assets/6dbf7f24-c445-488c-95c6-ed921e2cabaa" />

## Checklist

- [x] New components are modularized/separated where sensible *(portal + props; no new standalone chart file)*
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked *(author to confirm)*
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes *(author: run before merge)*
- [x] Screenshots included for any UI/visual changes