### PR TITLE
fix: Unify clear-button behavior across search inputs

### DIFF
--- a/src/components/common/SearchInput.tsx
+++ b/src/components/common/SearchInput.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
+import CloseIcon from '@mui/icons-material/Close';
 import SearchIcon from '@mui/icons-material/Search';
-import { TextField, InputAdornment } from '@mui/material';
+import { TextField, InputAdornment, IconButton } from '@mui/material';
 import { alpha } from '@mui/material/styles';
 
 interface SearchInputProps {
@@ -32,6 +33,18 @@ export const SearchInput: React.FC<SearchInputProps> = ({
           />
         </InputAdornment>
       ),
+      endAdornment: value ? (
+        <InputAdornment position="end">
+          <IconButton
+            size="small"
+            onClick={() => onChange('')}
+            edge="end"
+            aria-label="clear search"
+          >
+            <CloseIcon fontSize="small" />
+          </IconButton>
+        </InputAdornment>
+      ) : undefined,
     }}
     sx={[
       (theme) => ({

--- a/src/components/issues/IssuesList.tsx
+++ b/src/components/issues/IssuesList.tsx
@@ -23,6 +23,7 @@ import {
 } from '@mui/material';
 import BarChartIcon from '@mui/icons-material/BarChart';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
+import CloseIcon from '@mui/icons-material/Close';
 import SearchIcon from '@mui/icons-material/Search';
 import TableChartIcon from '@mui/icons-material/TableChart';
 import ReactECharts from 'echarts-for-react';
@@ -756,6 +757,21 @@ const IssuesList: React.FC<IssuesListProps> = ({
                   />
                 </InputAdornment>
               ),
+              endAdornment: searchQuery ? (
+                <InputAdornment position="end">
+                  <IconButton
+                    size="small"
+                    onClick={() => {
+                      setSearchQuery('');
+                      setPage(0);
+                    }}
+                    edge="end"
+                    aria-label="clear search"
+                  >
+                    <CloseIcon fontSize="small" />
+                  </IconButton>
+                </InputAdornment>
+              ) : undefined,
             }}
             sx={{
               width: '200px',

--- a/src/components/leaderboard/TopRepositoriesTable.tsx
+++ b/src/components/leaderboard/TopRepositoriesTable.tsx
@@ -38,6 +38,7 @@ import {
   type Theme,
 } from '@mui/material';
 import SearchIcon from '@mui/icons-material/Search';
+import CloseIcon from '@mui/icons-material/Close';
 import BarChartIcon from '@mui/icons-material/BarChart';
 import TableChartIcon from '@mui/icons-material/TableChart';
 import ViewModuleIcon from '@mui/icons-material/ViewModule';
@@ -623,6 +624,18 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
       autoFocus={isMobileSearchOpen}
       InputProps={{
         startAdornment: searchAdornment,
+        endAdornment: searchQuery ? (
+          <InputAdornment position="end">
+            <IconButton
+              size="small"
+              onClick={() => setSearchQuery('')}
+              edge="end"
+              aria-label="clear search"
+            >
+              <CloseIcon fontSize="small" />
+            </IconButton>
+          </InputAdornment>
+        ) : undefined,
       }}
       sx={{
         width: '200px',

--- a/src/components/miners/MinerPRsTable.tsx
+++ b/src/components/miners/MinerPRsTable.tsx
@@ -5,6 +5,7 @@ import {
   Card,
   Chip,
   CircularProgress,
+  IconButton,
   InputAdornment,
   TextField,
   Tooltip,
@@ -12,7 +13,7 @@ import {
   alpha,
   useTheme,
 } from '@mui/material';
-import { Search as SearchIcon } from '@mui/icons-material';
+import { Search as SearchIcon, Close as CloseIcon } from '@mui/icons-material';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useMinerPRs, type CommitLog } from '../../api';
 import {
@@ -528,6 +529,21 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
               />
             </InputAdornment>
           ),
+          endAdornment: searchQuery ? (
+            <InputAdornment position="end">
+              <IconButton
+                size="small"
+                onClick={() => {
+                  setSearchQuery('');
+                  setPage(0);
+                }}
+                edge="end"
+                aria-label="clear search"
+              >
+                <CloseIcon fontSize="small" />
+              </IconButton>
+            </InputAdornment>
+          ) : undefined,
         }}
         sx={{
           mt: 2,

--- a/src/components/miners/MinerRepositoriesTable.tsx
+++ b/src/components/miners/MinerRepositoriesTable.tsx
@@ -4,12 +4,13 @@ import {
   Box,
   Card,
   CircularProgress,
+  IconButton,
   InputAdornment,
   TextField,
   Typography,
   alpha,
 } from '@mui/material';
-import { Search as SearchIcon } from '@mui/icons-material';
+import { Search as SearchIcon, Close as CloseIcon } from '@mui/icons-material';
 import { useMinerPRs, useReposAndWeights } from '../../api';
 import { LinkBox } from '../common/linkBehavior';
 import {
@@ -293,6 +294,21 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
                 />
               </InputAdornment>
             ),
+            endAdornment: searchQuery ? (
+              <InputAdornment position="end">
+                <IconButton
+                  size="small"
+                  onClick={() => {
+                    setSearchQuery('');
+                    setPage(0);
+                  }}
+                  edge="end"
+                  aria-label="clear search"
+                >
+                  <CloseIcon fontSize="small" />
+                </IconButton>
+              </InputAdornment>
+            ) : undefined,
           }}
           sx={searchFieldSx}
         />

--- a/src/components/repositories/LanguageWeightsTable.tsx
+++ b/src/components/repositories/LanguageWeightsTable.tsx
@@ -75,6 +75,11 @@ const LanguageWeightsTable: React.FC = () => {
     setPage(0);
   };
 
+  const handleClearSearch = () => {
+    setSearchQuery('');
+    setPage(0);
+  };
+
   const filteredAndSortedLanguages = useMemo(() => {
     if (!languages) return [];
 
@@ -319,6 +324,18 @@ const LanguageWeightsTable: React.FC = () => {
                   />
                 </InputAdornment>
               ),
+              endAdornment: searchQuery ? (
+                <InputAdornment position="end">
+                  <IconButton
+                    size="small"
+                    onClick={handleClearSearch}
+                    edge="end"
+                    aria-label="clear search"
+                  >
+                    <Close fontSize="small" />
+                  </IconButton>
+                </InputAdornment>
+              ) : undefined,
             }}
             sx={{
               width: '200px',


### PR DESCRIPTION
## Summary

- Fixes inconsistent search UX by adding a clear (`x`) button to search inputs that previously lacked it.
- Aligns Onboard, Miner, Issues, and Leaderboard search fields with the existing clear-button pattern used in `GlobalSearchBar`.
- Ensures clear actions also reset related pagination where applicable.


## Related Issues

Closes #717 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

https://github.com/user-attachments/assets/5c318108-f43e-416f-9a41-08f74f1aaa5d


## Problem
Several search inputs accepted typed text but did not provide an inline clear control, while `GlobalSearchBar` did. This produced inconsistent behavior for the same interaction pattern across pages.

## Root Cause
Multiple `TextField` implementations only defined `startAdornment` (search icon) and omitted conditional `endAdornment` with a clear action.

## Changes
- Added clear-button support in shared and local search components:
  - `src/components/common/SearchInput.tsx`
  - `src/components/repositories/LanguageWeightsTable.tsx`
  - `src/components/miners/MinerRepositoriesTable.tsx`
  - `src/components/miners/MinerPRsTable.tsx`
  - `src/components/issues/IssuesList.tsx`
  - `src/components/leaderboard/TopRepositoriesTable.tsx`
- Clear behavior:
  - Shows clear icon only when query is non-empty.
  - Clears query in one click.
  - Resets page index where search/pagination are coupled.

## Behavioral Impact
- Improves UX consistency and discoverability of quick-reset action.
- No API/data contract changes.
- No routing changes.
