### PR TITLE
fix: valid table DOM for LinkTableRow (no anchor wrapping td)

### DIFF
--- a/src/components/common/linkBehavior.tsx
+++ b/src/components/common/linkBehavior.tsx
@@ -8,6 +8,10 @@ import {
 } from '@mui/material';
 import type { SxProps, Theme } from '@mui/material/styles';
 
+const openHrefInNewTab = (href: string) => {
+  window.open(href, '_blank', 'noopener,noreferrer');
+};
+
 type LinkState = Record<string, unknown> | undefined;
 
 const isModifiedEvent = (e: React.MouseEvent): boolean =>
@@ -85,23 +89,65 @@ export const LinkBox = forwardRef<HTMLAnchorElement, BoxProps & LinkProps>(
 LinkBox.displayName = 'LinkBox';
 
 /**
- * A `TableRow` that renders as `<a href>`. Drop-in replacement for any
- * `<TableRow onClick={() => navigate(...)}>` row.
+ * A clickable `TableRow` (`<tr>`) that navigates like a link.
+ *
+ * **Important:** `TableRow` must not use `component="a"` — table rows must be
+ * `<tr>`, with `<td>` only inside `<tr>`. Wrapping cells in `<a>` breaks
+ * `validateDOMNesting` in React. This component uses a real `<tr>` plus
+ * click / aux-click / keyboard handling.
  */
 export const LinkTableRow = forwardRef<
-  HTMLAnchorElement,
+  HTMLTableRowElement,
   TableRowProps & LinkProps
->(({ href, linkState, sx, ...rest }, ref) => {
-  const linkProps = useLinkBehavior<HTMLAnchorElement>(href, {
-    state: linkState,
-  });
+>(({ href, linkState, sx, onClick, onKeyDown, ...rest }, ref) => {
+  const navigate = useNavigate();
+
+  const handleClick = useCallback(
+    (e: React.MouseEvent<HTMLTableRowElement>) => {
+      onClick?.(e);
+      if (e.defaultPrevented) return;
+      if (isModifiedEvent(e)) {
+        openHrefInNewTab(href);
+        return;
+      }
+      e.preventDefault();
+      navigate(href, { state: linkState });
+    },
+    [href, linkState, navigate, onClick],
+  );
+
+  const handleAuxClick = useCallback(
+    (e: React.MouseEvent<HTMLTableRowElement>) => {
+      if (e.button === 1) {
+        e.preventDefault();
+        openHrefInNewTab(href);
+      }
+    },
+    [href],
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLTableRowElement>) => {
+      onKeyDown?.(e);
+      if (e.defaultPrevented) return;
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        navigate(href, { state: linkState });
+      }
+    },
+    [href, linkState, navigate, onKeyDown],
+  );
+
   return (
     <TableRow
-      component="a"
       ref={ref}
-      {...linkProps}
-      sx={mergeSx(linkResetSx, sx)}
+      role="link"
+      tabIndex={0}
       {...rest}
+      onClick={handleClick}
+      onAuxClick={handleAuxClick}
+      onKeyDown={handleKeyDown}
+      sx={mergeSx({ cursor: 'pointer', ...linkResetSx } as SxProps<Theme>, sx)}
     />
   );
 });


### PR DESCRIPTION
## Summary

- Replaces TableRow component="a" with a real <tr> and click / aux-click / keyboard handling so <td> is no longer nested under <a>.
- Resolves React validateDOMNesting warnings on /repositories and anywhere else LinkTableRow is used.

## Related Issues

Fixes: [668](https://github.com/entrius/gittensor-ui/issues/668)

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

Before:
<img width="1845" height="929" alt="image" src="https://github.com/user-attachments/assets/240a6324-b7fc-467e-a959-6f2bb1cac7c8" />

After:
<img width="1847" height="893" alt="image" src="https://github.com/user-attachments/assets/ce863956-ede2-4da4-811c-df87a54fb4a8" />

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
