### PR TITLE
fix(miner): centralize count-copy formatting in activity heatmap

### DIFF
--- a/src/components/ContributionHeatmap.tsx
+++ b/src/components/ContributionHeatmap.tsx
@@ -6,6 +6,7 @@ import {
   TEXT_OPACITY,
   scrollbarSx,
 } from '../theme';
+import { formatCountLabel, formatNounLabel, type CountCopyStyle } from '../utils';
 
 interface ContributionData {
   date: string;
@@ -18,6 +19,9 @@ interface ContributionHeatmapProps {
   contributionsLast30Days: number;
   totalDaysShown: number;
   subtitle?: string;
+  nounSingular?: string;
+  nounPlural?: string;
+  copyStyle?: CountCopyStyle;
   footerText?: string;
   emptyTitle?: string;
   emptySubtitle?: string;
@@ -28,7 +32,10 @@ const ContributionHeatmap: React.FC<ContributionHeatmapProps> = ({
   data,
   contributionsLast30Days,
   totalDaysShown,
-  subtitle = 'network contributions in the last 30 days',
+  subtitle,
+  nounSingular = 'contribution',
+  nounPlural,
+  copyStyle = 'compact',
   footerText,
   emptyTitle = 'No contributions yet',
   emptySubtitle = 'Activity will appear here once PRs are merged',
@@ -38,6 +45,12 @@ const ContributionHeatmap: React.FC<ContributionHeatmapProps> = ({
   const heatmapLevels = [...CONTRIBUTION_HEATMAP_SCALE];
   const heatmapTheme = { light: heatmapLevels, dark: heatmapLevels };
   const isEmpty = data.length === 0;
+  const nounLabel = formatNounLabel({
+    singular: nounSingular,
+    plural: nounPlural,
+    style: copyStyle,
+  });
+  const resolvedSubtitle = subtitle ?? `${nounLabel} in the last 30 days`;
 
   const content = (
     <>
@@ -60,7 +73,7 @@ const ContributionHeatmap: React.FC<ContributionHeatmapProps> = ({
             mt: 0.5,
           }}
         >
-          {subtitle}
+          {resolvedSubtitle}
         </Typography>
       </Box>
 
@@ -118,7 +131,7 @@ const ContributionHeatmap: React.FC<ContributionHeatmapProps> = ({
                 'Nov',
                 'Dec',
               ],
-              totalCount: `{{count}} contributions in the last ${totalDaysShown} day(s)`,
+              totalCount: `{{count}} ${nounLabel} in the last ${totalDaysShown} day(s)`,
               weekdays: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
             }}
             blockSize={11}
@@ -128,7 +141,7 @@ const ContributionHeatmap: React.FC<ContributionHeatmapProps> = ({
             showWeekdayLabels={false}
             renderBlock={(block, activity) => (
               <Tooltip
-                title={`${activity.count} contribution${activity.count !== 1 ? 's' : ''} on ${new Date(activity.date).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}`}
+                title={`${formatCountLabel({ count: activity.count, singular: nounSingular, plural: nounPlural, style: copyStyle })} on ${new Date(activity.date).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}`}
                 arrow
                 placement="top"
                 enterDelay={0}

--- a/src/components/ContributionHeatmap.tsx
+++ b/src/components/ContributionHeatmap.tsx
@@ -50,6 +50,12 @@ const ContributionHeatmap: React.FC<ContributionHeatmapProps> = ({
     plural: nounPlural,
     style: copyStyle,
   });
+  // ActivityCalendar's totalCount supports a string template only, so keep this
+  // label in compact form to avoid singular/plural mismatches at runtime.
+  const totalCountNounLabel = formatNounLabel({
+    singular: nounSingular,
+    style: 'compact',
+  });
   const resolvedSubtitle = subtitle ?? `${nounLabel} in the last 30 days`;
 
   const content = (
@@ -131,7 +137,7 @@ const ContributionHeatmap: React.FC<ContributionHeatmapProps> = ({
                 'Nov',
                 'Dec',
               ],
-              totalCount: `{{count}} ${nounLabel} in the last ${totalDaysShown} day(s)`,
+              totalCount: `{{count}} ${totalCountNounLabel} in the last ${totalDaysShown} day(s)`,
               weekdays: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
             }}
             blockSize={11}

--- a/src/components/miners/MinerActivity.tsx
+++ b/src/components/miners/MinerActivity.tsx
@@ -561,7 +561,6 @@ const MinerActivity: React.FC<MinerActivityProps> = ({
               data={contributionData}
               contributionsLast30Days={contributionsLast30Days}
               totalDaysShown={totalDaysShown}
-              subtitle="contributions in the last 30 days"
               footerText="* Activity based on merged PRs in Gittensor-tracked repositories"
               bare
             />

--- a/src/tests/countCopy.test.ts
+++ b/src/tests/countCopy.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import { formatCountLabel, formatNounLabel } from '../utils/countCopy';
+
+describe('formatNounLabel', () => {
+  it('returns compact noun label by default', () => {
+    expect(formatNounLabel({ singular: 'contribution' })).toBe('contribution(s)');
+  });
+
+  it('returns natural plural noun label in natural mode', () => {
+    expect(
+      formatNounLabel({
+        singular: 'contribution',
+        style: 'natural',
+      }),
+    ).toBe('contributions');
+  });
+
+  it('uses custom plural label when provided', () => {
+    expect(
+      formatNounLabel({
+        singular: 'repository',
+        plural: 'repositories',
+        style: 'natural',
+      }),
+    ).toBe('repositories');
+  });
+});
+
+describe('formatCountLabel', () => {
+  it('returns compact count labels by default', () => {
+    expect(formatCountLabel({ count: 1, singular: 'contribution' })).toBe(
+      '1 contribution(s)',
+    );
+    expect(formatCountLabel({ count: 3, singular: 'contribution' })).toBe(
+      '3 contribution(s)',
+    );
+  });
+
+  it('returns natural singular/plural labels in natural mode', () => {
+    expect(
+      formatCountLabel({
+        count: 1,
+        singular: 'contribution',
+        style: 'natural',
+      }),
+    ).toBe('1 contribution');
+    expect(
+      formatCountLabel({
+        count: 3,
+        singular: 'contribution',
+        style: 'natural',
+      }),
+    ).toBe('3 contributions');
+  });
+
+  it('supports custom natural plural labels', () => {
+    expect(
+      formatCountLabel({
+        count: 2,
+        singular: 'repository',
+        plural: 'repositories',
+        style: 'natural',
+      }),
+    ).toBe('2 repositories');
+  });
+});

--- a/src/utils/countCopy.ts
+++ b/src/utils/countCopy.ts
@@ -1,0 +1,35 @@
+export type CountCopyStyle = 'compact' | 'natural';
+
+interface NounLabelOptions {
+  singular: string;
+  plural?: string;
+  style?: CountCopyStyle;
+}
+
+interface CountLabelOptions extends NounLabelOptions {
+  count: number;
+}
+
+function getPluralLabel(singular: string, plural?: string): string {
+  return plural ?? `${singular}s`;
+}
+
+export function formatNounLabel({
+  singular,
+  plural,
+  style = 'compact',
+}: NounLabelOptions): string {
+  if (style === 'compact') return `${singular}(s)`;
+  return getPluralLabel(singular, plural);
+}
+
+export function formatCountLabel({
+  count,
+  singular,
+  plural,
+  style = 'compact',
+}: CountLabelOptions): string {
+  if (style === 'compact') return `${count} ${singular}(s)`;
+  const resolvedPlural = getPluralLabel(singular, plural);
+  return `${count} ${count === 1 ? singular : resolvedPlural}`;
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -4,3 +4,4 @@ export * from './prStatus';
 export * from './prTable';
 export * from './issueStatus';
 export * from './multiplierDefs';
+export * from './countCopy';


### PR DESCRIPTION
## Summary
- Adds a reusable count-copy utility in `src/utils/countCopy.ts` with two modes:
  - `compact`: `contribution(s)` / `1 contribution(s)`
  - `natural`: `contributions` / `1 contribution`
- Updates `ContributionHeatmap` to use the shared formatter for:
  - subtitle fallback
  - total-count line
  - per-day tooltip copy
- Removes hard-coded plural subtitle text from `MinerActivity` so this copy stays consistent in one place.
- Adds focused tests in `src/tests/countCopy.test.ts`.

## Related Issues
Fixes #624

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Why this approach
This fixes the immediate pluralization bug and addresses the root cause (duplicated hard-coded count strings) by centralizing count-copy formatting.

## Test plan
- Open `/miners/details?githubId=<id>&tab=activity`
- Verify subtitle shows `contribution(s) in the last 30 days`
- Verify heatmap total-count line shows `{{count}} contribution(s) in the last N day(s)`
- Verify block tooltip shows `N contribution(s) on ...`
- Spot-check zero/one/many contribution days

## Notes
- Lint diagnostics on changed files are clean in-editor.
- Full npm test/build execution was not run in this runtime due local Node version mismatch.