### PR TITLE
fix: show tooltips on first tap on mobile

### DIFF
--- a/src/theme.ts
+++ b/src/theme.ts
@@ -547,6 +547,12 @@ const theme = createTheme({
         disableRipple: true,
       },
     },
+    MuiTooltip: {
+      defaultProps: {
+        enterTouchDelay: 0,
+        leaveTouchDelay: 15000,
+      },
+    },
     MuiAppBar: {
       styleOverrides: {
         root: {


### PR DESCRIPTION
## Summary

Tooltips were not appearing on the first tap on mobile — users had to long-press (700ms hold) to trigger them. Fixed by setting `enterTouchDelay: 0` globally via the MUI theme's `MuiTooltip.defaultProps`, so tooltips show instantly on a single tap. Also set `leaveTouchDelay: 15000ms` so users have enough time to read the content before it auto-dismisses.

## Related Issues

Fixes https://github.com/entrius/gittensor-ui/issues/576

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

## Before

https://github.com/user-attachments/assets/f7364279-40ee-4b3c-ba98-1c056db9896a

## After

https://github.com/user-attachments/assets/d3815473-e38d-46c3-98f7-01c493086e97



## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes