### PR TITLE
feat(watchlist): split eligibility filter into OSS, Issues, and both

### DIFF
--- a/src/components/leaderboard/TopMinersTable.tsx
+++ b/src/components/leaderboard/TopMinersTable.tsx
@@ -1,5 +1,14 @@
 import React, { useCallback, useEffect, useMemo } from 'react';
-import { Box, Typography, CircularProgress, Grid } from '@mui/material';
+import {
+  Box,
+  Typography,
+  CircularProgress,
+  Grid,
+  FormControl,
+  Select,
+  MenuItem,
+  type SelectChangeEvent,
+} from '@mui/material';
 import { alpha, type Theme } from '@mui/material/styles';
 import { useSearchParams } from 'react-router-dom';
 import { SectionCard } from './SectionCard';
@@ -57,11 +66,26 @@ const getSortOptionFromQuery = (
     : 'totalScore';
 };
 
-type EligibilityFilter = 'all' | 'eligible' | 'ineligible';
+type EligibilityFilter =
+  | 'all'
+  | 'eligible'
+  | 'ineligible'
+  | 'oss'
+  | 'issues'
+  | 'both';
 
 const getEligibilityFilterFromQuery = (
   value: string | null,
+  variant: LeaderboardVariant,
 ): EligibilityFilter => {
+  if (variant === 'watchlist') {
+    if (!value) return 'all';
+    if (value === 'false') return 'ineligible';
+    if (value === 'oss' || value === 'issues' || value === 'both') return value;
+    // Legacy single "Eligible" (?eligible=true) meant OSS ∪ Issues — map to OSS-only filter.
+    if (value === 'true') return 'oss';
+    return 'all';
+  }
   if (value === 'true') return 'eligible';
   if (value === 'false') return 'ineligible';
   return 'all';
@@ -94,8 +118,12 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
     [sortParamValue, variant],
   );
   const eligibilityFilter = useMemo(
-    () => getEligibilityFilterFromQuery(searchParams.get(ELIGIBLE_QUERY_PARAM)),
-    [searchParams],
+    () =>
+      getEligibilityFilterFromQuery(
+        searchParams.get(ELIGIBLE_QUERY_PARAM),
+        variant,
+      ),
+    [searchParams, variant],
   );
   const visibleCount = useMemo(
     () => getVisibleCountFromQuery(searchParams.get(VISIBLE_QUERY_PARAM)),
@@ -135,8 +163,14 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
             nextSearchParams.delete(ELIGIBLE_QUERY_PARAM);
           } else if (nextFilter === 'eligible') {
             nextSearchParams.set(ELIGIBLE_QUERY_PARAM, 'true');
-          } else {
+          } else if (nextFilter === 'ineligible') {
             nextSearchParams.set(ELIGIBLE_QUERY_PARAM, 'false');
+          } else if (
+            nextFilter === 'oss' ||
+            nextFilter === 'issues' ||
+            nextFilter === 'both'
+          ) {
+            nextSearchParams.set(ELIGIBLE_QUERY_PARAM, nextFilter);
           }
           nextSearchParams.delete(VISIBLE_QUERY_PARAM);
 
@@ -182,7 +216,21 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
       );
     }
 
-    if (eligibilityFilter === 'eligible') {
+    if (variant === 'watchlist') {
+      const ossOk = (m: MinerStats) => m.ossIsEligible ?? false;
+      const issuesOk = (m: MinerStats) =>
+        m.discoveriesIsEligible ?? m.isIssueEligible ?? false;
+
+      if (eligibilityFilter === 'oss') {
+        result = result.filter((m) => ossOk(m));
+      } else if (eligibilityFilter === 'issues') {
+        result = result.filter((m) => issuesOk(m));
+      } else if (eligibilityFilter === 'both') {
+        result = result.filter((m) => ossOk(m) && issuesOk(m));
+      } else if (eligibilityFilter === 'ineligible') {
+        result = result.filter((m) => !ossOk(m) && !issuesOk(m));
+      }
+    } else if (eligibilityFilter === 'eligible') {
       result = result.filter((m) => m.isEligible);
     } else if (eligibilityFilter === 'ineligible') {
       result = result.filter((m) => !m.isEligible);
@@ -192,7 +240,7 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
       ...miner,
       rank: index + 1,
     }));
