### PR TITLE
fix(ui): improve mobile toolbar layout in onboard languages

### DIFF
--- a/src/components/repositories/LanguageWeightsTable.tsx
+++ b/src/components/repositories/LanguageWeightsTable.tsx
@@ -268,19 +268,29 @@ const LanguageWeightsTable: React.FC = () => {
       <Box
         sx={{
           display: 'flex',
+          flexDirection: { xs: 'column', md: 'row' },
           justifyContent: 'space-between',
-          alignItems: 'center',
-          gap: 2,
+          alignItems: { xs: 'stretch', md: 'center' },
+          gap: { xs: 1.25, md: 2 },
           mb: 3,
         }}
       >
-        <Box sx={{ flex: 1 }}>
+        <Box sx={{ flex: 1, minWidth: 0 }}>
           <Typography variant="body2" color="text.secondary">
             Programming language multipliers used in scoring calculations
           </Typography>
         </Box>
 
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: { xs: 'space-between', md: 'flex-end' },
+            flexWrap: 'wrap',
+            gap: 1,
+            width: { xs: '100%', md: 'auto' },
+          }}
+        >
           <Tooltip title={showChart ? 'Hide Chart' : 'Show Chart'}>
             <IconButton
               onClick={() => setShowChart(!showChart)}
@@ -370,11 +380,11 @@ const LanguageWeightsTable: React.FC = () => {
               ),
             }}
             sx={{
-              width: '200px',
+              width: { xs: '100%', sm: '200px' },
               '& .MuiOutlinedInput-root': {
                 color: theme.palette.text.primary,
                 backgroundColor: alpha(theme.palette.common.black, 0.4),
-                fontSize: '0.8rem',
+                fontSize: { xs: '0.75rem', sm: '0.8rem' },
                 height: '36px',
                 borderRadius: 2,
                 '& fieldset': { borderColor: theme.palette.border.light },


### PR DESCRIPTION
## Summary

- Fix responsive crowding in table toolbars on small screens.
  LanguageWeightsTable: split description and controls cleanly on mobile; make search input responsive.
- Verified locally with mobile viewport testing and npm run build.

## Related Issues

Fixes [#686](https://github.com/entrius/gittensor-ui/issues/686)

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

Before:
<img width="1046" height="968" alt="image" src="https://github.com/user-attachments/assets/986ca657-849b-434e-9211-bfbd3649307d" />

After:
<img width="1118" height="886" alt="image" src="https://github.com/user-attachments/assets/a2cb01a1-35c7-4828-8cf4-a367191a9804" />

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
