### PR TITLE
Feat: Request Unified Leaderboard Redesign Plan (OSS + Discoveries)

### DIFF
--- a/issue-enhancement-watchlist-miners-activity-status-card.md
+++ b/issue-enhancement-watchlist-miners-activity-status-card.md
@@ -1,0 +1,92 @@
+---
+name: Feature Request
+about: Suggest a new feature or improvement
+labels: enhancement
+---
+
+## Summary
+
+Add a new **status card** to the **right-side sidebar** on the **Watchlist** page (`src/pages/WatchlistPage.tsx`).
+
+The card should be titled **"Miners Activity"** and show watched-miner counts in a **3×2 table**:
+
+- **Rows**: All / Eligible / Ineligible
+- **Columns**: PR / Issue
+- The card should be placed **at the top** of the right sidebar status cards.
+
+## Motivation
+
+The Watchlist page is where users monitor a curated subset of miners. The right sidebar already summarizes activity (PR/Issue activity, code impact), but it does not show **how many watched miners are currently eligible vs. ineligible** for OSS (PR) rewards vs. Issue Discovery rewards. A compact eligibility matrix makes it easier to interpret watchlist health at a glance.
+
+## Proposed Solution
+
+### Where
+
+`WatchlistPage` renders the right sidebar here:
+
+- `src/pages/WatchlistPage.tsx` → `<ActivitySidebarCards miners={minerStats} />`
+
+Add the new card inside `ActivitySidebarCards` (`src/components/leaderboard/ActivitySidebarCards.tsx`) so it appears consistently anywhere that component is used (Watchlist, and any leaderboard pages that also reuse it).
+
+This should be implemented similarly to the work on branch `feat/new-status-card-miner`.
+
+### What to Display
+
+Render a **3×2** table with:
+
+- **Rows**
+  - All
+  - Eligible
+  - Ineligible
+- **Columns**
+  - PR (OSS contribution eligibility)
+  - Issue (Issue discovery eligibility)
+
+Counts should be computed from the `miners: MinerStats[]` array passed into `ActivitySidebarCards` (on Watchlist this is the watched-miner subset).
+
+Suggested definitions:
+
+- **All (PR/Issue)**: `miners.length`
+- **Eligible (PR)**: `miners.filter((m) => m.ossIsEligible).length`
+- **Ineligible (PR)**: `all - eligiblePR`
+- **Eligible (Issue)**: `miners.filter((m) => m.discoveriesIsEligible).length`
+- **Ineligible (Issue)**: `all - eligibleIssue`
+
+### Data Source
+
+Watchlist already builds `minerStats` from `mapAllMinersToStats(allMinersData ?? [])` and the watched miner IDs:
+
+- `src/pages/WatchlistPage.tsx`
+
+Eligibility fields already exist on `MinerStats`:
+
+- `src/components/leaderboard/types.ts`
+  - `ossIsEligible?: boolean`
+  - `discoveriesIsEligible?: boolean`
+
+No new API endpoints should be required.
+
+## Acceptance Criteria
+
+- A new status card appears in the Watchlist right sidebar when the watchlist is non-empty:
+  - `src/pages/WatchlistPage.tsx`
+- The card title is **"Miners Activity"**.
+- The card shows watched-miner counts in a **3×2** table:
+  - **Rows**: All / Eligible / Ineligible
+  - **Columns**: PR / Issue
+- The card is rendered **at the top** of the sidebar card stack (above the other status cards).
+- Counts are computed from the existing `miners` array passed to `ActivitySidebarCards` (watchlist subset).
+- The card handles loading/empty states gracefully:
+  - When `miners` is empty, show zeros (or a clear “No miner data yet” state) without errors.
+- Styling matches existing sidebar cards (uses `SectionCard` and the typography conventions in `src/components/leaderboard/*`).
+
+## Out of Scope
+
+- Changing eligibility rules (backend-driven; backend is not open source).
+- Adding new API endpoints.
+- Modifying watchlist tab behavior, storage, or pinning logic.
+
+## Notes / Implementation Hints
+
+- `WatchlistPage` computes watched miners as `minerStats`; the card should reflect _watched miners only_ (not all miners on the network).
+- `ActivitySidebarCards` is also used in other places (e.g. leaderboards); keep the card implementation generic and driven purely by the `miners` prop.

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -21,8 +21,7 @@ const Sidebar: React.FC<SidebarProps> = ({ onNavigate }) => {
 
   const navItems = [
     { label: 'dashboard', path: '/dashboard' },
-    { label: 'oss contributions', path: '/top-miners' },
-    { label: 'discoveries', path: '/discoveries', badge: 'new' },
+    { label: 'leaderboard', path: '/leaderboard' },
     {
       label: 'watchlist',
       path: '/watchlist',

--- a/src/components/leaderboard/ActivitySidebarCards.tsx
+++ b/src/components/leaderboard/ActivitySidebarCards.tsx
@@ -78,18 +78,33 @@ export const ActivitySidebarCards: React.FC<ActivitySidebarCardsProps> = ({
       (acc, m) => acc + (m.uniqueReposCount || 0),
       0,
     );
-    const credibilityValues = miners
+    return { linesAdded, linesDeleted, reposTouched };
+  }, [miners]);
+
+  const avgCredibilityStats = useMemo(() => {
+    // Match the `test` branch logic: average of provided numeric values,
+    // then expressed as a percentage (0-100).
+    const ossValues = miners
       .map((m) => m.credibility)
       .filter((c): c is number => typeof c === 'number');
-    const avgCredibility =
-      credibilityValues.length > 0
+    const discValues = miners
+      .map((m) => m.issueCredibility)
+      .filter((c): c is number => typeof c === 'number');
+
+    const ossAvg =
+      ossValues.length > 0
         ? Math.round(
-            (credibilityValues.reduce((acc, c) => acc + c, 0) /
-              credibilityValues.length) *
+            (ossValues.reduce((acc, c) => acc + c, 0) / ossValues.length) * 100,
+          )
+        : 0;
+    const discAvg =
+      discValues.length > 0
+        ? Math.round(
+            (discValues.reduce((acc, c) => acc + c, 0) / discValues.length) *
               100,
           )
         : 0;
-    return { linesAdded, linesDeleted, reposTouched, avgCredibility };
+    return { ossAvg, discAvg };
   }, [miners]);
 
   const solveRateColor =
@@ -237,6 +252,43 @@ export const ActivitySidebarCards: React.FC<ActivitySidebarCardsProps> = ({
             </Box>
           </Box>
 
+          <Box
+            sx={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              alignItems: 'center',
+              mt: 1.25,
+            }}
+          >
+            <Typography
+              sx={{
+                fontFamily: FONTS.mono,
+                fontSize: '0.85rem',
+                color: STATUS_COLORS.open,
+              }}
+            >
+              Avg Credibility
+            </Typography>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
+              <RateBar
+                rate={avgCredibilityStats.ossAvg}
+                color={credibilityColor(avgCredibilityStats.ossAvg / 100)}
+              />
+              <Typography
+                sx={{
+                  fontFamily: FONTS.mono,
+                  fontWeight: 600,
+                  fontSize: '1.1rem',
+                  color: credibilityColor(avgCredibilityStats.ossAvg / 100),
+                  minWidth: 40,
+                  textAlign: 'right',
+                }}
+              >
+                {avgCredibilityStats.ossAvg}%
+              </Typography>
+            </Box>
+          </Box>
+
           <StatRow
             label="Total $/day"
             value={`$${Math.round(ossUsdPerDay).toLocaleString()}`}
@@ -308,6 +360,43 @@ export const ActivitySidebarCards: React.FC<ActivitySidebarCardsProps> = ({
             </Box>
           </Box>
 
+          <Box
+            sx={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              alignItems: 'center',
+              mt: 1.25,
+            }}
+          >
+            <Typography
+              sx={{
+                fontFamily: FONTS.mono,
+                fontSize: '0.85rem',
+                color: STATUS_COLORS.open,
+              }}
+            >
+              Avg Credibility
+            </Typography>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
+              <RateBar
+                rate={avgCredibilityStats.discAvg}
+                color={credibilityColor(avgCredibilityStats.discAvg / 100)}
+              />
+              <Typography
+                sx={{
+                  fontFamily: FONTS.mono,
+                  fontWeight: 600,
+                  fontSize: '1.1rem',
+                  color: credibilityColor(avgCredibilityStats.discAvg / 100),
+                  minWidth: 40,
+                  textAlign: 'right',
+                }}
+              >
+                {avgCredibilityStats.discAvg}%
+              </Typography>
+            </Box>
+          </Box>
+
           <StatRow
             label="Total $/day"
             value={`$${Math.round(issueUsdPerDay).toLocaleString()}`}
@@ -342,41 +431,6 @@ export const ActivitySidebarCards: React.FC<ActivitySidebarCardsProps> = ({
             label="Repos Touched"
             value={codeStats.reposTouched.toLocaleString()}
           />
-          <Box
-            sx={{
-              display: 'flex',
-              justifyContent: 'space-between',
-              alignItems: 'center',
-            }}
-          >
-            <Typography
-              sx={{
-                fontFamily: FONTS.mono,
-                fontSize: '0.85rem',
-                color: STATUS_COLORS.open,
-              }}
-            >
-              Avg Credibility
-            </Typography>
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
-              <RateBar
-                rate={codeStats.avgCredibility}
-                color={credibilityColor(codeStats.avgCredibility / 100)}
-              />
-              <Typography
-                sx={{
-                  fontFamily: FONTS.mono,
-                  fontWeight: 600,
-                  fontSize: '1.1rem',
-                  color: credibilityColor(codeStats.avgCredibility / 100),
-                  minWidth: 40,
-                  textAlign: 'right',
-                }}
-              >
-                {codeStats.avgCredibility}%
-              </Typography>
-            </Box>
-          </Box>
         </Box>
       </SectionCard>
     </>

--- a/src/components/leaderboard/LeaderboardSidebar.tsx
+++ b/src/components/leaderboard/LeaderboardSidebar.tsx
@@ -16,7 +16,7 @@ interface LeaderboardSidebarProps {
   miners: MinerStats[];
   getMinerHref: (miner: MinerStats) => string;
   linkState?: Record<string, unknown>;
-  variant?: 'oss' | 'discoveries';
+  variant?: 'oss' | 'discoveries' | 'watchlist';
 }
 
 export const LeaderboardSidebar: React.FC<LeaderboardSidebarProps> = ({
@@ -26,9 +26,9 @@ export const LeaderboardSidebar: React.FC<LeaderboardSidebarProps> = ({
   variant = 'oss',
 }) => {
   // State for toggling lists
-  const [leaderboardType, setLeaderboardType] = useState<'earners' | 'active'>(
-    'earners',
-  );
+  const [leaderboardType, setLeaderboardType] = useState<
+    'earners' | 'prs' | 'issues'
+  >('earners');
 
   const filteredMiners = useEligibilityFilteredMiners(miners);
 
@@ -40,16 +40,20 @@ export const LeaderboardSidebar: React.FC<LeaderboardSidebarProps> = ({
     [filteredMiners],
   );
 
-  const mostActive = useMemo(
+  const mostActivePRs = useMemo(
     () =>
       [...filteredMiners]
-        .sort((a, b) =>
-          variant === 'discoveries'
-            ? (b.totalIssues || 0) - (a.totalIssues || 0)
-            : (b.totalPRs || 0) - (a.totalPRs || 0),
-        )
+        .sort((a, b) => (b.totalPRs || 0) - (a.totalPRs || 0))
         .slice(0, 5),
-    [filteredMiners, variant],
+    [filteredMiners],
+  );
+
+  const mostActiveIssues = useMemo(
+    () =>
+      [...filteredMiners]
+        .sort((a, b) => (b.totalIssues || 0) - (a.totalIssues || 0))
+        .slice(0, 5),
+    [filteredMiners],
   );
 
   return (
@@ -62,7 +66,13 @@ export const LeaderboardSidebar: React.FC<LeaderboardSidebarProps> = ({
 
       {/* Leaderboard Lists (Tabs) */}
       <SectionCard
-        title={leaderboardType === 'earners' ? 'Top Earners' : 'Most Active'}
+        title={
+          leaderboardType === 'earners'
+            ? 'Top Earners'
+            : leaderboardType === 'issues'
+              ? 'Most Issues'
+              : 'Most PRs'
+        }
         action={
           <LeaderboardTabs
             activeTab={leaderboardType}
@@ -73,20 +83,22 @@ export const LeaderboardSidebar: React.FC<LeaderboardSidebarProps> = ({
         sx={{ flexShrink: 0 }}
       >
         <Box sx={{ px: 2, pb: 2 }}>
-          <LeaderboardHeader type={leaderboardType} variant={variant} />
-          {(leaderboardType === 'earners' ? topEarners : mostActive).map(
-            (miner, i) => (
-              <LeaderboardRow
-                key={miner.id}
-                miner={miner}
-                rank={i + 1}
-                type={leaderboardType}
-                variant={variant}
-                href={getMinerHref(miner)}
-                linkState={linkState}
-              />
-            ),
-          )}
+          <LeaderboardHeader type={leaderboardType} />
+          {(leaderboardType === 'earners'
+            ? topEarners
+            : leaderboardType === 'issues'
+              ? mostActiveIssues
+              : mostActivePRs
+          ).map((miner, i) => (
+            <LeaderboardRow
+              key={miner.id}
+              miner={miner}
+              rank={i + 1}
+              type={leaderboardType}
+              href={getMinerHref(miner)}
+              linkState={linkState}
+            />
+          ))}
         </Box>
       </SectionCard>
     </Stack>
@@ -94,9 +106,9 @@ export const LeaderboardSidebar: React.FC<LeaderboardSidebarProps> = ({
 };
 
 interface LeaderboardTabsProps {
-  activeTab: 'earners' | 'active';
-  onTabChange: (tab: 'earners' | 'active') => void;
-  variant?: 'oss' | 'discoveries';
+  activeTab: 'earners' | 'prs' | 'issues';
+  onTabChange: (tab: 'earners' | 'prs' | 'issues') => void;
+  variant?: 'oss' | 'discoveries' | 'watchlist';
 }
 
 const LeaderboardTabs: React.FC<LeaderboardTabsProps> = ({
@@ -113,13 +125,22 @@ const LeaderboardTabs: React.FC<LeaderboardTabsProps> = ({
       borderRadius: 2,
     })}
   >
-    {[
-      { label: '$', value: 'earners' as const },
-      {
-        label: variant === 'discoveries' ? 'Issues' : 'PRs',
-        value: 'active' as const,
-      },
-    ].map((option) => (
+    {(variant === 'watchlist'
+      ? ([
+          { label: '$', value: 'earners' as const },
+          { label: 'PRs', value: 'prs' as const },
+          { label: 'Issues', value: 'issues' as const },
+        ] as const)
+      : variant === 'discoveries'
+        ? ([
+            { label: '$', value: 'earners' as const },
+            { label: 'Issues', value: 'issues' as const },
+          ] as const)
+        : ([
+            { label: '$', value: 'earners' as const },
+            { label: 'PRs', value: 'prs' as const },
+          ] as const)
+    ).map((option) => (
       <Box
         key={option.value}
         onClick={() => onTabChange(option.value)}
@@ -160,14 +181,10 @@ const LeaderboardTabs: React.FC<LeaderboardTabsProps> = ({
 );
 
 interface LeaderboardHeaderProps {
-  type: 'earners' | 'active';
-  variant?: 'oss' | 'discoveries';
+  type: 'earners' | 'prs' | 'issues';
 }
 
-const LeaderboardHeader: React.FC<LeaderboardHeaderProps> = ({
-  type,
-  variant = 'oss',
-}) => (
+const LeaderboardHeader: React.FC<LeaderboardHeaderProps> = ({ type }) => (
   <Box
     sx={(theme) => ({
       display: 'flex',
@@ -206,11 +223,7 @@ const LeaderboardHeader: React.FC<LeaderboardHeaderProps> = ({
         textTransform: 'uppercase',
       }}
     >
-      {type === 'earners'
-        ? '$/Day'
-        : variant === 'discoveries'
-          ? 'Issues'
-          : 'PRs'}
+      {type === 'earners' ? '$/Day' : type === 'issues' ? 'Issues' : 'PRs'}
     </Typography>
   </Box>
 );
@@ -218,8 +231,7 @@ const LeaderboardHeader: React.FC<LeaderboardHeaderProps> = ({
 interface LeaderboardRowProps {
   miner: MinerStats;
   rank: number;
-  type: 'earners' | 'active';
-  variant?: 'oss' | 'discoveries';
+  type: 'earners' | 'prs' | 'issues';
   href: string;
   linkState?: Record<string, unknown>;
 }
@@ -228,7 +240,6 @@ const LeaderboardRow: React.FC<LeaderboardRowProps> = ({
   miner,
   rank,
   type,
-  variant = 'oss',
   href,
   linkState,
 }) => {
@@ -297,7 +308,7 @@ const LeaderboardRow: React.FC<LeaderboardRowProps> = ({
       >
         {type === 'earners'
           ? `$${Math.round(miner.usdPerDay || 0).toLocaleString()}`
-          : variant === 'discoveries'
+          : type === 'issues'
             ? miner.totalIssues
             : miner.totalPRs}
       </Typography>

--- a/src/components/leaderboard/MinersList.tsx
+++ b/src/components/leaderboard/MinersList.tsx
@@ -9,6 +9,7 @@ import {
   type LeaderboardVariant,
   type MinerStats,
   type SortOption,
+  type LeaderboardMode,
 } from './types';
 
 const SEGMENT_COLORS = [
@@ -25,6 +26,7 @@ const cellTypographySx = {
 interface MinersListProps {
   miners: MinerStats[];
   variant: LeaderboardVariant;
+  mode?: LeaderboardMode;
   sortOption: SortOption;
   sortDirection: SortOrder;
   onSort: (option: SortOption) => void;
@@ -35,6 +37,7 @@ interface MinersListProps {
 export const MinersList: React.FC<MinersListProps> = ({
   miners,
   variant,
+  mode = 'default',
   sortOption,
   sortDirection,
   onSort,
@@ -42,6 +45,7 @@ export const MinersList: React.FC<MinersListProps> = ({
   linkState,
 }) => {
   const isDiscoveries = variant === 'discoveries';
+  const isLeaderboard = mode === 'leaderboard';
   const prLabel = isDiscoveries ? 'Issues' : 'PRs';
   const prSortKey: SortOption = isDiscoveries ? 'totalIssues' : 'totalPRs';
 
@@ -77,40 +81,117 @@ export const MinersList: React.FC<MinersListProps> = ({
         </Typography>
       ),
     },
-    {
-      key: 'activity',
-      header: prLabel,
-      width: '18%',
-      align: 'right',
-      sortKey: prSortKey,
-      renderCell: (miner) => (
-        <MinerActivitySegments miner={miner} variant={variant} />
-      ),
-    },
-    {
-      key: 'credibility',
-      header: 'Credibility',
-      width: '12%',
-      align: 'right',
-      sortKey: 'credibility',
-      renderCell: (miner) => (
-        <Typography sx={{ ...cellTypographySx, color: 'text.primary' }}>
-          {((miner.credibility ?? 0) * 100).toFixed(0)}%
-        </Typography>
-      ),
-    },
-    {
-      key: 'totalScore',
-      header: 'Score',
-      width: '11%',
-      align: 'right',
-      sortKey: 'totalScore',
-      renderCell: (miner) => (
-        <Typography sx={{ ...cellTypographySx, color: 'text.primary' }}>
-          {Number(miner.totalScore).toFixed(2)}
-        </Typography>
-      ),
-    },
+    ...(isLeaderboard
+      ? ([
+          {
+            key: 'prs',
+            header: 'PRs',
+            width: '12%',
+            align: 'right',
+            sortKey: 'totalPRs',
+            renderCell: (miner) => (
+              <Typography sx={{ ...cellTypographySx, color: 'text.primary' }}>
+                {(miner.totalPRs ?? 0).toLocaleString()}
+              </Typography>
+            ),
+          },
+          {
+            key: 'issues',
+            header: 'Issues',
+            width: '12%',
+            align: 'right',
+            sortKey: 'totalIssues',
+            renderCell: (miner) => (
+              <Typography sx={{ ...cellTypographySx, color: 'text.primary' }}>
+                {(miner.totalIssues ?? 0).toLocaleString()}
+              </Typography>
+            ),
+          },
+          {
+            key: 'ossCred',
+            header: 'OSS Cred',
+            width: '10%',
+            align: 'right',
+            sortKey: 'ossCredibility',
+            renderCell: (miner) => (
+              <Typography sx={{ ...cellTypographySx, color: 'text.primary' }}>
+                {(((miner.credibility ?? 0) as number) * 100).toFixed(0)}%
+              </Typography>
+            ),
+          },
+          {
+            key: 'issueCred',
+            header: 'Issues Cred',
+            width: '12%',
+            align: 'right',
+            sortKey: 'issueCredibility',
+            renderCell: (miner) => (
+              <Typography sx={{ ...cellTypographySx, color: 'text.primary' }}>
+                {(((miner.issueCredibility ?? 0) as number) * 100).toFixed(0)}%
+              </Typography>
+            ),
+          },
+          {
+            key: 'ossScore',
+            header: 'OSS Score',
+            width: '11%',
+            align: 'right',
+            sortKey: 'ossScore',
+            renderCell: (miner) => (
+              <Typography sx={{ ...cellTypographySx, color: 'text.primary' }}>
+                {Number(miner.totalScore ?? 0).toFixed(2)}
+              </Typography>
+            ),
+          },
+          {
+            key: 'issueScore',
+            header: 'Issues Score',
+            width: '12%',
+            align: 'right',
+            sortKey: 'issueScore',
+            renderCell: (miner) => (
+              <Typography sx={{ ...cellTypographySx, color: 'text.primary' }}>
+                {Number(miner.issueDiscoveryScore ?? 0).toFixed(2)}
+              </Typography>
+            ),
+          },
+        ] as DataTableColumn<MinerStats, SortOption>[])
+      : ([
+          {
+            key: 'activity',
+            header: prLabel,
+            width: '18%',
+            align: 'right',
+            sortKey: prSortKey,
+            renderCell: (miner) => (
+              <MinerActivitySegments miner={miner} variant={variant} />
+            ),
+          },
+          {
+            key: 'credibility',
+            header: 'Credibility',
+            width: '12%',
+            align: 'right',
+            sortKey: 'credibility',
+            renderCell: (miner) => (
+              <Typography sx={{ ...cellTypographySx, color: 'text.primary' }}>
+                {((miner.credibility ?? 0) * 100).toFixed(0)}%
+              </Typography>
+            ),
+          },
+          {
+            key: 'totalScore',
+            header: 'Score',
+            width: '11%',
+            align: 'right',
+            sortKey: 'totalScore',
+            renderCell: (miner) => (
+              <Typography sx={{ ...cellTypographySx, color: 'text.primary' }}>
+                {Number(miner.totalScore).toFixed(2)}
+              </Typography>
+            ),
+          },
+        ] as DataTableColumn<MinerStats, SortOption>[])),
     {
       key: 'watch',
       header: '\u2605',
@@ -157,7 +238,7 @@ export const MinersList: React.FC<MinersListProps> = ({
           opacity: (miner.isEligible ?? false) ? 1 : 0.5,
           transition: 'opacity 0.2s, background-color 0.2s',
         })}
-        minWidth="900px"
+        minWidth={isLeaderboard ? '1250px' : '900px'}
         stickyHeader
         sort={{
           field: sortOption,

--- a/src/components/leaderboard/TopMinersTable.tsx
+++ b/src/components/leaderboard/TopMinersTable.tsx
@@ -1,22 +1,18 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo } from 'react';
 import {
   Box,
   Typography,
   CircularProgress,
   Grid,
   Tooltip,
-  Menu,
-  MenuItem,
-  ListItemText,
-  Divider,
   Select,
   FormControl,
   IconButton,
+  MenuItem,
 } from '@mui/material';
 import { alpha, type Theme } from '@mui/material/styles';
 import ViewModuleIcon from '@mui/icons-material/ViewModule';
 import ViewListIcon from '@mui/icons-material/ViewList';
-import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
 import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
 import { SectionCard } from './SectionCard';
@@ -32,6 +28,7 @@ import {
   type LeaderboardMode,
   FONTS,
 } from './types';
+import FilterButton from '../FilterButton';
 
 type ViewMode = 'cards' | 'list';
 
@@ -305,6 +302,21 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
     [setFilter],
   );
 
+  const eligibilityCounts = useMemo(() => {
+    if (mode !== 'leaderboard') return null;
+    const ossEligibleCount = miners.filter((m) => m.ossIsEligible).length;
+    const discoveriesEligibleCount = miners.filter(
+      (m) => m.discoveriesIsEligible,
+    ).length;
+    return {
+      all: miners.length,
+      ossEligible: ossEligibleCount,
+      ossIneligible: miners.length - ossEligibleCount,
+      discoveriesEligible: discoveriesEligibleCount,
+      discoveriesIneligible: miners.length - discoveriesEligibleCount,
+    };
+  }, [miners, mode]);
+
   // Rank is computed on the full sorted leaderboard so each miner keeps their
   // true position regardless of filters. Filtering (search / eligibility) then
   // only hides rows without renumbering the ones that remain. Sort direction
@@ -397,38 +409,188 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
         }}
       >
         <Box sx={{ p: 2, display: 'flex', flexDirection: 'column', gap: 1.5 }}>
-          {/* Row 1: Title + Search + Filters + View */}
-          <Box
-            sx={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: 2,
-              flexWrap: { xs: 'wrap', sm: 'nowrap' },
-            }}
-          >
-            <Typography
-              variant="h6"
-              sx={{ fontSize: '1.25rem', fontWeight: 600, flexShrink: 0 }}
-            >
-              Miners ({filteredMiners.length})
-            </Typography>
+          {mode === 'leaderboard' ? (
+            <>
+              {/* Row 1: Filter (left) + Sort (right) */}
+              <Box
+                sx={{
+                  width: '100%',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'space-between',
+                  gap: 2,
+                  flexWrap: { xs: 'wrap', md: 'nowrap' },
+                }}
+              >
+                <Box sx={{ flex: 1, minWidth: 0 }}>
+                  <EligibilityTimelineToggle
+                    value={(eligibilityFilter ?? 'all') as EligibilityFilter}
+                    onChange={(next) => handleEligibilityChange(next)}
+                    counts={eligibilityCounts}
+                  />
+                </Box>
+                {viewMode === 'cards' ? (
+                  <Box
+                    sx={{
+                      display: 'flex',
+                      justifyContent: 'flex-end',
+                      alignItems: 'center',
+                      gap: 1,
+                      flexShrink: 0,
+                    }}
+                  >
+                    <Typography
+                      sx={{
+                        fontSize: '0.8rem',
+                        color: 'text.secondary',
+                        whiteSpace: 'nowrap',
+                      }}
+                    >
+                      Sort:
+                    </Typography>
+                    <FormControl size="small">
+                      <Select
+                        value={sortOption}
+                        onChange={(e) => {
+                          const next = e.target.value as SortOption;
+                          if (next !== sortOption) handleSortChange(next);
+                        }}
+                        sx={{
+                          color: 'text.primary',
+                          backgroundColor: 'background.default',
+                          fontSize: '0.8rem',
+                          height: '36px',
+                          borderRadius: 2,
+                          minWidth: '190px',
+                          '& fieldset': { borderColor: 'border.light' },
+                          '&:hover fieldset': { borderColor: 'border.medium' },
+                          '&.Mui-focused fieldset': {
+                            borderColor: 'primary.main',
+                          },
+                          '& .MuiSelect-select': { py: 0.75 },
+                        }}
+                      >
+                        {(
+                          [
+                            { value: 'ossScore', label: 'OSS Score' },
+                            { value: 'issueScore', label: 'Issues Score' },
+                            { value: 'usdPerDay', label: 'Earnings' },
+                            { value: 'totalPRs', label: 'PRs' },
+                            { value: 'totalIssues', label: 'Issues' },
+                            {
+                              value: 'ossCredibility',
+                              label: 'OSS Credibility',
+                            },
+                            {
+                              value: 'issueCredibility',
+                              label: 'Issues Credibility',
+                            },
+                          ] as const
+                        ).map((opt) => (
+                          <MenuItem key={opt.value} value={opt.value}>
+                            {opt.label}
+                          </MenuItem>
+                        ))}
+                      </Select>
+                    </FormControl>
+                    <Tooltip
+                      title={
+                        sortDirection === 'asc' ? 'Ascending' : 'Descending'
+                      }
+                    >
+                      <IconButton
+                        size="small"
+                        onClick={() => handleSortChange(sortOption)}
+                        sx={{
+                          color: 'text.primary',
+                          border: '1px solid',
+                          borderColor: 'border.light',
+                          borderRadius: 2,
+                          padding: '6px',
+                          '&:hover': {
+                            backgroundColor: 'surface.light',
+                            borderColor: 'border.medium',
+                          },
+                        }}
+                        aria-label={
+                          sortDirection === 'asc'
+                            ? 'Sort descending'
+                            : 'Sort ascending'
+                        }
+                      >
+                        {sortDirection === 'asc' ? (
+                          <ArrowUpwardIcon fontSize="small" />
+                        ) : (
+                          <ArrowDownwardIcon fontSize="small" />
+                        )}
+                      </IconButton>
+                    </Tooltip>
+                  </Box>
+                ) : null}
+              </Box>
+
+              {/* Row 2: Search (left) + View mode (right) */}
+              <Box
+                sx={{
+                  width: '100%',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'space-between',
+                  gap: 2,
+                  flexWrap: { xs: 'wrap', sm: 'nowrap' },
+                }}
+              >
+                <Box
+                  sx={{
+                    flex: 1,
+                    minWidth: 0,
+                    width: { xs: '100%', sm: 'auto' },
+                  }}
+                >
+                  <SearchInput
+                    value={searchQuery}
+                    onChange={handleSearchChange}
+                    width="100%"
+                    placeholder="Search miners..."
+                  />
+                </Box>
+                <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
+                  <ViewModeToggle
+                    viewMode={viewMode}
+                    onChange={handleViewModeChange}
+                  />
+                </Box>
+              </Box>
+            </>
+          ) : (
+            /* Row 1: Title + Search + Filters + View */
             <Box
-              sx={{ flex: 1, minWidth: 0, width: { xs: '100%', sm: 'auto' } }}
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 2,
+                width: '100%',
+                justifyContent: 'space-between',
+                flexWrap: { xs: 'wrap', sm: 'nowrap' },
+              }}
             >
-              <SearchInput
-                value={searchQuery}
-                onChange={handleSearchChange}
-                width="100%"
-                placeholder="Search miners..."
-              />
-            </Box>
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-              {mode === 'leaderboard' ? (
-                <EligibilityMenu
-                  value={(eligibilityFilter ?? 'all') as EligibilityFilter}
-                  onChange={(next) => handleEligibilityChange(next)}
+              <Typography
+                variant="h6"
+                sx={{ fontSize: '1.25rem', fontWeight: 600, flexShrink: 0 }}
+              >
+                Miners ({filteredMiners.length})
+              </Typography>
+              <Box
+                sx={{ flex: 1, minWidth: 0, width: { xs: '100%', sm: 'auto' } }}
+              >
+                <SearchInput
+                  value={searchQuery}
+                  onChange={handleSearchChange}
+                  width="100%"
+                  placeholder="Search miners..."
                 />
-              ) : (
+              </Box>
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
                 <EligibilityToggle
                   value={
                     (legacyEligibilityFilter ??
@@ -436,16 +598,16 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
                   }
                   onChange={handleEligibilityChange}
                 />
-              )}
-              <ViewModeToggle
-                viewMode={viewMode}
-                onChange={handleViewModeChange}
-              />
+                <ViewModeToggle
+                  viewMode={viewMode}
+                  onChange={handleViewModeChange}
+                />
+              </Box>
             </Box>
-          </Box>
+          )}
 
-          {/* Row 2: Sort controls (card view only — matches repositories UX) */}
-          {viewMode === 'cards' ? (
+          {/* Sort controls (card view only — non-leaderboard) */}
+          {mode !== 'leaderboard' && viewMode === 'cards' ? (
             <Box
               sx={{
                 display: 'flex',
@@ -482,30 +644,18 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
                     '& .MuiSelect-select': { py: 0.75 },
                   }}
                 >
-                  {(mode === 'leaderboard'
-                    ? ([
-                        { value: 'ossScore', label: 'OSS Score' },
-                        { value: 'issueScore', label: 'Issues Score' },
-                        { value: 'usdPerDay', label: 'Earnings' },
-                        { value: 'totalPRs', label: 'PRs' },
-                        { value: 'totalIssues', label: 'Issues' },
-                        { value: 'ossCredibility', label: 'OSS Credibility' },
-                        {
-                          value: 'issueCredibility',
-                          label: 'Issues Credibility',
-                        },
-                      ] as const)
-                    : ([
-                        { value: 'totalScore', label: 'Score' },
-                        { value: 'usdPerDay', label: 'Earnings' },
-                        ...(variant !== 'discoveries'
-                          ? [{ value: 'totalPRs', label: 'PRs' } as const]
-                          : []),
-                        ...(variant === 'discoveries' || variant === 'watchlist'
-                          ? [{ value: 'totalIssues', label: 'Issues' } as const]
-                          : []),
-                        { value: 'credibility', label: 'Credibility' },
-                      ] as const)
+                  {(
+                    [
+                      { value: 'totalScore', label: 'Score' },
+                      { value: 'usdPerDay', label: 'Earnings' },
+                      ...(variant !== 'discoveries'
+                        ? [{ value: 'totalPRs', label: 'PRs' } as const]
+                        : []),
+                      ...(variant === 'discoveries' || variant === 'watchlist'
+                        ? [{ value: 'totalIssues', label: 'Issues' } as const]
+                        : []),
+                      { value: 'credibility', label: 'Credibility' },
+                    ] as const
                   ).map((opt) => (
                     <MenuItem key={opt.value} value={opt.value}>
                       {opt.label}
@@ -796,72 +946,46 @@ const ELIGIBILITY_MENU_OPTIONS: Array<{
   { value: 'all', label: 'All' },
   { value: 'ossEligible', label: 'OSS eligible' },
   { value: 'ossIneligible', label: 'OSS ineligible' },
-  { value: 'discoveriesEligible', label: 'Discoveries eligible' },
-  { value: 'discoveriesIneligible', label: 'Discoveries ineligible' },
+  { value: 'discoveriesEligible', label: 'Issues eligible' },
+  { value: 'discoveriesIneligible', label: 'Issues ineligible' },
 ];
 
-const EligibilityMenu: React.FC<{
+const EligibilityTimelineToggle: React.FC<{
   value: EligibilityFilter;
   onChange: (next: EligibilityFilter) => void;
-}> = ({ value, onChange }) => {
-  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
-  const open = Boolean(anchorEl);
-  const label =
-    ELIGIBILITY_MENU_OPTIONS.find((x) => x.value === value)?.label ?? 'All';
-
-  return (
-    <>
-      <Box
-        component="button"
-        type="button"
-        onClick={(e) => setAnchorEl(e.currentTarget)}
-        sx={(theme) => ({
-          display: 'inline-flex',
-          alignItems: 'center',
-          gap: 0.5,
-          height: 32,
-          px: 1.25,
-          borderRadius: 2,
-          border: `1px solid ${theme.palette.border.light}`,
-          backgroundColor: theme.palette.surface.subtle,
-          color: theme.palette.text.primary,
-          cursor: 'pointer',
-          fontFamily: FONTS.mono,
-          fontSize: '0.72rem',
-          fontWeight: 700,
-          textTransform: 'uppercase',
-          letterSpacing: '0.06em',
-          '&:hover': {
-            backgroundColor: theme.palette.surface.light,
-          },
-        })}
-      >
-        {label}
-        <KeyboardArrowDownIcon sx={{ fontSize: '1.1rem', opacity: 0.85 }} />
-      </Box>
-      <Menu
-        anchorEl={anchorEl}
-        open={open}
-        onClose={() => setAnchorEl(null)}
-        MenuListProps={{ dense: true }}
-      >
-        {ELIGIBILITY_MENU_OPTIONS.map((option, idx) => (
-          <React.Fragment key={option.value}>
-            {idx === 1 ? <Divider /> : null}
-            <MenuItem
-              selected={value === option.value}
-              onClick={() => {
-                onChange(option.value);
-                setAnchorEl(null);
-              }}
-            >
-              <ListItemText primary={option.label} />
-            </MenuItem>
-          </React.Fragment>
-        ))}
-      </Menu>
-    </>
-  );
-};
+  counts: null | {
+    all: number;
+    ossEligible: number;
+    ossIneligible: number;
+    discoveriesEligible: number;
+    discoveriesIneligible: number;
+  };
+}> = ({ value, onChange, counts }) => (
+  <Box
+    sx={{
+      display: 'flex',
+      gap: 0.5,
+      alignItems: 'center',
+      flexWrap: 'wrap',
+    }}
+    role="tablist"
+    aria-label="Eligibility timeline"
+  >
+    {ELIGIBILITY_MENU_OPTIONS.map((opt) => {
+      const isActive = value === opt.value;
+      const count = counts?.[opt.value as keyof NonNullable<typeof counts>];
+      return (
+        <FilterButton
+          key={opt.value}
+          label={opt.label}
+          isActive={isActive}
+          count={count}
+          color={STATUS_COLORS.open}
+          onClick={() => onChange(opt.value)}
+        />
+      );
+    })}
+  </Box>
+);
 
 export default TopMinersTable;

--- a/src/components/leaderboard/TopMinersTable.tsx
+++ b/src/components/leaderboard/TopMinersTable.tsx
@@ -1,25 +1,35 @@
-import React, { useCallback, useEffect, useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   Box,
   Typography,
   CircularProgress,
   Grid,
   Tooltip,
+  Menu,
+  MenuItem,
+  ListItemText,
+  Divider,
+  Select,
+  FormControl,
+  IconButton,
 } from '@mui/material';
 import { alpha, type Theme } from '@mui/material/styles';
 import ViewModuleIcon from '@mui/icons-material/ViewModule';
 import ViewListIcon from '@mui/icons-material/ViewList';
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
+import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
 import { SectionCard } from './SectionCard';
 import { MinerCard } from './MinerCard';
 import { MinersList } from './MinersList';
 import { SearchInput } from '../common/SearchInput';
 import { STATUS_COLORS } from '../../theme';
 import { useDataTableParams } from '../../hooks/useDataTableParams';
-import { type SortOrder } from '../../utils/ExplorerUtils';
 import {
   type MinerStats,
   type SortOption,
   type LeaderboardVariant,
+  type LeaderboardMode,
   FONTS,
 } from './types';
 
@@ -34,6 +44,7 @@ const VIEW_QUERY_PARAM = 'view';
 const SEARCH_QUERY_PARAM = 'search';
 const VISIBLE_QUERY_PARAM = 'visible';
 const VIEW_STORAGE_KEY = 'leaderboard:viewMode';
+const ELIGIBILITY_QUERY_PARAM = 'eligibility';
 // Sort state (`sort`, `dir`) is owned by `useDataTableParams`. We reuse the
 // `page` param slot for our "show more" count via the paramKeys override.
 
@@ -62,9 +73,23 @@ interface TopMinersTableProps {
   linkState?: Record<string, unknown>;
   variant?: LeaderboardVariant;
   showDualEligibilityBadges?: boolean;
+  mode?: LeaderboardMode;
 }
 
-const getAllowedSortOptions = (variant: LeaderboardVariant): SortOption[] => {
+const getAllowedSortOptions = (
+  variant: LeaderboardVariant,
+  mode: LeaderboardMode,
+): SortOption[] => {
+  if (mode === 'leaderboard')
+    return [
+      'ossScore',
+      'issueScore',
+      'usdPerDay',
+      'totalPRs',
+      'totalIssues',
+      'ossCredibility',
+      'issueCredibility',
+    ];
   if (variant === 'discoveries')
     return ['totalScore', 'usdPerDay', 'totalIssues', 'credibility'];
   if (variant === 'watchlist')
@@ -78,16 +103,46 @@ const getAllowedSortOptions = (variant: LeaderboardVariant): SortOption[] => {
   return ['totalScore', 'usdPerDay', 'totalPRs', 'credibility'];
 };
 
-type EligibilityFilter = 'all' | 'eligible' | 'ineligible';
+type LegacyEligibilityFilter = 'all' | 'eligible' | 'ineligible';
+type EligibilityFilter =
+  | 'all'
+  | 'ossEligible'
+  | 'ossIneligible'
+  | 'discoveriesEligible'
+  | 'discoveriesIneligible';
 
 const compareMiners = (
   a: MinerStats,
   b: MinerStats,
   option: SortOption,
+  mode: LeaderboardMode,
 ): number => {
+  const getScore = (m: MinerStats) => {
+    if (mode === 'leaderboard') {
+      // If someone passes legacy `totalScore` while in leaderboard mode,
+      // treat it as OSS score (default program).
+      return Number(m.totalScore ?? 0);
+    }
+    return Number(m.totalScore ?? 0);
+  };
+
+  const getCred = (m: MinerStats) => {
+    if (mode === 'leaderboard') {
+      // Legacy key in leaderboard mode maps to OSS credibility.
+      return Number(m.credibility ?? 0);
+    }
+    return Number(m.credibility ?? 0);
+  };
+
   switch (option) {
     case 'totalScore':
-      return a.totalScore - b.totalScore;
+      return getScore(a) - getScore(b);
+    case 'ossScore':
+      return Number(a.totalScore ?? 0) - Number(b.totalScore ?? 0);
+    case 'issueScore':
+      return (
+        Number(a.issueDiscoveryScore ?? 0) - Number(b.issueDiscoveryScore ?? 0)
+      );
     case 'usdPerDay':
       return (a.usdPerDay ?? 0) - (b.usdPerDay ?? 0);
     case 'totalPRs':
@@ -95,7 +150,11 @@ const compareMiners = (
     case 'totalIssues':
       return (a.totalIssues ?? 0) - (b.totalIssues ?? 0);
     case 'credibility':
-      return (a.credibility ?? 0) - (b.credibility ?? 0);
+      return getCred(a) - getCred(b);
+    case 'ossCredibility':
+      return Number(a.credibility ?? 0) - Number(b.credibility ?? 0);
+    case 'issueCredibility':
+      return Number(a.issueCredibility ?? 0) - Number(b.issueCredibility ?? 0);
     default:
       return 0;
   }
@@ -108,10 +167,11 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
   linkState,
   variant = 'oss',
   showDualEligibilityBadges = false,
+  mode = 'default',
 }) => {
   const allowedSortKeys = useMemo(
-    () => getAllowedSortOptions(variant),
-    [variant],
+    () => getAllowedSortOptions(variant, mode),
+    [variant, mode],
   );
 
   // Stable filter configs — values are destructured below.
@@ -134,20 +194,48 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
         serialize: (value: ViewMode): string => value,
         resetPageOnChange: false,
       },
-      eligible: {
-        paramKey: ELIGIBLE_QUERY_PARAM,
-        parse: (raw: string | null): EligibilityFilter =>
-          raw === 'true' ? 'eligible' : raw === 'false' ? 'ineligible' : 'all',
-        serialize: (value: EligibilityFilter): string | null =>
-          value === 'all' ? null : value === 'eligible' ? 'true' : 'false',
-      },
+      ...(mode === 'leaderboard'
+        ? {
+            eligibility: {
+              paramKey: ELIGIBILITY_QUERY_PARAM,
+              parse: (raw: string | null): EligibilityFilter =>
+                raw === 'ossEligible' ||
+                raw === 'ossIneligible' ||
+                raw === 'discoveriesEligible' ||
+                raw === 'discoveriesIneligible'
+                  ? raw
+                  : 'all',
+              serialize: (
+                value: EligibilityFilter | undefined,
+              ): string | null => (!value || value === 'all' ? null : value),
+            },
+          }
+        : {
+            eligible: {
+              paramKey: ELIGIBLE_QUERY_PARAM,
+              parse: (raw: string | null): LegacyEligibilityFilter =>
+                raw === 'true'
+                  ? 'eligible'
+                  : raw === 'false'
+                    ? 'ineligible'
+                    : 'all',
+              serialize: (
+                value: LegacyEligibilityFilter | undefined,
+              ): string | null =>
+                value === 'all'
+                  ? null
+                  : value === 'eligible'
+                    ? 'true'
+                    : 'false',
+            },
+          }),
       search: {
         paramKey: SEARCH_QUERY_PARAM,
         parse: (raw: string | null): string => raw ?? '',
         serialize: (value: string): string | null => value.trim() || null,
       },
     }),
-    [],
+    [mode],
   );
 
   const {
@@ -156,23 +244,32 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
     setSort: handleSortChange,
     page: storedVisibleCount,
     setPage: setVisibleCount,
-    filters: {
-      view: viewMode,
-      eligible: eligibilityFilter,
-      search: searchQuery,
-    },
+    filters,
     setFilter,
   } = useDataTableParams<
     SortOption,
-    { view: ViewMode; eligible: EligibilityFilter; search: string }
+    {
+      view: ViewMode;
+      search: string;
+      eligible?: LegacyEligibilityFilter;
+      eligibility?: EligibilityFilter;
+    }
   >({
     sortKeys: allowedSortKeys,
-    defaultSortKey: 'totalScore',
+    defaultSortKey: mode === 'leaderboard' ? 'ossScore' : 'totalScore',
     // Reuse the hook's `page` slot for our "show more" count — setSort and
     // filter changes reset it, which is the behavior we want.
     paramKeys: { page: VISIBLE_QUERY_PARAM },
     filters: filtersConfig,
   });
+
+  const viewMode = filters.view as ViewMode;
+  const searchQuery = filters.search as string;
+  const legacyEligibilityFilter = (
+    filters as { eligible?: LegacyEligibilityFilter }
+  ).eligible;
+  const eligibilityFilter = (filters as { eligibility?: EligibilityFilter })
+    .eligibility;
 
   // `page` is 0 when no visible param is set — clamp to the initial batch.
   const visibleCount =
@@ -193,8 +290,14 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
   );
 
   const handleEligibilityChange = useCallback(
-    (nextFilter: EligibilityFilter) => setFilter('eligible', nextFilter),
-    [setFilter],
+    (nextFilter: EligibilityFilter | LegacyEligibilityFilter) => {
+      if (mode === 'leaderboard') {
+        setFilter('eligibility' as never, nextFilter as never);
+        return;
+      }
+      setFilter('eligible' as never, nextFilter as never);
+    },
+    [mode, setFilter],
   );
 
   const handleSearchChange = useCallback(
@@ -209,9 +312,11 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
   const rankedMiners = useMemo(() => {
     const directionMultiplier = sortDirection === 'asc' ? 1 : -1;
     return [...miners]
-      .sort((a, b) => compareMiners(a, b, sortOption) * directionMultiplier)
+      .sort(
+        (a, b) => compareMiners(a, b, sortOption, mode) * directionMultiplier,
+      )
       .map((miner, index) => ({ ...miner, rank: index + 1 }));
-  }, [miners, sortOption, sortDirection]);
+  }, [miners, sortOption, sortDirection, mode]);
 
   const filteredMiners = useMemo(() => {
     let result = rankedMiners;
@@ -225,14 +330,31 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
       );
     }
 
-    if (eligibilityFilter === 'eligible') {
-      result = result.filter((m) => m.isEligible);
-    } else if (eligibilityFilter === 'ineligible') {
-      result = result.filter((m) => !m.isEligible);
+    if (mode === 'leaderboard') {
+      const filterValue: EligibilityFilter = eligibilityFilter ?? 'all';
+      if (filterValue === 'ossEligible')
+        result = result.filter((m) => m.ossIsEligible ?? false);
+      else if (filterValue === 'ossIneligible')
+        result = result.filter((m) => !(m.ossIsEligible ?? false));
+      else if (filterValue === 'discoveriesEligible')
+        result = result.filter((m) => m.discoveriesIsEligible ?? false);
+      else if (filterValue === 'discoveriesIneligible')
+        result = result.filter((m) => !(m.discoveriesIsEligible ?? false));
+    } else {
+      const legacy = legacyEligibilityFilter ?? 'all';
+      if (legacy === 'eligible') result = result.filter((m) => m.isEligible);
+      else if (legacy === 'ineligible')
+        result = result.filter((m) => !m.isEligible);
     }
 
     return result;
-  }, [rankedMiners, searchQuery, eligibilityFilter]);
+  }, [
+    rankedMiners,
+    searchQuery,
+    eligibilityFilter,
+    legacyEligibilityFilter,
+    mode,
+  ]);
 
   useEffect(() => {
     if (visibleCount <= filteredMiners.length) return;
@@ -275,7 +397,7 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
         }}
       >
         <Box sx={{ p: 2, display: 'flex', flexDirection: 'column', gap: 1.5 }}>
-          {/* Row 1: Title + Search */}
+          {/* Row 1: Title + Search + Filters + View */}
           <Box
             sx={{
               display: 'flex',
@@ -300,35 +422,129 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
                 placeholder="Search miners..."
               />
             </Box>
-          </Box>
-
-          {/* Row 2: Sort tabs + Eligibility toggle */}
-          <Box
-            sx={{
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'space-between',
-              gap: 1,
-              flexWrap: 'wrap',
-            }}
-          >
-            <SortButtons
-              sortOption={sortOption}
-              sortDirection={sortDirection}
-              onSortChange={handleSortChange}
-              variant={variant}
-            />
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-              <EligibilityToggle
-                value={eligibilityFilter}
-                onChange={handleEligibilityChange}
-              />
+              {mode === 'leaderboard' ? (
+                <EligibilityMenu
+                  value={(eligibilityFilter ?? 'all') as EligibilityFilter}
+                  onChange={(next) => handleEligibilityChange(next)}
+                />
+              ) : (
+                <EligibilityToggle
+                  value={
+                    (legacyEligibilityFilter ??
+                      'all') as LegacyEligibilityFilter
+                  }
+                  onChange={handleEligibilityChange}
+                />
+              )}
               <ViewModeToggle
                 viewMode={viewMode}
                 onChange={handleViewModeChange}
               />
             </Box>
           </Box>
+
+          {/* Row 2: Sort controls (card view only — matches repositories UX) */}
+          {viewMode === 'cards' ? (
+            <Box
+              sx={{
+                display: 'flex',
+                justifyContent: 'flex-end',
+                alignItems: 'center',
+                gap: 1,
+              }}
+            >
+              <Typography
+                sx={{
+                  fontSize: '0.8rem',
+                  color: 'text.secondary',
+                }}
+              >
+                Sort:
+              </Typography>
+              <FormControl size="small">
+                <Select
+                  value={sortOption}
+                  onChange={(e) => {
+                    const next = e.target.value as SortOption;
+                    if (next !== sortOption) handleSortChange(next);
+                  }}
+                  sx={{
+                    color: 'text.primary',
+                    backgroundColor: 'background.default',
+                    fontSize: '0.8rem',
+                    height: '36px',
+                    borderRadius: 2,
+                    minWidth: '170px',
+                    '& fieldset': { borderColor: 'border.light' },
+                    '&:hover fieldset': { borderColor: 'border.medium' },
+                    '&.Mui-focused fieldset': { borderColor: 'primary.main' },
+                    '& .MuiSelect-select': { py: 0.75 },
+                  }}
+                >
+                  {(mode === 'leaderboard'
+                    ? ([
+                        { value: 'ossScore', label: 'OSS Score' },
+                        { value: 'issueScore', label: 'Issues Score' },
+                        { value: 'usdPerDay', label: 'Earnings' },
+                        { value: 'totalPRs', label: 'PRs' },
+                        { value: 'totalIssues', label: 'Issues' },
+                        { value: 'ossCredibility', label: 'OSS Credibility' },
+                        {
+                          value: 'issueCredibility',
+                          label: 'Issues Credibility',
+                        },
+                      ] as const)
+                    : ([
+                        { value: 'totalScore', label: 'Score' },
+                        { value: 'usdPerDay', label: 'Earnings' },
+                        ...(variant !== 'discoveries'
+                          ? [{ value: 'totalPRs', label: 'PRs' } as const]
+                          : []),
+                        ...(variant === 'discoveries' || variant === 'watchlist'
+                          ? [{ value: 'totalIssues', label: 'Issues' } as const]
+                          : []),
+                        { value: 'credibility', label: 'Credibility' },
+                      ] as const)
+                  ).map((opt) => (
+                    <MenuItem key={opt.value} value={opt.value}>
+                      {opt.label}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+              <Tooltip
+                title={sortDirection === 'asc' ? 'Ascending' : 'Descending'}
+              >
+                <IconButton
+                  size="small"
+                  onClick={() => handleSortChange(sortOption)}
+                  sx={{
+                    color: 'text.primary',
+                    border: '1px solid',
+                    borderColor: 'border.light',
+                    borderRadius: 2,
+                    padding: '6px',
+                    '&:hover': {
+                      backgroundColor: 'surface.light',
+                      borderColor: 'border.medium',
+                    },
+                  }}
+                  aria-label={
+                    sortDirection === 'asc'
+                      ? 'Sort descending'
+                      : 'Sort ascending'
+                  }
+                >
+                  {sortDirection === 'asc' ? (
+                    <ArrowUpwardIcon fontSize="small" />
+                  ) : (
+                    <ArrowDownwardIcon fontSize="small" />
+                  )}
+                </IconButton>
+              </Tooltip>
+            </Box>
+          ) : null}
         </Box>
       </SectionCard>
 
@@ -353,6 +569,7 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
           <MinersList
             miners={visibleMiners}
             variant={variant}
+            mode={mode}
             sortOption={sortOption}
             sortDirection={sortDirection}
             onSort={handleSortChange}
@@ -422,87 +639,6 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
     </Box>
   );
 };
-
-interface SortButtonsProps {
-  sortOption: SortOption;
-  sortDirection: SortOrder;
-  onSortChange: (option: SortOption) => void;
-  variant: LeaderboardVariant;
-}
-
-const SortButtons: React.FC<SortButtonsProps> = ({
-  sortOption,
-  sortDirection,
-  onSortChange,
-  variant,
-}) => (
-  <Box
-    sx={{
-      display: 'flex',
-      gap: 0.5,
-      flexWrap: 'wrap',
-      justifyContent: 'center',
-    }}
-  >
-    {[
-      { label: 'Score', value: 'totalScore' },
-      { label: 'Earnings', value: 'usdPerDay' },
-      ...(variant !== 'discoveries'
-        ? [{ label: 'PRs', value: 'totalPRs' as const }]
-        : []),
-      ...(variant === 'discoveries' || variant === 'watchlist'
-        ? [{ label: 'Issues', value: 'totalIssues' as const }]
-        : []),
-      { label: 'Credibility', value: 'credibility' },
-    ].map((option) => {
-      const isActive = sortOption === option.value;
-      return (
-        <Box
-          key={option.value}
-          onClick={() => onSortChange(option.value as SortOption)}
-          sx={(theme) => ({
-            px: 1.5,
-            height: 32,
-            display: 'flex',
-            alignItems: 'center',
-            gap: 0.5,
-            borderRadius: 2,
-            cursor: 'pointer',
-            backgroundColor: isActive
-              ? alpha(theme.palette.text.primary, 0.1)
-              : 'transparent',
-            color: isActive ? theme.palette.text.primary : STATUS_COLORS.open,
-            border: '1px solid',
-            borderColor: isActive ? theme.palette.border.medium : 'transparent',
-            transition: 'all 0.2s',
-            '&:hover': {
-              backgroundColor: theme.palette.surface.light,
-              color: theme.palette.text.primary,
-            },
-          })}
-        >
-          <Typography
-            sx={{
-              fontFamily: FONTS.mono,
-              fontSize: '0.75rem',
-              fontWeight: 600,
-            }}
-          >
-            {option.label}
-          </Typography>
-          {isActive && (
-            <Typography
-              component="span"
-              sx={{ fontSize: '0.7rem', opacity: 0.7 }}
-            >
-              {sortDirection === 'asc' ? '▲' : '▼'}
-            </Typography>
-          )}
-        </Box>
-      );
-    })}
-  </Box>
-);
 
 interface ViewModeToggleProps {
   viewMode: ViewMode;
@@ -582,16 +718,18 @@ const ViewModeToggle: React.FC<ViewModeToggleProps> = ({
 };
 
 interface EligibilityToggleProps {
-  value: EligibilityFilter;
-  onChange: (next: EligibilityFilter) => void;
+  value: LegacyEligibilityFilter;
+  onChange: (next: LegacyEligibilityFilter) => void;
 }
 
-const ELIGIBILITY_OPTIONS: Array<{ value: EligibilityFilter; label: string }> =
-  [
-    { value: 'all', label: 'All' },
-    { value: 'eligible', label: 'Eligible' },
-    { value: 'ineligible', label: 'Ineligible' },
-  ];
+const ELIGIBILITY_OPTIONS: Array<{
+  value: LegacyEligibilityFilter;
+  label: string;
+}> = [
+  { value: 'all', label: 'All' },
+  { value: 'eligible', label: 'Eligible' },
+  { value: 'ineligible', label: 'Ineligible' },
+];
 
 const EligibilityToggle: React.FC<EligibilityToggleProps> = ({
   value,
@@ -650,5 +788,80 @@ const EligibilityToggle: React.FC<EligibilityToggleProps> = ({
     })}
   </Box>
 );
+
+const ELIGIBILITY_MENU_OPTIONS: Array<{
+  value: EligibilityFilter;
+  label: string;
+}> = [
+  { value: 'all', label: 'All' },
+  { value: 'ossEligible', label: 'OSS eligible' },
+  { value: 'ossIneligible', label: 'OSS ineligible' },
+  { value: 'discoveriesEligible', label: 'Discoveries eligible' },
+  { value: 'discoveriesIneligible', label: 'Discoveries ineligible' },
+];
+
+const EligibilityMenu: React.FC<{
+  value: EligibilityFilter;
+  onChange: (next: EligibilityFilter) => void;
+}> = ({ value, onChange }) => {
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const open = Boolean(anchorEl);
+  const label =
+    ELIGIBILITY_MENU_OPTIONS.find((x) => x.value === value)?.label ?? 'All';
+
+  return (
+    <>
+      <Box
+        component="button"
+        type="button"
+        onClick={(e) => setAnchorEl(e.currentTarget)}
+        sx={(theme) => ({
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: 0.5,
+          height: 32,
+          px: 1.25,
+          borderRadius: 2,
+          border: `1px solid ${theme.palette.border.light}`,
+          backgroundColor: theme.palette.surface.subtle,
+          color: theme.palette.text.primary,
+          cursor: 'pointer',
+          fontFamily: FONTS.mono,
+          fontSize: '0.72rem',
+          fontWeight: 700,
+          textTransform: 'uppercase',
+          letterSpacing: '0.06em',
+          '&:hover': {
+            backgroundColor: theme.palette.surface.light,
+          },
+        })}
+      >
+        {label}
+        <KeyboardArrowDownIcon sx={{ fontSize: '1.1rem', opacity: 0.85 }} />
+      </Box>
+      <Menu
+        anchorEl={anchorEl}
+        open={open}
+        onClose={() => setAnchorEl(null)}
+        MenuListProps={{ dense: true }}
+      >
+        {ELIGIBILITY_MENU_OPTIONS.map((option, idx) => (
+          <React.Fragment key={option.value}>
+            {idx === 1 ? <Divider /> : null}
+            <MenuItem
+              selected={value === option.value}
+              onClick={() => {
+                onChange(option.value);
+                setAnchorEl(null);
+              }}
+            >
+              <ListItemText primary={option.label} />
+            </MenuItem>
+          </React.Fragment>
+        ))}
+      </Menu>
+    </>
+  );
+};
 
 export default TopMinersTable;

--- a/src/components/leaderboard/TopMinersTable.tsx
+++ b/src/components/leaderboard/TopMinersTable.tsx
@@ -157,7 +157,7 @@ const compareMiners = (
   }
 };
 
-const TopMinersTable: React.FC<TopMinersTableProps> = ({
+export const TopMinersTable: React.FC<TopMinersTableProps> = ({
   miners,
   isLoading,
   getMinerHref,

--- a/src/components/leaderboard/index.ts
+++ b/src/components/leaderboard/index.ts
@@ -1,5 +1,5 @@
 // Components
-export { default as TopMinersTable } from './TopMinersTable';
+export { TopMinersTable } from './TopMinersTable';
 export { default as TopRepositoriesTable } from './TopRepositoriesTable';
 export { LeaderboardSidebar } from './LeaderboardSidebar';
 export { ActivitySidebarCards, StatRow } from './ActivitySidebarCards';

--- a/src/components/leaderboard/types.ts
+++ b/src/components/leaderboard/types.ts
@@ -53,12 +53,18 @@ export interface RepoStats {
 
 export type LeaderboardVariant = 'oss' | 'discoveries' | 'watchlist';
 
+export type LeaderboardMode = 'default' | 'leaderboard';
+
 export type SortOption =
   | 'totalScore'
+  | 'ossScore'
+  | 'issueScore'
   | 'usdPerDay'
   | 'totalPRs'
   | 'totalIssues'
-  | 'credibility';
+  | 'credibility'
+  | 'ossCredibility'
+  | 'issueCredibility';
 
 export const FONTS = {
   mono: '"JetBrains Mono", monospace',

--- a/src/pages/LeaderboardPage.tsx
+++ b/src/pages/LeaderboardPage.tsx
@@ -1,0 +1,114 @@
+import React, { useMemo } from 'react';
+import { Box, Typography, alpha, useMediaQuery } from '@mui/material';
+import { Page } from '../components/layout';
+import {
+  LeaderboardSidebar,
+  SEO,
+  TopMinersTable,
+  type MinerStats,
+} from '../components';
+import { useAllMiners } from '../api';
+import { mapAllMinersToStats } from '../utils/minerMapper';
+import theme, { scrollbarSx } from '../theme';
+
+const MINER_LINK_STATE = { backLabel: 'Back to Leaderboard' } as const;
+
+const getMinerHref = (miner: MinerStats) =>
+  `/miners/details?githubId=${miner.githubId}`;
+
+const LeaderboardPage: React.FC = () => {
+  const allMinerStatsQuery = useAllMiners();
+  const allMinersStats = allMinerStatsQuery?.data;
+  const isLoadingMinerStats = allMinerStatsQuery?.isLoading;
+
+  const minerStats = useMemo(
+    () =>
+      Array.isArray(allMinersStats) ? mapAllMinersToStats(allMinersStats) : [],
+    [allMinersStats],
+  );
+
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+  const isTablet = useMediaQuery(theme.breakpoints.between('sm', 'md'));
+  const isLargeScreen = useMediaQuery(theme.breakpoints.up('xl'));
+  const showSidebarRight = useMediaQuery(theme.breakpoints.up('xl'));
+
+  const sidebarWidth =
+    isMobile || isTablet ? '100%' : isLargeScreen ? '340px' : '300px';
+
+  return (
+    <Page title="Leaderboard">
+      <SEO
+        title="Leaderboard"
+        description="Gittensor leaderboard across OSS contributions and discoveries."
+      />
+      <Box
+        sx={{
+          width: '100%',
+          height: showSidebarRight ? 'calc(100vh - 64px)' : 'auto',
+          display: 'flex',
+          flexDirection: showSidebarRight ? 'row' : 'column',
+          gap: { xs: 2, sm: 2, md: 2.5, lg: 3 },
+          py: { xs: 2, sm: 2, md: 2.5, lg: 3 },
+          px: { xs: 2, sm: 2, md: 2.5, lg: 3 },
+          overflow: 'hidden',
+        }}
+      >
+        <Box
+          sx={{
+            flex: 1,
+            display: 'flex',
+            flexDirection: 'column',
+            gap: { xs: 2, sm: 1.5 },
+            minHeight: 0,
+            overflow: showSidebarRight ? 'auto' : 'visible',
+            minWidth: 0,
+            pr: showSidebarRight ? 1 : 0,
+            ...scrollbarSx,
+          }}
+        >
+          <Typography
+            sx={{
+              fontSize: '0.8rem',
+              color: (t) => alpha(t.palette.text.primary, 0.5),
+              lineHeight: 1.6,
+            }}
+          >
+            Compare OSS contribution rewards and discovery rewards in one place.
+            Score and Credibility can be sorted by either program.
+          </Typography>
+
+          <TopMinersTable
+            miners={minerStats}
+            isLoading={isLoadingMinerStats}
+            getMinerHref={(m) => getMinerHref(m)}
+            linkState={MINER_LINK_STATE}
+            variant="watchlist"
+            mode="leaderboard"
+            showDualEligibilityBadges
+          />
+        </Box>
+
+        <Box
+          sx={{
+            width: showSidebarRight ? sidebarWidth : '100%',
+            height: showSidebarRight ? '100%' : 'auto',
+            maxHeight: showSidebarRight ? '100%' : 'none',
+            flexShrink: 0,
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 2,
+          }}
+        >
+          <LeaderboardSidebar
+            miners={minerStats}
+            getMinerHref={(m) => getMinerHref(m)}
+            linkState={MINER_LINK_STATE}
+            variant="watchlist"
+          />
+        </Box>
+      </Box>
+    </Page>
+  );
+};
+
+export default LeaderboardPage;

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -16,14 +16,13 @@ const DashboardPage = React.lazy(
 const IssuesPage = React.lazy(() => import('./pages/IssuesPage'));
 const SearchPage = React.lazy(() => import('./pages/search/SearchPage'));
 const IssueDetailsPage = React.lazy(() => import('./pages/IssueDetailsPage'));
-const TopMinersPage = React.lazy(() => import('./pages/TopMinersPage'));
 const RepositoriesPage = React.lazy(() => import('./pages/RepositoriesPage'));
 const MinerDetailsPage = React.lazy(() => import('./pages/MinerDetailsPage'));
 const RepositoryDetailsPage = React.lazy(
   () => import('./pages/RepositoryDetailsPage'),
 );
 const PRDetailsPage = React.lazy(() => import('./pages/PRDetailsPage'));
-const DiscoveriesPage = React.lazy(() => import('./pages/DiscoveriesPage'));
+const LeaderboardPage = React.lazy(() => import('./pages/LeaderboardPage'));
 const OnboardPage = React.lazy(() => import('./pages/OnboardPage'));
 const WatchlistPage = React.lazy(() => import('./pages/WatchlistPage'));
 
@@ -53,13 +52,19 @@ const routesArray: AppRoute[] = [
   {
     name: 'discoveries',
     path: '/discoveries',
-    element: <DiscoveriesPage />,
+    element: <Navigate to="/leaderboard" replace />,
+    showGlobalSearch: true,
+  },
+  {
+    name: 'leaderboard',
+    path: '/leaderboard',
+    element: <LeaderboardPage />,
     showGlobalSearch: true,
   },
   {
     name: 'top-miners',
     path: '/top-miners',
-    element: <TopMinersPage />,
+    element: <Navigate to="/leaderboard" replace />,
     showGlobalSearch: true,
   },
   {

--- a/src/utils/minerMapper.ts
+++ b/src/utils/minerMapper.ts
@@ -18,6 +18,12 @@ export const mapAllMinersToStats = (
     totalScore: parseNumber(stat.totalScore),
     baseTotalScore: parseNumber(stat.baseTotalScore),
     totalPRs: parseNumber(stat.totalPrs),
+    // Discovered issues count (issue discovery program):
+    // total issues the miner has discovered across statuses.
+    totalIssues:
+      parseNumber(stat.totalSolvedIssues) +
+      parseNumber(stat.totalOpenIssues) +
+      parseNumber(stat.totalClosedIssues),
     linesChanged: parseNumber(stat.totalNodesScored),
     linesAdded: parseNumber(stat.totalAdditions),
     linesDeleted: parseNumber(stat.totalDeletions),


### PR DESCRIPTION
## Summary

- Merged “OSS Contributions” and “Issue Discoveries” into a single Leaderboard nav entry and unified /leaderboard page with an OSS/Issues toggle.
- Kept legacy deep links working by redirecting /top-miners → /leaderboard?tab=oss and /discoveries → /leaderboard?tab=discoveries.
- Updated leaderboard UI so miner cards stay visually consistent (Watchlist-style dual PR/Issue signals) while OSS/Issues mode primarily affects sorting/labels and the right sidebar context.

## Related Issues

Closes #704 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

<img width="1823" height="948" alt="image" src="https://github.com/user-attachments/assets/1c53edff-b1ef-40a4-bed8-faca27d327f4" />