### PR TITLE
feat(miner): show credibility rank on profile stat tiles

### DIFF
--- a/src/components/miners/MinerScoreCard.tsx
+++ b/src/components/miners/MinerScoreCard.tsx
@@ -302,6 +302,10 @@ const MinerScoreCard: React.FC<MinerScoreCardProps> = ({
     return {
       score: rank('score', (m) => Number(m.totalScore)),
       totalPrs: rank('prs', (m) => Number(m.totalPrs)),
+      credibility: rank('credibility', (m) => Number(m.credibility ?? 0)),
+      issueCredibility: rank('issueCredibility', (m) =>
+        Number(m.issueCredibility ?? 0),
+      ),
     };
   }, [allMinersStats, minerStats, githubId]);
 
@@ -580,6 +584,7 @@ const MinerScoreCard: React.FC<MinerScoreCardProps> = ({
               value={`${(cred * 100).toFixed(1)}%`}
               sub={`${minerStats.totalMergedPrs || 0} merged · ${minerStats.totalClosedPrs || 0} closed`}
               color={credibilityColor(cred)}
+              rank={rankings?.credibility}
               tooltip="Ratio of merged PRs to total attempts (merged + closed). Higher credibility means a stronger multiplier on your scores."
             />
           </Grid>
@@ -642,6 +647,7 @@ const MinerScoreCard: React.FC<MinerScoreCardProps> = ({
               value={`${(parseNumber(minerStats.issueCredibility) * 100).toFixed(1)}%`}
               sub={`${minerStats.totalSolvedIssues || 0} solved · ${minerStats.totalClosedIssues || 0} closed`}
               color={credibilityColor(Number(minerStats.issueCredibility || 0))}
+              rank={rankings?.issueCredibility}
               tooltip="Credibility = solved / (solved + max(0, closed − 1)). One closed issue is forgiven. 80%+ required for eligibility."
             />
           </Grid>


### PR DESCRIPTION
## Summary

The miner profile stat row showed a superscript **rank** next to **Score** and **PRs**, but **Credibility** had no rank even though it is a leaderboard-style metric. This change extends the existing `rankings` memo in `MinerScoreCard` so it also ranks all miners from `useAllMiners` by **PR `credibility`** (descending) for the default PR view, and by **`issueCredibility`** for the issues/discoveries view. Those ranks are passed into the Credibility `StatTile` via the same `rank` prop used elsewhere, so the badge matches Score/PRs styling and behavior.

## Related Issues
 #598

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots
<img width="1905" height="824" alt="2026-04-18_09h25_33" src="https://github.com/user-attachments/assets/463aad8a-c6f4-4bd0-bbb5-8667f9b9824b" />
<img width="1887" height="912" alt="2026-04-18_09h33_15" src="https://github.com/user-attachments/assets/639ca63b-81bf-4130-8c7d-df8855aa56b4" />



## Checklist

- [x] New components are modularized/separated where sensible *(logic stays in existing `rankings` / `StatTile` usage)*
- [x] Uses predefined theme (e.g. no hardcoded colors) *(reuses existing `StatTile` rank styling)*
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes *(TypeScript `tsc -b` was verified during implementation)*
- [x] Screenshots included for any UI/visual changes

