### PR TITLE
fix: Repositories hub: global search on route + aligned width with other hubs

### DIFF
--- a/src/components/layout/GlobalSearchBar.tsx
+++ b/src/components/layout/GlobalSearchBar.tsx
@@ -499,7 +499,14 @@ const GlobalSearchBar: React.FC = () => {
   );
 
   return (
-    <Box sx={{ position: 'relative', width: '100%', maxWidth: 900 }}>
+    <Box
+      sx={{
+        position: 'relative',
+        width: '100%',
+        maxWidth: 1200,
+        mx: 'auto',
+      }}
+    >
       <TextField
         fullWidth
         size="small"

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -72,6 +72,7 @@ const routesArray: AppRoute[] = [
     name: 'repositories',
     path: '/repositories',
     element: <RepositoriesPage />,
+    showGlobalSearch: true,
   },
   {
     name: 'miner-details',


### PR DESCRIPTION
## Summary

**Repositories** is a first-class hub (same mental model as **Dashboard** / **Discoveries**). Users expect the **sticky global search** there too: it is the main shortcut to miners, repos, PRs, and bounties, and it stays visible while scrolling long lists on other hubs.

Two problems were addressed:

1. **Missing search on `/repositories`** — The route never set **`showGlobalSearch`**, so **`AppLayout`** did not mount **`GlobalSearchBar`** on that page. That broke parity with other hubs and felt like the UI “forgot” a core affordance.

2. **Misaligned search once visible** — **`GlobalSearchBar`** used **`maxWidth: 900`** with no horizontal centering, while **`AppLayout`**’s sticky slot and **`RepositoriesPage`** content use **`maxWidth: 1200`**. The field sat **left-aligned** in a wider column, with empty space on the right (especially obvious on **Repositories**).

## Related Issues

Closes #603

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

Before:

<img width="1850" height="727" alt="Screenshot_1" src="https://github.com/user-attachments/assets/6fd9c110-12ad-4287-b5bb-03adc9d9f5b3" />

After:

<img width="1807" height="704" alt="Screenshot_2" src="https://github.com/user-attachments/assets/723007df-0ffa-4513-ab91-35841371c1ae" />

<!-- Include before/after screenshots for every UI/visual change. Remove this section if not applicable. -->

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [ ] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
