### PR TITLE
feat: add eligible vs ineligible perfectages

### DIFF
--- a/src/pages/dashboard/dashboardData.ts
+++ b/src/pages/dashboard/dashboardData.ts
@@ -362,24 +362,36 @@ export const buildDashboardOverview = (
   const eligibleIds = new Set(
     miners.filter((m) => m.isEligible).map((m) => m.githubId),
   );
-  const eligiblePrs = prs.filter((pr) => pr.githubId && eligibleIds.has(pr.githubId));
-  const ineligiblePrs = prs.filter((pr) => !pr.githubId || !eligibleIds.has(pr.githubId));
+  const eligiblePrs = prs.filter(
+    (pr) => pr.githubId && eligibleIds.has(pr.githubId),
+  );
+  const ineligiblePrs = prs.filter(
+    (pr) => !pr.githubId || !eligibleIds.has(pr.githubId),
+  );
 
   const eligibleMiners = miners.filter((m) => m.isIssueEligible);
   const ineligibleMiners = miners.filter((m) => !m.isIssueEligible);
 
-  const currentEligiblePrMetrics = getPrOverviewMetrics(eligiblePrs, currentWindow);
+  const currentEligiblePrMetrics = getPrOverviewMetrics(
+    eligiblePrs,
+    currentWindow,
+  );
   const previousEligiblePrMetrics = previousWindow
     ? getPrOverviewMetrics(eligiblePrs, previousWindow)
     : null;
 
-  const currentIneligiblePrMetrics = getPrOverviewMetrics(ineligiblePrs, currentWindow);
+  const currentIneligiblePrMetrics = getPrOverviewMetrics(
+    ineligiblePrs,
+    currentWindow,
+  );
   const previousIneligiblePrMetrics = previousWindow
     ? getPrOverviewMetrics(ineligiblePrs, previousWindow)
     : null;
 
-  const eligibleIssueMetrics = getIssueOverviewMetricsFromMiners(eligibleMiners);
-  const ineligibleIssueMetrics = getIssueOverviewMetricsFromMiners(ineligibleMiners);
+  const eligibleIssueMetrics =
+    getIssueOverviewMetricsFromMiners(eligibleMiners);
+  const ineligibleIssueMetrics =
+    getIssueOverviewMetricsFromMiners(ineligibleMiners);
 
   const getMetricDelta = (currentValue: number, previousValue?: number) =>
     range === 'all' || previousValue === undefined
@@ -395,12 +407,31 @@ export const buildDashboardOverview = (
       { label: 'Open', value: current.open },
       { label: 'Closed', value: current.closed },
     ],
-    chartCenterLabel: formatCenterPercent(current.merged, current.merged + current.closed),
+    chartCenterLabel: formatCenterPercent(
+      current.merged,
+      current.merged + current.closed,
+    ),
     metrics: [
-      { label: 'Total', value: current.total, delta: getMetricDelta(current.total, previous?.total) },
-      { label: 'Merged', value: current.merged, delta: getMetricDelta(current.merged, previous?.merged) },
-      { label: 'Open', value: current.open, delta: getMetricDelta(current.open, previous?.open) },
-      { label: 'Closed', value: current.closed, delta: getMetricDelta(current.closed, previous?.closed) },
+      {
+        label: 'Total',
+        value: current.total,
+        delta: getMetricDelta(current.total, previous?.total),
+      },
+      {
+        label: 'Merged',
+        value: current.merged,
+        delta: getMetricDelta(current.merged, previous?.merged),
+      },
+      {
+        label: 'Open',
+        value: current.open,
+        delta: getMetricDelta(current.open, previous?.open),
+      },
+      {
+        label: 'Closed',
+        value: current.closed,
+        delta: getMetricDelta(current.closed, previous?.closed),
+      },
     ],
   });
 
