### PR TITLE
Feat: Add `No` serial column to Onboard Languages table

### DIFF
--- a/src/components/repositories/LanguageWeightsTable.tsx
+++ b/src/components/repositories/LanguageWeightsTable.tsx
@@ -387,6 +387,19 @@ const LanguageWeightsTable: React.FC = () => {
                     ),
                     backdropFilter: 'blur(8px)',
                     borderBottom: `1px solid ${theme.palette.border.light}`,
+                    width: '72px',
+                  }}
+                >
+                  <Typography variant="dataLabel">No</Typography>
+                </TableCell>
+                <TableCell
+                  sx={{
+                    backgroundColor: alpha(
+                      theme.palette.background.paper,
+                      0.95,
+                    ),
+                    backdropFilter: 'blur(8px)',
+                    borderBottom: `1px solid ${theme.palette.border.light}`,
                   }}
                 >
                   <TableSortLabel
@@ -478,8 +491,13 @@ const LanguageWeightsTable: React.FC = () => {
               </TableRow>
             </TableHead>
             <TableBody>
-              {paginatedLanguages.map((lang) => (
+              {paginatedLanguages.map((lang, index) => (
                 <TableRow key={lang.extension} hover>
+                  <TableCell>
+                    <Typography variant="body2" color="text.secondary">
+                      {page * rowsPerPage + index + 1}
+                    </Typography>
+                  </TableCell>
                   <TableCell>
                     <Typography variant="body1" fontWeight="medium">
                       {lang.extension}


### PR DESCRIPTION
## Summary

Updated `LanguageWeightsTable` to include a new first column labeled `No`. Each row now displays a stable serial index calculated from current page and rows per page, so numbering remains correct after pagination and sorting. Column order now matches the requested format:
`No` → `Extension` → `Language` → `Token Scoring` → `Weight`.
## Related Issues

<!-- Link to related issues: Fixes #123, Closes #456 -->

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

###before
<img width="944" height="647" alt="2026-04-20_15h14_09" src="https://github.com/user-attachments/assets/35110257-5648-4545-a033-cbd814f1ad93" />

###after
<img width="944" height="633" alt="2026-04-20_15h26_32" src="https://github.com/user-attachments/assets/27558275-589c-48f0-94ee-3ecc02d35278" />


## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
