### PR TITLE
fix: rename dashboard trend series to reflect actual data

### DIFF
--- a/src/pages/dashboard/dashboardData.ts
+++ b/src/pages/dashboard/dashboardData.ts
@@ -14,7 +14,11 @@ import { formatTokenAmount } from '../../utils/format';
 
 export type PresetTimeRange = '1d' | '7d' | '35d';
 export type TrendTimeRange = PresetTimeRange | 'all';
-export type TrendSeriesKey = 'mergedPrs' | 'issuesResolved' | 'prsOpened';
+export type TrendSeriesKey =
+  | 'mergedPrs'
+  | 'issuesResolved'
+  | 'prsOpened'
+  | 'issuesOpened';
 
 export interface DashboardTrendSeries {
   key: TrendSeriesKey;
@@ -101,6 +105,7 @@ const TREND_SERIES_KEYS: TrendSeriesKey[] = [
   'mergedPrs',
   'issuesResolved',
   'prsOpened',
+  'issuesOpened',
 ];
 const CURRENT_LOOKBACK_WINDOW: PresetTimeRange = '35d';
 
@@ -265,6 +270,9 @@ export const buildDashboardTrendData = (
   const resolvedIssueTimestamps = issues
     .filter((issue) => issue.status === 'completed')
     .map((issue) => toTimestamp(issue.completedAt));
+  const openedIssueTimestamps = issues.map((issue) =>
+    toTimestamp(issue.createdAt),
+  );
   const buckets = buildTrendBuckets(range, now);
   const mergedPrValues = bucketTimestamps(mergedPrTimestamps, buckets);
   const openedPrValues = bucketTimestamps(openedPrTimestamps, buckets);
@@ -272,6 +280,7 @@ export const buildDashboardTrendData = (
     resolvedIssueTimestamps,
     buckets,
   );
+  const openedIssueValues = bucketTimestamps(openedIssueTimestamps, buckets);
 
   const seriesByKey: Record<TrendSeriesKey, number[]> = {
     mergedPrs: mergedPrValues,
@@ -284,12 +293,6 @@ export const buildDashboardTrendData = (
     labels: buckets.map((bucket) => bucket.label),
     series: TREND_SERIES_KEYS.map((key) => ({
       key,
-      values:
-        key === 'mergedPrs'
-          ? mergedPrValues
-          : key === 'prsOpened'
-            ? openedPrValues
-            : resolvedIssueValues,
       values: seriesByKey[key],
     })),
   };

--- a/src/pages/dashboard/dashboardData.ts
+++ b/src/pages/dashboard/dashboardData.ts
@@ -13,11 +13,7 @@ import { getPrStatusLabel, parseNumber } from '../../utils';
 
 export type PresetTimeRange = '1d' | '7d' | '35d';
 export type TrendTimeRange = PresetTimeRange | 'all';
-export type TrendSeriesKey =
-  | 'mergedPrs'
-  | 'issuesResolved'
-  | 'prsOpened'
-  | 'issuesOpened';
+export type TrendSeriesKey = 'mergedPrs' | 'issuesResolved' | 'prsOpened';
 
 export interface DashboardTrendSeries {
   key: TrendSeriesKey;
@@ -76,7 +72,6 @@ const TREND_SERIES_KEYS: TrendSeriesKey[] = [
   'mergedPrs',
   'issuesResolved',
   'prsOpened',
-  'issuesOpened',
 ];
 const CURRENT_LOOKBACK_WINDOW: PresetTimeRange = '35d';
 
@@ -158,7 +153,6 @@ const formatTrendBucketLabel = (timestamp: number, range: TrendTimeRange) => {
 };
 
 const buildTrendBuckets = (
-  timestamps: Array<number | null>,
   range: TrendTimeRange,
   now = new Date(),
 ): Array<{ startMs: number; endMs: number; label: string }> => {
@@ -239,25 +233,12 @@ export const buildDashboardTrendData = (
 ): { labels: string[]; series: DashboardTrendSeries[] } => {
   const mergedPrTimestamps = prs.map((pr) => toTimestamp(pr.mergedAt));
   const openedPrTimestamps = prs.map((pr) => toTimestamp(pr.prCreatedAt));
-  const openedIssueTimestamps = issues.map((issue) =>
-    toTimestamp(issue.createdAt),
-  );
   const resolvedIssueTimestamps = issues
     .filter((issue) => issue.status === 'completed')
     .map((issue) => toTimestamp(issue.completedAt));
-  const buckets = buildTrendBuckets(
-    [
-      ...mergedPrTimestamps,
-      ...openedPrTimestamps,
-      ...openedIssueTimestamps,
-      ...resolvedIssueTimestamps,
-    ],
-    range,
-    now,
-  );
+  const buckets = buildTrendBuckets(range, now);
   const mergedPrValues = bucketTimestamps(mergedPrTimestamps, buckets);
   const openedPrValues = bucketTimestamps(openedPrTimestamps, buckets);
-  const openedIssueValues = bucketTimestamps(openedIssueTimestamps, buckets);
   const resolvedIssueValues = bucketTimestamps(
     resolvedIssueTimestamps,
     buckets,
@@ -272,9 +253,7 @@ export const buildDashboardTrendData = (
           ? mergedPrValues
           : key === 'prsOpened'
             ? openedPrValues
-            : key === 'issuesResolved'
-              ? resolvedIssueValues
-              : openedIssueValues,
+            : resolvedIssueValues,
     })),
   };
 };
@@ -486,9 +465,9 @@ export const buildDashboardKpis = (
       subtitle: 'Total PR snapshots',
     },
     {
-      title: 'Issues Solved',
+      title: 'Bounties Completed',
       value: totalIssuesSolved,
-      subtitle: 'Problem resolved and closed',
+      subtitle: 'Bounty issues fully paid out',
     },
     {
       title: 'Total Lines Committed',

--- a/src/pages/dashboard/views/ContributionTrends.tsx
+++ b/src/pages/dashboard/views/ContributionTrends.tsx
@@ -25,14 +25,16 @@ interface ContributionTrendsProps {
   onRangeChange: (range: TrendTimeRange) => void;
 }
 
-const TREND_SERIES_PRESENTATION: Record<
-  TrendSeriesKey,
-  {
-    label: string;
-    colorOpacity: number;
-    lineWidth: number;
-    lineOpacity: number;
-  }
+const TREND_SERIES_PRESENTATION: Partial<
+  Record<
+    TrendSeriesKey,
+    {
+      label: string;
+      colorOpacity: number;
+      lineWidth: number;
+      lineOpacity: number;
+    }
+  >
 > = {
   mergedPrs: {
     label: 'Merged PRs',
@@ -62,7 +64,7 @@ const getTrendSeriesBaseColor = (theme: Theme, seriesKey: TrendSeriesKey) =>
 const getTrendSeriesColor = (theme: Theme, seriesKey: TrendSeriesKey) =>
   alpha(
     getTrendSeriesBaseColor(theme, seriesKey),
-    TREND_SERIES_PRESENTATION[seriesKey].colorOpacity,
+    TREND_SERIES_PRESENTATION[seriesKey]?.colorOpacity ?? 1,
   );
 
 const ContributionTrends: React.FC<ContributionTrendsProps> = ({
@@ -75,9 +77,14 @@ const ContributionTrends: React.FC<ContributionTrendsProps> = ({
   const theme = useTheme();
   const [hiddenSeries, setHiddenSeries] = useState<TrendSeriesKey[]>([]);
 
+  const presentedSeries = useMemo(
+    () => series.filter((entry) => TREND_SERIES_PRESENTATION[entry.key]),
+    [series],
+  );
+
   const visibleSeries = useMemo(
-    () => series.filter((entry) => !hiddenSeries.includes(entry.key)),
-    [series, hiddenSeries],
+    () => presentedSeries.filter((entry) => !hiddenSeries.includes(entry.key)),
+    [presentedSeries, hiddenSeries],
   );
 
   const chartOption = useMemo(() => {
@@ -184,22 +191,25 @@ const ContributionTrends: React.FC<ContributionTrendsProps> = ({
         axisLine: { show: false },
         axisTick: { show: false },
       },
-      series: visibleSeries.map((series) => ({
-        name: TREND_SERIES_PRESENTATION[series.key].label,
-        type: 'line',
-        smooth: 0.2,
-        showSymbol: false,
-        symbol: 'circle',
-        data: series.values,
-        lineStyle: {
-          width: TREND_SERIES_PRESENTATION[series.key].lineWidth,
-          color: getTrendSeriesColor(theme, series.key),
-          opacity: TREND_SERIES_PRESENTATION[series.key].lineOpacity,
-        },
-        emphasis: {
-          focus: 'series',
-        },
-      })),
+      series: visibleSeries.map((series) => {
+        const presentation = TREND_SERIES_PRESENTATION[series.key]!;
+        return {
+          name: presentation.label,
+          type: 'line',
+          smooth: 0.2,
+          showSymbol: false,
+          symbol: 'circle',
+          data: series.values,
+          lineStyle: {
+            width: presentation.lineWidth,
+            color: getTrendSeriesColor(theme, series.key),
+            opacity: presentation.lineOpacity,
+          },
+          emphasis: {
+            focus: 'series',
+          },
+        };
+      }),
     };
   }, [labels, range, theme, visibleSeries]);
 
@@ -209,7 +219,7 @@ const ContributionTrends: React.FC<ContributionTrendsProps> = ({
         return current.filter((key) => key !== seriesKey);
       }
 
-      if (current.length >= series.length - 1) {
+      if (current.length >= presentedSeries.length - 1) {
         return current;
       }
 
@@ -303,9 +313,9 @@ const ContributionTrends: React.FC<ContributionTrendsProps> = ({
             flexWrap="wrap"
             sx={{ mb: 1.1 }}
           >
-            {series.map((entry) => {
+            {presentedSeries.map((entry) => {
               const isHidden = hiddenSeries.includes(entry.key);
-              const presentation = TREND_SERIES_PRESENTATION[entry.key];
+              const presentation = TREND_SERIES_PRESENTATION[entry.key]!;
               const seriesColor = getTrendSeriesColor(theme, entry.key);
 
               return (

--- a/src/pages/dashboard/views/ContributionTrends.tsx
+++ b/src/pages/dashboard/views/ContributionTrends.tsx
@@ -41,7 +41,7 @@ const TREND_SERIES_PRESENTATION: Record<
     lineOpacity: 1,
   },
   issuesResolved: {
-    label: 'Issues Resolved',
+    label: 'Bounties Completed',
     colorOpacity: 0.85,
     lineWidth: 2.5,
     lineOpacity: 0.9,
@@ -51,12 +51,6 @@ const TREND_SERIES_PRESENTATION: Record<
     colorOpacity: 0.35,
     lineWidth: 1.75,
     lineOpacity: 0.6,
-  },
-  issuesOpened: {
-    label: 'Issues Opened',
-    colorOpacity: 0.3,
-    lineWidth: 1.5,
-    lineOpacity: 0.5,
   },
 };
 


### PR DESCRIPTION
## Summary
Removes the "Issues" vs "Bounties" naming conflation on the Dashboard by renaming the two bounty-derived labels to say "Bounties" explicitly, and removes the unused "Issues Opened" chart series that sat at zero most days and added noise to the tooltip + toggle row.

## Root cause
The Dashboard had three places using the word "issues" for two completely different concepts:

- **Issue Discoveries card (171)** - aggregated discovery-mechanism solved counts from `totalSolvedIssues` on miner stats
- **Chart "Issues Resolved" line** - `IssueBounty[]` filtered by `status === 'completed'` (bounty system)
- **"Issues Solved" stat tile (6)** - same bounty data, 35-day window

Users compared 171 vs 6 and concluded the chart was broken. It wasn't - it was plotting correct bounty data under a misleading label.

Additionally, the chart's "Issues Opened" series plotted `IssueBounty.createdAt` - it too sat at or near zero most days, contributing nothing visible but cluttering the tooltip and the toggle-button row.

## What changed

### Label renames (2 strings, 2 files)
- `ContributionTrends.tsx` - chart legend `"Issues Resolved"` → `"Bounties Completed"`
- `dashboardData.ts` - stat tile `"Issues Solved"` / subtitle `"Problem resolved and closed"` → `"Bounties Completed"` / `"Bounty issues fully paid out"`

### Chart series removal (`issuesOpened`)
- Removed `'issuesOpened'` from the `TrendSeriesKey` union
- Removed from `TREND_SERIES_KEYS` array (now 3 entries)
- Removed `openedIssueTimestamps` / `openedIssueValues` computation in `buildDashboardTrendData`
- Removed `issuesOpened` entry from `TREND_SERIES_PRESENTATION`
- Incidentally cleaned up the unused `timestamps` parameter on `buildTrendBuckets` (it was already dead but protected by the other call site's array spread)

Result: the chart now shows **Merged PRs / Bounties Completed / PRs Opened**. Tooltip rows match. Toggle buttons match. No zero-line noise.

## Type of Change
- [x] Bug fix (UI labeling clarity + chart cleanup)

## Testing
- [ ] `npm run build`
- [ ] `npm run lint:fix`
- [ ] `npm run format`
- [ ] Manual:
  - Dashboard chart legend reads `Merged PRs · Bounties Completed · PRs Opened` (3 items, not 4)
  - Chart tooltip (hover any day) shows the same 3 rows
  - Bottom stat tile reads `Bounties Completed` with subtitle `Bounty issues fully paid out`

## Screenshots
### Before
<img width="1651" height="916" alt="chrome_8kn4sjrcDy" src="https://github.com/user-attachments/assets/28905c64-c082-43d3-ae17-3ef9de8ed261" />


### After
<img width="1571" height="809" alt="image" src="https://github.com/user-attachments/assets/f2af0c15-8c38-4299-bff3-81707031875f" />

<img width="1204" height="769" alt="Screenshot from 2026-04-22 10-58-14" src="https://github.com/user-attachments/assets/5f6f35e9-1d04-4e65-b6de-42f759f67b6b" />
