### PR TITLE
Sanitize markdown HTML rendering in issue/PR/repository viewers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "react-syntax-highlighter": "^16.1.0",
         "react-tooltip": "^5.30.0",
         "rehype-raw": "^7.0.0",
+        "rehype-sanitize": "^6.0.0",
         "remark-gfm": "^4.0.1"
       },
       "devDependencies": {
@@ -3911,6 +3912,20 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-sanitize": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-sanitize/-/hast-util-sanitize-5.0.2.tgz",
+      "integrity": "sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "unist-util-position": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-to-jsx-runtime": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
@@ -6077,6 +6092,19 @@
         "@types/hast": "^3.0.0",
         "hast-util-raw": "^9.0.0",
         "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-sanitize": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-sanitize/-/rehype-sanitize-6.0.0.tgz",
+      "integrity": "sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-sanitize": "^5.0.0"
       },
       "funding": {
         "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "react-syntax-highlighter": "^16.1.0",
     "react-tooltip": "^5.30.0",
     "rehype-raw": "^7.0.0",
+    "rehype-sanitize": "^6.0.0",
     "remark-gfm": "^4.0.1"
   },
   "devDependencies": {

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -2,3 +2,4 @@ export * from './SearchInput';
 export * from './linkBehavior';
 export * from './WatchlistButton';
 export * from './DataTable';
+export * from './markdownSecurity';

--- a/src/components/common/markdownSecurity.ts
+++ b/src/components/common/markdownSecurity.ts
@@ -1,5 +1,6 @@
 import rehypeRaw from 'rehype-raw';
 import rehypeSanitize, { defaultSchema } from 'rehype-sanitize';
+import type { PluggableList } from 'unified';
 
 const markdownSanitizeSchema = {
   ...defaultSchema,
@@ -23,7 +24,7 @@ const markdownSanitizeSchema = {
  * Shared, sanitized markdown pipeline for user/repository-sourced content.
  * Raw HTML is parsed, then constrained by a strict schema.
  */
-export const safeMarkdownRehypePlugins = [
+export const safeMarkdownRehypePlugins: PluggableList = [
   rehypeRaw,
   [rehypeSanitize, markdownSanitizeSchema],
 ];

--- a/src/components/common/markdownSecurity.ts
+++ b/src/components/common/markdownSecurity.ts
@@ -1,0 +1,29 @@
+import rehypeRaw from 'rehype-raw';
+import rehypeSanitize, { defaultSchema } from 'rehype-sanitize';
+
+const markdownSanitizeSchema = {
+  ...defaultSchema,
+  tagNames: [
+    ...(defaultSchema.tagNames || []),
+    'input',
+    'span',
+    'div',
+    'details',
+    'summary',
+  ],
+  attributes: {
+    ...defaultSchema.attributes,
+    input: ['type', 'checked', 'disabled'],
+    div: [],
+    span: [],
+  },
+};
+
+/**
+ * Shared, sanitized markdown pipeline for user/repository-sourced content.
+ * Raw HTML is parsed, then constrained by a strict schema.
+ */
+export const safeMarkdownRehypePlugins = [
+  rehypeRaw,
+  [rehypeSanitize, markdownSanitizeSchema],
+];

--- a/src/components/issues/IssueConversation.tsx
+++ b/src/components/issues/IssueConversation.tsx
@@ -12,8 +12,8 @@ import {
 import { useTheme } from '@mui/material/styles';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import rehypeRaw from 'rehype-raw';
 import { type IssueDetails } from '../../api/models/Issues';
+import { safeMarkdownRehypePlugins } from '../common';
 import { STATUS_COLORS, scrollbarSx } from '../../theme';
 
 import 'github-markdown-css/github-markdown-dark.css';
@@ -344,7 +344,7 @@ const IssueConversation: React.FC<IssueConversationProps> = ({ issue }) => {
               <div className="markdown-body" style={{ fontSize: '14px' }}>
                 <ReactMarkdown
                   remarkPlugins={[remarkGfm]}
-                  rehypePlugins={[rehypeRaw]}
+                  rehypePlugins={safeMarkdownRehypePlugins}
                 >
                   {item.body}
                 </ReactMarkdown>

--- a/src/components/prs/PRComments.tsx
+++ b/src/components/prs/PRComments.tsx
@@ -12,12 +12,12 @@ import {
 import { alpha } from '@mui/material/styles';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import rehypeRaw from 'rehype-raw';
 import { usePullRequestComments } from '../../api';
 import {
   type PullRequestComment,
   type PullRequestDetails,
 } from '../../api/models/Dashboard';
+import { safeMarkdownRehypePlugins } from '../common';
 import { STATUS_COLORS, UI_COLORS, scrollbarSx } from '../../theme';
 import 'github-markdown-css/github-markdown-dark.css'; // Import standard GitHub Dark styles
 
@@ -372,7 +372,7 @@ const PRComments: React.FC<PRCommentsProps> = ({
               <div className="markdown-body" style={{ fontSize: '14px' }}>
                 <ReactMarkdown
                   remarkPlugins={[remarkGfm]}
-                  rehypePlugins={[rehypeRaw]}
+                  rehypePlugins={safeMarkdownRehypePlugins}
                 >
                   {item.body}
                 </ReactMarkdown>

--- a/src/components/repositories/ContributingViewer.tsx
+++ b/src/components/repositories/ContributingViewer.tsx
@@ -9,8 +9,8 @@ import {
 } from '@mui/material';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import rehypeRaw from 'rehype-raw';
 import axios from 'axios';
+import { safeMarkdownRehypePlugins } from '../common';
 import { resolveRelativeUrl } from './MarkdownRenderers';
 import { markdownDocumentPaperSx } from '../../theme';
 
@@ -100,7 +100,7 @@ const ContributingViewer: React.FC<ContributingViewerProps> = ({
     <Paper elevation={0} sx={markdownDocumentPaperSx(theme)}>
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
-        rehypePlugins={[rehypeRaw]}
+        rehypePlugins={safeMarkdownRehypePlugins}
         components={{
           a: ({
             href,

--- a/src/components/repositories/ReadmeViewer.tsx
+++ b/src/components/repositories/ReadmeViewer.tsx
@@ -9,8 +9,8 @@ import {
 } from '@mui/material';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import rehypeRaw from 'rehype-raw';
 import axios from 'axios';
+import { safeMarkdownRehypePlugins } from '../common';
 import { resolveRelativeUrl } from './MarkdownRenderers';
 import { markdownDocumentPaperSx } from '../../theme';
 
@@ -91,7 +91,7 @@ const ReadmeViewer: React.FC<ReadmeViewerProps> = ({ repositoryFullName }) => {
     <Paper elevation={0} sx={markdownDocumentPaperSx(theme)}>
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
-        rehypePlugins={[rehypeRaw]}
+        rehypePlugins={safeMarkdownRehypePlugins}
         components={{
           a: ({
             href,


### PR DESCRIPTION
## Summary
- add `rehype-sanitize` and a shared safe markdown plugin pipeline
- apply sanitized markdown rendering to issue conversation, PR comments, README viewer, and CONTRIBUTING viewer
- include typing hardening so the shared plugin config is build-safe (`PluggableList`)

## Problem
Several core markdown views enabled `rehypeRaw` without a sanitization layer. That allowed raw HTML from issue/PR/repository content to be rendered in-app without a strict allowlist.

## Fix
- added `src/components/common/markdownSecurity.ts` with a shared plugin list:
  - `rehypeRaw`
  - `rehypeSanitize` with schema constraints
- typed the shared plugin list as `PluggableList` to satisfy ReactMarkdown/TypeScript build expectations
- switched these components to use the shared safe plugin pipeline:
  - `src/components/issues/IssueConversation.tsx`
  - `src/components/prs/PRComments.tsx`
  - `src/components/repositories/ReadmeViewer.tsx`
  - `src/components/repositories/ContributingViewer.tsx`

Closes #702

## Node 20 Runtime Recheck (Apr 21, 2026)
Executed on this branch with upgraded Node:
- `node -v` = `v20.20.2`
- `npm -v` = `10.8.2`

Validation command:
- `npm ci && npm run lint && npm run test && npm run build`

Result:
- [x] `npm ci`
- [x] `npm run lint`
- [x] `npm run test`
- [x] `npm run build`

Additional verification:
- [x] repo-wide search confirms previous `rehypeRaw` call sites now route through the shared sanitized pipeline