### PR TITLE
fix(faq): keyboard access and link click collapse

### DIFF
--- a/src/components/FAQ.tsx
+++ b/src/components/FAQ.tsx
@@ -1,5 +1,10 @@
-import React, { useState } from 'react';
-import { Box, Collapse, Stack, Typography } from '@mui/material';
+import React from 'react';
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Typography,
+} from '@mui/material';
 import { ExpandMore } from '@mui/icons-material';
 
 export interface FAQProps {
@@ -7,49 +12,38 @@ export interface FAQProps {
   answer: React.ReactNode;
 }
 
-export const FAQ: React.FC<FAQProps> = ({ question, answer }) => {
-  const [expanded, setExpanded] = useState(false);
-
-  return (
-    <Box
+export const FAQ: React.FC<FAQProps> = ({ question, answer }) => (
+  <Accordion
+    disableGutters
+    elevation={0}
+    sx={{
+      borderRadius: 3,
+      backgroundColor: 'surface.transparent',
+      border: '1px solid',
+      borderColor: 'border.light',
+      overflow: 'hidden',
+      transition: 'border-color 0.2s ease-in-out',
+      '&:before': { display: 'none' },
+      '&:hover': { borderColor: 'border.medium' },
+    }}
+  >
+    <AccordionSummary
+      expandIcon={<ExpandMore sx={{ color: 'text.secondary' }} />}
       sx={{
         p: 3,
-        borderRadius: 3,
-        backgroundColor: 'surface.transparent',
-        border: '1px solid',
-        borderColor: 'border.light',
-        cursor: 'pointer',
-        transition: 'all 0.2s ease-in-out',
-        '&:hover': {
-          borderColor: 'border.medium',
-        },
+        '& .MuiAccordionSummary-content': { my: 0 },
       }}
-      onClick={() => setExpanded(!expanded)}
     >
-      <Stack
-        direction="row"
-        justifyContent="space-between"
-        alignItems="center"
-        sx={{ mb: expanded ? 1.5 : 0 }}
-      >
-        <Typography variant="h6" fontWeight="bold">
-          {question}
-        </Typography>
-        <ExpandMore
-          sx={{
-            transform: expanded ? 'rotate(180deg)' : 'rotate(0deg)',
-            transition: 'transform 0.3s ease-in-out',
-            color: 'text.secondary',
-          }}
-        />
-      </Stack>
-      <Collapse in={expanded}>
-        <Typography variant="body1" lineHeight={1.8} color="text.secondary">
-          {answer}
-        </Typography>
-      </Collapse>
-    </Box>
-  );
-};
+      <Typography variant="h6" fontWeight="bold">
+        {question}
+      </Typography>
+    </AccordionSummary>
+    <AccordionDetails sx={{ px: 3, pt: 0, pb: 3 }}>
+      <Typography variant="body1" lineHeight={1.8} color="text.secondary">
+        {answer}
+      </Typography>
+    </AccordionDetails>
+  </Accordion>
+);
 
 export default FAQ;

--- a/src/components/leaderboard/MinersList.tsx
+++ b/src/components/leaderboard/MinersList.tsx
@@ -119,7 +119,11 @@ export const MinersList: React.FC<MinersListProps> = ({
       cellSx: { p: 0 },
       renderCell: (miner) =>
         miner.githubId ? (
-          <WatchlistButton githubId={miner.githubId} size="small" />
+          <WatchlistButton
+            category="miners"
+            itemKey={miner.githubId}
+            size="small"
+          />
         ) : null,
     },
   ];


### PR DESCRIPTION
## Summary

FAQ entries on `/onboard?tab=faq` could not be reached or opened with the keyboard. Tab navigation skipped them entirely, and Enter/Space did nothing once focused. Clicking a link inside an expanded answer also collapsed the entry, even though the link still opened a new tab.

Both bugs trace back to the same wrapper: a plain `Box` with an `onClick` handler, so every click inside the card (chevron, question, answer body, anchor tags) toggled the panel. The wrapper was also not focusable and had no ARIA role, leaving keyboard and screen reader users without a way in.

Swapped the custom `Box` and `Collapse` for MUI `Accordion`, `AccordionSummary`, and `AccordionDetails`:

- The summary is now a real button with `aria-expanded`, focus styles, and Enter/Space handling
- Only the summary toggles the panel, so anchor tags inside the answer behave like normal links (left click and middle click both work without collapsing the entry)
- Visual styling, padding, hover border, and chevron rotation are preserved

`Accordion` is already used in `PRFilesChanged`, so this stays consistent with existing patterns in the repo.

## Related Issues

Fixes #688

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

Before:
[before.webm](https://github.com/user-attachments/assets/3e6fc5ea-80d1-4689-a066-67670ed64597)

After:
[after.webm](https://github.com/user-attachments/assets/0eb62f9e-1d1a-4267-ae01-59440550aa0d)


## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
