### PR TITLE
fix(repositories): use semantic table rows for linkable table entries

### DIFF
--- a/src/components/common/linkBehavior.tsx
+++ b/src/components/common/linkBehavior.tsx
@@ -81,24 +81,72 @@ export const LinkBox = forwardRef<HTMLAnchorElement, BoxProps & LinkProps>(
 LinkBox.displayName = 'LinkBox';
 
 /**
- * A `TableRow` that renders as `<a href>`. Drop-in replacement for any
- * `<TableRow onClick={() => navigate(...)}>` row.
+ * A keyboard-accessible `TableRow` with SPA navigation behavior.
+ * Keeps valid table semantics (`tbody > tr > td`) while still acting like a link.
  */
 export const LinkTableRow = forwardRef<
-  HTMLAnchorElement,
+  HTMLTableRowElement,
   TableRowProps & LinkProps
->(({ href, linkState, sx, ...rest }, ref) => {
-  const linkProps = useLinkBehavior<HTMLAnchorElement>(href, {
-    state: linkState,
-  });
-  return (
-    <TableRow
-      component="a"
-      ref={ref}
-      {...linkProps}
-      sx={mergeSx(linkResetSx, sx)}
-      {...rest}
-    />
-  );
-});
+>(
+  (
+    { href, linkState, sx, onClick, onKeyDown, onAuxClick, ...rest },
+    ref,
+  ) => {
+    const navigate = useNavigate();
+    const openInNewTab = useCallback(() => {
+      window.open(href, '_blank', 'noopener,noreferrer');
+    }, [href]);
+
+    const handleClick = useCallback(
+      (e: React.MouseEvent<HTMLTableRowElement>) => {
+        onClick?.(e);
+        if (e.defaultPrevented) return;
+        if (isModifiedEvent(e)) {
+          openInNewTab();
+          return;
+        }
+        navigate(href, { state: linkState });
+      },
+      [href, linkState, navigate, onClick, openInNewTab],
+    );
+
+    const handleKeyDown = useCallback(
+      (e: React.KeyboardEvent<HTMLTableRowElement>) => {
+        onKeyDown?.(e);
+        if (e.defaultPrevented) return;
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          navigate(href, { state: linkState });
+        }
+      },
+      [href, linkState, navigate, onKeyDown],
+    );
+
+    const handleAuxClick = useCallback(
+      (e: React.MouseEvent<HTMLTableRowElement>) => {
+        onAuxClick?.(e);
+        if (e.defaultPrevented) return;
+        if (e.button === 1) {
+          e.preventDefault();
+          openInNewTab();
+        }
+      },
+      [onAuxClick, openInNewTab],
+    );
+
+    return (
+      <TableRow
+        component="tr"
+        ref={ref}
+        onClick={handleClick}
+        onKeyDown={handleKeyDown}
+        onAuxClick={handleAuxClick}
+        role="link"
+        tabIndex={0}
+        sx={mergeSx(linkResetSx, sx)}
+        {...rest}
+      />
+    );
+  },
+);
 LinkTableRow.displayName = 'LinkTableRow';

--- a/src/components/leaderboard/MinersList.tsx
+++ b/src/components/leaderboard/MinersList.tsx
@@ -119,7 +119,11 @@ export const MinersList: React.FC<MinersListProps> = ({
       cellSx: { p: 0 },
       renderCell: (miner) =>
         miner.githubId ? (
-          <WatchlistButton githubId={miner.githubId} size="small" />
+          <WatchlistButton
+            category="miners"
+            itemKey={miner.githubId}
+            size="small"
+          />
         ) : null,
     },
   ];


### PR DESCRIPTION
## Summary
- switch `LinkTableRow` to semantic `<tr>` rendering to resolve invalid table DOM nesting
- preserve keyboard navigation and modified-click/new-tab behavior for row navigation
- include a compatibility follow-up to align `WatchlistButton` usage with current props API

## Problem
`LinkTableRow` previously rendered anchor semantics in a table-row context, which triggered invalid table nesting warnings.

## Fix
- update shared table-row link behavior in `src/components/common/linkBehavior.tsx`
- keep link-like interactions while maintaining valid `tbody > tr > td` semantics
- update `src/components/leaderboard/MinersList.tsx` to use `WatchlistButton` props (`category` + `itemKey`) so this branch remains build-compatible with current `test`

Closes #668

## Node 20 Runtime Recheck (Apr 21, 2026)
Executed on this branch with upgraded Node:
- `node -v` = `v20.20.2`
- `npm -v` = `10.8.2`

Validation command:
- `npm ci && npm run lint && npm run test && npm run build`

Result:
- [x] `npm ci`
- [x] `npm run lint`
- [x] `npm run test`
- [x] `npm run build`