### PR TITLE
fix: replace URL on miner mode toggle instead of pushing new history entry

### DIFF
--- a/src/components/common/linkBehavior.tsx
+++ b/src/components/common/linkBehavior.tsx
@@ -26,11 +26,12 @@ export const useLinkBehavior = <E extends Element = HTMLElement>(
   href: string,
   options: {
     state?: LinkState;
+    replace?: boolean;
     onClick?: (e: React.MouseEvent<E>) => void;
   } = {},
 ) => {
   const navigate = useNavigate();
-  const { state, onClick } = options;
+  const { state, replace, onClick } = options;
 
   const handleClick = useCallback(
     (e: React.MouseEvent<E>) => {
@@ -38,9 +39,9 @@ export const useLinkBehavior = <E extends Element = HTMLElement>(
       if (e.defaultPrevented) return;
       if (isModifiedEvent(e)) return;
       e.preventDefault();
-      navigate(href, { state });
+      navigate(href, { state, replace });
     },
-    [href, state, navigate, onClick],
+    [href, state, replace, navigate, onClick],
   );
 
   return { href, onClick: handleClick } as const;
@@ -56,6 +57,8 @@ const mergeSx = (base: SxProps<Theme>, extra: SxProps<Theme> | undefined) =>
 type LinkProps = {
   href: string;
   linkState?: LinkState;
+  /** When true, navigation replaces the current history entry instead of pushing. */
+  replace?: boolean;
 };
 
 /**
@@ -63,9 +66,10 @@ type LinkProps = {
  * Drop-in replacement for any `<Box onClick={() => navigate(...)}>` row.
  */
 export const LinkBox = forwardRef<HTMLAnchorElement, BoxProps & LinkProps>(
-  ({ href, linkState, sx, ...rest }, ref) => {
+  ({ href, linkState, replace, sx, ...rest }, ref) => {
     const linkProps = useLinkBehavior<HTMLAnchorElement>(href, {
       state: linkState,
+      replace,
     });
     return (
       <Box

--- a/src/pages/MinerDetailsPage.tsx
+++ b/src/pages/MinerDetailsPage.tsx
@@ -128,6 +128,7 @@ const MinerDetailsPage: React.FC = () => {
                   <LinkBox
                     key={option.value}
                     href={buildModeHref(option.value)}
+                    replace
                     sx={{
                       px: 2,
                       py: 0.75,


### PR DESCRIPTION
## Summary
The OSS Contributions ↔ Issue Discovery toggle on the Miner Details page was pushing a new browser history entry on every switch. Users comparing the two modes by toggling back and forth then had to press Back multiple times to exit the page - pressing Back would walk through every toggle before reaching their original entry point (e.g. the leaderboard).

## Root cause
`handleModeChange` in `src/pages/MinerDetailsPage.tsx` called `setSearchParams(p)` without the `{ replace: true }` option. React Router defaults to pushing a new history entry, which is correct for genuine navigation but wrong for same-page UI toggles.

The sibling `handleTabChange` function in the same file already uses `{ replace: true }`. Only the mode handler was missed.

## Video to upload

https://github.com/user-attachments/assets/8ca83de1-208c-4cac-80e4-9ba059f236e9


Closes #653 .