### PR TITLE
fix(ui): manage timeout lifecycles to prevent unmounted state updates

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -58,4 +58,39 @@ module.exports = {
     // Arrow function style
     'arrow-parens': ['error', 'always'],
   },
+  overrides: [
+    {
+      files: ['src/**/*.tsx'],
+      rules: {
+        'no-restricted-globals': [
+          'error',
+          {
+            name: 'setTimeout',
+            message:
+              'Use useManagedTimeout in React components to ensure unmount-safe timer cleanup.',
+          },
+          {
+            name: 'clearTimeout',
+            message:
+              'Use useManagedTimeout in React components to ensure unmount-safe timer cleanup.',
+          },
+        ],
+        'no-restricted-properties': [
+          'error',
+          {
+            object: 'window',
+            property: 'setTimeout',
+            message:
+              'Use useManagedTimeout in React components to ensure unmount-safe timer cleanup.',
+          },
+          {
+            object: 'window',
+            property: 'clearTimeout',
+            message:
+              'Use useManagedTimeout in React components to ensure unmount-safe timer cleanup.',
+          },
+        ],
+      },
+    },
+  ],
 };

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -58,39 +58,4 @@ module.exports = {
     // Arrow function style
     'arrow-parens': ['error', 'always'],
   },
-  overrides: [
-    {
-      files: ['src/**/*.tsx'],
-      rules: {
-        'no-restricted-globals': [
-          'error',
-          {
-            name: 'setTimeout',
-            message:
-              'Use useManagedTimeout in React components to ensure unmount-safe timer cleanup.',
-          },
-          {
-            name: 'clearTimeout',
-            message:
-              'Use useManagedTimeout in React components to ensure unmount-safe timer cleanup.',
-          },
-        ],
-        'no-restricted-properties': [
-          'error',
-          {
-            object: 'window',
-            property: 'setTimeout',
-            message:
-              'Use useManagedTimeout in React components to ensure unmount-safe timer cleanup.',
-          },
-          {
-            object: 'window',
-            property: 'clearTimeout',
-            message:
-              'Use useManagedTimeout in React components to ensure unmount-safe timer cleanup.',
-          },
-        ],
-      },
-    },
-  ],
 };

--- a/src/components/layout/GlobalSearchBar.tsx
+++ b/src/components/layout/GlobalSearchBar.tsx
@@ -22,6 +22,7 @@ import SearchIcon from '@mui/icons-material/Search';
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
 import CloseIcon from '@mui/icons-material/Close';
 import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
+import { useManagedTimeout } from '../../hooks/useManagedTimeout';
 import { useSearchResults } from '../../pages/search/searchData';
 import { useLinkBehavior, linkResetSx } from '../common/linkBehavior';
 
