### PR TITLE
Fix Watchlist OSS Englible Display

### DIFF
--- a/src/components/leaderboard/MinerCard.tsx
+++ b/src/components/leaderboard/MinerCard.tsx
@@ -350,13 +350,13 @@ export const MinerCard: React.FC<MinerCardProps> = ({
             <CredDonut
               segments={getPrSegments(miner)}
               percent={credibilityPercent}
-              isEligible={miner.isEligible ?? false}
+              isEligible={ossEligible}
               label="PRs"
             />
             <CredDonut
               segments={getIssueSegments(miner)}
               percent={issueCredPercent}
-              isEligible={miner.isIssueEligible ?? false}
+              isEligible={discoveriesEligible}
               label="Issues"
             />
           </Box>


### PR DESCRIPTION

## Summary

Fixes a Watchlist UI inconsistency where a miner who is OSS ineligible could still have the PRs donut/ring rendered as active/colored. Watchlist donuts now key off the correct per-program eligibility flags:

- PRs donut uses ossIsEligible
- Issues donut uses discoveriesIsEligible

## Related Issues

Closes #659 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes

## Screenshots

<img width="1796" height="900" alt="image" src="https://github.com/user-attachments/assets/eddff036-ade8-4a7c-94a7-a0afc5107847" />

