### PR TITLE
fix: add row index to Onboard Languages table

### DIFF
--- a/src/components/repositories/LanguageWeightsTable.tsx
+++ b/src/components/repositories/LanguageWeightsTable.tsx
@@ -375,6 +375,16 @@ const LanguageWeightsTable: React.FC = () => {
           <Table stickyHeader>
             <TableHead>
               <TableRow>
+                <TableCell
+                  align="right"
+                  sx={{
+                    ...headerCellStyle,
+                    width: '1%',
+                    whiteSpace: 'nowrap',
+                  }}
+                >
+                  <Typography variant="dataLabel">#</Typography>
+                </TableCell>
                 <TableCell sx={headerCellStyle}>
                   <TableSortLabel
                     active={sortField === 'extension'}
@@ -434,8 +444,16 @@ const LanguageWeightsTable: React.FC = () => {
               </TableRow>
             </TableHead>
             <TableBody>
-              {paginatedLanguages.map((lang) => (
+              {paginatedLanguages.map((lang, rowIndex) => (
                 <TableRow key={lang.extension} hover>
+                  <TableCell align="right" sx={bodyCellStyle}>
+                    <Typography
+                      variant="dataValue"
+                      sx={{ fontVariantNumeric: 'tabular-nums' }}
+                    >
+                      {page * rowsPerPage + rowIndex + 1}
+                    </Typography>
+                  </TableCell>
                   <TableCell sx={bodyCellStyle}>{lang.extension}</TableCell>
                   <TableCell
                     sx={{


### PR DESCRIPTION
## Summary

Adds a leading `#` column to the Onboard -> Languages table so each visible row has a stable 1-based index.

The displayed index is derived from the current page offset and row position, so it stays accurate after sorting, searching, and pagination changes.

## Related Issues

Closes #628

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

-Before

<img width="1207" height="773" alt="image" src="https://github.com/user-attachments/assets/0c364db0-7aec-4205-aba5-657db062cc8f" />

-After

<img width="1209" height="743" alt="image" src="https://github.com/user-attachments/assets/cdd9a861-f45f-42e8-b3ed-92e3afaae4c8" />
