### PR TITLE
fix: show centered empty state in Recent Pull Requests card

### DIFF
--- a/src/pages/RepositoriesPage.tsx
+++ b/src/pages/RepositoriesPage.tsx
@@ -562,6 +562,31 @@ const RepositoriesPage: React.FC = () => {
                 </Box>
               </>
             ) : null}
+            {!isLoading && recentPrs.length === 0 ? (
+              <>
+                <SectionHeader>Recent Pull Requests</SectionHeader>
+                <Box
+                  sx={{
+                    flex: 1,
+                    minHeight: ROW_HEIGHT * 5,
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                  }}
+                >
+                  <Typography
+                    sx={(theme) => ({
+                      color: alpha(theme.palette.text.primary, 0.3),
+                      fontSize: '0.8rem',
+                      p: 1,
+                      textAlign: 'center',
+                    })}
+                  >
+                    No merged PRs today
+                  </Typography>
+                </Box>
+              </>
+            ) : null}
           </Card>
         </Box>
 


### PR DESCRIPTION
## Summary

Show a clear empty state on the Repositories page when there are no merged pull requests today.

## Related Issues

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

**Before**
<img width="1703" height="883" alt="image" src="https://github.com/user-attachments/assets/5883f811-d854-4505-816d-d1890c89724b" />

**After**
<img width="1372" height="352" alt="image" src="https://github.com/user-attachments/assets/a7f7235e-ab1f-4219-abaf-3c6caa8c71dc" />

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes