### PR TITLE
change mobile layout of top-miners page

### DIFF
--- a/src/components/leaderboard/LeaderboardSidebar.tsx
+++ b/src/components/leaderboard/LeaderboardSidebar.tsx
@@ -53,7 +53,13 @@ export const LeaderboardSidebar: React.FC<LeaderboardSidebarProps> = ({
   return (
     <Stack
       spacing={2}
-      sx={{ height: '100%', overflow: 'auto', pr: 1, ...scrollbarSx }}
+      sx={{
+        width: '100%',
+        height: '100%',
+        overflow: 'auto',
+        pr: { xs: 0, xl: 1 },
+        ...scrollbarSx,
+      }}
     >
       {/* Activity Cards: PR Activity, Issue Activity, Code Impact */}
       <ActivitySidebarCards miners={miners} />

--- a/src/components/leaderboard/TopMinersTable.tsx
+++ b/src/components/leaderboard/TopMinersTable.tsx
@@ -250,7 +250,7 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
   }
 
   return (
-    <Box sx={{ p: 2 }}>
+    <Box sx={{ width: '100%', px: { xs: 0, md: 1 }, py: 0 }}>
       {/* Header Card — two-row toolbar */}
       <SectionCard
         sx={{
@@ -298,7 +298,7 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
           <Box
             sx={{
               display: 'flex',
-              alignItems: 'center',
+              alignItems: { xs: 'stretch', sm: 'center' },
               justifyContent: 'space-between',
               gap: 1,
               flexWrap: 'wrap',
@@ -310,7 +310,15 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
               onSortChange={handleSortChange}
               variant={variant}
             />
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <Box
+              sx={{
+                display: 'flex',
+                flexDirection: { xs: 'column', sm: 'row' },
+                alignItems: { xs: 'center', sm: 'center' },
+                gap: 1,
+                width: { xs: '100%', sm: 'auto' },
+              }}
+            >
               <EligibilityToggle
                 value={eligibilityFilter}
                 onChange={handleEligibilityChange}
@@ -324,7 +332,9 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
         </Box>
       </SectionCard>
 
-      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+      <Box
+        sx={{ width: '100%', display: 'flex', flexDirection: 'column', gap: 2 }}
+      >
         {filteredMiners.length > 0 && viewMode === 'cards' && (
           <Grid container spacing={2}>
             {visibleMiners.map((miner) => (

--- a/src/components/leaderboard/TopMinersTable.tsx
+++ b/src/components/leaderboard/TopMinersTable.tsx
@@ -416,29 +416,33 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
                 value={eligibilityFilter}
                 onChange={handleEligibilityChange}
               />
-                alignItems: 'center',
-                gap: 1,
-                flexWrap: 'wrap',
-                justifyContent: 'flex-end',
-              }}
-            >
-              {variant === 'watchlist' ? (
-                <WatchlistEligibilityBar
-                  ossValue={eligibleOssFilter}
-                  discoveryValue={eligibleDiscoveryFilter}
-                  onOssChange={handleEligibleOssChange}
-                  onDiscoveryChange={handleEligibleDiscoveryChange}
+              <Box
+                sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 1,
+                  flexWrap: 'wrap',
+                  justifyContent: 'flex-end',
+                }}
+              >
+                {variant === 'watchlist' ? (
+                  <WatchlistEligibilityBar
+                    ossValue={eligibleOssFilter}
+                    discoveryValue={eligibleDiscoveryFilter}
+                    onOssChange={handleEligibleOssChange}
+                    onDiscoveryChange={handleEligibleDiscoveryChange}
+                  />
+                ) : (
+                  <EligibilityToggle
+                    value={eligibleOssFilter}
+                    onChange={handleEligibleOssChange}
+                  />
+                )}
+                <ViewModeToggle
+                  viewMode={viewMode}
+                  onChange={handleViewModeChange}
                 />
-              ) : (
-                <EligibilityToggle
-                  value={eligibleOssFilter}
-                  onChange={handleEligibleOssChange}
-                />
-              )}
-              <ViewModeToggle
-                viewMode={viewMode}
-                onChange={handleViewModeChange}
-              />
+              </Box>
             </Box>
           </Box>
         </Box>

--- a/src/components/leaderboard/TopMinersTable.tsx
+++ b/src/components/leaderboard/TopMinersTable.tsx
@@ -391,10 +391,9 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
           <Box
             sx={{
               display: 'flex',
-              alignItems: { xs: 'stretch', sm: 'center' },
-              justifyContent: 'space-between',
+              flexDirection: 'column',
+              alignItems: 'stretch',
               gap: 1,
-              flexWrap: 'wrap',
             }}
           >
             <SortButtons
@@ -406,10 +405,11 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
             <Box
               sx={{
                 display: 'flex',
-                flexDirection: { xs: 'column', sm: 'row' },
-                alignItems: { xs: 'center', sm: 'center' },
+                flexDirection: 'row',
+                alignItems: 'center',
+                justifyContent: 'space-between',
                 gap: 1,
-                width: { xs: '100%', sm: 'auto' },
+                width: '100%',
               }}
             >
               <Box
@@ -417,8 +417,9 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
                   display: 'flex',
                   alignItems: 'center',
                   gap: 1,
-                  flexWrap: 'wrap',
-                  justifyContent: 'flex-end',
+                  flexWrap: 'nowrap',
+                  justifyContent: 'space-between',
+                  width: '100%',
                 }}
               >
                 {variant === 'watchlist' ? (
@@ -578,9 +579,11 @@ const SortButtons: React.FC<SortButtonsProps> = ({
   <Box
     sx={{
       display: 'flex',
-      gap: 0.5,
-      flexWrap: 'wrap',
-      justifyContent: 'center',
+      gap: { xs: 0.45, sm: 0.5 },
+      flexWrap: 'nowrap',
+      justifyContent: 'space-between',
+      width: '100%',
+      minWidth: 0,
     }}
   >
     {getSortButtonOptions(variant).map((option) => {
@@ -590,13 +593,16 @@ const SortButtons: React.FC<SortButtonsProps> = ({
           key={option.value}
           onClick={() => onSortChange(option.value)}
           sx={(theme) => ({
-            px: 1.5,
-            height: 32,
+            px: { xs: 0.75, sm: 1.5 },
+            height: { xs: 30, sm: 32 },
             display: 'flex',
             alignItems: 'center',
+            justifyContent: 'center',
             gap: 0.5,
             borderRadius: 2,
             cursor: 'pointer',
+            flex: 1,
+            minWidth: 0,
             backgroundColor: isActive
               ? alpha(theme.palette.text.primary, 0.1)
               : 'transparent',
@@ -613,8 +619,9 @@ const SortButtons: React.FC<SortButtonsProps> = ({
           <Typography
             sx={{
               fontFamily: FONTS.mono,
-              fontSize: '0.75rem',
+              fontSize: { xs: '0.62rem', sm: '0.75rem' },
               fontWeight: 600,
+              whiteSpace: 'nowrap',
             }}
           >
             {option.label}
@@ -937,8 +944,8 @@ const EligibilityToggle: React.FC<EligibilityToggleProps> = ({
   <Box
     sx={(theme) => ({
       display: 'inline-flex',
-      gap: compact ? 0.35 : 0.5,
-      p: compact ? 0.35 : 0.5,
+      gap: compact ? 0.3 : 0.28,
+      p: compact ? 0.3 : 0.35,
       borderRadius: 1.75,
       backgroundColor: theme.palette.surface.light,
       flexShrink: 0,
@@ -954,7 +961,7 @@ const EligibilityToggle: React.FC<EligibilityToggleProps> = ({
           aria-pressed={isActive}
           onClick={() => onChange(option.value)}
           sx={(theme) => ({
-            px: compact ? 1 : 1.5,
+            px: compact ? 0.9 : 1.2,
             height: compact ? 22 : 24,
             display: 'flex',
             alignItems: 'center',

--- a/src/components/leaderboard/TopMinersTable.tsx
+++ b/src/components/leaderboard/TopMinersTable.tsx
@@ -16,13 +16,15 @@ import {
   Portal,
   useMediaQuery,
 } from '@mui/material';
-import { alpha } from '@mui/material/styles';
+import { alpha, type Theme } from '@mui/material/styles';
 import TuneOutlinedIcon from '@mui/icons-material/TuneOutlined';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import ViewModuleIcon from '@mui/icons-material/ViewModule';
 import ViewListIcon from '@mui/icons-material/ViewList';
 import { MinerCard } from './MinerCard';
 import { MinersList } from './MinersList';
+import { SectionCard } from './SectionCard';
+import { SearchInput } from '../common/SearchInput';
 import theme, { STATUS_COLORS } from '../../theme';
 import { useDataTableParams } from '../../hooks/useDataTableParams';
 import { useWatchlist } from '../../hooks/useWatchlist';
@@ -298,6 +300,11 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
     [setFilter, variant],
   );
 
+  const handleSearchChange = useCallback(
+    (next: string) => setFilter('search', next),
+    [setFilter],
+  );
+
   const handleEligibleOssChange = useCallback(
     (next: EligibilityFilter) => {
       if (variant === 'watchlist') {
@@ -378,6 +385,8 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
   useEffect(() => {
     setPortalTarget(document.getElementById('tabs-options-portal'));
   }, []);
+
+  const usePortal = Boolean(portalTarget && isLargeScreen);
 
   useEffect(() => {
     if (!observerTarget.current || remainingMiners <= 0) return;
@@ -509,98 +518,104 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
               </Box>
             </Box>
           </Box>
-  const usePortal = portalTarget && isLargeScreen;
-
-  return (
-    <Box sx={{ pt: 2 }}>
-      {/* On large screens: render controls expanded in the sidebar */}
-      {usePortal ? (
-        <Portal container={portalTarget}>
-          <ToolbarSidebarPanel
-            sortOption={sortOption}
-            sortDirection={sortDirection}
-            onSortChange={handleSortChange}
-            variant={variant}
-            viewMode={viewMode}
-            onViewModeChange={handleViewModeChange}
-            eligibleOssFilter={eligibleOssFilter}
-            eligibleDiscoveryFilter={eligibleDiscoveryFilter}
-            onEligibleOssChange={handleEligibleOssChange}
-            onEligibleDiscoveryChange={handleEligibleDiscoveryChange}
-          />
-        </Portal>
-      ) : (
-        <Box
-          sx={{
-            mb: 1.5,
-            px: 2,
-            display: 'flex',
-            justifyContent: 'flex-end',
-          }}
-        >
-          <ToolbarPopover
-            sortOption={sortOption}
-            sortDirection={sortDirection}
-            onSortChange={handleSortChange}
-            variant={variant}
-            viewMode={viewMode}
-            onViewModeChange={handleViewModeChange}
-            eligibleOssFilter={eligibleOssFilter}
-            eligibleDiscoveryFilter={eligibleDiscoveryFilter}
-            onEligibleOssChange={handleEligibleOssChange}
-            onEligibleDiscoveryChange={handleEligibleDiscoveryChange}
-          />
         </Box>
-      )}
+      </SectionCard>
 
-      <Box
-        sx={{ width: '100%', display: 'flex', flexDirection: 'column', gap: 2 }}
-      >
-        {filteredMiners.length > 0 && viewMode === 'cards' && (
-          <Grid container spacing={2}>
-            {visibleMiners.map((miner) => (
-              <Grid item xs={12} sm={12} md={6} lg={4} xl={4} key={miner.id}>
-                <MinerCard
-                  miner={miner}
-                  variant={variant}
-                  href={getMinerHref(miner)}
-                  linkState={linkState}
-                  showDualEligibilityBadges={showDualEligibilityBadges}
-                />
-              </Grid>
-            ))}
-          </Grid>
-        )}
-
-        {filteredMiners.length > 0 && viewMode === 'list' && (
-          <MinersList
-            miners={visibleMiners}
-            variant={variant}
-            sortOption={sortOption}
-            sortDirection={sortDirection}
-            onSort={handleSortChange}
-            getHref={getMinerHref}
-            linkState={linkState}
-          />
-        )}
-
-        {remainingMiners > 0 && (
-          <Box ref={observerTarget} sx={{ height: 20, width: '100%' }} />
-        )}
-
-        {filteredMiners.length === 0 && (
+      <Box sx={{ pt: 2 }}>
+        {/* On large screens: render controls expanded in the sidebar */}
+        {usePortal ? (
+          <Portal container={portalTarget}>
+            <ToolbarSidebarPanel
+              sortOption={sortOption}
+              sortDirection={sortDirection}
+              onSortChange={handleSortChange}
+              variant={variant}
+              viewMode={viewMode}
+              onViewModeChange={handleViewModeChange}
+              eligibleOssFilter={eligibleOssFilter}
+              eligibleDiscoveryFilter={eligibleDiscoveryFilter}
+              onEligibleOssChange={handleEligibleOssChange}
+              onEligibleDiscoveryChange={handleEligibleDiscoveryChange}
+            />
+          </Portal>
+        ) : (
           <Box
-            sx={(theme) => ({
-              py: 8,
-              textAlign: 'center',
-              color: theme.palette.text.secondary,
-            })}
+            sx={{
+              mb: 1.5,
+              px: 2,
+              display: 'flex',
+              justifyContent: 'flex-end',
+            }}
           >
-            <Typography sx={{ fontFamily: FONTS.mono }}>
-              No miners found matching your filters.
-            </Typography>
+            <ToolbarPopover
+              sortOption={sortOption}
+              sortDirection={sortDirection}
+              onSortChange={handleSortChange}
+              variant={variant}
+              viewMode={viewMode}
+              onViewModeChange={handleViewModeChange}
+              eligibleOssFilter={eligibleOssFilter}
+              eligibleDiscoveryFilter={eligibleDiscoveryFilter}
+              onEligibleOssChange={handleEligibleOssChange}
+              onEligibleDiscoveryChange={handleEligibleDiscoveryChange}
+            />
           </Box>
         )}
+
+        <Box
+          sx={{
+            width: '100%',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 2,
+          }}
+        >
+          {filteredMiners.length > 0 && viewMode === 'cards' && (
+            <Grid container spacing={2}>
+              {visibleMiners.map((miner) => (
+                <Grid item xs={12} sm={12} md={6} lg={4} xl={4} key={miner.id}>
+                  <MinerCard
+                    miner={miner}
+                    variant={variant}
+                    href={getMinerHref(miner)}
+                    linkState={linkState}
+                    showDualEligibilityBadges={showDualEligibilityBadges}
+                  />
+                </Grid>
+              ))}
+            </Grid>
+          )}
+
+          {filteredMiners.length > 0 && viewMode === 'list' && (
+            <MinersList
+              miners={visibleMiners}
+              variant={variant}
+              sortOption={sortOption}
+              sortDirection={sortDirection}
+              onSort={handleSortChange}
+              getHref={getMinerHref}
+              linkState={linkState}
+            />
+          )}
+
+          {remainingMiners > 0 && (
+            <Box ref={observerTarget} sx={{ height: 20, width: '100%' }} />
+          )}
+
+          {filteredMiners.length === 0 && (
+            <Box
+              sx={(theme) => ({
+                py: 8,
+                textAlign: 'center',
+                color: theme.palette.text.secondary,
+              })}
+            >
+              <Typography sx={{ fontFamily: FONTS.mono }}>
+                No miners found matching your filters.
+              </Typography>
+            </Box>
+          )}
+        </Box>
       </Box>
     </Box>
   );
@@ -647,14 +662,11 @@ const SortButtons: React.FC<SortButtonsProps> = ({
   <Box
     sx={{
       display: 'flex',
-      gap: { xs: 0.45, sm: 0.5 },
-      flexWrap: 'nowrap',
-      justifyContent: 'space-between',
-      width: '100%',
-      minWidth: 0,
       gap: 0.5,
       flexWrap: 'wrap',
       justifyContent: 'flex-start',
+      width: '100%',
+      minWidth: 0,
     }}
   >
     {getSortButtonOptions(variant).map((option) => {

--- a/src/components/leaderboard/TopMinersTable.tsx
+++ b/src/components/leaderboard/TopMinersTable.tsx
@@ -412,10 +412,6 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
                 width: { xs: '100%', sm: 'auto' },
               }}
             >
-              <EligibilityToggle
-                value={eligibilityFilter}
-                onChange={handleEligibilityChange}
-              />
               <Box
                 sx={{
                   display: 'flex',


### PR DESCRIPTION
## Summary

Fixes mobile layout issues on the Top Miner page to improve clarity and width consistency:

- Removed extra horizontal padding around the miners section so the Miners block and miners table align with surrounding content width.
- Adjusted sidebar container spacing so PR Activity, Issue Activity, Code Impact, and Top Earners match the same effective width as the miner table in mobile/stacked layout.
- Updated control layout in the miners toolbar on mobile by stacking the view toggle under the eligibility pills (All / Eligible / Ineligible) and center-aligning both groups for better readability/tap targets.

## Related Issues

Fixes #728 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Other (describe below)

## Screenshots

- before
<br/>
<img width="458" height="759" alt="top-miner" src="https://github.com/user-attachments/assets/4bc336af-d139-4ee0-9da6-df5426a5abd6" />
<br/>

- after
<br/>
<img width="466" height="745" alt="top-miner_fix" src="https://github.com/user-attachments/assets/5f253a2b-1299-41c3-9d1f-ab3305355b70" />
<br/>

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [ ] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [ ] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
