### PR TITLE
fix(onboard): language weights sort header color and hover accent

### DIFF
--- a/src/components/repositories/LanguageWeightsTable.tsx
+++ b/src/components/repositories/LanguageWeightsTable.tsx
@@ -33,6 +33,17 @@ import { useLanguagesAndWeights } from '../../api';
 type SortField = 'extension' | 'weight' | 'language';
 type SortOrder = 'asc' | 'desc';
 
+/** Match other header labels (primary text); accent only on hover. */
+const languageWeightsSortLabelSx = {
+  color: 'text.primary',
+  '&.Mui-active': {
+    color: 'text.primary',
+  },
+  '&:hover': {
+    color: 'secondary.main',
+  },
+} as const;
+
 const LanguageWeightsTable: React.FC = () => {
   const theme = useTheme();
   const { data: languages, isLoading } = useLanguagesAndWeights();
@@ -393,14 +404,7 @@ const LanguageWeightsTable: React.FC = () => {
                     active={sortField === 'extension'}
                     direction={sortField === 'extension' ? sortOrder : 'asc'}
                     onClick={() => handleSort('extension')}
-                    sx={{
-                      '&:hover': {
-                        color: 'secondary.main',
-                      },
-                      '&.Mui-active': {
-                        color: 'secondary.main',
-                      },
-                    }}
+                    sx={languageWeightsSortLabelSx}
                   >
                     <Typography variant="dataLabel">Extension</Typography>
                   </TableSortLabel>
@@ -419,14 +423,7 @@ const LanguageWeightsTable: React.FC = () => {
                     active={sortField === 'language'}
                     direction={sortField === 'language' ? sortOrder : 'asc'}
                     onClick={() => handleSort('language')}
-                    sx={{
-                      '&:hover': {
-                        color: 'secondary.main',
-                      },
-                      '&.Mui-active': {
-                        color: 'secondary.main',
-                      },
-                    }}
+                    sx={languageWeightsSortLabelSx}
                   >
                     <Typography variant="dataLabel">Language</Typography>
                   </TableSortLabel>
@@ -463,14 +460,7 @@ const LanguageWeightsTable: React.FC = () => {
                     active={sortField === 'weight'}
                     direction={sortField === 'weight' ? sortOrder : 'desc'}
                     onClick={() => handleSort('weight')}
-                    sx={{
-                      '&:hover': {
-                        color: 'secondary.main',
-                      },
-                      '&.Mui-active': {
-                        color: 'secondary.main',
-                      },
-                    }}
+                    sx={languageWeightsSortLabelSx}
                   >
                     <Typography variant="dataLabel">Weight</Typography>
                   </TableSortLabel>


### PR DESCRIPTION
## Summary

On the Onboard **Languages** table (`LanguageWeightsTable`), sortable headers used **`secondary.main` whenever a column was the active sort**. Because **Weight** is the default sort, its header stayed gold/yellow at all times and did not match **Extension**, **Language**, or **Token Scoring**.

This change introduces shared `TableSortLabel` styles: **`text.primary`** for the default and active sort state (aligned with other header labels), and **`secondary.main` only on `:hover`**. The same rules apply to all three sortable columns for consistent behavior.

## Related Issues



## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots
<img width="1875" height="893" alt="2026-04-18_10h10_48" src="https://github.com/user-attachments/assets/d1d4c23d-d516-4d76-83e9-a4db2fa1d3ba" />

https://github.com/user-attachments/assets/cecca2cd-9413-4320-9049-a2e20d7f338c




## Checklist

- [x] New components are modularized/separated where sensible *(shared `languageWeightsSortLabelSx` constant)*
- [x] Uses predefined theme (e.g. no hardcoded colors) *(`text.primary`, `secondary.main`)*
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes



