### PR TITLE
feat: add Featured Discoveries section to dashboard 

### DIFF
--- a/src/pages/dashboard/DashboardPage.tsx
+++ b/src/pages/dashboard/DashboardPage.tsx
@@ -84,7 +84,7 @@ const DashboardFeaturePage: React.FC = () => {
             />
 
             <DashboardTopContributors
-              title="Featured Discoveries"
+              title="Featured Discoverers"
               contributors={featuredDiscoveryContributors}
               isLoading={isLoading}
             />

--- a/src/pages/dashboard/DashboardPage.tsx
+++ b/src/pages/dashboard/DashboardPage.tsx
@@ -22,6 +22,7 @@ const DashboardFeaturePage: React.FC = () => {
     trendLabels,
     trendSeries,
     featuredContributors,
+    featuredDiscoveryContributors,
     isLoading,
   } = useDashboardData(range);
 
@@ -79,6 +80,12 @@ const DashboardFeaturePage: React.FC = () => {
 
             <DashboardTopContributors
               contributors={featuredContributors}
+              isLoading={isLoading}
+            />
+
+            <DashboardTopContributors
+              title="Featured Discoveries"
+              contributors={featuredDiscoveryContributors}
               isLoading={isLoading}
             />
           </Box>

--- a/src/pages/dashboard/dashboardData.ts
+++ b/src/pages/dashboard/dashboardData.ts
@@ -727,9 +727,7 @@ const pickMostSolvedIssuesMiner = (
   miners: MinerEvaluation[],
 ): DashboardFeaturedContributor | undefined => {
   const top = [...miners]
-    .filter(
-      (m) => m.isIssueEligible && (m.totalValidSolvedIssues ?? 0) > 0,
-    )
+    .filter((m) => m.isIssueEligible && (m.totalValidSolvedIssues ?? 0) > 0)
     .sort((a, b) => {
       const diff =
         (b.totalValidSolvedIssues ?? 0) - (a.totalValidSolvedIssues ?? 0);
@@ -807,7 +805,8 @@ export const buildFeaturedDiscoveryContributors = (
 
   if (topDiscoveryMiner) contributors.push(topDiscoveryMiner);
   if (mostSolvedIssuesMiner) contributors.push(mostSolvedIssuesMiner);
-  if (highestIssueTokenScoreMiner) contributors.push(highestIssueTokenScoreMiner);
+  if (highestIssueTokenScoreMiner)
+    contributors.push(highestIssueTokenScoreMiner);
 
   return contributors;
 };

--- a/src/pages/dashboard/dashboardData.ts
+++ b/src/pages/dashboard/dashboardData.ts
@@ -682,3 +682,132 @@ export const buildFeaturedContributors = (
 
   return contributors;
 };
+
+const pickTopDiscoveryMiner = (
+  prs: CommitLog[],
+  miners: MinerEvaluation[],
+): DashboardFeaturedContributor | undefined => {
+  const top = [...miners]
+    .filter((m) => m.isIssueEligible && parseNumber(m.issueDiscoveryScore) > 0)
+    .sort((a, b) => {
+      const diff =
+        parseNumber(b.issueDiscoveryScore) - parseNumber(a.issueDiscoveryScore);
+      return diff !== 0 ? diff : a.id - b.id;
+    })[0];
+
+  if (!top) return undefined;
+
+  return {
+    featuredLabel: 'Top Discovery Miner',
+    githubId: top.githubId,
+    githubUsername: top.githubUsername,
+    name: top.githubUsername ?? top.githubId,
+    metrics: [
+      {
+        value: Math.round(
+          parseNumber(top.issueDiscoveryScore),
+        ).toLocaleString(),
+        unit: 'Score',
+      },
+      ...(parseNumber(top.issueCredibility) > 0
+        ? [
+            {
+              value: `${Math.round(parseNumber(top.issueCredibility) * 100)}%`,
+              unit: 'Cred.',
+            },
+          ]
+        : []),
+    ],
+    repos: getTopContributorRepos(prs, top.githubId),
+  };
+};
+
+const pickMostSolvedIssuesMiner = (
+  prs: CommitLog[],
+  miners: MinerEvaluation[],
+): DashboardFeaturedContributor | undefined => {
+  const top = [...miners]
+    .filter(
+      (m) => m.isIssueEligible && (m.totalValidSolvedIssues ?? 0) > 0,
+    )
+    .sort((a, b) => {
+      const diff =
+        (b.totalValidSolvedIssues ?? 0) - (a.totalValidSolvedIssues ?? 0);
+      if (diff !== 0) return diff;
+      return (
+        parseNumber(b.issueDiscoveryScore) - parseNumber(a.issueDiscoveryScore)
+      );
+    })[0];
+
+  if (!top) return undefined;
+
+  return {
+    featuredLabel: 'Most Solved Issues',
+    githubId: top.githubId,
+    githubUsername: top.githubUsername,
+    name: top.githubUsername ?? top.githubId,
+    metrics: [
+      {
+        value: `${top.totalValidSolvedIssues ?? 0}`,
+        unit: 'Solved',
+      },
+      ...(parseNumber(top.issueCredibility) > 0
+        ? [
+            {
+              value: `${Math.round(parseNumber(top.issueCredibility) * 100)}%`,
+              unit: 'Cred.',
+            },
+          ]
+        : []),
+    ],
+    repos: getTopContributorRepos(prs, top.githubId),
+  };
+};
+
+const pickHighestIssueTokenScoreMiner = (
+  prs: CommitLog[],
+  miners: MinerEvaluation[],
+): DashboardFeaturedContributor | undefined => {
+  const top = [...miners]
+    .filter((m) => m.isIssueEligible && parseNumber(m.issueTokenScore) > 0)
+    .sort((a, b) => {
+      const diff =
+        parseNumber(b.issueTokenScore) - parseNumber(a.issueTokenScore);
+      return diff !== 0 ? diff : a.id - b.id;
+    })[0];
+
+  if (!top) return undefined;
+
+  return {
+    featuredLabel: 'Highest-Scoring Issue Author',
+    githubId: top.githubId,
+    githubUsername: top.githubUsername,
+    name: top.githubUsername ?? top.githubId,
+    metrics: [
+      {
+        value: Math.round(parseNumber(top.issueTokenScore)).toLocaleString(),
+        unit: 'Score',
+      },
+    ],
+    repos: getTopContributorRepos(prs, top.githubId),
+  };
+};
+
+export const buildFeaturedDiscoveryContributors = (
+  prs: CommitLog[],
+  miners: MinerEvaluation[],
+): DashboardFeaturedContributor[] => {
+  const topDiscoveryMiner = pickTopDiscoveryMiner(prs, miners);
+  const mostSolvedIssuesMiner = pickMostSolvedIssuesMiner(prs, miners);
+  const highestIssueTokenScoreMiner = pickHighestIssueTokenScoreMiner(
+    prs,
+    miners,
+  );
+  const contributors: DashboardFeaturedContributor[] = [];
+
+  if (topDiscoveryMiner) contributors.push(topDiscoveryMiner);
+  if (mostSolvedIssuesMiner) contributors.push(mostSolvedIssuesMiner);
+  if (highestIssueTokenScoreMiner) contributors.push(highestIssueTokenScoreMiner);
+
+  return contributors;
+};

--- a/src/pages/dashboard/useDashboardData.ts
+++ b/src/pages/dashboard/useDashboardData.ts
@@ -20,6 +20,7 @@ import {
   buildDashboardOverview,
   buildDashboardTrendData,
   buildFeaturedContributors,
+  buildFeaturedDiscoveryContributors,
   type TrendTimeRange,
 } from './dashboardData';
 
@@ -69,6 +70,15 @@ export const useDashboardData = (range: TrendTimeRange) => {
     [datasets.miners.data, datasets.prs.data],
   );
 
+  const featuredDiscoveryContributors = useMemo(
+    () =>
+      buildFeaturedDiscoveryContributors(
+        datasets.prs.data,
+        datasets.miners.data,
+      ),
+    [datasets.miners.data, datasets.prs.data],
+  );
+
   const kpis = useMemo(
     () => buildDashboardKpis(datasets.prs.data, datasets.issues.data, range),
     [datasets.issues.data, datasets.prs.data, range],
@@ -81,6 +91,7 @@ export const useDashboardData = (range: TrendTimeRange) => {
     trendLabels: trendData.labels,
     trendSeries: trendData.series,
     featuredContributors,
+    featuredDiscoveryContributors,
     isLoading:
       datasets.prs.isLoading ||
       datasets.miners.isLoading ||

--- a/src/pages/dashboard/views/DashboardTopContributors.tsx
+++ b/src/pages/dashboard/views/DashboardTopContributors.tsx
@@ -14,6 +14,7 @@ import { type DashboardFeaturedContributor } from '../dashboardData';
 interface DashboardTopContributorsProps {
   contributors: DashboardFeaturedContributor[];
   isLoading?: boolean;
+  title?: string;
 }
 
 const getInitials = (name: string) =>
@@ -27,6 +28,7 @@ const getInitials = (name: string) =>
 const DashboardTopContributors: React.FC<DashboardTopContributorsProps> = ({
   contributors,
   isLoading = false,
+  title = 'Featured Contributors',
 }) => {
   const theme = useTheme();
   const navigate = useNavigate();
@@ -57,7 +59,7 @@ const DashboardTopContributors: React.FC<DashboardTopContributorsProps> = ({
             fontWeight: 700,
           }}
         >
-          Featured Contributors
+          {title}
         </Typography>
       </Box>
 


### PR DESCRIPTION
## Summary

- Adds a new "Featured Discoveries" panel to the Dashboard, parallel to the  existing "Featured Contributors" section, spotlighting the top miners in  the issue discovery program
- Introduces three discovery-specific spotlights: **Top Discovery Miner**  (highest `issueDiscoveryScore`), **Most Solved Issues** (highest  `totalValidSolvedIssues`), and **Highest-Scoring Issue Author** (highest  `issueTokenScore`) — all filtered to `isIssueEligible` miners
- Makes `DashboardTopContributors` title-configurable via a `title` prop  (defaults to `"Featured Contributors"`) so the same component drives both panels
- Also exposes `buildFeaturedWork` (top-scoring PRs + highest-bounty issues in  the 35-day window) for future use

## How it works

Three new private picker functions in `dashboardData.ts` mirror the existing OSS picker pattern (`pickTopOssContributor`, etc.) and are orchestrated by the new `buildFeaturedDiscoveryContributors` export. `useDashboardData` computes it alongside the existing `featuredContributors` memo, and `DashboardPage` renders it as a second `DashboardTopContributors` block.

## Test plan

- [ ] Navigate to `/dashboard` and confirm a "Featured Discoveries" panel  appears below "Featured Contributors"
- [ ] Confirm the three cards show correct labels, green metrics, and repo pills
- [ ] Confirm the panel is absent / shows empty state when no  `isIssueEligible` miners are in the dataset
- [ ] Confirm the existing "Featured Contributors" panel is unaffected
- [ ] Check responsive layout: stacks on mobile, 2-col on tablet, 3-col on desktop

## Closes #721

## Screenshot

<img width="1050" height="375" alt="image" src="https://github.com/user-attachments/assets/1ed54c24-80c6-422c-b05c-2dfebaf527f3" />
