### PR TITLE
feat(repositories): add author filter to pull requests tab

### DIFF
--- a/src/components/repositories/AuthorFilter.tsx
+++ b/src/components/repositories/AuthorFilter.tsx
@@ -1,0 +1,367 @@
+import React, { useCallback, useMemo, useState } from 'react';
+import {
+  Avatar,
+  Box,
+  Button,
+  IconButton,
+  InputAdornment,
+  List,
+  ListItemButton,
+  Popover,
+  Stack,
+  TextField,
+  Typography,
+  alpha,
+} from '@mui/material';
+import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
+import CheckIcon from '@mui/icons-material/Check';
+import CloseIcon from '@mui/icons-material/Close';
+import SearchIcon from '@mui/icons-material/Search';
+import { useAllMiners } from '../../api';
+import { TEXT_OPACITY, scrollbarSx } from '../../theme';
+
+export const AUTHOR_FILTER_ALL = 'all';
+
+type AuthorStatus = 'eligible' | 'ineligible';
+
+interface AuthorOption {
+  author: string;
+  count: number;
+  status: AuthorStatus;
+}
+
+export interface AuthorFilterProps<T> {
+  items: T[];
+  getAuthor: (item: T) => string | null | undefined;
+  getGithubId: (item: T) => string | null | undefined;
+  value: string;
+  onChange: (nextAuthor: string) => void;
+}
+
+export const AuthorFilter = <T,>({
+  items,
+  getAuthor,
+  getGithubId,
+  value,
+  onChange,
+}: AuthorFilterProps<T>): React.ReactElement | null => {
+  const { data: allMiners } = useAllMiners();
+
+  const eligibilityByGithubId = useMemo(() => {
+    const map = new Map<string, boolean>();
+    for (const m of allMiners ?? []) {
+      if (m.githubId) map.set(m.githubId, Boolean(m.isEligible));
+    }
+    return map;
+  }, [allMiners]);
+
+  const authorOptions = useMemo<AuthorOption[]>(() => {
+    const meta = new Map<string, { count: number; githubId: string | null }>();
+    for (const item of items) {
+      const author = getAuthor(item);
+      if (!author) continue;
+      const existing = meta.get(author);
+      meta.set(author, {
+        count: (existing?.count ?? 0) + 1,
+        githubId: existing?.githubId ?? getGithubId(item) ?? null,
+      });
+    }
+    return Array.from(meta.entries())
+      .map(([author, { count, githubId }]) => {
+        const eligible = githubId
+          ? eligibilityByGithubId.get(githubId)
+          : undefined;
+        if (eligible === undefined) return null;
+        return {
+          author,
+          count,
+          status: eligible ? 'eligible' : 'ineligible',
+        } satisfies AuthorOption;
+      })
+      .filter((option): option is AuthorOption => option !== null)
+      .sort((a, b) => b.count - a.count || a.author.localeCompare(b.author));
+  }, [items, getAuthor, getGithubId, eligibilityByGithubId]);
+
+  const [anchor, setAnchor] = useState<HTMLElement | null>(null);
+  const [search, setSearch] = useState('');
+  const isOpen = Boolean(anchor);
+
+  const open = useCallback((event: React.MouseEvent<HTMLElement>) => {
+    setAnchor(event.currentTarget);
+  }, []);
+
+  const close = useCallback(() => {
+    setAnchor(null);
+    setSearch('');
+  }, []);
+
+  const pick = useCallback(
+    (nextAuthor: string) => {
+      onChange(nextAuthor);
+      close();
+    },
+    [onChange, close],
+  );
+
+  const normalizedSearch = search.trim().toLowerCase();
+  const visibleOptions = useMemo(
+    () =>
+      normalizedSearch
+        ? authorOptions.filter(({ author }) =>
+            author.toLowerCase().includes(normalizedSearch),
+          )
+        : authorOptions,
+    [authorOptions, normalizedSearch],
+  );
+
+  if (authorOptions.length <= 1) return null;
+
+  const isFiltering = value !== AUTHOR_FILTER_ALL;
+
+  return (
+    <>
+      <Button
+        size="small"
+        onClick={open}
+        aria-haspopup="true"
+        aria-expanded={isOpen}
+        endIcon={<ArrowDropDownIcon sx={{ fontSize: '1rem' }} />}
+        sx={{
+          color: isFiltering ? 'text.primary' : 'text.tertiary',
+          backgroundColor: isFiltering ? 'border.subtle' : 'transparent',
+          borderRadius: '6px',
+          px: 2,
+          minWidth: 'auto',
+          textTransform: 'none',
+          fontSize: '0.8rem',
+          border: '1px solid',
+          borderColor: isFiltering ? 'border.light' : 'transparent',
+          '&:hover': { backgroundColor: 'border.light' },
+        }}
+      >
+        {!isFiltering ? (
+          'Author'
+        ) : (
+          <Stack direction="row" alignItems="center" spacing={0.75}>
+            <Avatar
+              src={`https://avatars.githubusercontent.com/${value}`}
+              alt={value}
+              sx={{ width: 16, height: 16 }}
+            />
+            <Box
+              component="span"
+              sx={{
+                maxWidth: 120,
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+              }}
+            >
+              {value}
+            </Box>
+            <Box
+              component="span"
+              role="button"
+              aria-label="Clear author filter"
+              tabIndex={0}
+              onClick={(event) => {
+                event.stopPropagation();
+                pick(AUTHOR_FILTER_ALL);
+              }}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter' || event.key === ' ') {
+                  event.stopPropagation();
+                  event.preventDefault();
+                  pick(AUTHOR_FILTER_ALL);
+                }
+              }}
+              sx={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                width: 16,
+                height: 16,
+                borderRadius: '50%',
+                color: 'text.tertiary',
+                cursor: 'pointer',
+                '&:hover': { color: 'text.primary' },
+              }}
+            >
+              <CloseIcon sx={{ fontSize: '0.85rem' }} />
+            </Box>
+          </Stack>
+        )}
+      </Button>
+      <Popover
+        open={isOpen}
+        anchorEl={anchor}
+        onClose={close}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+        transformOrigin={{ vertical: 'top', horizontal: 'left' }}
+        slotProps={{
+          paper: {
+            elevation: 8,
+            sx: {
+              mt: 0.5,
+              width: 280,
+              backgroundColor: 'background.default',
+              backgroundImage: 'none',
+            },
+          },
+        }}
+      >
+        <Box
+          sx={{
+            px: 1.5,
+            py: 1,
+            borderBottom: '1px solid',
+            borderColor: 'border.light',
+          }}
+        >
+          <Stack
+            direction="row"
+            alignItems="center"
+            justifyContent="space-between"
+            sx={{ mb: 1 }}
+          >
+            <Typography
+              sx={{
+                fontSize: '0.75rem',
+                fontWeight: 600,
+                color: 'text.secondary',
+              }}
+            >
+              Filter by author
+            </Typography>
+            {isFiltering && (
+              <IconButton
+                size="small"
+                aria-label="Clear author filter"
+                onClick={() => pick(AUTHOR_FILTER_ALL)}
+                sx={{
+                  p: 0.25,
+                  color: 'text.tertiary',
+                  '&:hover': { color: 'text.primary' },
+                }}
+              >
+                <CloseIcon sx={{ fontSize: '0.95rem' }} />
+              </IconButton>
+            )}
+          </Stack>
+          <TextField
+            size="small"
+            fullWidth
+            autoFocus
+            placeholder="Filter users"
+            value={search}
+            onChange={(event) => setSearch(event.target.value)}
+            InputProps={{
+              startAdornment: (
+                <InputAdornment position="start">
+                  <SearchIcon
+                    sx={{ fontSize: '0.95rem', color: 'text.tertiary' }}
+                  />
+                </InputAdornment>
+              ),
+            }}
+            sx={{
+              '& .MuiOutlinedInput-root': {
+                fontSize: '0.8rem',
+                color: 'text.primary',
+                backgroundColor: 'transparent',
+                height: 30,
+                borderRadius: 1.5,
+                '& fieldset': { borderColor: 'border.light' },
+                '&:hover fieldset': { borderColor: 'border.medium' },
+                '&.Mui-focused fieldset': { borderColor: 'primary.main' },
+              },
+            }}
+          />
+        </Box>
+        <List
+          dense
+          disablePadding
+          sx={{
+            maxHeight: 280,
+            overflowY: 'auto',
+            ...scrollbarSx,
+          }}
+        >
+          {visibleOptions.length === 0 ? (
+            <Box sx={{ px: 1.5, py: 1.5 }}>
+              <Typography sx={{ fontSize: '0.75rem', color: 'text.tertiary' }}>
+                No authors match &ldquo;{search}&rdquo;
+              </Typography>
+            </Box>
+          ) : (
+            visibleOptions.map(({ author, count, status }) => (
+              <AuthorRow
+                key={author}
+                author={author}
+                count={count}
+                isSelected={value === author}
+                isDisabled={status === 'ineligible'}
+                onClick={() => pick(author)}
+              />
+            ))
+          )}
+        </List>
+      </Popover>
+    </>
+  );
+};
+
+interface AuthorRowProps {
+  author: string;
+  count: number;
+  isSelected: boolean;
+  isDisabled: boolean;
+  onClick: () => void;
+}
+
+const AuthorRow: React.FC<AuthorRowProps> = ({
+  author,
+  count,
+  isSelected,
+  isDisabled,
+  onClick,
+}) => (
+  <ListItemButton
+    onClick={onClick}
+    selected={isSelected}
+    disabled={isDisabled}
+    sx={{ py: 0.5, px: 1.5, gap: 1, minHeight: 32 }}
+  >
+    <CheckIcon
+      sx={{
+        fontSize: '0.95rem',
+        color: isSelected ? 'text.primary' : 'transparent',
+      }}
+    />
+    <Avatar
+      src={`https://avatars.githubusercontent.com/${author}`}
+      alt={author}
+      sx={{ width: 18, height: 18 }}
+    />
+    <Typography
+      sx={{
+        fontSize: '0.8rem',
+        flex: 1,
+        color: 'text.primary',
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+        whiteSpace: 'nowrap',
+      }}
+    >
+      {author}
+    </Typography>
+    <Typography
+      sx={{
+        fontSize: '0.72rem',
+        color: (t) => alpha(t.palette.text.primary, TEXT_OPACITY.tertiary),
+      }}
+    >
+      {count}
+    </Typography>
+  </ListItemButton>
+);

