### PR TITLE
feat(miner): add visible copy control for profile hotkey

### DIFF
--- a/src/components/miners/MinerScoreCard.tsx
+++ b/src/components/miners/MinerScoreCard.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import {
-  ButtonBase,
   Card,
   Typography,
   Box,
@@ -10,9 +9,12 @@ import {
   Chip,
   Stack,
   Tooltip,
+  IconButton,
   alpha,
 } from '@mui/material';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
+import CheckIcon from '@mui/icons-material/Check';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import {
   GitHub as GitHubIcon,
   Update as UpdateIcon,
@@ -226,45 +228,69 @@ const CopyableHotkey: React.FC<{ hotkey: string }> = ({ hotkey }) => {
   };
 
   return (
-    <ButtonBase
-      onClick={handleCopy}
-      aria-label={
-        copied ? 'Hotkey copied to clipboard' : 'Copy hotkey to clipboard'
-      }
-      aria-live="polite"
-      disableRipple
+    <Box
       sx={{
-        display: 'block',
-        textAlign: 'left',
-        borderRadius: '4px',
-        color: (t) =>
-          copied
-            ? t.palette.status.success
-            : alpha(t.palette.text.primary, 0.45),
-        transition: 'color 0.15s ease',
-        '&:hover': {
-          color: (t) =>
-            copied
-              ? t.palette.status.success
-              : alpha(t.palette.text.primary, 0.8),
-        },
-        '&:focus-visible': {
-          outline: (t) => `2px solid ${t.palette.primary.main}`,
-          outlineOffset: '2px',
-        },
+        display: 'flex',
+        alignItems: 'flex-start',
+        gap: 0.25,
+        minWidth: 0,
+        maxWidth: '100%',
       }}
     >
       <Typography
         component="span"
         sx={{
-          color: 'inherit',
+          flex: 1,
+          minWidth: 0,
+          color: (t) => alpha(t.palette.text.primary, 0.45),
           fontSize: { xs: '0.55rem', sm: '0.65rem' },
           wordBreak: 'break-all',
+          lineHeight: 1.35,
+          userSelect: 'text',
         }}
       >
-        {copied ? '✓ Copied to clipboard' : hotkey}
+        {hotkey}
       </Typography>
-    </ButtonBase>
+      <Tooltip
+        title={copied ? 'Copied' : 'Copy hotkey'}
+        arrow
+        placement="top"
+        slotProps={tooltipSlotProps}
+      >
+        <IconButton
+          size="small"
+          onClick={(e) => {
+            e.preventDefault();
+            void handleCopy();
+          }}
+          aria-label={
+            copied ? 'Hotkey copied to clipboard' : 'Copy hotkey to clipboard'
+          }
+          aria-live="polite"
+          sx={{
+            flexShrink: 0,
+            mt: '-2px',
+            color: (t) =>
+              copied
+                ? t.palette.status.success
+                : alpha(t.palette.text.primary, 0.45),
+            '&:hover': {
+              color: (t) =>
+                copied
+                  ? t.palette.status.success
+                  : alpha(t.palette.text.primary, 0.85),
+              backgroundColor: (t) => alpha(t.palette.text.primary, 0.06),
+            },
+          }}
+        >
+          {copied ? (
+            <CheckIcon sx={{ fontSize: '1rem' }} />
+          ) : (
+            <ContentCopyIcon sx={{ fontSize: '1rem' }} />
+          )}
+        </IconButton>
+      </Tooltip>
+    </Box>
   );
 };
 


### PR DESCRIPTION
## Summary

The miner profile header showed the SS58 hotkey as plain text with no obvious way to copy it for search. `CopyableHotkey` in `MinerScoreCard` is updated so the hotkey stays readable and selectable, with a small **copy** icon button next to it. The button uses a tooltip (“Copy hotkey” / “Copied”), switches to a check icon briefly after a successful copy, and keeps the existing clipboard fallback behavior when the API is unavailable.

## Related Issues



## Type of Change

- [x] Bug fix *(UX/discoverability: copy was non-obvious)*
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

<!-- Add before: hotkey text only, no icon. After: hotkey + copy icon + optional “Copied” check state. Remove this section if you skip screenshots. -->
<img width="1918" height="923" alt="2026-04-18_09h09_22" src="https://github.com/user-attachments/assets/47e0d879-2d16-4049-930f-e2bc878c04ef" />
<img width="1899" height="849" alt="2026-04-18_09h19_31" src="https://github.com/user-attachments/assets/0f825f0e-b429-4c32-b1cc-125ca9429794" />

## Checklist

- [x] New components are modularized/separated where sensible *(change is localized to existing `CopyableHotkey` in `MinerScoreCard`)*
- [x] Uses predefined theme (e.g. no hardcoded colors) *(uses `alpha`, `palette.status.success`, `tooltipSlotProps`)*
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes *(TypeScript `tsc -b` was verified in session)*
- [x] Screenshots included for any UI/visual changes