-  }, [miners, searchQuery, eligibilityFilter, sortOption]);
+  }, [miners, searchQuery, eligibilityFilter, sortOption, variant]);
 
   useEffect(() => {
     if (visibleCount <= filteredMiners.length) return;
@@ -312,10 +360,23 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
               onSortChange={handleSortChange}
               variant={variant}
             />
-            <EligibilityToggle
-              value={eligibilityFilter}
-              onChange={handleEligibilityChange}
-            />
+            {variant === 'watchlist' ? (
+              <WatchlistEligibilityToolbar
+                value={eligibilityFilter}
+                onChange={handleEligibilityChange}
+              />
+            ) : (
+              <EligibilityToggle
+                value={
+                  eligibilityFilter === 'eligible' ||
+                  eligibilityFilter === 'ineligible' ||
+                  eligibilityFilter === 'all'
+                    ? eligibilityFilter
+                    : 'all'
+                }
+                onChange={handleEligibilityChange}
+              />
+            )}
           </Box>
         </Box>
       </SectionCard>
@@ -416,6 +477,171 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
   );
 };
 
+interface WatchlistEligibilityToolbarProps {
+  value: EligibilityFilter;
+  onChange: (next: EligibilityFilter) => void;
+}
+
+const WatchlistEligibilityToolbar: React.FC<
+  WatchlistEligibilityToolbarProps
+> = ({ value, onChange }) => {
+  const granularEligible =
+    value === 'oss' || value === 'issues' || value === 'both' ? value : '';
+
+  const handleEligibleProgramChange = (event: SelectChangeEvent<string>) => {
+    const v = event.target.value;
+    if (v === 'oss' || v === 'issues' || v === 'both') {
+      onChange(v);
+    }
+  };
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 1,
+        flexWrap: 'wrap',
+        justifyContent: 'flex-end',
+      }}
+    >
+      <Box
+        sx={(theme) => ({
+          display: 'inline-flex',
+          gap: 0.5,
+          p: 0.5,
+          borderRadius: 2,
+          backgroundColor: theme.palette.surface.light,
+        })}
+      >
+        {(
+          [
+            { key: 'all' as const, label: 'All' },
+            { key: 'ineligible' as const, label: 'Ineligible' },
+          ] as const
+        ).map(({ key, label }) => {
+          const isActive = value === key;
+          return (
+            <Box
+              key={key}
+              component="button"
+              type="button"
+              aria-pressed={isActive}
+              onClick={() => onChange(key)}
+              sx={(theme) => ({
+                px: 1.5,
+                height: 24,
+                display: 'flex',
+                alignItems: 'center',
+                border: 0,
+                borderRadius: 1.5,
+                backgroundColor: isActive
+                  ? alpha(theme.palette.text.primary, 0.15)
+                  : 'transparent',
+                color: isActive
+                  ? theme.palette.text.primary
+                  : theme.palette.text.tertiary,
+                cursor: 'pointer',
+                fontFamily: FONTS.mono,
+                fontSize: '0.72rem',
+                fontWeight: isActive ? 600 : 500,
+                lineHeight: 1,
+                transition: 'all 0.2s ease',
+                '&:hover': {
+                  backgroundColor: alpha(theme.palette.text.primary, 0.1),
+                  color: theme.palette.text.primary,
+                },
+                '&:focus-visible': {
+                  outline: `1px solid ${theme.palette.border.medium}`,
+                  outlineOffset: 1,
+                },
+              })}
+            >
+              {label}
+            </Box>
+          );
+        })}
+      </Box>
+
+      <FormControl size="small" sx={{ minWidth: { xs: 140, sm: 172 } }}>
+        <Select<string>
+          displayEmpty
+          value={granularEligible}
+          onChange={handleEligibleProgramChange}
+          aria-label="Eligible program filter"
+          renderValue={(selected) => {
+            if (!selected) {
+              return (
+                <Typography
+                  sx={{
+                    fontFamily: FONTS.mono,
+                    fontSize: '0.72rem',
+                    color: 'text.tertiary',
+                  }}
+                >
+                  Eligible
+                </Typography>
+              );
+            }
+            const labels = {
+              oss: 'OSS eligible',
+              issues: 'Issues eligible',
+              both: 'Both eligible',
+            };
+            return (
+              <Typography
+                sx={{
+                  fontFamily: FONTS.mono,
+                  fontSize: '0.72rem',
+                  fontWeight: 600,
+                  color: 'text.primary',
+                }}
+              >
+                {labels[selected as keyof typeof labels]}
+              </Typography>
+            );
+          }}
+          sx={(theme) => ({
+            height: 32,
+            borderRadius: 1.5,
+            fontFamily: FONTS.mono,
+            fontSize: '0.72rem',
+            backgroundColor: theme.palette.surface.light,
+            '& .MuiOutlinedInput-notchedOutline': {
+              borderColor: theme.palette.border.light,
+            },
+            '&:hover .MuiOutlinedInput-notchedOutline': {
+              borderColor: theme.palette.border.medium,
+            },
+            '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
+              borderColor: theme.palette.primary.main,
+            },
+          })}
+        >
+          <MenuItem
+            value="oss"
+            sx={{ fontFamily: FONTS.mono, fontSize: '0.75rem' }}
+          >
+            OSS eligible
+          </MenuItem>
+          <MenuItem
+            value="issues"
+            sx={{ fontFamily: FONTS.mono, fontSize: '0.75rem' }}
+          >
+            Issues eligible
+          </MenuItem>
+          <MenuItem
+            value="both"
+            sx={{ fontFamily: FONTS.mono, fontSize: '0.75rem' }}
+          >
+            Both eligible
+          </MenuItem>
+        </Select>
+      </FormControl>
+    </Box>
+  );
+};
+
 interface SortButtonsProps {
   sortOption: SortOption;
   onSortChange: (option: SortOption) => void;
@@ -491,7 +717,7 @@ const SortButtons: React.FC<SortButtonsProps> = ({
 );
 
 interface EligibilityToggleProps {
-  value: EligibilityFilter;
+  value: 'all' | 'eligible' | 'ineligible';
   onChange: (next: EligibilityFilter) => void;
 }
 


### PR DESCRIPTION
## Summary

Watchlist **Miners** used a single **Eligible** toggle that meant **OSS ∪ Issue Discoveries**, which was ambiguous and did not let users filter by program.

This change keeps **All** and **Ineligible** (neither program) as pill buttons and replaces the old Eligible toggle with a **`Select`**: **OSS eligible**, **Issues eligible**, and **Both eligible**, wired to `ossIsEligible` / `discoveriesIsEligible` (with `isIssueEligible` fallback). Query param **`eligible`** supports `oss`, `issues`, `both`, and `false`; legacy **`eligible=true`** maps to **`oss`**. OSS and Discoveries leaderboards still use the original **All / Eligible / Ineligible** three-way control. The empty select shows **“Eligible”** as the label.



## Related Issues

#634

---

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

---

## Screenshots

<img width="1918" height="897" alt="2026-04-19_07h11_02" src="https://github.com/user-attachments/assets/5f0bcb7f-a569-427a-a545-f708af5f4ad9" />

https://github.com/user-attachments/assets/96dc89b4-1f36-4b32-9c81-744bccfe7b3d



---

## Checklist

- [x] New components are modularized/separated where sensible *(watchlist-only `WatchlistEligibilityToolbar` in `TopMinersTable.tsx`)*
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
