### PR TITLE
Watchlist controls on Repositories + Bounties surfaces

### DIFF
--- a/src/components/issues/IssuesList.tsx
+++ b/src/components/issues/IssuesList.tsx
@@ -38,6 +38,7 @@ import { STATUS_COLORS, TEXT_OPACITY } from '../../theme';
 import { DataTable, type DataTableColumn } from '../common/DataTable';
 import BountyProgress from './BountyProgress';
 import FilterButton from '../FilterButton';
+import { WatchlistButton } from '../common/WatchlistButton';
 
 type FilterType = 'all' | 'available' | 'pending' | 'history';
 type SortDirection = 'asc' | 'desc';
@@ -563,6 +564,16 @@ const IssuesList: React.FC<IssuesListProps> = ({
       ),
     };
 
+    const watchlistColumn: DataTableColumn<IssueBounty, SortKey> = {
+      key: 'watchlist',
+      header: '',
+      width: '56px',
+      align: 'center',
+      renderCell: (issue) => (
+        <WatchlistButton category="bounties" itemKey={String(issue.id)} />
+      ),
+    };
+
     if (filterType === 'pending') {
       return [
         idColumn,
@@ -571,6 +582,7 @@ const IssuesList: React.FC<IssuesListProps> = ({
         bountyColumn('Target Bounty', '140px'),
         fundingColumn,
         statusColumn('110px'),
+        watchlistColumn,
       ];
     }
     if (filterType === 'history') {
@@ -586,6 +598,7 @@ const IssuesList: React.FC<IssuesListProps> = ({
         solverColumn,
         statusColumn('110px'),
         dateColumn,
+        watchlistColumn,
       ];
     }
     // 'all' and 'available' share the same column set
@@ -595,6 +608,7 @@ const IssuesList: React.FC<IssuesListProps> = ({
       issueColumn,
       bountyColumn('Bounty', '120px'),
       statusColumn('110px'),
+      watchlistColumn,
     ];
   }, [filterType, theme, taoPrice, alphaPrice]);
 

--- a/src/components/leaderboard/RepositoryCard.tsx
+++ b/src/components/leaderboard/RepositoryCard.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Avatar, Box, Card, Tooltip, Typography } from '@mui/material';
 import { alpha } from '@mui/material/styles';
 import { linkResetSx, useLinkBehavior } from '../common/linkBehavior';
+import { WatchlistButton } from '../common/WatchlistButton';
 import { RankIcon } from './RankIcon';
 import {
   FONTS,
@@ -161,6 +162,8 @@ export const RepositoryCard: React.FC<RepositoryCardProps> = ({
         >
           {isInactive ? 'Inactive' : 'Active'}
         </Typography>
+
+        <WatchlistButton category="repos" itemKey={repo.repository || ''} />
       </Box>
 
       <Box>

--- a/src/components/leaderboard/TopRepositoriesTable.tsx
+++ b/src/components/leaderboard/TopRepositoriesTable.tsx
@@ -45,6 +45,7 @@ import ViewListIcon from '@mui/icons-material/ViewList';
 import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
 import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
 import FilterButton from '../FilterButton';
+import { WatchlistButton } from '../common/WatchlistButton';
 import { RepositoryCard } from './RepositoryCard';
 import {
   REPOSITORIES_CARD_ROWS,
@@ -1127,6 +1128,11 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
                 >
                   Contributors
                 </SortableHeader>
+                <TableCell
+                  sx={{ ...headerCellStyle, width: '56px', textAlign: 'center' }}
+                >
+                  
+                </TableCell>
               </TableRow>
             </TableHead>
             <TableBody>
@@ -1279,6 +1285,20 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
                               ? repo.uniqueMiners?.size
                               : '-'}
                           </Typography>
+                        </TableCell>
+
+                        <TableCell
+                          sx={{
+                            ...bodyCellStyle,
+                            width: '56px',
+                            textAlign: 'center',
+                            pr: 1,
+                          }}
+                        >
+                          <WatchlistButton
+                            category="repos"
+                            itemKey={repo.repository || ''}
+                          />
                         </TableCell>
                       </LinkTableRow>
                     );


### PR DESCRIPTION
Implements watchlist (star) controls on key surfaces so users can pin/unpin without leaving context:\n\n- Repositories: adds WatchlistButton to TopRepositoriesTable (list view) and RepositoryCard (card view)\n- Bounties: adds WatchlistButton column to IssuesList tables\n\nThis supports Watchlist UX parity requested in #706.\n\nRefs: #706