### PR TITLE
change mobile layout of onboard page

### DIFF
--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -21,6 +21,7 @@ import { getRouteForPathname } from '../../routes';
 
 const SIDEBAR_OPEN_STORAGE_KEY = 'gittensor.sidebar.open';
 const SIDEBAR_WIDTH = 240;
+const MOBILE_APP_BAR_HEIGHT = 56;
 
 const PanelLeftIcon: React.FC<{ size?: number }> = ({ size = 20 }) => (
   <svg
@@ -53,7 +54,7 @@ const AppLayout: React.FC = () => {
   const mainRef = useRef<HTMLElement>(null);
   const location = useLocation();
   useOnNavigate(() => mainRef.current?.scrollTo(0, 0));
-  const isMobile = useMediaQuery(theme.breakpoints.down('md'));
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
   const [mobileOpen, setMobileOpen] = useState(false);
   const [sidebarOpen, setSidebarOpen] = useState<boolean>(
     readStoredSidebarOpen,
@@ -85,9 +86,9 @@ const AppLayout: React.FC = () => {
     <Box
       sx={{
         display: 'flex',
-        width: '100vw',
-        minHeight: '100vh',
-        height: '100vh',
+        width: '100%',
+        minHeight: '100dvh',
+        height: '100dvh',
         overflow: 'hidden',
         justifyContent: 'center', // Center for ultra-wide screens
       }}
@@ -103,7 +104,7 @@ const AppLayout: React.FC = () => {
           }}
           elevation={0}
         >
-          <Toolbar>
+          <Toolbar sx={{ minHeight: `${MOBILE_APP_BAR_HEIGHT}px !important` }}>
             <IconButton
               color="inherit"
               aria-label="open drawer"
@@ -117,7 +118,7 @@ const AppLayout: React.FC = () => {
               src="/gt-logo.svg"
               alt="Gittensor"
               style={{
-                height: '40px',
+                height: '32px',
                 width: 'auto',
                 filter: `brightness(0) invert(1) drop-shadow(0 0 6px ${alpha(theme.palette.common.white, 0.8)})`,
               }}
@@ -139,7 +140,7 @@ const AppLayout: React.FC = () => {
             display: { xs: 'block', md: 'none' },
             '& .MuiDrawer-paper': {
               boxSizing: 'border-box',
-              width: 280,
+              width: { xs: '100%', sm: 320 },
               backgroundColor: 'background.default',
               backgroundImage: `linear-gradient(${alpha(theme.palette.common.white, 0.05)}, ${alpha(theme.palette.common.white, 0.05)})`,
               borderRight: `1px solid ${theme.palette.border.light}`,
@@ -283,15 +284,15 @@ const AppLayout: React.FC = () => {
           flexGrow: 1,
           maxWidth: '1920px', // Max content width for ultra-wide screens
           width: '100%',
-          height: { xs: 'calc(100vh - 64px)', md: '100vh' },
-          mt: { xs: '64px', md: 0 },
+          height: { xs: `calc(100dvh - ${MOBILE_APP_BAR_HEIGHT}px)`, sm: '100dvh' },
+          mt: { xs: `${MOBILE_APP_BAR_HEIGHT}px`, sm: 0 },
           overflowY: 'auto',
           overflowX: 'hidden',
           display: 'flex',
           flexDirection: 'column',
           px: { xs: 1, sm: 2, md: 3 },
           ...scrollbarSx,
-          alignItems: 'center',
+          alignItems: { xs: 'stretch', md: 'center' },
         }}
       >
         <Suspense fallback={<LoadingPage />}>
@@ -301,7 +302,7 @@ const AppLayout: React.FC = () => {
                 width: '100%',
                 pt: { xs: 1, md: 1.5 },
                 pb: { xs: 1, md: 1.5 },
-                px: { xs: 2, md: 3 },
+                px: { xs: 1, sm: 2, md: 3 },
                 position: 'sticky',
                 top: 0,
                 zIndex: 500,

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -20,33 +20,6 @@ import { getRouteForPathname } from '../../routes';
 
 const SIDEBAR_WIDTH = 240;
 const MOBILE_APP_BAR_HEIGHT = 56;
-
-const PanelLeftIcon: React.FC<{ size?: number }> = ({ size = 20 }) => (
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    width={size}
-    height={size}
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth={2}
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    aria-hidden="true"
-  >
-    <rect width="18" height="18" x="3" y="3" rx="2" />
-    <path d="M9 3v18" />
-  </svg>
-);
-
-const readStoredSidebarOpen = (): boolean => {
-  try {
-    const raw = window.localStorage.getItem(SIDEBAR_OPEN_STORAGE_KEY);
-    return raw === null ? true : raw === 'true';
-  } catch {
-    return true;
-  }
-};
 const SIDEBAR_COLLAPSED_WIDTH = 72;
 
 const AppLayout: React.FC = () => {
@@ -54,7 +27,6 @@ const AppLayout: React.FC = () => {
   const location = useLocation();
   useOnNavigate(() => mainRef.current?.scrollTo(0, 0));
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
-  const isMobile = useMediaQuery(theme.breakpoints.down('md'));
   const isCompactDesktop = useMediaQuery(theme.breakpoints.down('lg'));
   const isDesktopSidebarCollapsed = !isMobile && isCompactDesktop;
   const [mobileOpen, setMobileOpen] = useState(false);

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -138,7 +138,10 @@ const AppLayout: React.FC = () => {
           flexGrow: 1,
           maxWidth: '1920px', // Max content width for ultra-wide screens
           width: '100%',
-          height: { xs: `calc(100dvh - ${MOBILE_APP_BAR_HEIGHT}px)`, sm: '100dvh' },
+          height: {
+            xs: `calc(100dvh - ${MOBILE_APP_BAR_HEIGHT}px)`,
+            sm: '100dvh',
+          },
           mt: { xs: `${MOBILE_APP_BAR_HEIGHT}px`, sm: 0 },
           overflowY: 'auto',
           overflowX: 'hidden',

--- a/src/components/onboard/AboutContent.tsx
+++ b/src/components/onboard/AboutContent.tsx
@@ -7,6 +7,7 @@ import {
   Stack,
   alpha,
   useTheme,
+  useMediaQuery,
 } from '@mui/material';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import CodeIcon from '@mui/icons-material/Code';
@@ -16,6 +17,7 @@ import { useMonthlyRewards } from '../../hooks/useMonthlyRewards';
 
 export const AboutContent: React.FC = () => {
   const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
   const monthlyRewards = useMonthlyRewards();
 
   return (
@@ -250,16 +252,17 @@ export const AboutContent: React.FC = () => {
             rel="noopener noreferrer"
             endIcon={<OpenInNewIcon />}
             sx={{
-              px: 5,
-              py: 2,
-              fontSize: '1.1rem',
+              px: { xs: 3.5, sm: 5 },
+              py: { xs: 1, sm: 2 },
+              fontSize: { xs: '0.95rem', sm: '1.1rem' },
+              lineHeight: 1.35,
               fontWeight: 'bold',
               borderRadius: '50px',
               boxShadow: `0 0 20px ${alpha(theme.palette.common.black, 0.3)}`,
               textTransform: 'none',
             }}
           >
-            View Documentation & Setup Guide
+            {isMobile ? 'View Docs & Setup Guide' : 'View Documentation & Setup Guide'}
           </Button>
         </Box>
 

--- a/src/components/onboard/AboutContent.tsx
+++ b/src/components/onboard/AboutContent.tsx
@@ -262,7 +262,9 @@ export const AboutContent: React.FC = () => {
               textTransform: 'none',
             }}
           >
-            {isMobile ? 'View Docs & Setup Guide' : 'View Documentation & Setup Guide'}
+            {isMobile
+              ? 'View Docs & Setup Guide'
+              : 'View Documentation & Setup Guide'}
           </Button>
         </Box>
 

--- a/src/components/onboard/Scoring.tsx
+++ b/src/components/onboard/Scoring.tsx
@@ -97,9 +97,13 @@ export const Scoring: React.FC = () => {
           value={category}
           onChange={(_e, v) => setCategory(v)}
           sx={{
+            width: { xs: '100%', sm: 'auto' },
             '& .MuiTab-root': {
               textTransform: 'none',
-              fontSize: '0.9rem',
+              minWidth: { xs: 0, sm: 'auto' },
+              flex: { xs: 1, sm: 'initial' },
+              px: { xs: 1, sm: 2 },
+              fontSize: { xs: '0.82rem', sm: '0.9rem' },
               color: alpha(theme.palette.common.white, 0.55),
               '&.Mui-selected': { color: 'text.primary' },
             },

--- a/src/components/repositories/LanguageWeightsTable.tsx
+++ b/src/components/repositories/LanguageWeightsTable.tsx
@@ -219,19 +219,32 @@ const LanguageWeightsTable: React.FC = () => {
       <Box
         sx={{
           display: 'flex',
+          flexDirection: { xs: 'column', sm: 'row' },
           justifyContent: 'space-between',
-          alignItems: 'center',
+          alignItems: { xs: 'stretch', sm: 'center' },
           gap: 2,
           mb: 3,
         }}
       >
         <Box sx={{ flex: 1 }}>
-          <Typography variant="body2" color="text.secondary">
+          <Typography
+            variant="body2"
+            color="text.secondary"
+            sx={{ lineHeight: 1.6 }}
+          >
             Programming language multipliers used in scoring calculations
           </Typography>
         </Box>
 
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: { xs: 'flex-start', sm: 'flex-end' },
+            flexWrap: 'wrap',
+            gap: 1.5,
+          }}
+        >
           <Tooltip title={showChart ? 'Hide Chart' : 'Show Chart'}>
             <IconButton
               onClick={() => setShowChart(!showChart)}
@@ -321,7 +334,7 @@ const LanguageWeightsTable: React.FC = () => {
               ),
             }}
             sx={{
-              width: '200px',
+              width: { xs: '100%', sm: '200px' },
               '& .MuiOutlinedInput-root': {
                 color: theme.palette.text.primary,
                 backgroundColor: alpha(theme.palette.common.black, 0.4),

--- a/src/pages/OnboardPage.tsx
+++ b/src/pages/OnboardPage.tsx
@@ -62,6 +62,7 @@ const OnboardPage: React.FC = () => {
           sx={(theme) => ({
             maxWidth: 1200,
             width: '100%',
+            px: { xs: 2, sm: 3, md: 0 },
             mb: 4,
             borderBottom: '1px solid',
             borderColor: theme.palette.border.light,
@@ -74,11 +75,21 @@ const OnboardPage: React.FC = () => {
             scrollButtons="auto"
             allowScrollButtonsMobile
             sx={(theme) => ({
-              px: 2,
+              px: 0,
+              '& .MuiTabs-scrollButtons.Mui-disabled': {
+                display: 'none',
+              },
+              '& .MuiTabs-flexContainer': {
+                gap: { xs: 3, sm: 4 },
+              },
               '& .MuiTab-root': {
                 textTransform: 'none',
                 fontWeight: 500,
-                fontSize: '1rem',
+                minWidth: 'auto',
+                minHeight: 48,
+                paddingLeft: 0,
+                paddingRight: 0,
+                fontSize: { xs: '0.95rem', sm: '1rem' },
                 color: theme.palette.text.secondary,
                 '&.Mui-selected': {
                   color: theme.palette.primary.main,


### PR DESCRIPTION
## Summary

Improves mobile responsiveness for the Onboard page across key sections:

- Aligned top navigation tabs and content edges on mobile so the first tab (About) starts at the same left boundary as section content.
- Fixed tab indicator alignment by removing internal tab horizontal padding and using container gap spacing, so underlines match tab labels cleanly.
- Reduced mobile CTA button height in the About section by tightening padding/font sizing and using a shorter mobile label for better visual balance.
- Fixed clipping/readability of OSS Contributions / Issue Discovery in Scoring tabs by reducing mobile tab font size/padding and improving tab width behavior.
- Reworked the Languages table header controls for mobile by stacking description text above controls and allowing controls/search to wrap and render cleanly.

## Related Issues

Fixes #724 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Other (describe below)

## Screenshots

- before
<br/>
<img width="471" height="759" alt="onboard_1" src="https://github.com/user-attachments/assets/52fb7f4c-8986-45fd-b204-e952a6bb4ff7" />
<br/>
<img width="450" height="670" alt="onboard_2" src="https://github.com/user-attachments/assets/6ca06598-dd56-4a8d-b4dc-1e32dc2ec84e" />
<br/>
<img width="457" height="755" alt="onboard_3" src="https://github.com/user-attachments/assets/120f1446-4cff-44cf-8356-f1ec3d67b667" />
<br/>
<img width="462" height="764" alt="onboard_4" src="https://github.com/user-attachments/assets/79787ef2-36cb-4878-a4ba-fa48b74a8514" />

- after
<br/>
<img width="450" height="738" alt="onboard_1_fix" src="https://github.com/user-attachments/assets/4c606049-94d0-413b-8752-fc6ac890113f" />
<br/>
<img width="451" height="751" alt="onboard_2_fix" src="https://github.com/user-attachments/assets/95387e00-f52f-41bc-8859-8a9db0cce0bb" />
<br/>
<img width="451" height="755" alt="onboard_3_fix" src="https://github.com/user-attachments/assets/ddf8c2c6-fe0f-4b89-9d26-8368cfcd3bf3" />
<br/>
<img width="458" height="746" alt="onboard_4_fix" src="https://github.com/user-attachments/assets/f263eebc-d433-4814-b164-5383bd347457" />


## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [ ] Tested against the test API
- [ ] `npm run format` and `npm run lint:fix` have been run
- [ ] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
