### PR TITLE
feat: redesign PR details overview tab with inline header chips and token composition donut

### DIFF
--- a/src/components/prs/PRDetailsCard.tsx
+++ b/src/components/prs/PRDetailsCard.tsx
@@ -5,14 +5,19 @@ import {
   Typography,
   CircularProgress,
   Avatar,
-  Grid,
   alpha,
   Tooltip,
 } from '@mui/material';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
+import ReactECharts from 'echarts-for-react';
 import { usePullRequestDetails } from '../../api';
 import { linkResetSx, useLinkBehavior } from '../common/linkBehavior';
-import theme, { RANK_COLORS, STATUS_COLORS, TEXT_OPACITY } from '../../theme';
+import theme, {
+  CHART_COLORS,
+  STATUS_COLORS,
+  TEXT_OPACITY,
+  tooltipSlotProps,
+} from '../../theme';
 import { buildMultiplierGrid } from '../../utils/multiplierDefs';
 
 interface PRDetailsCardProps {
@@ -34,11 +39,6 @@ const PRDetailsCard: React.FC<PRDetailsCardProps> = ({
     `/miners/repository?name=${encodeURIComponent(repository)}`,
     { state: { backLabel: `Back to PR #${pullRequestNumber}` } },
   );
-  const authorLinkProps = useLinkBehavior<HTMLAnchorElement>(
-    `/miners/details?githubId=${prDetails?.githubId ?? ''}`,
-    { state: { backLabel: `Back to PR #${pullRequestNumber}` } },
-  );
-
   if (isDetailsLoading) {
     return (
       <Card
@@ -81,62 +81,119 @@ const PRDetailsCard: React.FC<PRDetailsCardProps> = ({
   }
 
   const [owner] = repository.split('/');
-
   const isOpenPR = prDetails.prState === 'OPEN';
-
-  // Score/Collateral is now shown in header, so only show other stats here
-  const statItems = [
+  const multipliers = buildMultiplierGrid(prDetails, isOpenPR);
+  const structuralScoreNum = parseFloat(String(prDetails.structuralScore ?? 0));
+  const leafScoreNum = parseFloat(String(prDetails.leafScore ?? 0));
+  const showTokenDonut = structuralScoreNum > 0 || leafScoreNum > 0;
+  const tokenScoreValue = parseFloat(prDetails.tokenScore ?? '0');
+  type DetailItem = {
+    label: string;
+    value: string;
+    subValue?: string;
+    tooltip?: string;
+    additions?: number;
+    deletions?: number;
+    isMonospace?: boolean;
+  };
+  const detailItems: DetailItem[] = [
     {
       label: 'Base Score',
       value: parseFloat(prDetails.baseScore ?? '0').toFixed(2),
-      rank: null,
-      color: alpha(theme.palette.common.white, TEXT_OPACITY.secondary),
     },
     {
       label: 'Tokens Scored',
       value: (prDetails.totalNodesScored ?? 0).toLocaleString(),
-      rank: null,
     },
-    {
-      label: 'Token Score',
-      value: parseFloat(prDetails.tokenScore ?? '0').toFixed(2),
-      rank: null,
-    },
+    { label: 'Token Score', value: tokenScoreValue.toFixed(2) },
     {
       label: 'Structural',
-      value:
-        prDetails.structuralCount != null
-          ? `${prDetails.structuralCount} (${parseFloat(String(prDetails.structuralScore ?? 0)).toFixed(2)})`
-          : '-',
-      rank: null,
+      value: String(prDetails.structuralCount ?? '-'),
+      subValue:
+        prDetails.structuralScore != null
+          ? `Score ${structuralScoreNum.toFixed(2)}`
+          : undefined,
       tooltip:
         'Functions, classes, and modules scored via AST analysis. Structural nodes carry more weight per node because they represent high-value code organization.',
     },
     {
       label: 'Leaf',
-      value:
-        prDetails.leafCount != null
-          ? `${prDetails.leafCount} (${parseFloat(String(prDetails.leafScore ?? 0)).toFixed(2)})`
-          : '-',
-      rank: null,
+      value: String(prDetails.leafCount ?? '-'),
+      subValue:
+        prDetails.leafScore != null
+          ? `Score ${leafScoreNum.toFixed(2)}`
+          : undefined,
       tooltip:
         'Individual statements and expressions scored via AST analysis. More leaf nodes means a larger diff, but structural nodes contribute more score per node.',
     },
     {
       label: 'Changes',
       value: '',
-      rank: null,
       additions: prDetails.additions,
       deletions: prDetails.deletions,
     },
-    {
-      label: 'Commits',
-      value: prDetails.commits,
-      rank: null,
-    },
+    { label: 'Commits', value: String(prDetails.commits ?? '-') },
+    ...(prDetails.hotkey
+      ? [{ label: 'Hotkey', value: prDetails.hotkey, isMonospace: true }]
+      : []),
   ];
-
-  const multipliers = buildMultiplierGrid(prDetails, isOpenPR);
+  const tokenDonutOption = showTokenDonut
+    ? {
+        backgroundColor: 'transparent',
+        title: {
+          text: tokenScoreValue.toFixed(2),
+          subtext: 'Token Score',
+          left: 'center',
+          top: '38%',
+          textStyle: {
+            color: theme.palette.text.primary,
+            fontSize: 24,
+            fontWeight: 'bold',
+          },
+          subtextStyle: {
+            color: alpha(theme.palette.common.white, TEXT_OPACITY.muted),
+            fontSize: 11,
+            fontWeight: 500,
+          },
+        },
+        tooltip: {
+          trigger: 'item',
+          formatter: '{b}: {c} ({d}%)',
+          backgroundColor: alpha(theme.palette.common.black, 0.9),
+          borderColor: alpha(theme.palette.common.white, 0.15),
+          borderWidth: 1,
+          textStyle: { color: theme.palette.text.primary },
+        },
+        series: [
+          {
+            name: 'Token Composition',
+            type: 'pie',
+            radius: ['58%', '72%'],
+            avoidLabelOverlap: false,
+            itemStyle: {
+              borderRadius: 6,
+              borderColor: theme.palette.background.paper,
+              borderWidth: 3,
+            },
+            label: { show: false, position: 'center' },
+            emphasis: { label: { show: false }, scale: true, scaleSize: 5 },
+            labelLine: { show: false },
+            data: [
+              {
+                value: structuralScoreNum,
+                name: 'Structural',
+                itemStyle: { color: CHART_COLORS.merged },
+              },
+              {
+                value: leafScoreNum,
+                name: 'Leaf',
+                itemStyle: { color: CHART_COLORS.open },
+              },
+            ],
+          },
+        ],
+      }
+    : null;
 
   return (
     <Card
@@ -262,28 +319,165 @@ const PRDetailsCard: React.FC<PRDetailsCardProps> = ({
         </Box>
       )}
 
-      {/* Stats Grid */}
-      <Grid container spacing={2} sx={{ mb: 3 }}>
-        {statItems.map((item, index) => (
-          <Grid item xs={12} sm={6} md={4} lg={2.4} key={index}>
+      <Box
+        sx={{
+          border: `1px solid ${theme.palette.border.light}`,
+          borderRadius: 3,
+          p: { xs: 2, sm: 2.5 },
+          mb: 3,
+          backgroundColor: alpha(theme.palette.common.white, 0.015),
+        }}
+      >
+        <Typography
+          sx={{
+            color: alpha(theme.palette.common.white, TEXT_OPACITY.secondary),
+            fontSize: '0.8rem',
+            textTransform: 'uppercase',
+            letterSpacing: '1px',
+            fontWeight: 600,
+            mb: 2,
+          }}
+        >
+          Score Story
+        </Typography>
+        <Box
+          sx={{
+            display: 'flex',
+            flexWrap: 'wrap',
+            gap: 1,
+            justifyContent: { md: 'center' },
+          }}
+        >
+          {multipliers.map((m, index) => {
+            const numeric = parseFloat(m.value);
+            const accent = isNaN(numeric)
+              ? theme.palette.text.tertiary
+              : numeric > 1
+                ? STATUS_COLORS.success
+                : numeric < 1
+                  ? STATUS_COLORS.warningOrange
+                  : theme.palette.text.tertiary;
+            const chip = (
+              <Box
+                sx={{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  gap: 1,
+                  px: 1.75,
+                  py: 1,
+                  borderRadius: 1.5,
+                  border: `1px solid ${alpha(accent, 0.35)}`,
+                  backgroundColor: alpha(accent, 0.1),
+                  cursor: m.isCredibility ? 'help' : 'default',
+                }}
+              >
+                <Typography
+                  sx={{
+                    color: alpha(
+                      theme.palette.common.white,
+                      TEXT_OPACITY.secondary,
+                    ),
+                    fontSize: '0.75rem',
+                    textTransform: 'uppercase',
+                    letterSpacing: '0.5px',
+                    fontWeight: 600,
+                  }}
+                >
+                  {m.label}
+                </Typography>
+                <Typography
+                  sx={{
+                    color: accent,
+                    fontSize: '1rem',
+                    fontWeight: 700,
+                  }}
+                >
+                  {m.value}
+                </Typography>
+                {m.isCredibility && (
+                  <InfoOutlinedIcon
+                    sx={{ fontSize: '0.85rem', color: accent, opacity: 0.7 }}
+                  />
+                )}
+              </Box>
+            );
+            return m.isCredibility ? (
+              <Tooltip
+                key={index}
+                title={
+                  <Box sx={{ p: 0.5 }}>
+                    <Typography
+                      sx={{ fontSize: '0.75rem', fontWeight: 600, mb: 1 }}
+                    >
+                      Credibility Multiplier
+                    </Typography>
+                    <Typography
+                      sx={{
+                        fontSize: '0.7rem',
+                        color: alpha(theme.palette.common.white, 0.9),
+                      }}
+                    >
+                      Based on your PR success rate, scaled to reward
+                      consistency.
+                    </Typography>
+                  </Box>
+                }
+                arrow
+                placement="top"
+                slotProps={tooltipSlotProps}
+              >
+                {chip}
+              </Tooltip>
+            ) : (
+              <React.Fragment key={index}>{chip}</React.Fragment>
+            );
+          })}
+        </Box>
+      </Box>
+
+      <Box
+        sx={{
+          display: 'grid',
+          gridTemplateColumns: {
+            xs: '1fr',
+            md: showTokenDonut ? 'minmax(0, 1fr) 220px' : '1fr',
+          },
+          gap: 2,
+          alignItems: 'start',
+        }}
+      >
+        <Box
+          sx={{
+            border: `1px solid ${theme.palette.border.light}`,
+            borderRadius: 3,
+            overflow: 'hidden',
+          }}
+        >
+          {detailItems.map((item, index, arr) => (
             <Box
+              key={index}
               sx={{
-                backgroundColor: 'transparent',
-                borderRadius: 3,
-                border: `1px solid ${theme.palette.border.light}`,
-                p: 2.5,
-                height: '100%',
-                display: 'flex',
-                flexDirection: 'column',
-                justifyContent: 'center',
+                display: 'grid',
+                gridTemplateColumns: { xs: '1fr', sm: '180px 1fr' },
+                alignItems: 'center',
+                rowGap: 0.5,
+                columnGap: 2,
+                px: { xs: 2, sm: 2.5 },
+                py: 1.5,
+                borderBottom:
+                  index < arr.length - 1
+                    ? `1px solid ${theme.palette.border.subtle}`
+                    : undefined,
+                '&:hover': {
+                  backgroundColor: alpha(theme.palette.common.white, 0.02),
+                },
               }}
             >
               <Box
                 sx={{
                   display: 'flex',
                   alignItems: 'center',
-                  gap: 1,
-                  mb: 1,
+                  gap: 0.5,
                 }}
               >
                 <Typography
@@ -296,414 +490,112 @@ const PRDetailsCard: React.FC<PRDetailsCardProps> = ({
                     textTransform: 'uppercase',
                     letterSpacing: '1px',
                     fontWeight: 600,
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: 0.5,
                   }}
                 >
                   {item.label}
-                  {item.tooltip && (
-                    <Tooltip
-                      title={item.tooltip}
-                      arrow
-                      slotProps={{
-                        tooltip: {
-                          sx: {
-                            backgroundColor: 'surface.tooltip',
-                            color: 'text.primary',
-                            fontSize: '0.7rem',
-                            maxWidth: 280,
-                            p: 1.5,
-                            border: '1px solid',
-                            borderColor: 'border.light',
-                          },
-                        },
-                        arrow: { sx: { color: 'surface.tooltip' } },
-                      }}
-                    >
-                      <InfoOutlinedIcon
-                        sx={{
-                          fontSize: '0.7rem',
-                          cursor: 'help',
-                          opacity: 0.5,
-                        }}
-                      />
-                    </Tooltip>
-                  )}
                 </Typography>
-                {item.rank && (
+                {item.tooltip && (
+                  <Tooltip
+                    title={item.tooltip}
+                    arrow
+                    slotProps={tooltipSlotProps}
+                  >
+                    <InfoOutlinedIcon
+                      sx={{ fontSize: '0.75rem', cursor: 'help', opacity: 0.5 }}
+                    />
+                  </Tooltip>
+                )}
+              </Box>
+              <Box
+                sx={{
+                  display: 'flex',
+                  alignItems: 'baseline',
+                  flexWrap: 'wrap',
+                  gap: 1.5,
+                }}
+              >
+                {item.additions !== undefined &&
+                item.deletions !== undefined ? (
                   <Box
                     sx={{
-                      backgroundColor: 'background.default',
-                      borderRadius: '2px',
-                      width: '20px',
-                      height: '20px',
                       display: 'inline-flex',
                       alignItems: 'center',
-                      justifyContent: 'center',
-                      flexShrink: 0,
-                      border: '1px solid',
-                      borderColor:
-                        item.rank === 1
-                          ? alpha(RANK_COLORS.first, 0.4)
-                          : item.rank === 2
-                            ? alpha(RANK_COLORS.second, 0.4)
-                            : item.rank === 3
-                              ? alpha(RANK_COLORS.third, 0.4)
-                              : alpha(theme.palette.common.white, 0.15),
-                      boxShadow:
-                        item.rank === 1
-                          ? `0 0 12px ${alpha(RANK_COLORS.first, 0.4)}, 0 0 4px ${alpha(RANK_COLORS.first, 0.2)}`
-                          : item.rank === 2
-                            ? `0 0 12px ${alpha(RANK_COLORS.second, 0.4)}, 0 0 4px ${alpha(RANK_COLORS.second, 0.2)}`
-                            : item.rank === 3
-                              ? `0 0 12px ${alpha(RANK_COLORS.third, 0.4)}, 0 0 4px ${alpha(RANK_COLORS.third, 0.2)}`
-                              : 'none',
+                      gap: 0.75,
                     }}
                   >
                     <Typography
                       component="span"
                       sx={{
-                        color:
-                          item.rank === 1
-                            ? RANK_COLORS.first
-                            : item.rank === 2
-                              ? RANK_COLORS.second
-                              : item.rank === 3
-                                ? RANK_COLORS.third
-                                : alpha(theme.palette.common.white, 0.6),
-                        fontSize: '0.6rem',
+                        color: alpha(theme.palette.diff.additions, 0.9),
+                        fontSize: '1rem',
                         fontWeight: 600,
-                        lineHeight: 1,
-                        display: 'flex',
-                        alignItems: 'center',
-                        justifyContent: 'center',
                       }}
                     >
-                      {item.rank}
+                      +{item.additions}
+                    </Typography>
+                    <Typography
+                      component="span"
+                      sx={{
+                        color: alpha(
+                          theme.palette.common.white,
+                          TEXT_OPACITY.muted,
+                        ),
+                        fontSize: '1rem',
+                      }}
+                    >
+                      /
+                    </Typography>
+                    <Typography
+                      component="span"
+                      sx={{
+                        color: alpha(theme.palette.diff.deletions, 0.9),
+                        fontSize: '1rem',
+                        fontWeight: 600,
+                      }}
+                    >
+                      -{item.deletions}
                     </Typography>
                   </Box>
-                )}
-              </Box>
-              {item.additions !== undefined && item.deletions !== undefined ? (
-                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                ) : (
                   <Typography
-                    component="span"
                     sx={{
-                      color: alpha(theme.palette.diff.additions, 0.8),
-                      fontSize: '1.5rem',
+                      color: theme.palette.text.primary,
+                      fontSize: '1rem',
                       fontWeight: 600,
+                      fontFamily: item.isMonospace ? 'monospace' : undefined,
+                      wordBreak: 'break-all',
                     }}
                   >
-                    +{item.additions}
+                    {item.value}
                   </Typography>
+                )}
+                {item.subValue && (
                   <Typography
-                    component="span"
                     sx={{
                       color: alpha(
                         theme.palette.common.white,
-                        TEXT_OPACITY.muted,
+                        TEXT_OPACITY.tertiary,
                       ),
-                      fontSize: '1.5rem',
-                      fontWeight: 400,
+                      fontSize: '0.8rem',
+                      fontWeight: 500,
                     }}
                   >
-                    /
+                    {item.subValue}
                   </Typography>
-                  <Typography
-                    component="span"
-                    sx={{
-                      color: alpha(theme.palette.diff.deletions, 0.8),
-                      fontSize: '1.5rem',
-                      fontWeight: 600,
-                    }}
-                  >
-                    -{item.deletions}
-                  </Typography>
-                </Box>
-              ) : (
-                <Typography
-                  sx={{
-                    color: item.color || theme.palette.text.primary,
-                    fontSize: '1.5rem',
-                    fontWeight: 600,
-                    wordBreak: 'break-all',
-                  }}
-                >
-                  {item.value}
-                </Typography>
-              )}
-            </Box>
-          </Grid>
-        ))}
-      </Grid>
-
-      {/* Multipliers Breakdown */}
-      <Box sx={{ mb: 3 }}>
-        <Typography
-          sx={{
-            color: alpha(theme.palette.common.white, TEXT_OPACITY.secondary),
-            fontSize: '0.8rem',
-            textTransform: 'uppercase',
-            letterSpacing: '1px',
-            fontWeight: 600,
-            mb: 2,
-          }}
-        >
-          {isOpenPR ? 'Collateral Multipliers' : 'Score Multipliers'}
-        </Typography>
-        <Grid container spacing={2}>
-          {multipliers.map((item, index) => {
-            const isCredibilityItem = item.isCredibility === true;
-
-            const content = (
-              <Box
-                sx={{
-                  backgroundColor: alpha(theme.palette.common.white, 0.03),
-                  borderRadius: 2,
-                  border: `1px solid ${alpha(theme.palette.common.white, 0.05)}`,
-                  p: 2,
-                  display: 'flex',
-                  flexDirection: 'column',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  textAlign: 'center',
-                  cursor: isCredibilityItem ? 'help' : 'default',
-                }}
-              >
-                <Typography
-                  sx={{
-                    color: alpha(
-                      theme.palette.common.white,
-                      TEXT_OPACITY.tertiary,
-                    ),
-                    fontSize: '0.7rem',
-                    mb: 0.5,
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: 0.5,
-                  }}
-                >
-                  {item.label}
-                  {isCredibilityItem && (
-                    <InfoOutlinedIcon sx={{ fontSize: '0.7rem' }} />
-                  )}
-                </Typography>
-                <Typography
-                  sx={{
-                    color: 'text.primary',
-                    fontSize: '1.1rem',
-                    fontWeight: 600,
-                  }}
-                >
-                  {item.value}
-                </Typography>
-              </Box>
-            );
-
-            return (
-              <Grid item xs={6} sm={4} md={2} key={index}>
-                {isCredibilityItem ? (
-                  <Tooltip
-                    title={
-                      <Box sx={{ p: 0.5 }}>
-                        <Typography
-                          sx={{ fontSize: '0.75rem', fontWeight: 600, mb: 1 }}
-                        >
-                          Credibility Multiplier
-                        </Typography>
-                        <Typography
-                          sx={{
-                            fontSize: '0.7rem',
-                            color: alpha(theme.palette.common.white, 0.9),
-                          }}
-                        >
-                          This multiplier is based on your PR success rate,
-                          scaled to reward consistency.
-                        </Typography>
-                      </Box>
-                    }
-                    arrow
-                    placement="top"
-                    slotProps={{
-                      tooltip: {
-                        sx: {
-                          backgroundColor: 'surface.tooltip',
-                          border: `1px solid ${alpha(theme.palette.common.white, 0.15)}`,
-                          borderRadius: '8px',
-                          maxWidth: 280,
-                        },
-                      },
-                      arrow: {
-                        sx: {
-                          color: 'surface.tooltip',
-                        },
-                      },
-                    }}
-                  >
-                    {content}
-                  </Tooltip>
-                ) : (
-                  content
                 )}
-              </Grid>
-            );
-          })}
-        </Grid>
-      </Box>
-
-      {/* Additional Info */}
-      <Grid container spacing={2}>
-        {/* Author */}
-        <Grid item xs={12} sm={6}>
-          <Box
-            sx={{
-              backgroundColor: 'transparent',
-              borderRadius: 3,
-              border: `1px solid ${theme.palette.border.light}`,
-              p: 2.5,
-              height: '100%',
-            }}
-          >
-            <Typography
-              sx={{
-                color: alpha(theme.palette.common.white, TEXT_OPACITY.tertiary),
-                fontSize: '0.7rem',
-                textTransform: 'uppercase',
-                letterSpacing: '1px',
-                fontWeight: 600,
-                mb: 1.5,
-              }}
-            >
-              Author
-            </Typography>
-            <Box
-              component="a"
-              {...authorLinkProps}
-              sx={{
-                ...linkResetSx,
-                display: 'flex',
-                alignItems: 'center',
-                gap: 1.5,
-                cursor: 'pointer',
-                '&:hover': {
-                  '& .MuiTypography-root': {
-                    color: 'primary.main',
-                    textDecoration: 'underline',
-                  },
-                },
-                transition: 'color 0.2s',
-              }}
-            >
-              <Avatar
-                src={`https://avatars.githubusercontent.com/${prDetails.authorLogin}`}
-                alt={prDetails.authorLogin}
-                sx={{ width: 32, height: 32 }}
-              />
-              <Typography
-                sx={{
-                  color: 'text.primary',
-                  fontSize: '0.95rem',
-                  fontWeight: 500,
-                  transition: 'color 0.2s',
-                }}
-              >
-                {prDetails.authorLogin}
-              </Typography>
+              </Box>
             </Box>
-          </Box>
-        </Grid>
-
-        {/* Merged Date */}
-        <Grid item xs={12} sm={6}>
+          ))}
+        </Box>
+        {showTokenDonut && tokenDonutOption && (
           <Box
             sx={{
-              backgroundColor: 'transparent',
-              borderRadius: 3,
               border: `1px solid ${theme.palette.border.light}`,
-              p: 2.5,
-              height: '100%',
-            }}
-          >
-            <Typography
-              sx={{
-                color: alpha(theme.palette.common.white, TEXT_OPACITY.tertiary),
-                fontSize: '0.7rem',
-                textTransform: 'uppercase',
-                letterSpacing: '1px',
-                fontWeight: 600,
-                mb: 1.5,
-              }}
-            >
-              Merged
-            </Typography>
-            <Typography
-              sx={{
-                color: 'text.primary',
-                fontSize: '0.95rem',
-                fontWeight: 500,
-              }}
-            >
-              {prDetails.mergedAt
-                ? new Date(prDetails.mergedAt).toLocaleDateString('en-US', {
-                    year: 'numeric',
-                    month: 'long',
-                    day: 'numeric',
-                  })
-                : 'Not Merged'}
-            </Typography>
-          </Box>
-        </Grid>
-
-        {/* Hotkey */}
-        {prDetails.hotkey && (
-          <Grid item xs={12}>
-            <Box
-              sx={{
-                backgroundColor: 'transparent',
-                borderRadius: 3,
-                border: `1px solid ${theme.palette.border.light}`,
-                p: 2.5,
-              }}
-            >
-              <Typography
-                sx={{
-                  color: alpha(
-                    theme.palette.common.white,
-                    TEXT_OPACITY.tertiary,
-                  ),
-                  fontSize: '0.7rem',
-                  textTransform: 'uppercase',
-                  letterSpacing: '1px',
-                  fontWeight: 600,
-                  mb: 1.5,
-                }}
-              >
-                Hotkey
-              </Typography>
-              <Typography
-                sx={{
-                  fontSize: '0.85rem',
-                  wordBreak: 'break-all',
-                }}
-              >
-                {prDetails.hotkey}
-              </Typography>
-            </Box>
-          </Grid>
-        )}
-
-        {/* GitHub Link */}
-        <Grid item xs={12}>
-          <Box
-            sx={{
-              backgroundColor: 'transparent',
               borderRadius: 3,
-              border: `1px solid ${theme.palette.border.light}`,
-              p: 2.5,
+              p: 2,
               display: 'flex',
+              flexDirection: 'column',
               alignItems: 'center',
-              justifyContent: 'space-between',
             }}
           >
             <Typography
@@ -712,27 +604,66 @@ const PRDetailsCard: React.FC<PRDetailsCardProps> = ({
                   theme.palette.common.white,
                   TEXT_OPACITY.secondary,
                 ),
-                fontSize: '0.85rem',
+                fontSize: '0.7rem',
+                textTransform: 'uppercase',
+                letterSpacing: '1px',
+                fontWeight: 600,
+                mb: 1,
+                alignSelf: 'flex-start',
               }}
             >
-              View this pull request on GitHub
+              Token Composition
             </Typography>
-            <a
-              href={`https://github.com/${repository}/pull/${pullRequestNumber}`}
-              target="_blank"
-              rel="noopener noreferrer"
-              style={{
-                color: STATUS_COLORS.info,
-                textDecoration: 'none',
-                fontSize: '0.85rem',
-                fontWeight: 500,
+            <Box sx={{ width: '100%', height: 160 }}>
+              <ReactECharts
+                option={tokenDonutOption}
+                style={{ height: '100%', width: '100%' }}
+                opts={{ renderer: 'svg' }}
+                notMerge
+              />
+            </Box>
+            <Box
+              sx={{
+                display: 'flex',
+                gap: 1.5,
+                mt: 1,
+                flexWrap: 'wrap',
+                justifyContent: 'center',
               }}
             >
-              Open →
-            </a>
+              {[
+                { label: 'Structural', color: CHART_COLORS.merged },
+                { label: 'Leaf', color: CHART_COLORS.open },
+              ].map(({ label, color }) => (
+                <Box
+                  key={label}
+                  sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}
+                >
+                  <Box
+                    sx={{
+                      width: 8,
+                      height: 8,
+                      borderRadius: '50%',
+                      backgroundColor: color,
+                    }}
+                  />
+                  <Typography
+                    sx={{
+                      color: alpha(
+                        theme.palette.common.white,
+                        TEXT_OPACITY.tertiary,
+                      ),
+                      fontSize: '0.7rem',
+                    }}
+                  >
+                    {label}
+                  </Typography>
+                </Box>
+              ))}
+            </Box>
           </Box>
-        </Grid>
-      </Grid>
+        )}
+      </Box>
     </Card>
   );
 };

--- a/src/components/prs/PRDetailsCard.tsx
+++ b/src/components/prs/PRDetailsCard.tsx
@@ -18,6 +18,7 @@ import theme, {
   TEXT_OPACITY,
   tooltipSlotProps,
 } from '../../theme';
+import { parseNumber } from '../../utils';
 import { buildMultiplierGrid } from '../../utils/multiplierDefs';
 
 interface PRDetailsCardProps {
@@ -83,10 +84,12 @@ const PRDetailsCard: React.FC<PRDetailsCardProps> = ({
   const [owner] = repository.split('/');
   const isOpenPR = prDetails.prState === 'OPEN';
   const multipliers = buildMultiplierGrid(prDetails, isOpenPR);
-  const structuralScoreNum = parseFloat(String(prDetails.structuralScore ?? 0));
-  const leafScoreNum = parseFloat(String(prDetails.leafScore ?? 0));
+  const structuralScoreNum = parseNumber(prDetails.structuralScore);
+  const leafScoreNum = parseNumber(prDetails.leafScore);
   const showTokenDonut = structuralScoreNum > 0 || leafScoreNum > 0;
-  const tokenScoreValue = parseFloat(prDetails.tokenScore ?? '0');
+  const tokenScoreValue = parseNumber(prDetails.tokenScore);
+  const scoreSubValue = (raw: unknown, num: number) =>
+    raw != null ? `Score ${num.toFixed(2)}` : undefined;
   type DetailItem = {
     label: string;
     value: string;
@@ -97,10 +100,7 @@ const PRDetailsCard: React.FC<PRDetailsCardProps> = ({
     isMonospace?: boolean;
   };
   const detailItems: DetailItem[] = [
-    {
-      label: 'Base Score',
-      value: parseFloat(prDetails.baseScore ?? '0').toFixed(2),
-    },
+    { label: 'Base Score', value: parseNumber(prDetails.baseScore).toFixed(2) },
     {
       label: 'Tokens Scored',
       value: (prDetails.totalNodesScored ?? 0).toLocaleString(),
@@ -109,20 +109,14 @@ const PRDetailsCard: React.FC<PRDetailsCardProps> = ({
     {
       label: 'Structural',
       value: String(prDetails.structuralCount ?? '-'),
-      subValue:
-        prDetails.structuralScore != null
-          ? `Score ${structuralScoreNum.toFixed(2)}`
-          : undefined,
+      subValue: scoreSubValue(prDetails.structuralScore, structuralScoreNum),
       tooltip:
         'Functions, classes, and modules scored via AST analysis. Structural nodes carry more weight per node because they represent high-value code organization.',
     },
     {
       label: 'Leaf',
       value: String(prDetails.leafCount ?? '-'),
-      subValue:
-        prDetails.leafScore != null
-          ? `Score ${leafScoreNum.toFixed(2)}`
-          : undefined,
+      subValue: scoreSubValue(prDetails.leafScore, leafScoreNum),
       tooltip:
         'Individual statements and expressions scored via AST analysis. More leaf nodes means a larger diff, but structural nodes contribute more score per node.',
     },

--- a/src/components/prs/PRHeader.tsx
+++ b/src/components/prs/PRHeader.tsx
@@ -32,6 +32,15 @@ const PRHeader: React.FC<PRHeaderProps> = ({
   const mergedDateLabel = prDetails.mergedAt
     ? formatDate(prDetails.mergedAt)
     : null;
+  const chipSx = {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: 0.75,
+    px: 1,
+    py: 0.5,
+    borderRadius: 1,
+    border: '1px solid',
+  };
   const isOpenPR = prDetails.prState === 'OPEN';
   const isClosed = prDetails.prState === 'CLOSED';
   const collateralScore = parseFloat(prDetails.collateralScore || '0');
@@ -176,22 +185,14 @@ const PRHeader: React.FC<PRHeaderProps> = ({
               {...authorLinkProps}
               sx={{
                 ...linkResetSx,
-                display: 'inline-flex',
-                alignItems: 'center',
-                gap: 0.75,
-                px: 1,
-                py: 0.5,
-                borderRadius: 1,
-                border: '1px solid',
+                ...chipSx,
                 borderColor: 'border.light',
                 backgroundColor: 'surface.subtle',
                 cursor: 'pointer',
                 transition: 'color 0.15s, border-color 0.15s',
                 '&:hover': {
                   borderColor: 'primary.main',
-                  '& .author-login': {
-                    color: 'primary.main',
-                  },
+                  '& .author-login': { color: 'primary.main' },
                 },
               }}
             >
@@ -216,13 +217,7 @@ const PRHeader: React.FC<PRHeaderProps> = ({
           {mergedDateLabel && (
             <Box
               sx={{
-                display: 'inline-flex',
-                alignItems: 'center',
-                gap: 0.75,
-                px: 1,
-                py: 0.5,
-                borderRadius: 1,
-                border: '1px solid',
+                ...chipSx,
                 borderColor: alpha(STATUS_COLORS.merged, 0.25),
                 backgroundColor: alpha(STATUS_COLORS.merged, 0.08),
               }}

--- a/src/components/prs/PRHeader.tsx
+++ b/src/components/prs/PRHeader.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
-import { Box, Typography, Avatar, Tooltip, alpha } from '@mui/material';
+import { Box, Typography, Avatar, Button, Tooltip, alpha } from '@mui/material';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
+import EventAvailableIcon from '@mui/icons-material/EventAvailable';
 import { linkResetSx, useLinkBehavior } from '../common/linkBehavior';
-import { formatUsdEstimate } from '../../utils';
+import { formatDate, formatUsdEstimate } from '../../utils';
 import { type PullRequestDetails } from '../../api/models/Dashboard';
 import { STATUS_COLORS } from '../../theme';
 import { getRepositoryOwnerAvatarBackground } from '../leaderboard/types';
@@ -22,7 +24,14 @@ const PRHeader: React.FC<PRHeaderProps> = ({
     `/miners/repository?name=${encodeURIComponent(repository)}`,
     { state: { backLabel: `Back to PR #${pullRequestNumber}` } },
   );
-
+  const authorLinkProps = useLinkBehavior<HTMLAnchorElement>(
+    `/miners/details?githubId=${prDetails.githubId ?? ''}`,
+    { state: { backLabel: `Back to PR #${pullRequestNumber}` } },
+  );
+  const githubPrUrl = `https://github.com/${repository}/pull/${pullRequestNumber}`;
+  const mergedDateLabel = prDetails.mergedAt
+    ? formatDate(prDetails.mergedAt)
+    : null;
   const isOpenPR = prDetails.prState === 'OPEN';
   const isClosed = prDetails.prState === 'CLOSED';
   const collateralScore = parseFloat(prDetails.collateralScore || '0');
@@ -96,6 +105,32 @@ const PRHeader: React.FC<PRHeaderProps> = ({
               {prDetails.prState}
             </Typography>
           </Box>
+          <Button
+            component="a"
+            href={githubPrUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            variant="outlined"
+            size="small"
+            startIcon={<OpenInNewIcon />}
+            aria-label="Open on GitHub"
+            sx={{
+              color: STATUS_COLORS.info,
+              borderColor: alpha(STATUS_COLORS.info, 0.5),
+              backgroundColor: alpha(STATUS_COLORS.info, 0.1),
+              textTransform: 'none',
+              fontFamily: '"JetBrains Mono", monospace',
+              fontSize: '0.8rem',
+              fontWeight: 600,
+              '&:hover': {
+                borderColor: STATUS_COLORS.info,
+                color: STATUS_COLORS.info,
+                backgroundColor: alpha(STATUS_COLORS.info, 0.2),
+              },
+            }}
+          >
+            Open on GitHub
+          </Button>
         </Box>
         <Typography
           sx={{
@@ -125,6 +160,90 @@ const PRHeader: React.FC<PRHeaderProps> = ({
           >
             {repository}
           </Typography>
+        </Box>
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            flexWrap: 'wrap',
+            gap: 1,
+            mt: 1,
+          }}
+        >
+          {prDetails.authorLogin && (
+            <Box
+              component="a"
+              {...authorLinkProps}
+              sx={{
+                ...linkResetSx,
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: 0.75,
+                px: 1,
+                py: 0.5,
+                borderRadius: 1,
+                border: '1px solid',
+                borderColor: 'border.light',
+                backgroundColor: 'surface.subtle',
+                cursor: 'pointer',
+                transition: 'color 0.15s, border-color 0.15s',
+                '&:hover': {
+                  borderColor: 'primary.main',
+                  '& .author-login': {
+                    color: 'primary.main',
+                  },
+                },
+              }}
+            >
+              <Avatar
+                src={`https://avatars.githubusercontent.com/${prDetails.authorLogin}`}
+                alt={prDetails.authorLogin}
+                sx={{ width: 22, height: 22 }}
+              />
+              <Typography
+                className="author-login"
+                sx={{
+                  color: 'text.primary',
+                  fontSize: '0.9rem',
+                  fontWeight: 500,
+                  transition: 'color 0.15s',
+                }}
+              >
+                @{prDetails.authorLogin}
+              </Typography>
+            </Box>
+          )}
+          {mergedDateLabel && (
+            <Box
+              sx={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: 0.75,
+                px: 1,
+                py: 0.5,
+                borderRadius: 1,
+                border: '1px solid',
+                borderColor: alpha(STATUS_COLORS.merged, 0.25),
+                backgroundColor: alpha(STATUS_COLORS.merged, 0.08),
+              }}
+            >
+              <EventAvailableIcon
+                sx={{
+                  fontSize: '0.95rem',
+                  color: STATUS_COLORS.merged,
+                }}
+              />
+              <Typography
+                sx={{
+                  color: 'text.primary',
+                  fontSize: '0.9rem',
+                  fontWeight: 500,
+                }}
+              >
+                Merged {mergedDateLabel}
+              </Typography>
+            </Box>
+          )}
         </Box>
       </Box>
 


### PR DESCRIPTION
Closes #641

## Summary
Restructures the PR Details page for a denser, more scannable layout. The header now surfaces the GitHub link, author, and merged date as inline chips next to the PR number. The Overview tab replaces the previous scattered card grid with a Score Story card (multiplier pills), a unified key/value detail table, and a Token Composition donut sidebar that matches the existing Credibility chart style.

## What changed

### `PRHeader.tsx`
- Added "Open on GitHub" button (blue accent) inline next to the PR number and status badge
- Added author chip (avatar + @login, links to miner details) and merged date chip below the repository link
- Reuses the shared `formatDate` utility for the merged date label

### `PRDetailsCard.tsx`
- Score Story card consolidates all score multipliers into a single pill row with success/warning accents and a credibility tooltip
- Details section replaces the old Grid of stat cards with one compact key/value table: Base Score, Tokens Scored, Token Score, Structural, Leaf, Changes (+X/-Y), Commits, Hotkey
- Token Composition donut sidebar shows the Structural vs Leaf score split with Token Score in the center, using `CHART_COLORS.merged`/`CHART_COLORS.open` to match the Credibility chart palette
- Removed the standalone Author, Merged Date, Hotkey, and GitHub Link cards (now in the header or table)
- Uses the shared `tooltipSlotProps` helper from `src/theme.ts` for consistent tooltip styling

## Why
The old Overview used a sparse stat-card grid that pushed key metadata (author, merge date, GitHub link) well below the fold and offered no visual breakdown of structural vs leaf token scoring. Moving identity info into the header and collapsing stats into a single table makes the most important fields visible without scrolling, and the donut gives reviewers an at-a-glance view of how Token Score is composed.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## How to test
1. `npm run build` / `npm run lint:fix` / `npm run format`
2. Open a merged PR, e.g. `/miners/pr?repo=entrius/gittensor&number=487`
3. Verify header shows: PR number, status badge, "Open on GitHub" (blue), title, repo link, @author chip, merged date chip
4. Verify Overview tab shows Score Story pills, detail table (Base Score → Hotkey), and Token Composition donut on the right
5. Hover Structural/Leaf labels in the table to see tooltip explanations
6. Open an OPEN PR to verify Potential/Collateral still render in the header and the donut hides when no token scores exist

## Checklist
- [x] Uses predefined theme (no hardcoded colors)
- [x] Responsive/mobile checked (table collapses to single column, donut stacks below)
- [x] Reuses existing `formatDate` and `tooltipSlotProps` helpers instead of inlining
- [x] `npm run format` and `npm run lint:fix` run
- [x] `npm run build` passes
- [x] Screenshots included

## Screenshots

Before:

<img width="886" height="764" alt="overview_1" src="https://github.com/user-attachments/assets/70ca5d55-1e35-4b4d-b53d-c17c32dbc138" />


After:

<img width="1109" height="829" alt="overview_after" src="https://github.com/user-attachments/assets/73567c7a-ccd8-49d7-91a3-0066b14b6bd7" />
