### PR TITLE
feat(watchlist): OSS section label on miner card footer

### DIFF
--- a/src/components/leaderboard/MinerCard.tsx
+++ b/src/components/leaderboard/MinerCard.tsx
@@ -423,6 +423,21 @@ const MinerCardFooter: React.FC<MinerCardFooterProps> = ({
         p: 1,
       })}
     >
+      {variant === 'watchlist' && (
+        <Typography
+          sx={{
+            fontFamily: FONTS.mono,
+            fontSize: '0.7rem',
+            fontWeight: 700,
+            color: muiTheme.palette.status.open,
+            textTransform: 'uppercase',
+            mb: 0.35,
+            letterSpacing: '0.04em',
+          }}
+        >
+          OSS
+        </Typography>
+      )}
       <Box
         sx={{
           display: 'grid',


### PR DESCRIPTION
## Summary

Watchlist **miner cards** show two footer stat grids: **PR** counts (Merged / Open / Closed + Score) and **issue** counts (Solved / Open / Closed + Total). The second block already had an **“ISSUES”** heading; the first did not, which made the PR row harder to interpret and looked inconsistent.

This change adds an **“OSS”** label above the PR stats grid in `MinerCardFooter` when `variant === 'watchlist'`, using the same typography pattern as the **Issues** heading (`FONTS.mono`, uppercase, `status.open`, spacing).

---

## Related Issues

#630



## Type of Change

- [ ] Bug fix
- [x] New feature *(small UI enhancement / labeling)*
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)



## Screenshots
<img width="1900" height="894" alt="2026-04-19_06h48_03" src="https://github.com/user-attachments/assets/5e84e5ea-61a3-4875-a82d-ddb49b249cdf" />


<img width="1910" height="906" alt="2026-04-19_06h59_41" src="https://github.com/user-attachments/assets/e6884214-89e3-44c2-9ecd-feed1f4b9d26" />


## Checklist

- [x] New components are modularized/separated where sensible *(localized to `MinerCard.tsx`)*
- [x] Uses predefined theme (e.g. no hardcoded colors) *(`status.open`, theme typography)*
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
