### PR TITLE
Fix mobile clipping of trust badge in Miner Activity header

### DIFF
--- a/src/components/miners/MinerActivity.tsx
+++ b/src/components/miners/MinerActivity.tsx
@@ -479,23 +479,27 @@ const MinerActivity: React.FC<MinerActivityProps> = ({
           borderColor: 'border.light',
           backgroundColor: 'surface.subtle',
           display: 'flex',
+          flexDirection: { xs: 'column', sm: 'row' },
           justifyContent: 'space-between',
-          alignItems: 'center',
+          alignItems: { xs: 'flex-start', sm: 'center' },
+          gap: { xs: 1, sm: 0.75 },
         }}
       >
         <Typography variant="sectionTitle">
           {isIssueMode ? 'Issue Discovery Activity' : 'Developer Activity'}
         </Typography>
-        <TrustBadge
-          credibility={
-            isIssueMode
-              ? (issueData?.issueCred ?? 0)
-              : minerStats.credibility || 0
-          }
-          totalPRs={
-            isIssueMode ? (issueData?.solved ?? 0) : minerStats.totalPrs || 0
-          }
-        />
+        <Box sx={{ alignSelf: { xs: 'stretch', sm: 'auto' }, minWidth: 0 }}>
+          <TrustBadge
+            credibility={
+              isIssueMode
+                ? (issueData?.issueCred ?? 0)
+                : minerStats.credibility || 0
+            }
+            totalPRs={
+              isIssueMode ? (issueData?.solved ?? 0) : minerStats.totalPrs || 0
+            }
+          />
+        </Box>
       </Box>
 
       {isIssueMode ? (

--- a/src/components/miners/TrustBadge.tsx
+++ b/src/components/miners/TrustBadge.tsx
@@ -115,6 +115,12 @@ const TrustBadge: React.FC<TrustBadgeProps> = ({ credibility, totalPRs }) => {
         color: assessment.color,
         borderColor: assessment.color,
         border: assessment.border,
+        maxWidth: '100%',
+        '& .MuiChip-label': {
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+        },
         '& .MuiChip-icon': { color: assessment.color },
       }}
     />


### PR DESCRIPTION
## Summary

Updated the Miner Activity header layout to be responsive: title and trust badge now stack on mobile and stay side-by-side on larger breakpoints. Also added chip-level overflow guards to prevent long trust messages from spilling out of the card. This ensures the trust label remains visible and readable in narrow viewports.

## Related Issues

Fixes #649 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

###before
<img width="313" height="546" alt="2026-04-20_14h54_48" src="https://github.com/user-attachments/assets/6c41e5c6-abb6-4826-ab03-463633d7b31f" />
###after
<img width="288" height="546" alt="2026-04-20_14h59_47" src="https://github.com/user-attachments/assets/6e6b5eac-bcf8-416b-8de0-c3e1ef1c4d72" />

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
