### PR TITLE
fix(onboard): hide Miner Setup step connector behind active step circles

### DIFF
--- a/src/components/onboard/GettingStarted.tsx
+++ b/src/components/onboard/GettingStarted.tsx
@@ -479,15 +479,14 @@ export const GettingStarted: React.FC = () => {
               <Box
                 className="step-circle"
                 sx={{
+                  position: 'relative',
+                  zIndex: 2,
                   width: 48,
                   height: 48,
                   borderRadius: '50%',
-                  bgcolor: (theme) =>
-                    activeStep === index
-                      ? index === steps.length - 1
-                        ? alpha(theme.palette.secondary.main, 0.15)
-                        : alpha(theme.palette.primary.main, 0.15)
-                      : theme.palette.background.default,
+                  // Opaque fill so the desktop connector line does not show through
+                  // active steps (semi-transparent tints would reveal the line).
+                  bgcolor: 'background.default',
                   border: '2px solid',
                   borderColor: item.active
                     ? 'secondary.main'


### PR DESCRIPTION
## Summary

On the **Getting Started → Miner Setup** horizontal stepper, the desktop connector line ran behind each step’s round badge. For the **active** step, the circle used a **semi-transparent** primary/secondary fill so the gray line was still visible through the badge.

Step circles now use an **opaque** `background.default` fill (same as inactive disks) so the line is fully covered. **Border, number color, and glow** still indicate active vs inactive. The circle also uses **`position: relative`** and **`zIndex: 2`** so it stays clearly above the connector.

## Related Issues


## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

<img width="1917" height="918" alt="2026-04-18_18h13_55" src="https://github.com/user-attachments/assets/f10365e5-180b-4fa0-8ca7-e649b1c48740" />
<img width="1916" height="905" alt="2026-04-18_18h23_02" src="https://github.com/user-attachments/assets/901d4ec2-33b1-417c-94f4-072173cac7fa" />


## Checklist

- [x] New components are modularized/separated where sensible *(localized change in `GettingStarted.tsx`)*
- [x] Uses predefined theme (e.g. no hardcoded colors) *(`background.default`, existing borders/shadows)*
- [x] Responsive/mobile checked *(connector is desktop-only; steps still stack on xs)*
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
