### PR TITLE
fix: right-align sidebar nav badges

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -258,7 +258,7 @@ const SidebarNavLink: React.FC<{
             fontSize: '0.65rem',
             color: 'secondary.main',
             fontStyle: 'italic',
-            ml: 1,
+            ml: 'auto',
           }}
         >
           {badge}


### PR DESCRIPTION
Fixes #584 

## Summary
Pushes sidebar nav badges ("new", watchlist count) to the right edge of their nav button using `marginLeft: 'auto'`. Currently the badges sit immediately after the label text with empty space to the right, which looks inconsistent with typical sidebar conventions.

## Fix
One-character change in `src/components/layout/Sidebar.tsx`: the badge `Typography`'s `ml: 1` → `ml: 'auto'`.

## Type of Change
- [x] Polish / visual refinement

## Testing
- [ ] `npm run build`
- [ ] `npm run lint:fix`
- [ ] Manual: pin a miner → watchlist badge appears on the right edge. "discoveries new" badge also right-aligned.

## Checklist
- [x] No behavior change
- [x] No new dependencies
- [x] Single file, single line touched

## Video to Upload

https://github.com/user-attachments/assets/de8239ef-78dd-4ee9-9e81-0678137849f8

