### PR TITLE
Fix heatmap tooltip date shifting by timezone

### DIFF
--- a/src/components/ContributionHeatmap.tsx
+++ b/src/components/ContributionHeatmap.tsx
@@ -6,6 +6,7 @@ import {
   TEXT_OPACITY,
   scrollbarSx,
 } from '../theme';
+import { formatIsoDateOnlyForDisplay } from '../utils';
 
 interface ContributionData {
   date: string;
@@ -128,7 +129,7 @@ const ContributionHeatmap: React.FC<ContributionHeatmapProps> = ({
             showWeekdayLabels={false}
             renderBlock={(block, activity) => (
               <Tooltip
-                title={`${activity.count} contribution${activity.count !== 1 ? 's' : ''} on ${new Date(activity.date).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}`}
+                title={`${activity.count} contribution${activity.count !== 1 ? 's' : ''} on ${formatIsoDateOnlyForDisplay(activity.date)}`}
                 arrow
                 placement="top"
                 enterDelay={0}

--- a/src/tests/dateFormat.test.ts
+++ b/src/tests/dateFormat.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { formatIsoDateOnlyForDisplay } from '../utils/dateFormat';
+
+describe('formatIsoDateOnlyForDisplay', () => {
+  it('formats a valid date-only string to a stable calendar date label', () => {
+    expect(formatIsoDateOnlyForDisplay('2026-04-21')).toBe('Apr 21, 2026');
+  });
+
+  it('returns the original value for invalid date formats', () => {
+    expect(formatIsoDateOnlyForDisplay('2026/04/21')).toBe('2026/04/21');
+    expect(formatIsoDateOnlyForDisplay('invalid-date')).toBe('invalid-date');
+  });
+
+  it('returns the original value for out-of-range month/day values', () => {
+    expect(formatIsoDateOnlyForDisplay('2026-13-21')).toBe('2026-13-21');
+    expect(formatIsoDateOnlyForDisplay('2026-04-32')).toBe('2026-04-32');
+  });
+});

--- a/src/utils/dateFormat.ts
+++ b/src/utils/dateFormat.ts
@@ -1,0 +1,36 @@
+/**
+ * Formats an ISO date-only string (`YYYY-MM-DD`) as a local calendar date.
+ * We intentionally avoid `new Date("YYYY-MM-DD")` because it is parsed as UTC
+ * and can shift to the previous/next day in non-UTC timezones.
+ */
+export const formatIsoDateOnlyForDisplay = (
+  isoDate: string,
+  locale = 'en-US',
+): string => {
+  const parts = isoDate.split('-');
+  if (parts.length !== 3) {
+    return isoDate;
+  }
+
+  const year = Number(parts[0]);
+  const month = Number(parts[1]);
+  const day = Number(parts[2]);
+
+  if (
+    !Number.isInteger(year) ||
+    !Number.isInteger(month) ||
+    !Number.isInteger(day) ||
+    month < 1 ||
+    month > 12 ||
+    day < 1 ||
+    day > 31
+  ) {
+    return isoDate;
+  }
+
+  return new Date(year, month - 1, day).toLocaleDateString(locale, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -4,3 +4,4 @@ export * from './prStatus';
 export * from './prTable';
 export * from './issueStatus';
 export * from './multiplierDefs';
+export * from './dateFormat';


### PR DESCRIPTION
## Summary
- fix contribution-heatmap tooltip date rendering to avoid UTC parsing shifts for `YYYY-MM-DD` values
- add a shared date-only formatter utility that preserves backend calendar dates across user timezones
- add unit tests for valid and invalid date-only inputs

## Problem
`ContributionHeatmap` used `new Date(activity.date)` for tooltip labels. For date-only strings, this is parsed in UTC and can render as the previous/next day depending on local timezone.

## Fix
Use `formatIsoDateOnlyForDisplay()` to parse date-only strings into local calendar dates (`new Date(year, month - 1, day)`) before formatting.

Closes #698

## Node 20 Runtime Recheck (Apr 21, 2026)
Executed on this branch with upgraded Node:
- `node -v` = `v20.20.2`
- `npm -v` = `10.8.2`

Validation command:
- `npm ci && npm run lint && npm run test && npm run build`

Result:
- [x] `npm ci`
- [x] `npm run lint`
- [x] `npm run test`
- [x] `npm run build`

Additional verification:
- [x] `src/tests/dateFormat.test.ts` passes in the full suite