### PR TITLE
fix: right-align bounty docs hint, add external-link icon, tighten spacing (#533)

### DIFF
--- a/src/pages/IssuesPage.tsx
+++ b/src/pages/IssuesPage.tsx
@@ -9,6 +9,7 @@
 import React from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { Box, Tabs, Tab, Stack, Typography, alpha } from '@mui/material';
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import { Page } from '../components/layout';
 import { SEO } from '../components';
 import { IssueStats, IssuesList } from '../components/issues';
@@ -102,12 +103,16 @@ const IssuesPage: React.FC = () => {
               </Tabs>
 
               <Typography
+                component="span"
                 sx={{
                   fontSize: '0.72rem',
                   color: (t) => alpha(t.palette.text.primary, 0.35),
-                  pr: 1,
-                  mb: { xs: 1, md: 0 },
-                  textAlign: { xs: 'left', md: 'right' },
+                  pr: 0.5,
+                  mb: 0.5,
+                  textAlign: 'right',
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 0.25,
                 }}
               >
                 Learn more about bounties in the{' '}
@@ -121,10 +126,16 @@ const IssuesPage: React.FC = () => {
                     fontSize: 'inherit',
                     fontFamily: 'inherit',
                     textDecoration: 'none',
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    gap: 0.25,
                     '&:hover': { textDecoration: 'underline' },
                   }}
                 >
                   docs
+                  <OpenInNewIcon
+                    sx={{ fontSize: '0.75rem', ml: 0.25 }}
+                  />
                 </Typography>
               </Typography>
             </Box>


### PR DESCRIPTION
## Summary

Right-aligns the 'Learn more about bounties in the docs' helper line on the Issue Bounties page, tightens spacing for a less noisy layout, and adds an OpenInNew icon to visually indicate the docs link opens in a new tab.

## Changes

- Added OpenInNewIcon from @mui/icons-material import
- Changed outer Typography from block to component=\span\` with flex display for proper inline alignment
- Tightened spacing: pr: 0.5 (was pr: 1) and mb: 0.5 (was mb: { xs: 1, md: 0 })
- Set 	extAlign: 'right' on the helper line
- Added display: 'inline-flex' and lignItems: 'center' with a small gap between 'docs' text and the icon
- Added matching flex/align styles to the inner link Typography for icon placement

## Testing

- Visual verification on /bounties page confirms the helper line is right-aligned
- External-link icon appears inline next to 'docs' text
- Spacing is tighter and consistent with the rest of the page layout

Fixes #533