### PR TITLE
Show earnings rank on miner profile stat tiles

### DIFF
--- a/src/components/miners/MinerScoreCard.tsx
+++ b/src/components/miners/MinerScoreCard.tsx
@@ -302,6 +302,7 @@ const MinerScoreCard: React.FC<MinerScoreCardProps> = ({
     return {
       score: rank('score', (m) => Number(m.totalScore)),
       totalPrs: rank('prs', (m) => Number(m.totalPrs)),
+      usdPerDay: rank('earnings', (m) => Number(m.usdPerDay ?? 0)),
     };
   }, [allMinersStats, minerStats, githubId]);
 
@@ -623,6 +624,7 @@ const MinerScoreCard: React.FC<MinerScoreCardProps> = ({
                   ? STATUS_COLORS.success
                   : undefined
               }
+              rank={rankings?.usdPerDay}
               tooltip="Estimated earnings based on current network incentive distribution. Actual payouts depend on validator consensus."
             />
           </Grid>
@@ -686,6 +688,7 @@ const MinerScoreCard: React.FC<MinerScoreCardProps> = ({
                   ? STATUS_COLORS.success
                   : undefined
               }
+              rank={rankings?.usdPerDay}
               tooltip="Estimated earnings from issue discovery based on current network incentive distribution."
             />
           </Grid>


### PR DESCRIPTION

## Summary

Adds a **leaderboard rank** for **daily earnings** (`usdPerDay`) on the miner profile **Earnings** `StatTile`, using the same ranking pattern as **Score** and **PRs** (sort all miners by metric descending, resolve position by `githubId`). Applied in **both** tile layouts (OSS/PR view and issue-discovery view) so the UI stays consistent across modes.

## Related Issues

#680

_(Add your issue link if you filed one; otherwise remove this line.)_

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

<img width="1920" height="913" alt="2026-04-20_21h30_58" src="https://github.com/user-attachments/assets/06d38ea2-880e-4969-b35e-8d3cc4254c66" />
<img width="1907" height="909" alt="2026-04-20_21h59_32" src="https://github.com/user-attachments/assets/6fd6161f-7b52-4a1b-bd83-6c1744dfe078" />


## Checklist

- [x] New components are modularized/separated where sensible _(no new components; small change in existing card)_
- [x] Uses predefined theme (e.g. no hardcoded colors) _(reuses existing `StatTile` rank styling)_
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes