### PR TITLE
feat: Miners Activity status card on the watchlist page

### DIFF
--- a/src/components/leaderboard/ActivitySidebarCards.tsx
+++ b/src/components/leaderboard/ActivitySidebarCards.tsx
@@ -13,6 +13,19 @@ interface ActivitySidebarCardsProps {
 export const ActivitySidebarCards: React.FC<ActivitySidebarCardsProps> = ({
   miners,
 }) => {
+  const minerActivityStats = useMemo(() => {
+    const all = miners.length;
+    const eligiblePr = miners.filter((m) => m.ossIsEligible).length;
+    const eligibleIssue = miners.filter((m) => m.discoveriesIsEligible).length;
+    return {
+      all,
+      eligiblePr,
+      ineligiblePr: Math.max(0, all - eligiblePr),
+      eligibleIssue,
+      ineligibleIssue: Math.max(0, all - eligibleIssue),
+    };
+  }, [miners]);
+
   const ossUsdPerDay = useMemo(
     () =>
       miners
@@ -93,7 +106,73 @@ export const ActivitySidebarCards: React.FC<ActivitySidebarCardsProps> = ({
 
   return (
     <>
-      {/* CARD 1: PR Activity */}
+      {/* CARD 1: Miners Activity */}
+      <SectionCard title="Miners Activity" sx={{ flexShrink: 0 }}>
+        <Box sx={{ px: 2, pt: 1, pb: 2 }}>
+          <Box
+            sx={(theme) => ({
+              display: 'grid',
+              gridTemplateColumns: '1fr 1fr 1fr',
+              gap: 1,
+              alignItems: 'center',
+              pb: 1.5,
+              borderBottom: `1px solid ${theme.palette.border.light}`,
+              mb: 1.5,
+            })}
+          >
+            <Typography
+              sx={{
+                fontFamily: FONTS.mono,
+                fontSize: '0.7rem',
+                color: STATUS_COLORS.open,
+                textTransform: 'uppercase',
+              }}
+            >
+              &nbsp;
+            </Typography>
+            <Typography
+              sx={{
+                fontFamily: FONTS.mono,
+                fontSize: '0.7rem',
+                color: STATUS_COLORS.open,
+                textTransform: 'uppercase',
+                textAlign: 'center',
+              }}
+            >
+              PR
+            </Typography>
+            <Typography
+              sx={{
+                fontFamily: FONTS.mono,
+                fontSize: '0.7rem',
+                color: STATUS_COLORS.open,
+                textTransform: 'uppercase',
+                textAlign: 'center',
+              }}
+            >
+              Issue
+            </Typography>
+          </Box>
+
+          <MinerActivityRow
+            label="All"
+            pr={minerActivityStats.all}
+            issue={minerActivityStats.all}
+          />
+          <MinerActivityRow
+            label="Eligible"
+            pr={minerActivityStats.eligiblePr}
+            issue={minerActivityStats.eligibleIssue}
+          />
+          <MinerActivityRow
+            label="Ineligible"
+            pr={minerActivityStats.ineligiblePr}
+            issue={minerActivityStats.ineligibleIssue}
+          />
+        </Box>
+      </SectionCard>
+
+      {/* CARD 2: PR Activity */}
       <SectionCard title="PR Activity" sx={{ flexShrink: 0 }}>
         <Box sx={{ px: 2, pt: 1, pb: 2 }}>
           <Box
@@ -164,7 +243,7 @@ export const ActivitySidebarCards: React.FC<ActivitySidebarCardsProps> = ({
         </Box>
       </SectionCard>
 
-      {/* CARD 2: Issue Activity */}
+      {/* CARD 3: Issue Activity */}
       <SectionCard title="Issue Activity" sx={{ flexShrink: 0 }}>
         <Box sx={{ px: 2, pt: 1, pb: 2 }}>
           <Box
@@ -235,7 +314,7 @@ export const ActivitySidebarCards: React.FC<ActivitySidebarCardsProps> = ({
         </Box>
       </SectionCard>
 
-      {/* CARD 3: Code Impact */}
+      {/* CARD 4: Code Impact */}
       <SectionCard title="Code Impact" sx={{ flexShrink: 0 }}>
         <Box
           sx={{
@@ -340,6 +419,62 @@ export const StatRow: React.FC<StatRowProps> = ({
       })}
     >
       {value}
+    </Typography>
+  </Box>
+);
+
+interface MinerActivityRowProps {
+  label: string;
+  pr: number;
+  issue: number;
+}
+
+const MinerActivityRow: React.FC<MinerActivityRowProps> = ({
+  label,
+  pr,
+  issue,
+}) => (
+  <Box
+    sx={(theme) => ({
+      display: 'grid',
+      gridTemplateColumns: '1fr 1fr 1fr',
+      gap: 1,
+      alignItems: 'center',
+      py: 1.1,
+      borderBottom: `1px solid ${alpha(theme.palette.text.primary, 0.06)}`,
+      '&:last-of-type': { borderBottom: 'none' },
+    })}
+  >
+    <Typography
+      sx={{
+        fontFamily: FONTS.mono,
+        fontSize: '0.85rem',
+        color: STATUS_COLORS.open,
+      }}
+    >
+      {label}
+    </Typography>
+    <Typography
+      sx={(theme) => ({
+        fontFamily: FONTS.mono,
+        fontWeight: 600,
+        fontSize: '1.1rem',
+        color: theme.palette.text.primary,
+        textAlign: 'center',
+      })}
+    >
+      {pr.toLocaleString()}
+    </Typography>
+    <Typography
+      sx={(theme) => ({
+        fontFamily: FONTS.mono,
+        fontWeight: 600,
+        fontSize: '1.1rem',
+        color: theme.palette.text.primary,
+        textAlign: 'center',
+      })}
+    >
+      {issue.toLocaleString()}
     </Typography>
   </Box>
 );


### PR DESCRIPTION
## Summary

Adds a new “Miners Activity” status card to the Watchlist right sidebar, rendered at the top of the status card stack. The card shows a 3×2 eligibility matrix for the currently watched miners:

Rows: All / Eligible / Ineligible
Columns: PR (OSS) / Issue (Discoveries)
Counts are derived from the existing miners: MinerStats[] passed into ActivitySidebarCards (no new API calls).

## Related Issues

Close #713 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

<img width="1816" height="690" alt="Screenshot from 2026-04-22 01-46-50" src="https://github.com/user-attachments/assets/aadb71d1-eeda-4a02-8e07-87e0a086292d" />

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [ ] Responsive/mobile checked
- [ ] Tested against the test API
- [ ] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [ ] Screenshots included for any UI/visual changes
