### PR TITLE
fix(pagination): make prev/next controls keyboard accessible

### DIFF
--- a/src/components/miners/TablePagination.tsx
+++ b/src/components/miners/TablePagination.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Box, IconButton, Typography, alpha } from '@mui/material';
+import type { SxProps, Theme } from '@mui/material';
 import {
   NavigateBefore as PrevIcon,
   NavigateNext as NextIcon,
@@ -11,6 +12,15 @@ interface TablePaginationProps {
   onPageChange: (newPage: number) => void;
 }
 
+const navButtonSx: SxProps<Theme> = {
+  p: 0.25,
+  color: (t) => alpha(t.palette.text.primary, 0.6),
+  '&:hover': { color: 'text.primary' },
+  '&.Mui-disabled': { opacity: 0.3 },
+};
+
+const navIconSx = { fontSize: '1.2rem' };
+
 const TablePagination: React.FC<TablePaginationProps> = ({
   page,
   totalPages,
@@ -19,21 +29,6 @@ const TablePagination: React.FC<TablePaginationProps> = ({
   if (totalPages <= 1) {
     return null;
   }
-
-  const canGoPrev = page > 0;
-  const canGoNext = page < totalPages - 1;
-
-  const handlePrev = () => {
-    if (canGoPrev) {
-      onPageChange(page - 1);
-    }
-  };
-
-  const handleNext = () => {
-    if (canGoNext) {
-      onPageChange(page + 1);
-    }
-  };
 
   return (
     <Box
@@ -48,18 +43,13 @@ const TablePagination: React.FC<TablePaginationProps> = ({
       }}
     >
       <IconButton
-        onClick={handlePrev}
-        disabled={!canGoPrev}
+        onClick={() => onPageChange(page - 1)}
+        disabled={page === 0}
         aria-label="Previous page"
         size="small"
-        sx={{
-          p: 0.25,
-          color: (t) => alpha(t.palette.text.primary, 0.6),
-          '&:hover': { color: 'text.primary' },
-          '&.Mui-disabled': { opacity: 0.3 },
-        }}
+        sx={navButtonSx}
       >
-        <PrevIcon sx={{ fontSize: '1.2rem' }} />
+        <PrevIcon sx={navIconSx} />
       </IconButton>
       <Typography
         sx={{
@@ -70,18 +60,13 @@ const TablePagination: React.FC<TablePaginationProps> = ({
         {page + 1} / {totalPages}
       </Typography>
       <IconButton
-        onClick={handleNext}
-        disabled={!canGoNext}
+        onClick={() => onPageChange(page + 1)}
+        disabled={page >= totalPages - 1}
         aria-label="Next page"
         size="small"
-        sx={{
-          p: 0.25,
-          color: (t) => alpha(t.palette.text.primary, 0.6),
-          '&:hover': { color: 'text.primary' },
-          '&.Mui-disabled': { opacity: 0.3 },
-        }}
+        sx={navButtonSx}
       >
-        <NextIcon sx={{ fontSize: '1.2rem' }} />
+        <NextIcon sx={navIconSx} />
       </IconButton>
     </Box>
   );

--- a/src/components/miners/TablePagination.tsx
+++ b/src/components/miners/TablePagination.tsx
@@ -22,6 +22,13 @@ const navButtonSx: SxProps<Theme> = {
   p: 0.25,
   color: (t) => alpha(t.palette.text.primary, 0.6),
   '&:hover': { color: 'text.primary' },
+  '&.Mui-focusVisible': {
+    backgroundColor: (t) => alpha(t.palette.primary.main, 0.2),
+    outline: '2px solid',
+    outlineColor: 'primary.main',
+    outlineOffset: '-2px',
+    color: 'text.primary',
+  },
   '&.Mui-disabled': { opacity: 0.3 },
 };
 

--- a/src/components/miners/TablePagination.tsx
+++ b/src/components/miners/TablePagination.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Box, Typography, alpha } from '@mui/material';
+import { Box, IconButton, Typography, alpha } from '@mui/material';
 import {
   NavigateBefore as PrevIcon,
   NavigateNext as NextIcon,
@@ -47,19 +47,20 @@ const TablePagination: React.FC<TablePaginationProps> = ({
         borderColor: 'border.subtle',
       }}
     >
-      <Box
+      <IconButton
         onClick={handlePrev}
+        disabled={!canGoPrev}
+        aria-label="Previous page"
+        size="small"
         sx={{
-          cursor: canGoPrev ? 'pointer' : 'default',
-          opacity: canGoPrev ? 1 : 0.3,
-          display: 'flex',
-          alignItems: 'center',
+          p: 0.25,
           color: (t) => alpha(t.palette.text.primary, 0.6),
-          '&:hover': canGoPrev ? { color: 'text.primary' } : {},
+          '&:hover': { color: 'text.primary' },
+          '&.Mui-disabled': { opacity: 0.3 },
         }}
       >
         <PrevIcon sx={{ fontSize: '1.2rem' }} />
-      </Box>
+      </IconButton>
       <Typography
         sx={{
           fontSize: '0.75rem',
@@ -68,19 +69,20 @@ const TablePagination: React.FC<TablePaginationProps> = ({
       >
         {page + 1} / {totalPages}
       </Typography>
-      <Box
+      <IconButton
         onClick={handleNext}
+        disabled={!canGoNext}
+        aria-label="Next page"
+        size="small"
         sx={{
-          cursor: canGoNext ? 'pointer' : 'default',
-          opacity: canGoNext ? 1 : 0.3,
-          display: 'flex',
-          alignItems: 'center',
+          p: 0.25,
           color: (t) => alpha(t.palette.text.primary, 0.6),
-          '&:hover': canGoNext ? { color: 'text.primary' } : {},
+          '&:hover': { color: 'text.primary' },
+          '&.Mui-disabled': { opacity: 0.3 },
         }}
       >
         <NextIcon sx={{ fontSize: '1.2rem' }} />
-      </Box>
+      </IconButton>
     </Box>
   );
 };

--- a/src/components/miners/TablePagination.tsx
+++ b/src/components/miners/TablePagination.tsx
@@ -1,6 +1,12 @@
 import React from 'react';
-import { Box, IconButton, Typography, alpha } from '@mui/material';
-import type { SxProps, Theme } from '@mui/material';
+import {
+  Box,
+  IconButton,
+  Typography,
+  alpha,
+  type SxProps,
+  type Theme,
+} from '@mui/material';
 import {
   NavigateBefore as PrevIcon,
   NavigateNext as NextIcon,


### PR DESCRIPTION
## Summary

The Prev and Next controls in the shared `TablePagination` were plain `<Box>` elements with only an `onClick`, so keyboard focus skipped past them and screen readers had no role or label to announce. Since this component backs the miners, repositories, and PR tables, pagination was effectively unreachable without a mouse on most list views.

Swapping the two Boxes for MUI `<IconButton>` fixes it with the native primitive: focus order, Enter/Space activation, `aria-label` ("Previous page" / "Next page"), and a real `disabled` state that also drives `aria-disabled`. The existing visual treatment (0.3 opacity at the boundary pages, hover color) is preserved via `&.Mui-disabled` and the hover rule.

## Related Issues

Fixes #590 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

No visual change. Before and after look identical; the difference is in the a11y tree and tab order.

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes

### Manual verification

1. Opened the miners leaderboard with enough rows to paginate.
2. Tabbed through the table footer: focus now lands on Prev, then Next, with a visible focus ring.
3. Pressed Enter and Space on each control; both advance the page.
4. On the first page, Prev is programmatically disabled (not just dimmed); same for Next on the last page.
5. VoiceOver announces "Previous page, button" and "Next page, button", with the dimmed state read as disabled.
