### PR TITLE
refactor: remove unused barrel re-exports and dead helpers

### DIFF
--- a/src/api/DashboardApi.ts
+++ b/src/api/DashboardApi.ts
@@ -35,18 +35,6 @@ export const useReposAndWeights = () =>
 export const useLanguagesAndWeights = () =>
   useDashboardQuery<LanguageWeight[]>('useLanguagesAndWeights', '/languages');
 
-export const useCommitLog = (
-  options?: { refetchInterval?: number },
-  page?: number,
-  limit?: number,
-) =>
-  useDashboardQuery<CommitLog[]>(
-    'useCommitLog',
-    '/commits',
-    options?.refetchInterval,
-    { page, limit },
-  );
-
 export const useInfiniteCommitLog = (options?: {
   refetchInterval?: number;
 }) => {

--- a/src/components/miners/index.ts
+++ b/src/components/miners/index.ts
@@ -1,13 +1,6 @@
-export { default as CredibilityChart } from './CredibilityChart';
-export { default as EmptyStateMessage } from './EmptyStateMessage';
-export { default as ExplorerFilterButton } from './ExplorerFilterButton';
 export { default as MinerActivity } from './MinerActivity';
 export { default as MinerInsightsCard } from './MinerInsightsCard';
 export { default as MinerPRsTable } from './MinerPRsTable';
 export { default as MinerRepositoriesTable } from './MinerRepositoriesTable';
 export { default as MinerScoreBreakdown } from './MinerScoreBreakdown';
 export { default as MinerScoreCard } from './MinerScoreCard';
-export { default as PerformanceRadar } from './PerformanceRadar';
-export { default as RankBadge } from './RankBadge';
-export { default as TablePagination } from './TablePagination';
-export { default as TrustBadge, getRiskAssessment } from './TrustBadge';

--- a/src/components/repositories/RepositoryCodeBrowser.tsx
+++ b/src/components/repositories/RepositoryCodeBrowser.tsx
@@ -19,7 +19,6 @@ import { STATUS_COLORS } from '../../theme';
 import { formatDistanceToNow } from 'date-fns';
 import FolderIcon from '@mui/icons-material/Folder';
 import InsertDriveFileIcon from '@mui/icons-material/InsertDriveFile';
-// import TextSnippetIcon from "@mui/icons-material/TextSnippet"; // Unused
 import CodeViewer from './CodeViewer';
 import { buildFileTree, type FileNode } from './FileExplorer';
 

--- a/src/utils/ExplorerUtils.ts
+++ b/src/utils/ExplorerUtils.ts
@@ -1,6 +1,5 @@
 import {
   type CommitLog,
-  type IssueBounty,
   type MinerEvaluation,
   type Repository,
   type RepositoryPrScoring,
@@ -33,21 +32,6 @@ export const getPrStatusLabel = (
   if (state === 'MERGED' || pr.mergedAt) return 'Merged';
   if (state === 'OPEN' || (!state && !pr.mergedAt)) return 'Open';
   return 'Closed';
-};
-
-export const getIssueStatusLabel = (
-  issue: Pick<IssueBounty, 'status'>,
-): 'Solved' | 'Open' | 'Closed' => {
-  switch (issue.status) {
-    case 'completed':
-      return 'Solved';
-    case 'cancelled':
-      return 'Closed';
-    case 'active':
-    case 'registered':
-    default:
-      return 'Open';
-  }
 };
 
 export const calculateDynamicOpenPrThreshold = (


### PR DESCRIPTION
### Closes: #739 
## Summary

Pure deletion of 36 lines of dead code across 4 files. No runtime changes — every consumer already imports components via their direct file paths, and the removed helpers had zero callers across the repo. 

**Files changed:**

| File | Lines removed |
|------|---------------|
| \`src/utils/ExplorerUtils.ts\` | 16 |
| \`src/api/DashboardApi.ts\` | 12 |
| \`src/components/miners/index.ts\` | 7 |
| \`src/components/repositories/RepositoryCodeBrowser.tsx\` | 1 |

## Test plan

- No TypeScript errors (\`npx tsc -b\`)
- No ESLint errors (\`npx eslint . --ext ts,tsx\`, including \`unused-imports/no-unused-imports\`)
- Unit tests pass (\`npm test\` — 37/37)
- Spot-check \`/miners/details?githubId=...\` renders (exercises all retained miners barrel exports)