### PR TITLE
fix: hide connector line behind active step in onboarding stepper

### DIFF
--- a/src/components/onboard/GettingStarted.tsx
+++ b/src/components/onboard/GettingStarted.tsx
@@ -3,7 +3,7 @@ import { Box, Typography, Button, Tabs, Tab, Tooltip } from '@mui/material';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import CheckIcon from '@mui/icons-material/Check';
-import { alpha } from '@mui/material/styles';
+import { alpha, darken } from '@mui/material/styles';
 import { scrollbarSx, tooltipSlotProps } from '../../theme';
 
 const MONO = '"JetBrains Mono", monospace';
@@ -482,8 +482,8 @@ export const GettingStarted: React.FC = () => {
                   bgcolor: (theme) =>
                     activeStep === index
                       ? index === steps.length - 1
-                        ? alpha(theme.palette.secondary.main, 0.15)
-                        : alpha(theme.palette.primary.main, 0.15)
+                        ? darken(theme.palette.secondary.main, 0.85)
+                        : darken(theme.palette.primary.main, 0.85)
                       : theme.palette.background.default,
                   border: '2px solid',
                   borderColor: item.active


### PR DESCRIPTION
## Summary


- Fixed step circle background to be opaque (`background.default` base + tint via `backgroundImage`) so the horizontal connector line is naturally hidden behind the active button while remaining visible between all other steps

## Test plan

- [ ] On page load, connector line is visible and no step detail panel is shown
- [ ] Clicking any step hides the line behind that step's circle only; line remains visible on either side
- [ ] Active step circle retains its tinted background and border highlight
- [ ] Step detail panel renders correctly after clicking any step
- [ ] No console errors on load or on step selection

## Screenshots

Before:
<img width="1845" height="855" alt="image" src="https://github.com/user-attachments/assets/59b56c54-848a-40f9-9c72-2839fe2bc450" />

<img width="1739" height="896" alt="image" src="https://github.com/user-attachments/assets/98dabbe3-cc4e-4a8b-9c3f-20a7bfd2bb90" />

After:
<img width="1636" height="749" alt="image" src="https://github.com/user-attachments/assets/9ebb6a36-7c76-4b5a-b917-f7b70a5c2899" />

<img width="1619" height="762" alt="image" src="https://github.com/user-attachments/assets/6cfe1ca4-bf88-4a4c-bfc5-5cd251d2d570" />