@@ -214,6 +215,7 @@ const GlobalSearchBar: React.FC = () => {
   const inputRef = useRef<HTMLInputElement | null>(null);
   const rowRefs = useRef<Record<string, HTMLButtonElement | null>>({});
   const blurTimerRef = useRef<number | null>(null);
+  const { schedule, clear } = useManagedTimeout();
 
   // Activate dataset loading after first interaction (or immediately on /search).
   const [isSearchActivated, setIsSearchActivated] = useState(isSearchPage);
@@ -274,12 +276,10 @@ const GlobalSearchBar: React.FC = () => {
   );
 
   const closeDropdown = useCallback(() => {
-    if (blurTimerRef.current !== null) {
-      window.clearTimeout(blurTimerRef.current);
-      blurTimerRef.current = null;
-    }
+    clear(blurTimerRef.current);
+    blurTimerRef.current = null;
     setIsDropdownOpen(false);
-  }, []);
+  }, [clear]);
 
   const navigateAndClose = useCallback(
     (path: string) => {
@@ -512,10 +512,8 @@ const GlobalSearchBar: React.FC = () => {
           setIsDropdownOpen(true);
         }}
         onBlur={() => {
-          if (blurTimerRef.current !== null) {
-            window.clearTimeout(blurTimerRef.current);
-          }
-          blurTimerRef.current = window.setTimeout(() => {
+          clear(blurTimerRef.current);
+          blurTimerRef.current = schedule(() => {
             setIsDropdownOpen(false);
             blurTimerRef.current = null;
           }, DROPDOWN_CLOSE_DELAY_MS);

--- a/src/components/leaderboard/MinersList.tsx
+++ b/src/components/leaderboard/MinersList.tsx
@@ -119,7 +119,11 @@ export const MinersList: React.FC<MinersListProps> = ({
       cellSx: { p: 0 },
       renderCell: (miner) =>
         miner.githubId ? (
-          <WatchlistButton githubId={miner.githubId} size="small" />
+          <WatchlistButton
+            category="miners"
+            itemKey={miner.githubId}
+            size="small"
+          />
         ) : null,
     },
   ];

--- a/src/components/miners/MinerScoreCard.tsx
+++ b/src/components/miners/MinerScoreCard.tsx
@@ -41,6 +41,7 @@ import {
   parseNumber,
 } from '../../utils/ExplorerUtils';
 import { credibilityColor } from '../../utils/format';
+import { useManagedTimeout } from '../../hooks/useManagedTimeout';
 
 const formatTimeAgo = (date: Date): string => {
   const now = new Date();
@@ -192,15 +193,7 @@ const COPY_FEEDBACK_MS = 1500;
 const CopyableHotkey: React.FC<{ hotkey: string }> = ({ hotkey }) => {
   const [copied, setCopied] = useState(false);
   const timerRef = useRef<number | null>(null);
-
-  useEffect(
-    () => () => {
-      if (timerRef.current !== null) {
-        window.clearTimeout(timerRef.current);
-      }
-    },
-    [],
-  );
+  const { schedule, clear } = useManagedTimeout();
 
   if (!hotkey) return null;
 
@@ -211,10 +204,8 @@ const CopyableHotkey: React.FC<{ hotkey: string }> = ({ hotkey }) => {
       }
       await navigator.clipboard.writeText(hotkey);
       setCopied(true);
-      if (timerRef.current !== null) {
-        window.clearTimeout(timerRef.current);
-      }
-      timerRef.current = window.setTimeout(() => {
+      clear(timerRef.current);
+      timerRef.current = schedule(() => {
         setCopied(false);
         timerRef.current = null;
       }, COPY_FEEDBACK_MS);

--- a/src/components/miners/MinerScoreCard.tsx
+++ b/src/components/miners/MinerScoreCard.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useMemo, useRef, useState } from 'react';
 import {
   ButtonBase,
   Card,

--- a/src/components/onboard/GettingStarted.tsx
+++ b/src/components/onboard/GettingStarted.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import {
   Box,
   Typography,
@@ -13,6 +13,7 @@ import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import CheckIcon from '@mui/icons-material/Check';
 import { alpha } from '@mui/material/styles';
 import { scrollbarSx, tooltipSlotProps } from '../../theme';
+import { useManagedTimeout } from '../../hooks/useManagedTimeout';
 
 const MONO = '"JetBrains Mono", monospace';
 
@@ -60,11 +61,17 @@ const CodeBlock: React.FC<{
   label?: string;
 }> = ({ children, label }) => {
   const [copied, setCopied] = useState(false);
+  const copyTimerRef = useRef<number | null>(null);
+  const { schedule, clear } = useManagedTimeout();
 
   const handleCopy = () => {
     navigator.clipboard.writeText(children.trim());
     setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
+    clear(copyTimerRef.current);
+    copyTimerRef.current = schedule(() => {
+      setCopied(false);
+      copyTimerRef.current = null;
+    }, 2000);
   };
 
   return (

--- a/src/components/prs/PRFilesChanged.tsx
+++ b/src/components/prs/PRFilesChanged.tsx
@@ -45,6 +45,7 @@ import IconButton from '@mui/material/IconButton';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import Switch from '@mui/material/Switch';
 import { STATUS_COLORS, DIFF_COLORS, scrollbarSx } from '../../theme';
+import { useManagedTimeout } from '../../hooks/useManagedTimeout';
 
 interface PRFile {
   sha: string;
@@ -1080,12 +1081,18 @@ const PRFileDiffViewer: React.FC<{
 
   const [copied, setCopied] = useState(false);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const copyTimerRef = useRef<number | null>(null);
+  const { schedule, clear } = useManagedTimeout();
 
   const handleCopyPath = (e: React.MouseEvent) => {
     e.stopPropagation();
     navigator.clipboard.writeText(file.filename);
     setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
+    clear(copyTimerRef.current);
+    copyTimerRef.current = schedule(() => {
+      setCopied(false);
+      copyTimerRef.current = null;
+    }, 2000);
   };
 
   if (!file.patch) {

--- a/src/hooks/useManagedTimeout.ts
+++ b/src/hooks/useManagedTimeout.ts
@@ -1,0 +1,40 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+type TimeoutId = number;
+
+/**
+ * Manages timeout lifecycles for components that schedule delayed state updates.
+ * All pending timers are cleared on unmount to prevent setState-on-unmounted warnings.
+ */
+export const useManagedTimeout = () => {
+  const timeoutIdsRef = useRef<Set<TimeoutId>>(new Set());
+
+  const clear = useCallback((id: TimeoutId | null | undefined) => {
+    if (id == null) return;
+    window.clearTimeout(id);
+    timeoutIdsRef.current.delete(id);
+  }, []);
+
+  const clearAll = useCallback(() => {
+    timeoutIdsRef.current.forEach((id) => window.clearTimeout(id));
+    timeoutIdsRef.current.clear();
+  }, []);
+
+  const schedule = useCallback(
+    (callback: () => void, delayMs: number): TimeoutId => {
+      const id = window.setTimeout(() => {
+        timeoutIdsRef.current.delete(id);
+        callback();
+      }, delayMs);
+      timeoutIdsRef.current.add(id);
+      return id;
+    },
+    [],
+  );
+
+  useEffect(() => clearAll, [clearAll]);
+
+  return { schedule, clear, clearAll };
+};
+
+export default useManagedTimeout;

--- a/src/pages/dashboard/views/LiveCommitLog.tsx
+++ b/src/pages/dashboard/views/LiveCommitLog.tsx
@@ -13,6 +13,7 @@ import {
 } from '@mui/material';
 import { LinkBox } from '../../../components/common/linkBehavior';
 import { useInfiniteCommitLog } from '../../../api';
+import { useManagedTimeout } from '../../../hooks/useManagedTimeout';
 import theme, {
   REPO_OWNER_AVATAR_BACKGROUNDS,
   scrollbarSx,
@@ -93,6 +94,7 @@ const COMMIT_STATUS_FILTERS: CommitStatusFilter[] = [
   'open',
   'closed',
 ];
+const NEW_ENTRY_HIGHLIGHT_MS = 2000;
 
 const getCommitId = (entry: CommitLogEntry) =>
   `${entry.repository}-${entry.pullRequestNumber}`;
@@ -318,6 +320,8 @@ const LiveCommitLog: React.FC = () => {
   const [newEntryIds, setNewEntryIds] = useState<Set<string>>(new Set());
   const logContainerRef = useRef<HTMLDivElement>(null);
   const loadMoreRef = useRef<HTMLAnchorElement>(null);
+  const highlightResetTimerRef = useRef<number | null>(null);
+  const { schedule, clear } = useManagedTimeout();
 
   const apiCommits = useMemo<CommitLogEntry[]>(
     () => data?.pages.flat() ?? [],
@@ -351,7 +355,11 @@ const LiveCommitLog: React.FC = () => {
 
       if (isHeadUpdate) {
         setNewEntryIds(new Set(novelItems.map(getCommitId)));
-        setTimeout(() => setNewEntryIds(new Set()), 2000);
+        clear(highlightResetTimerRef.current);
+        highlightResetTimerRef.current = schedule(() => {
+          setNewEntryIds(new Set());
+          highlightResetTimerRef.current = null;
+        }, NEW_ENTRY_HIGHLIGHT_MS);
         return [...novelItems, ...updatedLog];
       }
 

--- a/src/pages/dashboard/views/LiveCommitLog.tsx
+++ b/src/pages/dashboard/views/LiveCommitLog.tsx
@@ -365,7 +365,7 @@ const LiveCommitLog: React.FC = () => {
 
       return [...updatedLog, ...novelItems];
     });
-  }, [apiCommits]);
+  }, [apiCommits, clear, schedule]);
 
   const visibleEntries = useMemo(
     () =>


### PR DESCRIPTION
## Summary
- add `useManagedTimeout` hook to centralize timeout scheduling/cleanup
- migrate affected UI components to clear pending timers on unmount
- reduce setState-on-unmounted risks from delayed UI feedback timers
- include follow-up compatibility/lint fixes so this branch stays green against current `test`

## Problem
Multiple components used ad-hoc `setTimeout` patterns that could outlive component lifecycle and trigger delayed updates after unmount.

## Fix
- add `src/hooks/useManagedTimeout.ts`
- migrate timeout usage in:
  - `src/pages/dashboard/views/LiveCommitLog.tsx`
  - `src/components/prs/PRFilesChanged.tsx`
  - `src/components/onboard/GettingStarted.tsx`
  - `src/components/layout/GlobalSearchBar.tsx`
  - `src/components/miners/MinerScoreCard.tsx`
- follow-up compatibility fixes:
  - remove unused `useEffect` import in `MinerScoreCard`
  - include `clear` and `schedule` in `LiveCommitLog` effect deps
  - update `MinersList` `WatchlistButton` usage to `category` + `itemKey`

Closes #575

## Node 20 Runtime Recheck (Apr 21, 2026)
Executed on this branch with upgraded Node:
- `node -v` = `v20.20.2`
- `npm -v` = `10.8.2`

Validation command:
- `npm ci && npm run lint && npm run test && npm run build`

Result:
- [x] `npm ci`
- [x] `npm run lint`
- [x] `npm run test`
- [x] `npm run build`