### PR TITLE
Fix MinerScoreCard “Updated” chip overlapping eligibility badges on resize

### DIFF
--- a/src/components/miners/MinerScoreCard.tsx
+++ b/src/components/miners/MinerScoreCard.tsx
@@ -349,32 +349,18 @@ const MinerScoreCard: React.FC<MinerScoreCardProps> = ({
     : STATUS_COLORS.neutral;
 
   return (
-    <Card sx={{ p: 3, position: 'relative' }} elevation={0}>
-      {/* Updated chip — desktop */}
-      {minerStats.updatedAt && (
-        <Chip
-          icon={<UpdateIcon sx={{ fontSize: '0.9rem' }} />}
-          label={`Updated ${formatTimeAgo(new Date(minerStats.updatedAt))}`}
-          variant="outlined"
-          size="small"
-          sx={{
-            display: { xs: 'none', sm: 'flex' },
-            position: 'absolute',
-            top: 16,
-            right: 16,
-            fontSize: '0.7rem',
-            color: (t) => alpha(t.palette.text.primary, 0.5),
-            borderColor: 'border.light',
-            backgroundColor: 'surface.elevated',
-            '& .MuiChip-icon': {
-              color: (t) => alpha(t.palette.text.primary, 0.4),
-            },
-          }}
-        />
-      )}
-
+    <Card sx={{ p: 3 }} elevation={0}>
       {/* Identity row */}
-      <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 3 }}>
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 2,
+          mb: 3,
+          minWidth: 0,
+          width: '100%',
+        }}
+      >
         <Avatar
           src={`https://avatars.githubusercontent.com/${username}`}
           alt={username}
@@ -386,16 +372,53 @@ const MinerScoreCard: React.FC<MinerScoreCardProps> = ({
           }}
         />
         <Box sx={{ minWidth: 0, flex: 1 }}>
-          <Typography
+          <Box
             sx={{
-              fontSize: { xs: '1.15rem', sm: '1.35rem' },
-              fontWeight: 700,
-              color: 'text.primary',
+              display: 'flex',
+              flexWrap: 'wrap',
+              alignItems: 'center',
+              gap: 1,
+              columnGap: 2,
+              rowGap: 0.5,
               mb: 0.5,
+              width: '100%',
+              minWidth: 0,
             }}
           >
-            {githubData?.name || username}
-          </Typography>
+            <Typography
+              sx={{
+                fontSize: { xs: '1.15rem', sm: '1.35rem' },
+                fontWeight: 700,
+                color: 'text.primary',
+                minWidth: 0,
+                flex: '1 1 0',
+                overflowWrap: 'anywhere',
+                wordBreak: 'break-word',
+              }}
+            >
+              {githubData?.name || username}
+            </Typography>
+            {minerStats.updatedAt && (
+              <Chip
+                icon={<UpdateIcon sx={{ fontSize: '0.9rem' }} />}
+                label={`Updated ${formatTimeAgo(new Date(minerStats.updatedAt))}`}
+                variant="outlined"
+                size="small"
+                sx={{
+                  display: { xs: 'none', sm: 'inline-flex' },
+                  flexShrink: 0,
+                  ml: { sm: 'auto' },
+                  fontSize: '0.7rem',
+                  color: (t) => alpha(t.palette.text.primary, 0.5),
+                  borderColor: 'border.light',
+                  backgroundColor: 'surface.elevated',
+                  '& .MuiChip-icon': {
+                    color: (t) => alpha(t.palette.text.primary, 0.4),
+                  },
+                }}
+              />
+            )}
+          </Box>
           <Box
             sx={{
               display: 'flex',
@@ -403,6 +426,8 @@ const MinerScoreCard: React.FC<MinerScoreCardProps> = ({
               gap: 1.5,
               flexWrap: 'wrap',
               mb: 0.5,
+              minWidth: 0,
+              width: '100%',
             }}
           >
             <Tooltip


### PR DESCRIPTION
## Summary

Removed **absolute** positioning for the desktop **Updated** chip. It now lives in a **flex row with the display name** (`flexWrap`, title `flex: 1 1 0` / `minWidth: 0`, chip `flexShrink: 0` and `marginLeft: auto` from `sm` so it aligns to the **right** or wraps to its own line **above** the eligibility chips). Dropped **`position: 'relative'`** on the `Card` where it was only supporting the old overlay. Mobile (`xs`) behavior unchanged: **Updated** chip still shown in-flow at the bottom of the identity block.

## Related Issues

fix #614  

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots
<img width="904" height="633" alt="2026-04-19_12h50_21" src="https://github.com/user-attachments/assets/0c40c614-6795-41a3-b56d-d4014ec560a3" />



## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [ ] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes