### PR TITLE
feat: new status card for miners activity

### DIFF
--- a/src/components/leaderboard/ActivitySidebarCards.tsx
+++ b/src/components/leaderboard/ActivitySidebarCards.tsx
@@ -13,6 +13,26 @@ interface ActivitySidebarCardsProps {
 export const ActivitySidebarCards: React.FC<ActivitySidebarCardsProps> = ({
   miners,
 }) => {
+  const eligibilityStats = useMemo(() => {
+    const all = miners.length;
+    const ossEligible = miners.filter((m) => !!m.ossIsEligible).length;
+    const discoveryEligible = miners.filter(
+      (m) => !!m.discoveriesIsEligible,
+    ).length;
+
+    return {
+      all,
+      oss: {
+        eligible: ossEligible,
+        ineligible: Math.max(0, all - ossEligible),
+      },
+      discovery: {
+        eligible: discoveryEligible,
+        ineligible: Math.max(0, all - discoveryEligible),
+      },
+    };
+  }, [miners]);
+
   const minerActivityStats = useMemo(() => {
     const all = miners.length;
     const eligiblePr = miners.filter((m) => m.ossIsEligible).length;
@@ -106,6 +126,162 @@ export const ActivitySidebarCards: React.FC<ActivitySidebarCardsProps> = ({
 
   return (
     <>
+      {/* CARD 0: Miners Activity */}
+      <SectionCard title="Miners Activity" sx={{ flexShrink: 0 }}>
+        <Box sx={{ px: 2, pt: 1, pb: 2 }}>
+          <Box
+            sx={(theme) => ({
+              display: 'grid',
+              gridTemplateColumns: '1fr 1fr 1fr',
+              gap: 1,
+              pb: 2,
+              borderBottom: `1px solid ${theme.palette.border.light}`,
+              mb: 2,
+            })}
+          >
+            <Typography
+              sx={{
+                fontFamily: FONTS.mono,
+                fontSize: '0.7rem',
+                color: STATUS_COLORS.open,
+                textTransform: 'uppercase',
+              }}
+            />
+            <Typography
+              sx={{
+                fontFamily: FONTS.mono,
+                fontSize: '0.7rem',
+                color: STATUS_COLORS.open,
+                textTransform: 'uppercase',
+                textAlign: 'center',
+              }}
+            >
+              PR
+            </Typography>
+            <Typography
+              sx={{
+                fontFamily: FONTS.mono,
+                fontSize: '0.7rem',
+                color: STATUS_COLORS.open,
+                textTransform: 'uppercase',
+                textAlign: 'center',
+              }}
+            >
+              Issue
+            </Typography>
+          </Box>
+
+          <Box
+            sx={{
+              display: 'grid',
+              gridTemplateColumns: '1fr 1fr 1fr',
+              columnGap: 1,
+              rowGap: 1.5,
+              alignItems: 'center',
+            }}
+          >
+            <Typography
+              sx={{
+                fontFamily: FONTS.mono,
+                fontSize: '0.75rem',
+                color: STATUS_COLORS.open,
+                textTransform: 'uppercase',
+              }}
+            >
+              All
+            </Typography>
+            <Typography
+              sx={{
+                fontFamily: FONTS.mono,
+                fontSize: '1.05rem',
+                fontWeight: 600,
+                color: STATUS_COLORS.open,
+                textAlign: 'center',
+              }}
+            >
+              {eligibilityStats.all.toLocaleString()}
+            </Typography>
+            <Typography
+              sx={{
+                fontFamily: FONTS.mono,
+                fontSize: '1.05rem',
+                fontWeight: 600,
+                color: STATUS_COLORS.open,
+                textAlign: 'center',
+              }}
+            >
+              {eligibilityStats.all.toLocaleString()}
+            </Typography>
+
+            <Typography
+              sx={{
+                fontFamily: FONTS.mono,
+                fontSize: '0.75rem',
+                color: STATUS_COLORS.open,
+                textTransform: 'uppercase',
+              }}
+            >
+              Eligible
+            </Typography>
+            <Typography
+              sx={{
+                fontFamily: FONTS.mono,
+                fontSize: '1.05rem',
+                fontWeight: 600,
+                color: STATUS_COLORS.merged,
+                textAlign: 'center',
+              }}
+            >
+              {eligibilityStats.oss.eligible.toLocaleString()}
+            </Typography>
+            <Typography
+              sx={{
+                fontFamily: FONTS.mono,
+                fontSize: '1.05rem',
+                fontWeight: 600,
+                color: STATUS_COLORS.merged,
+                textAlign: 'center',
+              }}
+            >
+              {eligibilityStats.discovery.eligible.toLocaleString()}
+            </Typography>
+
+            <Typography
+              sx={{
+                fontFamily: FONTS.mono,
+                fontSize: '0.75rem',
+                color: STATUS_COLORS.open,
+                textTransform: 'uppercase',
+              }}
+            >
+              Ineligible
+            </Typography>
+            <Typography
+              sx={{
+                fontFamily: FONTS.mono,
+                fontSize: '1.05rem',
+                fontWeight: 600,
+                color: STATUS_COLORS.closed,
+                textAlign: 'center',
+              }}
+            >
+              {eligibilityStats.oss.ineligible.toLocaleString()}
+            </Typography>
+            <Typography
+              sx={{
+                fontFamily: FONTS.mono,
+                fontSize: '1.05rem',
+                fontWeight: 600,
+                color: STATUS_COLORS.closed,
+                textAlign: 'center',
+              }}
+            >
+              {eligibilityStats.discovery.ineligible.toLocaleString()}
+            </Typography>
+          </Box>
+        </Box>
+      </SectionCard>
+
       {/* CARD 1: Miners Activity */}
       <SectionCard title="Miners Activity" sx={{ flexShrink: 0 }}>
         <Box sx={{ px: 2, pt: 1, pb: 2 }}>

--- a/src/components/leaderboard/ActivitySidebarCards.tsx
+++ b/src/components/leaderboard/ActivitySidebarCards.tsx
@@ -13,26 +13,6 @@ interface ActivitySidebarCardsProps {
 export const ActivitySidebarCards: React.FC<ActivitySidebarCardsProps> = ({
   miners,
 }) => {
-  const eligibilityStats = useMemo(() => {
-    const all = miners.length;
-    const ossEligible = miners.filter((m) => !!m.ossIsEligible).length;
-    const discoveryEligible = miners.filter(
-      (m) => !!m.discoveriesIsEligible,
-    ).length;
-
-    return {
-      all,
-      oss: {
-        eligible: ossEligible,
-        ineligible: Math.max(0, all - ossEligible),
-      },
-      discovery: {
-        eligible: discoveryEligible,
-        ineligible: Math.max(0, all - discoveryEligible),
-      },
-    };
-  }, [miners]);
-
   const minerActivityStats = useMemo(() => {
     const all = miners.length;
     const eligiblePr = miners.filter((m) => m.ossIsEligible).length;
@@ -126,162 +106,6 @@ export const ActivitySidebarCards: React.FC<ActivitySidebarCardsProps> = ({
 
   return (
     <>
-      {/* CARD 0: Miners Activity */}
-      <SectionCard title="Miners Activity" sx={{ flexShrink: 0 }}>
-        <Box sx={{ px: 2, pt: 1, pb: 2 }}>
-          <Box
-            sx={(theme) => ({
-              display: 'grid',
-              gridTemplateColumns: '1fr 1fr 1fr',
-              gap: 1,
-              pb: 2,
-              borderBottom: `1px solid ${theme.palette.border.light}`,
-              mb: 2,
-            })}
-          >
-            <Typography
-              sx={{
-                fontFamily: FONTS.mono,
-                fontSize: '0.7rem',
-                color: STATUS_COLORS.open,
-                textTransform: 'uppercase',
-              }}
-            />
-            <Typography
-              sx={{
-                fontFamily: FONTS.mono,
-                fontSize: '0.7rem',
-                color: STATUS_COLORS.open,
-                textTransform: 'uppercase',
-                textAlign: 'center',
-              }}
-            >
-              PR
-            </Typography>
-            <Typography
-              sx={{
-                fontFamily: FONTS.mono,
-                fontSize: '0.7rem',
-                color: STATUS_COLORS.open,
-                textTransform: 'uppercase',
-                textAlign: 'center',
-              }}
-            >
-              Issue
-            </Typography>
-          </Box>
-
-          <Box
-            sx={{
-              display: 'grid',
-              gridTemplateColumns: '1fr 1fr 1fr',
-              columnGap: 1,
-              rowGap: 1.5,
-              alignItems: 'center',
-            }}
-          >
-            <Typography
-              sx={{
-                fontFamily: FONTS.mono,
-                fontSize: '0.75rem',
-                color: STATUS_COLORS.open,
-                textTransform: 'uppercase',
-              }}
-            >
-              All
-            </Typography>
-            <Typography
-              sx={{
-                fontFamily: FONTS.mono,
-                fontSize: '1.05rem',
-                fontWeight: 600,
-                color: STATUS_COLORS.open,
-                textAlign: 'center',
-              }}
-            >
-              {eligibilityStats.all.toLocaleString()}
-            </Typography>
-            <Typography
-              sx={{
-                fontFamily: FONTS.mono,
-                fontSize: '1.05rem',
-                fontWeight: 600,
-                color: STATUS_COLORS.open,
-                textAlign: 'center',
-              }}
-            >
-              {eligibilityStats.all.toLocaleString()}
-            </Typography>
-
-            <Typography
-              sx={{
-                fontFamily: FONTS.mono,
-                fontSize: '0.75rem',
-                color: STATUS_COLORS.open,
-                textTransform: 'uppercase',
-              }}
-            >
-              Eligible
-            </Typography>
-            <Typography
-              sx={{
-                fontFamily: FONTS.mono,
-                fontSize: '1.05rem',
-                fontWeight: 600,
-                color: STATUS_COLORS.merged,
-                textAlign: 'center',
-              }}
-            >
-              {eligibilityStats.oss.eligible.toLocaleString()}
-            </Typography>
-            <Typography
-              sx={{
-                fontFamily: FONTS.mono,
-                fontSize: '1.05rem',
-                fontWeight: 600,
-                color: STATUS_COLORS.merged,
-                textAlign: 'center',
-              }}
-            >
-              {eligibilityStats.discovery.eligible.toLocaleString()}
-            </Typography>
-
-            <Typography
-              sx={{
-                fontFamily: FONTS.mono,
-                fontSize: '0.75rem',
-                color: STATUS_COLORS.open,
-                textTransform: 'uppercase',
-              }}
-            >
-              Ineligible
-            </Typography>
-            <Typography
-              sx={{
-                fontFamily: FONTS.mono,
-                fontSize: '1.05rem',
-                fontWeight: 600,
-                color: STATUS_COLORS.closed,
-                textAlign: 'center',
-              }}
-            >
-              {eligibilityStats.oss.ineligible.toLocaleString()}
-            </Typography>
-            <Typography
-              sx={{
-                fontFamily: FONTS.mono,
-                fontSize: '1.05rem',
-                fontWeight: 600,
-                color: STATUS_COLORS.closed,
-                textAlign: 'center',
-              }}
-            >
-              {eligibilityStats.discovery.ineligible.toLocaleString()}
-            </Typography>
-          </Box>
-        </Box>
-      </SectionCard>
-
       {/* CARD 1: Miners Activity */}
       <SectionCard title="Miners Activity" sx={{ flexShrink: 0 }}>
         <Box sx={{ px: 2, pt: 1, pb: 2 }}>
@@ -609,51 +433,60 @@ const MinerActivityRow: React.FC<MinerActivityRowProps> = ({
   label,
   pr,
   issue,
-}) => (
-  <Box
-    sx={(theme) => ({
-      display: 'grid',
-      gridTemplateColumns: '1fr 1fr 1fr',
-      gap: 1,
-      alignItems: 'center',
-      py: 1.1,
-      borderBottom: `1px solid ${alpha(theme.palette.text.primary, 0.06)}`,
-      '&:last-of-type': { borderBottom: 'none' },
-    })}
-  >
-    <Typography
-      sx={{
-        fontFamily: FONTS.mono,
-        fontSize: '0.85rem',
-        color: STATUS_COLORS.open,
-      }}
-    >
-      {label}
-    </Typography>
-    <Typography
+}) => {
+  const valueColor =
+    label === 'Eligible'
+      ? STATUS_COLORS.merged
+      : label === 'Ineligible'
+        ? STATUS_COLORS.closed
+        : STATUS_COLORS.open;
+
+  return (
+    <Box
       sx={(theme) => ({
-        fontFamily: FONTS.mono,
-        fontWeight: 600,
-        fontSize: '1.1rem',
-        color: theme.palette.text.primary,
-        textAlign: 'center',
+        display: 'grid',
+        gridTemplateColumns: '1fr 1fr 1fr',
+        gap: 1,
+        alignItems: 'center',
+        py: 1.1,
+        borderBottom: `1px solid ${alpha(theme.palette.text.primary, 0.06)}`,
+        '&:last-of-type': { borderBottom: 'none' },
       })}
     >
-      {pr.toLocaleString()}
-    </Typography>
-    <Typography
-      sx={(theme) => ({
-        fontFamily: FONTS.mono,
-        fontWeight: 600,
-        fontSize: '1.1rem',
-        color: theme.palette.text.primary,
-        textAlign: 'center',
-      })}
-    >
-      {issue.toLocaleString()}
-    </Typography>
-  </Box>
-);
+      <Typography
+        sx={{
+          fontFamily: FONTS.mono,
+          fontSize: '0.85rem',
+          color: STATUS_COLORS.open,
+        }}
+      >
+        {label}
+      </Typography>
+      <Typography
+        sx={{
+          fontFamily: FONTS.mono,
+          fontWeight: 600,
+          fontSize: '1.1rem',
+          color: valueColor,
+          textAlign: 'center',
+        }}
+      >
+        {pr.toLocaleString()}
+      </Typography>
+      <Typography
+        sx={{
+          fontFamily: FONTS.mono,
+          fontWeight: 600,
+          fontSize: '1.1rem',
+          color: valueColor,
+          textAlign: 'center',
+        }}
+      >
+        {issue.toLocaleString()}
+      </Typography>
+    </Box>
+  );
+};
 
 interface PRColumnProps {
   label: string;


### PR DESCRIPTION
## Summary

Adds a new right-sidebar status card (“Miners Activity”) to the leaderboard sidebar cards, displaying miner counts in a 3×2 PR/Issue table (rows: All/Eligible/Ineligible; columns: PR/Issue). Updates the enhancement issue markdown to match the final UI/wording.

## Related Issues

Close #711 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

<img width="1816" height="690" alt="Screenshot from 2026-04-22 01-05-35" src="https://github.com/user-attachments/assets/8a890fee-9ec4-40fd-8482-df76b953bccf" />
<img width="1816" height="690" alt="Screenshot from 2026-04-22 01-06-14" src="https://github.com/user-attachments/assets/645d0256-2053-48d5-a406-7cf31c8e8047" />


## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
