### PR TITLE
fix: wrap repository header chips to prevent Inactive tag overflow

### DIFF
--- a/src/pages/RepositoryDetailsPage.tsx
+++ b/src/pages/RepositoryDetailsPage.tsx
@@ -184,7 +184,15 @@ const RepositoryDetailsPage: React.FC = () => {
               alignItems="center"
             >
               <Grid item xs={12} md={8}>
-                <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+                <Box
+                  sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 2,
+                    flexWrap: 'wrap',
+                    rowGap: 1,
+                  }}
+                >
                   <Avatar
                     src={`https://avatars.githubusercontent.com/${owner}`}
                     variant="rounded"


### PR DESCRIPTION
## Summary

Fixes a UI regression on the Repository Details page header where the `Inactive since <date>` chip was visually overlapped by the `View on GitHub` button at narrower (non-`xs`) viewport widths.

The Avatar, repo name, and status chips (`Public`, `Tracked`, `Inactive since …`) in [`src/pages/RepositoryDetailsPage.tsx`](src/pages/RepositoryDetailsPage.tsx) lived in a single flex row inside an `md={8}` Grid column, with no `flexWrap` set. Once the row could no longer fit on one line, the trailing `Inactive since …` chip overflowed its column and was rendered behind the `View on GitHub` button in the adjacent `md={4}` column.

Changes:
- Added `flexWrap: 'wrap'` and `rowGap: 1` to the header chip container so the chips wrap onto a second line instead of overflowing.

No theme tokens, components, or API surface changed - only the container's flex behavior.

## Related Issues

Fixes #692 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

**Before** — `Inactive since Apr 13, 2026` chip is overlapped by the `View on GitHub` button at narrow widths:

<img width="1069" height="904" alt="before" src="https://github.com/user-attachments/assets/984b88bd-c25f-4afa-8a86-2952d899eb30" />

**After** — chips wrap to a second line and remain fully visible:

<img width="1110" height="792" alt="after" src="https://github.com/user-attachments/assets/22f8496d-9f34-4e82-b181-c12b614756cf" />

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [ ] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