@@ -412,7 +443,10 @@ export const buildDashboardOverview = (
       { label: 'Open', value: issueMetrics.open },
       { label: 'Closed', value: issueMetrics.closed },
     ],
-    chartCenterLabel: formatCenterPercent(issueMetrics.solved, issueMetrics.solved + issueMetrics.closed),
+    chartCenterLabel: formatCenterPercent(
+      issueMetrics.solved,
+      issueMetrics.solved + issueMetrics.closed,
+    ),
     // Issue metrics come from per-miner aggregates (all-time totals), so
     // there is no previous-window comparison available — deltas are '0%'.
     metrics: [
@@ -426,8 +460,14 @@ export const buildDashboardOverview = (
   return [
     {
       title: 'OSS Contributions',
-      eligible: buildPrPool(currentEligiblePrMetrics, previousEligiblePrMetrics),
-      ineligible: buildPrPool(currentIneligiblePrMetrics, previousIneligiblePrMetrics),
+      eligible: buildPrPool(
+        currentEligiblePrMetrics,
+        previousEligiblePrMetrics,
+      ),
+      ineligible: buildPrPool(
+        currentIneligiblePrMetrics,
+        previousIneligiblePrMetrics,
+      ),
     },
     {
       title: 'Issue Discoveries',

--- a/src/pages/dashboard/dashboardData.ts
+++ b/src/pages/dashboard/dashboardData.ts
@@ -30,14 +30,16 @@ export interface DashboardOverviewMetric {
   delta: string;
 }
 
+export interface DashboardOverviewPool {
+  metrics: DashboardOverviewMetric[];
+  chartSegments: Array<{ label: string; value: number }>;
+  chartCenterLabel: string;
+}
+
 export interface DashboardOverviewSection {
   title: string;
-  metrics: DashboardOverviewMetric[];
-  chartSegments: Array<{
-    label: string;
-    value: number;
-  }>;
-  chartCenterLabel: string;
+  eligible: DashboardOverviewPool;
+  ineligible: DashboardOverviewPool;
 }
 
 export interface DashboardKpi {
@@ -357,95 +359,80 @@ export const buildDashboardOverview = (
   const currentWindow = getWindowBounds(range, now);
   const previousWindow = getPreviousWindowBounds(range, now);
 
-  const currentPrMetrics = getPrOverviewMetrics(prs, currentWindow);
-  const previousPrMetrics = previousWindow
-    ? getPrOverviewMetrics(prs, previousWindow)
+  const eligibleIds = new Set(
+    miners.filter((m) => m.isEligible).map((m) => m.githubId),
+  );
+  const eligiblePrs = prs.filter((pr) => pr.githubId && eligibleIds.has(pr.githubId));
+  const ineligiblePrs = prs.filter((pr) => !pr.githubId || !eligibleIds.has(pr.githubId));
+
+  const eligibleMiners = miners.filter((m) => m.isIssueEligible);
+  const ineligibleMiners = miners.filter((m) => !m.isIssueEligible);
+
+  const currentEligiblePrMetrics = getPrOverviewMetrics(eligiblePrs, currentWindow);
+  const previousEligiblePrMetrics = previousWindow
+    ? getPrOverviewMetrics(eligiblePrs, previousWindow)
     : null;
-  const currentIssueMetrics = getIssueOverviewMetricsFromMiners(miners);
+
+  const currentIneligiblePrMetrics = getPrOverviewMetrics(ineligiblePrs, currentWindow);
+  const previousIneligiblePrMetrics = previousWindow
+    ? getPrOverviewMetrics(ineligiblePrs, previousWindow)
+    : null;
+
+  const eligibleIssueMetrics = getIssueOverviewMetricsFromMiners(eligibleMiners);
+  const ineligibleIssueMetrics = getIssueOverviewMetricsFromMiners(ineligibleMiners);
+
   const getMetricDelta = (currentValue: number, previousValue?: number) =>
     range === 'all' || previousValue === undefined
       ? '0%'
       : formatDelta(currentValue, previousValue);
 
+  const buildPrPool = (
+    current: ReturnType<typeof getPrOverviewMetrics>,
+    previous: ReturnType<typeof getPrOverviewMetrics> | null,
+  ): DashboardOverviewPool => ({
+    chartSegments: [
+      { label: 'Merged', value: current.merged },
+      { label: 'Open', value: current.open },
+      { label: 'Closed', value: current.closed },
+    ],
+    chartCenterLabel: formatCenterPercent(current.merged, current.merged + current.closed),
+    metrics: [
+      { label: 'Total', value: current.total, delta: getMetricDelta(current.total, previous?.total) },
+      { label: 'Merged', value: current.merged, delta: getMetricDelta(current.merged, previous?.merged) },
+      { label: 'Open', value: current.open, delta: getMetricDelta(current.open, previous?.open) },
+      { label: 'Closed', value: current.closed, delta: getMetricDelta(current.closed, previous?.closed) },
+    ],
+  });
+
+  const buildIssuePool = (
+    issueMetrics: ReturnType<typeof getIssueOverviewMetricsFromMiners>,
+  ): DashboardOverviewPool => ({
+    chartSegments: [
+      { label: 'Solved', value: issueMetrics.solved },
+      { label: 'Open', value: issueMetrics.open },
+      { label: 'Closed', value: issueMetrics.closed },
+    ],
+    chartCenterLabel: formatCenterPercent(issueMetrics.solved, issueMetrics.solved + issueMetrics.closed),
+    // Issue metrics come from per-miner aggregates (all-time totals), so
+    // there is no previous-window comparison available — deltas are '0%'.
+    metrics: [
+      { label: 'Total', value: issueMetrics.total, delta: '0%' },
+      { label: 'Solved', value: issueMetrics.solved, delta: '0%' },
+      { label: 'Open', value: issueMetrics.open, delta: '0%' },
+      { label: 'Closed', value: issueMetrics.closed, delta: '0%' },
+    ],
+  });
+
   return [
     {
       title: 'OSS Contributions',
-      chartSegments: [
-        { label: 'Merged', value: currentPrMetrics.merged },
-        { label: 'Open', value: currentPrMetrics.open },
-        { label: 'Closed', value: currentPrMetrics.closed },
-      ],
-      chartCenterLabel: formatCenterPercent(
-        currentPrMetrics.merged,
-        currentPrMetrics.merged + currentPrMetrics.closed,
-      ),
-      metrics: [
-        {
-          label: 'Total',
-          value: currentPrMetrics.total,
-          delta: getMetricDelta(
-            currentPrMetrics.total,
-            previousPrMetrics?.total,
-          ),
-        },
-        {
-          label: 'Merged',
-          value: currentPrMetrics.merged,
-          delta: getMetricDelta(
-            currentPrMetrics.merged,
-            previousPrMetrics?.merged,
-          ),
-        },
-        {
-          label: 'Open',
-          value: currentPrMetrics.open,
-          delta: getMetricDelta(currentPrMetrics.open, previousPrMetrics?.open),
-        },
-        {
-          label: 'Closed',
-          value: currentPrMetrics.closed,
-          delta: getMetricDelta(
-            currentPrMetrics.closed,
-            previousPrMetrics?.closed,
-          ),
-        },
-      ],
+      eligible: buildPrPool(currentEligiblePrMetrics, previousEligiblePrMetrics),
+      ineligible: buildPrPool(currentIneligiblePrMetrics, previousIneligiblePrMetrics),
     },
     {
       title: 'Issue Discoveries',
-      chartSegments: [
-        { label: 'Solved', value: currentIssueMetrics.solved },
-        { label: 'Open', value: currentIssueMetrics.open },
-        { label: 'Closed', value: currentIssueMetrics.closed },
-      ],
-      chartCenterLabel: formatCenterPercent(
-        currentIssueMetrics.solved,
-        currentIssueMetrics.solved + currentIssueMetrics.closed,
-      ),
-      // Issue metrics come from per-miner aggregates (all-time totals), so
-      // there is no previous-window comparison available — deltas are '0%'.
-      metrics: [
-        {
-          label: 'Total',
-          value: currentIssueMetrics.total,
-          delta: '0%',
-        },
-        {
-          label: 'Solved',
-          value: currentIssueMetrics.solved,
-          delta: '0%',
-        },
-        {
-          label: 'Open',
-          value: currentIssueMetrics.open,
-          delta: '0%',
-        },
-        {
-          label: 'Closed',
-          value: currentIssueMetrics.closed,
-          delta: '0%',
-        },
-      ],
+      eligible: buildIssuePool(eligibleIssueMetrics),
+      ineligible: buildIssuePool(ineligibleIssueMetrics),
     },
   ];
 };

--- a/src/pages/dashboard/views/DashboardOverview.tsx
+++ b/src/pages/dashboard/views/DashboardOverview.tsx
@@ -5,6 +5,7 @@ import ReactECharts from 'echarts-for-react';
 import KpiCard from '../../../components/KpiCard';
 import {
   type DashboardKpi,
+  type DashboardOverviewPool,
   type DashboardOverviewSection,
   type TrendTimeRange,
 } from '../dashboardData';
@@ -41,7 +42,7 @@ const getDeltaColor = (theme: Theme, delta: string): string => {
 const buildStatusChartOption = (
   theme: Theme,
   centerLabel: string,
-  segments: DashboardOverviewSection['chartSegments'],
+  segments: DashboardOverviewPool['chartSegments'],
 ): Record<string, unknown> => {
   const totalValue = segments.reduce((sum, segment) => sum + segment.value, 0);
   const monoFontFamily = theme.typography.fontFamily;
@@ -54,7 +55,7 @@ const buildStatusChartOption = (
       top: '34%',
       textStyle: {
         color: theme.palette.text.primary,
-        fontSize: 18,
+        fontSize: 13,
         fontWeight: 'bold',
         fontFamily: monoFontFamily,
       },
@@ -124,6 +125,149 @@ const buildStatusChartOption = (
   };
 };
 
+interface PoolColumnProps {
+  sectionTitle: string;
+  pool: DashboardOverviewPool;
+  isEligible: boolean;
+}
+
+const PoolColumn: React.FC<PoolColumnProps> = ({ sectionTitle, pool, isEligible }) => {
+  const theme = useTheme();
+  const monoFontFamily = theme.typography.fontFamily;
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 0.75,
+        p: 1,
+        borderRadius: 2,
+        border: `1px solid ${theme.palette.border.light}`,
+      }}
+    >
+      {/* Pool label — matches MinerCard eligibility badge style */}
+      <Typography
+        sx={{
+          fontFamily: monoFontFamily,
+          fontSize: '0.62rem',
+          fontWeight: 700,
+          textTransform: 'uppercase',
+          letterSpacing: '0.06em',
+          alignSelf: 'flex-start',
+          borderRadius: 1,
+          px: 0.75,
+          py: 0.2,
+          border: `1px solid ${isEligible ? alpha(theme.palette.status.merged, 0.45) : theme.palette.border.subtle}`,
+          color: isEligible ? theme.palette.status.merged : theme.palette.text.secondary,
+          backgroundColor: isEligible ? alpha(theme.palette.status.merged, 0.08) : theme.palette.surface.subtle,
+        }}
+      >
+        {isEligible ? 'Eligible' : 'Not Eligible'}
+      </Typography>
+
+      {/* Donut chart */}
+      <Box
+        sx={{
+          width: '100%',
+          aspectRatio: '1',
+          maxWidth: 90,
+          alignSelf: 'center',
+          '& > div': { width: '100%', height: '100%' },
+        }}
+      >
+        <ReactECharts
+          option={buildStatusChartOption(theme, pool.chartCenterLabel, pool.chartSegments)}
+          style={{ width: '100%', height: '100%' }}
+          opts={{ renderer: 'svg' }}
+        />
+      </Box>
+
+      {/* Legend */}
+      <Stack direction="row" spacing={0.75} useFlexGap flexWrap="wrap" justifyContent="center">
+        {pool.chartSegments.map((segment) => (
+          <Stack
+            key={`${sectionTitle}-${isEligible}-${segment.label}`}
+            direction="row"
+            spacing={0.4}
+            alignItems="center"
+          >
+            <Box
+              sx={{
+                width: 6,
+                height: 6,
+                borderRadius: '50%',
+                backgroundColor: getSegmentColor(theme, segment.label),
+                flexShrink: 0,
+              }}
+            />
+            <Typography
+              sx={{
+                color: alpha(theme.palette.text.primary, 0.55),
+                fontFamily: monoFontFamily,
+                fontSize: '0.6rem',
+                textTransform: 'uppercase',
+                letterSpacing: '0.04em',
+              }}
+            >
+              {segment.label}
+            </Typography>
+          </Stack>
+        ))}
+      </Stack>
+
+      {/* Metrics */}
+      <Stack spacing={0} sx={{ mt: 0.25 }}>
+        {pool.metrics.map((metric) => (
+          <Box
+            key={`${sectionTitle}-${isEligible}-${metric.label}`}
+            sx={{
+              py: 0.45,
+              borderTop: `1px solid ${alpha(theme.palette.text.primary, 0.06)}`,
+            }}
+          >
+            <Stack direction="row" justifyContent="space-between" alignItems="baseline">
+              <Box>
+                <Typography
+                  sx={{
+                    color: alpha(theme.palette.text.primary, 0.75),
+                    fontFamily: monoFontFamily,
+                    fontSize: '0.62rem',
+                    textTransform: 'uppercase',
+                    letterSpacing: '0.07em',
+                  }}
+                >
+                  {metric.label}
+                </Typography>
+                <Typography
+                  sx={{
+                    color: getDeltaColor(theme, metric.delta),
+                    fontFamily: monoFontFamily,
+                    fontSize: '0.62rem',
+                  }}
+                >
+                  {metric.delta}
+                </Typography>
+              </Box>
+              <Typography
+                sx={{
+                  color: getMetricTone(theme, metric.label),
+                  fontFamily: monoFontFamily,
+                  fontSize: '0.9rem',
+                  fontWeight: 700,
+                  flexShrink: 0,
+                }}
+              >
+                {metric.value.toLocaleString()}
+              </Typography>
+            </Stack>
+          </Box>
+        ))}
+      </Stack>
+    </Box>
+  );
+};
+
 const DashboardOverview: React.FC<DashboardOverviewProps> = ({
   range,
   sections,
@@ -157,170 +301,46 @@ const DashboardOverview: React.FC<DashboardOverviewProps> = ({
                     '&:last-child': { pb: { xs: 1.35, sm: 1.5 } },
                   }}
                 >
-                  <Grid
-                    container
-                    spacing={{ xs: 1.5, md: 1.75 }}
-                    alignItems="center"
-                  >
-                    <Grid item xs={12} md={7}>
-                      <Box sx={{ minWidth: 0 }}>
-                        <Typography
-                          sx={{
-                            color: theme.palette.text.primary,
-                            fontFamily: monoFontFamily,
-                            fontSize: { xs: '0.98rem', sm: '1.05rem' },
-                            fontWeight: 700,
-                          }}
-                        >
-                          {section.title}
-                        </Typography>
-                        <Typography
-                          sx={{
-                            mt: 0.18,
-                            color: 'text.secondary',
-                            fontFamily: monoFontFamily,
-                            fontSize: '0.7rem',
-                            letterSpacing: '0.02em',
-                          }}
-                        >
-                          {rangeDescription}
-                        </Typography>
-                      </Box>
+                  {/* Card header */}
+                  <Box sx={{ mb: 1.25 }}>
+                    <Typography
+                      sx={{
+                        color: theme.palette.text.primary,
+                        fontFamily: monoFontFamily,
+                        fontSize: { xs: '0.98rem', sm: '1.05rem' },
+                        fontWeight: 700,
+                      }}
+                    >
+                      {section.title}
+                    </Typography>
+                    <Typography
+                      sx={{
+                        mt: 0.18,
+                        color: 'text.secondary',
+                        fontFamily: monoFontFamily,
+                        fontSize: '0.7rem',
+                        letterSpacing: '0.02em',
+                      }}
+                    >
+                      {rangeDescription}
+                    </Typography>
+                  </Box>
 
-                      <Stack spacing={0.55} sx={{ mt: 0.7 }}>
-                        {section.metrics.map((metric) => (
-                          <Box
-                            key={`${section.title}-${metric.label}`}
-                            sx={{
-                              py: 0.58,
-                              borderTop: `1px solid ${alpha(theme.palette.text.primary, 0.06)}`,
-                              '&:first-of-type': {
-                                borderTop: `1px solid ${alpha(theme.palette.text.primary, 0.08)}`,
-                              },
-                            }}
-                          >
-                            <Stack
-                              direction="row"
-                              justifyContent="space-between"
-                              alignItems="baseline"
-                              spacing={1.5}
-                            >
-                              <Box sx={{ minWidth: 0 }}>
-                                <Typography
-                                  sx={{
-                                    color: alpha(
-                                      theme.palette.text.primary,
-                                      0.82,
-                                    ),
-                                    fontFamily: monoFontFamily,
-                                    fontSize: '0.68rem',
-                                    textTransform: 'uppercase',
-                                    letterSpacing: '0.08em',
-                                  }}
-                                >
-                                  {metric.label}
-                                </Typography>
-                                <Typography
-                                  sx={{
-                                    mt: 0.12,
-                                    color: getDeltaColor(theme, metric.delta),
-                                    fontFamily: monoFontFamily,
-                                    fontSize: '0.7rem',
-                                  }}
-                                >
-                                  {metric.delta}
-                                </Typography>
-                              </Box>
-
-                              <Typography
-                                sx={{
-                                  color: getMetricTone(theme, metric.label),
-                                  fontFamily: monoFontFamily,
-                                  fontSize: { xs: '0.96rem', sm: '1.04rem' },
-                                  fontWeight: 700,
-                                  flexShrink: 0,
-                                }}
-                              >
-                                {metric.value.toLocaleString()}
-                              </Typography>
-                            </Stack>
-                          </Box>
-                        ))}
-                      </Stack>
+                  {/* Two pools side by side */}
+                  <Grid container spacing={1}>
+                    <Grid item xs={6}>
+                      <PoolColumn
+                        sectionTitle={section.title}
+                        pool={section.eligible}
+                        isEligible={true}
+                      />
                     </Grid>
-
-                    <Grid item xs={12} md={5}>
-                      <Box
-                        sx={{
-                          display: 'flex',
-                          flexDirection: 'column',
-                          alignItems: 'center',
-                          justifyContent: 'center',
-                          gap: 0.7,
-                        }}
-                      >
-                        <Box
-                          sx={{
-                            width: 116,
-                            height: 116,
-                            flexShrink: 0,
-                            '& > div': { width: '100%', height: '100%' },
-                          }}
-                        >
-                          <ReactECharts
-                            option={buildStatusChartOption(
-                              theme,
-                              section.chartCenterLabel,
-                              section.chartSegments,
-                            )}
-                            style={{ width: '100%', height: '100%' }}
-                            opts={{ renderer: 'svg' }}
-                          />
-                        </Box>
-
-                        <Stack
-                          direction="row"
-                          spacing={1}
-                          useFlexGap
-                          flexWrap="wrap"
-                          justifyContent="center"
-                        >
-                          {section.chartSegments.map((segment) => (
-                            <Stack
-                              key={`${section.title}-${segment.label}`}
-                              direction="row"
-                              spacing={0.6}
-                              alignItems="center"
-                            >
-                              <Box
-                                sx={{
-                                  width: 8,
-                                  height: 8,
-                                  borderRadius: '50%',
-                                  backgroundColor: getSegmentColor(
-                                    theme,
-                                    segment.label,
-                                  ),
-                                }}
-                              />
-                              <Typography
-                                sx={{
-                                  color: alpha(
-                                    theme.palette.text.primary,
-                                    0.58,
-                                  ),
-                                  fontFamily: monoFontFamily,
-                                  fontSize: '0.66rem',
-                                  textTransform: 'uppercase',
-                                  letterSpacing: '0.05em',
-                                }}
-                              >
-                                {segment.label}
-                              </Typography>
-                            </Stack>
-                          ))}
-                        </Stack>
-                      </Box>
+                    <Grid item xs={6}>
+                      <PoolColumn
+                        sectionTitle={section.title}
+                        pool={section.ineligible}
+                        isEligible={false}
+                      />
                     </Grid>
                   </Grid>
                 </CardContent>

--- a/src/pages/dashboard/views/DashboardOverview.tsx
+++ b/src/pages/dashboard/views/DashboardOverview.tsx
@@ -215,8 +215,9 @@ const PoolColumn: React.FC<PoolColumnProps> = ({
                 width: 6,
                 height: 6,
                 borderRadius: '50%',
-                backgroundColor: getSegmentColor(theme, segment.label),
                 flexShrink: 0,
+                mt: '1px',
+                backgroundColor: getSegmentColor(theme, segment.label),
               }}
             />
             <Typography
@@ -224,6 +225,7 @@ const PoolColumn: React.FC<PoolColumnProps> = ({
                 color: alpha(theme.palette.text.primary, 0.55),
                 fontFamily: monoFontFamily,
                 fontSize: '0.6rem',
+                lineHeight: 1,
                 textTransform: 'uppercase',
                 letterSpacing: '0.04em',
               }}
@@ -263,7 +265,9 @@ const PoolColumn: React.FC<PoolColumnProps> = ({
                 </Typography>
                 <Typography
                   sx={{
-                    color: getDeltaColor(theme, metric.delta),
+                    color: isEligible
+                      ? getDeltaColor(theme, metric.delta)
+                      : alpha(theme.palette.text.primary, 0.25),
                     fontFamily: monoFontFamily,
                     fontSize: '0.62rem',
                   }}
@@ -273,7 +277,9 @@ const PoolColumn: React.FC<PoolColumnProps> = ({
               </Box>
               <Typography
                 sx={{
-                  color: getMetricTone(theme, metric.label),
+                  color: isEligible
+                    ? getMetricTone(theme, metric.label)
+                    : alpha(theme.palette.text.primary, 0.4),
                   fontFamily: monoFontFamily,
                   fontSize: '0.9rem',
                   fontWeight: 700,

--- a/src/pages/dashboard/views/DashboardOverview.tsx
+++ b/src/pages/dashboard/views/DashboardOverview.tsx
@@ -131,7 +131,11 @@ interface PoolColumnProps {
   isEligible: boolean;
 }
 
-const PoolColumn: React.FC<PoolColumnProps> = ({ sectionTitle, pool, isEligible }) => {
+const PoolColumn: React.FC<PoolColumnProps> = ({
+  sectionTitle,
+  pool,
+  isEligible,
+}) => {
   const theme = useTheme();
   const monoFontFamily = theme.typography.fontFamily;
 
@@ -159,8 +163,12 @@ const PoolColumn: React.FC<PoolColumnProps> = ({ sectionTitle, pool, isEligible 
           px: 0.75,
           py: 0.2,
           border: `1px solid ${isEligible ? alpha(theme.palette.status.merged, 0.45) : theme.palette.border.subtle}`,
-          color: isEligible ? theme.palette.status.merged : theme.palette.text.secondary,
-          backgroundColor: isEligible ? alpha(theme.palette.status.merged, 0.08) : theme.palette.surface.subtle,
+          color: isEligible
+            ? theme.palette.status.merged
+            : theme.palette.text.secondary,
+          backgroundColor: isEligible
+            ? alpha(theme.palette.status.merged, 0.08)
+            : theme.palette.surface.subtle,
         }}
       >
         {isEligible ? 'Eligible' : 'Not Eligible'}
@@ -177,14 +185,24 @@ const PoolColumn: React.FC<PoolColumnProps> = ({ sectionTitle, pool, isEligible 
         }}
       >
         <ReactECharts
-          option={buildStatusChartOption(theme, pool.chartCenterLabel, pool.chartSegments)}
+          option={buildStatusChartOption(
+            theme,
+            pool.chartCenterLabel,
+            pool.chartSegments,
+          )}
           style={{ width: '100%', height: '100%' }}
           opts={{ renderer: 'svg' }}
         />
       </Box>
 
       {/* Legend */}
-      <Stack direction="row" spacing={0.75} useFlexGap flexWrap="wrap" justifyContent="center">
+      <Stack
+        direction="row"
+        spacing={0.75}
+        useFlexGap
+        flexWrap="wrap"
+        justifyContent="center"
+      >
         {pool.chartSegments.map((segment) => (
           <Stack
             key={`${sectionTitle}-${isEligible}-${segment.label}`}
@@ -226,7 +244,11 @@ const PoolColumn: React.FC<PoolColumnProps> = ({ sectionTitle, pool, isEligible 
               borderTop: `1px solid ${alpha(theme.palette.text.primary, 0.06)}`,
             }}
           >
-            <Stack direction="row" justifyContent="space-between" alignItems="baseline">
+            <Stack
+              direction="row"
+              justifyContent="space-between"
+              alignItems="baseline"
+            >
               <Box>
                 <Typography
                   sx={{


### PR DESCRIPTION
## Closes: #719

## Summary

- Split the **OSS Contributions** and **Issue Discoveries** dashboard overview cards into two side-by-side pools — **Eligible** and **Not Eligible** — each with its own donut chart and metrics
- Eligible pool uses a green badge; Not Eligible pool uses a gray badge, matching the existing `MinerCard` eligibility badge style
- Keeps the same 2-card layout (one card per section), so the dashboard takes no more vertical space than before

## Changes

- **`dashboardData.ts`** — replaced the flat `DashboardOverviewSection` shape with a `DashboardOverviewPool` sub-type; `buildDashboardOverview` now returns 2 sections (down from 4), each with `eligible` and `ineligible` pools computed by filtering miners on `isEligible` / `isIssueEligible`
- **`DashboardOverview.tsx`** — replaced the single-chart card layout with a two-column `PoolColumn` layout; badge styling mirrors the existing `MinerCard` eligibility chips (green tint for eligible, subtle gray for not eligible)

## Test plan

- [ ] Dashboard loads without errors in all time ranges (1D, 7D, 35D, All)
- [ ] Each section card shows two pools side by side with correct counts and center percentages
- [ ] Eligible badge renders green; Not Eligible badge renders gray (no red)
- [ ] Tooltip on chart segments shows correct values
- [ ] Layout is responsive — stacks gracefully on smaller viewports

## Screenshots

<img width="1249" height="459" alt="image" src="https://github.com/user-attachments/assets/70c3a69b-099e-418b-9a9d-adb06ad93d6b" />