--- a/src/components/repositories/RepositoryPRsTable.tsx
+++ b/src/components/repositories/RepositoryPRsTable.tsx
@@ -9,7 +9,7 @@ import {
   Typography,
   alpha,
 } from '@mui/material';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useAllPrs, type CommitLog } from '../../api';
 import {
   DataTable,
@@ -18,6 +18,7 @@ import {
 import theme, { TEXT_OPACITY, scrollbarSx } from '../../theme';
 import { filterPrs, getPrStatusCounts, type PrStatusFilter } from '../../utils';
 import FilterButton from '../FilterButton';
+import { AUTHOR_FILTER_ALL, AuthorFilter } from './AuthorFilter';
 
 type PrSortField =
   | 'pullRequestNumber'
@@ -40,9 +41,26 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
   state = 'all',
 }) => {
   const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
   const [filter, setFilter] = useState<PrStatusFilter>(state);
   const [sortField, setSortField] = useState<PrSortField>('score');
   const [sortOrder, setSortOrder] = useState<SortOrder>('desc');
+  const authorFilter = searchParams.get('prAuthor') ?? AUTHOR_FILTER_ALL;
+
+  const setAuthorFilter = useCallback(
+    (nextAuthor: string) => {
+      setSearchParams(
+        (prev) => {
+          const nextParams = new URLSearchParams(prev);
+          if (nextAuthor === AUTHOR_FILTER_ALL) nextParams.delete('prAuthor');
+          else nextParams.set('prAuthor', nextAuthor);
+          return nextParams;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
+  );
 
   const handleSort = (field: PrSortField) => {
     if (sortField === field) {
@@ -70,10 +88,11 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
     return getPrStatusCounts(allPRs);
   }, [allPRs]);
 
-  const filteredPRs = useMemo(
-    () => filterPrs(allPRs ?? [], { statusFilter: filter }),
-    [allPRs, filter],
-  );
+  const filteredPRs = useMemo(() => {
+    const byStatus = filterPrs(allPRs ?? [], { statusFilter: filter });
+    if (authorFilter === AUTHOR_FILTER_ALL) return byStatus;
+    return byStatus.filter((pr) => pr.author === authorFilter);
+  }, [allPRs, filter, authorFilter]);
 
   const sortedPRs = useMemo(() => {
     const dir = sortOrder === 'asc' ? 1 : -1;
@@ -126,7 +145,13 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
   );
 
   const filterButtons = (
-    <Stack direction="row" spacing={1}>
+    <Stack
+      direction="row"
+      spacing={1}
+      alignItems="center"
+      flexWrap="wrap"
+      useFlexGap
+    >
       <FilterButton
         label="All"
         isActive={filter === 'all'}
@@ -154,6 +179,13 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
         onClick={() => setFilter('closed')}
         count={counts.closed}
         color={theme.palette.status.closed}
+      />
+      <AuthorFilter
+        items={allPRs}
+        getAuthor={(pr) => pr.author}
+        getGithubId={(pr) => pr.githubId}
+        value={authorFilter}
+        onChange={setAuthorFilter}
       />
     </Stack>
   );


### PR DESCRIPTION
## Summary

Adds a GitHub-style **Author** filter to the Repository Detail page's Pull Requests tab. Sits inline with the existing status filter (`All / Open / Merged / Closed`) and narrows the PR list to a single miner's contributions.

### Behavior

- **Trigger**: compact button styled like sibling `FilterButton`s. Reads `Author ▾` when unset, shows `avatar + @login + × + ▾` chip when an author is selected. Clicking the inline × clears the filter without opening the popover.
- **Popover**: pure-black background (MUI's dark-mode elevation overlay is suppressed so it doesn't lift to grey), border-outlined search input, scrollable list with project scrollbar styling, header with `Filter by author` + clear × when a filter is active.
- **Miner-only list**: only miners appear in the dropdown (cross-referenced against `useAllMiners()` by `githubId`). Maintainers and external contributors are hidden since filtering by them doesn't tie into scoring.
- **Ineligible miners**: shown but **disabled** (greyed, unclickable) — visible as context of who's contributing, not selectable as a filter value.
- **URL persistence**: selected author syncs to `?prAuthor=<login>` with `{ replace: true }` — survives refresh, is shareable.
- **Auto-hide**: the filter button disappears when the tab has ≤1 miner contributor (nothing useful to filter).

### Implementation notes

- `AuthorFilter` extracted as a generic `<T>` component at `src/components/repositories/AuthorFilter.tsx`. It takes `items`, `getAuthor`, optional `getGithubId`, plus externally-owned `value` + `onChange` — keeps URL-param semantics per-caller so a future call site can pick its own param name.
- Classification cross-references `useAllMiners()` via two lookup maps: `githubId` (rename-stable) and `githubUsername` (fallback). PRs use `githubId` since `CommitLog.githubId` is always available.
- Popover styling mirrors the `Rows` Select dropdown convention in `TopRepositoriesTable` (MUI `elevation={8}`, default border-radius, default `action.hover` / `action.selected`).
- All colors reference theme tokens — zero hardcoded hex / rgba in the new code.
- `RepositoryPRsTable` inline implementation shrank once the shared component replaced the embedded filter UI.

## Related Issues

Closes https://github.com/entrius/gittensor-ui/issues/146

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

| Before | After |
| --------------------------- | ------------------------ |
| <img width="1211" height="803" alt="Screenshot 2026-04-21 173104" src="https://github.com/user-attachments/assets/732a0f4c-8f27-48ae-aba8-c119d0744a0f" /> | <img width="1304" height="806" alt="Screenshot 2026-04-21 174821" src="https://github.com/user-attachments/assets/9a2213cb-b8a7-47c7-b18f-402771b8892d" /> |

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes