### PR TITLE
Fix #454 by normalizing array API responses at boundary

### DIFF
--- a/src/api/ApiUtils.ts
+++ b/src/api/ApiUtils.ts
@@ -1,12 +1,52 @@
 import { useQuery } from '@tanstack/react-query';
 import axios, { type AxiosError } from 'axios';
 
+type ArrayEnvelope = {
+  items?: unknown;
+  results?: unknown;
+  data?: unknown;
+  rows?: unknown;
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
+/**
+ * Normalizes API payloads that should be arrays.
+ * Supports common envelope shapes while keeping the boundary strict:
+ * unknown/non-array payloads degrade to [] instead of crashing consumers.
+ */
+export const normalizeArrayResponse = <TItem = unknown>(
+  payload: unknown,
+): TItem[] => {
+  if (Array.isArray(payload)) {
+    return payload as TItem[];
+  }
+
+  if (isRecord(payload)) {
+    const envelope = payload as ArrayEnvelope;
+    const candidates = [
+      envelope.items,
+      envelope.results,
+      envelope.data,
+      envelope.rows,
+    ];
+    const firstArray = candidates.find((candidate) => Array.isArray(candidate));
+    if (Array.isArray(firstArray)) {
+      return firstArray as TItem[];
+    }
+  }
+
+  return [];
+};
+
 export const useApiQuery = <TResponse = void, TSelect = TResponse>(
   queryName: string,
   url: string,
   refetchInterval?: number,
   queryParams?: Record<string, string | number | undefined>,
   enabled?: boolean,
+  normalizeResponse?: (payload: unknown) => TResponse,
 ) => {
   const baseUrl = import.meta.env.VITE_REACT_APP_BASE_URL;
 
@@ -15,10 +55,29 @@ export const useApiQuery = <TResponse = void, TSelect = TResponse>(
     queryFn: async () => {
       const requestUrl = baseUrl ? `${baseUrl}${url}` : url;
       const { data } = await axios.get(requestUrl, { params: queryParams });
-      return data;
+      if (normalizeResponse) {
+        return normalizeResponse(data);
+      }
+      return data as TResponse;
     },
     retry: false,
     enabled: enabled ?? true,
     refetchInterval,
   });
 };
+
+export const useApiArrayQuery = <TItem = void>(
+  queryName: string,
+  url: string,
+  refetchInterval?: number,
+  queryParams?: Record<string, string | number | undefined>,
+  enabled?: boolean,
+) =>
+  useApiQuery<TItem[]>(
+    queryName,
+    url,
+    refetchInterval,
+    queryParams,
+    enabled,
+    normalizeArrayResponse<TItem>,
+  );

--- a/src/api/DashboardApi.ts
+++ b/src/api/DashboardApi.ts
@@ -1,4 +1,8 @@
-import { useApiQuery } from './ApiUtils';
+import {
+  normalizeArrayResponse,
+  useApiArrayQuery,
+  useApiQuery,
+} from './ApiUtils';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import axios from 'axios';
 import {
@@ -23,6 +27,21 @@ export const useDashboardQuery = <TResponse = void, TSelect = TResponse>(
     enabled,
   );
 
+export const useDashboardArrayQuery = <TItem = void>(
+  queryName: string,
+  url: string,
+  refetchInterval?: number,
+  queryParams?: Record<string, string | number | undefined>,
+  enabled?: boolean,
+) =>
+  useApiArrayQuery<TItem>(
+    queryName,
+    `/dash${url}`,
+    refetchInterval,
+    queryParams,
+    enabled,
+  );
+
 export const useStats = () => useDashboardQuery<Stats>('useStats', '/stats');
 
 // Shared cache key for the repositories dataset.
@@ -30,17 +49,20 @@ export const getReposQueryKey = () =>
   ['useReposAndWeights', '/dash/repos', undefined] as const;
 
 export const useReposAndWeights = () =>
-  useDashboardQuery<Repository[]>('useReposAndWeights', '/repos');
+  useDashboardArrayQuery<Repository>('useReposAndWeights', '/repos');
 
 export const useLanguagesAndWeights = () =>
-  useDashboardQuery<LanguageWeight[]>('useLanguagesAndWeights', '/languages');
+  useDashboardArrayQuery<LanguageWeight>(
+    'useLanguagesAndWeights',
+    '/languages',
+  );
 
 export const useCommitLog = (
   options?: { refetchInterval?: number },
   page?: number,
   limit?: number,
 ) =>
-  useDashboardQuery<CommitLog[]>(
+  useDashboardArrayQuery<CommitLog>(
     'useCommitLog',
     '/commits',
     options?.refetchInterval,
@@ -58,10 +80,10 @@ export const useInfiniteCommitLog = (options?: {
     queryFn: async ({ pageParam }: { pageParam: number }) => {
       const url = '/dash/commits';
       const requestUrl = baseUrl ? `${baseUrl}${url}` : url;
-      const { data } = await axios.get<CommitLog[]>(requestUrl, {
+      const { data } = await axios.get(requestUrl, {
         params: { page: pageParam, limit },
       });
-      return data;
+      return normalizeArrayResponse<CommitLog>(data);
     },
     getNextPageParam: (lastPage: CommitLog[], allPages: CommitLog[][]) => {
       // If the last page has fewer items than the limit, we've reached the end

--- a/src/api/IssuesApi.ts
+++ b/src/api/IssuesApi.ts
@@ -1,7 +1,7 @@
 /**
  * Issues API - For issue bounties.
  */
-import { useApiQuery } from './ApiUtils';
+import { useApiArrayQuery, useApiQuery } from './ApiUtils';
 import {
   IssueBounty,
   IssueDetails,
@@ -17,7 +17,7 @@ export const useIssues = (status?: string, repository?: string) => {
   const params: Record<string, string> = {};
   if (status) params.status = status;
   if (repository) params.repository = repository;
-  return useApiQuery<IssueBounty[]>(
+  return useApiArrayQuery<IssueBounty>(
     'useIssues',
     '/issues',
     undefined,
@@ -37,7 +37,7 @@ export const getIssuesQueryKey = (status?: string, repository?: string) =>
  * Fetch all bounties for a specific repository.
  */
 export const useRepoIssues = (repoFullName: string) =>
-  useApiQuery<IssueBounty[]>(
+  useApiArrayQuery<IssueBounty>(
     'useRepoIssues',
     '/issues',
     undefined,
@@ -67,7 +67,7 @@ export const useIssueDetails = (id: number) =>
  * Fetch PR submissions for an issue.
  */
 export const useIssueSubmissions = (id: number) =>
-  useApiQuery<IssueSubmission[]>(
+  useApiArrayQuery<IssueSubmission>(
     'useIssueSubmissions',
     `/issues/${id}/submissions`,
     undefined,

--- a/src/api/MinerApi.ts
+++ b/src/api/MinerApi.ts
@@ -1,5 +1,5 @@
 // Miner API hooks - uses /miners endpoints
-import { useApiQuery } from './ApiUtils';
+import { useApiArrayQuery, useApiQuery } from './ApiUtils';
 import {
   type GithubMinerData,
   type MinerEvaluation,
@@ -24,13 +24,28 @@ const useMinersQuery = <TResponse = void, TSelect = TResponse>(
     enabled,
   );
 
+const useMinersArrayQuery = <TItem = void>(
+  queryName: string,
+  url: string,
+  refetchInterval?: number,
+  queryParams?: Record<string, string | number | undefined>,
+  enabled?: boolean,
+) =>
+  useApiArrayQuery<TItem>(
+    queryName,
+    `/miners${url}`,
+    refetchInterval,
+    queryParams,
+    enabled,
+  );
+
 /**
  * Get all active miners with their pre-computed stats
  * Only includes miners currently registered on the subnet (in current_miners table)
  * Ideal for leaderboards
  */
 export const useAllMiners = () =>
-  useMinersQuery<MinerEvaluation[]>('useAllMiners', '');
+  useMinersArrayQuery<MinerEvaluation>('useAllMiners', '');
 
 // Shared cache key for the miners dataset.
 export const getAllMinersQueryKey = () =>
@@ -49,7 +64,7 @@ export const useMinerStats = (githubId: string) =>
  * @param enabled - Optional flag to enable/disable the query
  */
 export const useMinerPRs = (githubId: string, enabled?: boolean) =>
-  useMinersQuery<CommitLog[]>(
+  useMinersArrayQuery<CommitLog>(
     'useMinerPRs',
     `/${githubId}/prs`,
     undefined,

--- a/src/api/PrsApi.ts
+++ b/src/api/PrsApi.ts
@@ -1,5 +1,5 @@
 // Pull Request API hooks - uses /prs endpoints
-import { useApiQuery } from './ApiUtils';
+import { useApiArrayQuery, useApiQuery } from './ApiUtils';
 import {
   type CommitLog,
   type PullRequestComment,
@@ -24,11 +24,26 @@ const usePrsQuery = <TResponse = void, TSelect = TResponse>(
     enabled,
   );
 
+const usePrsArrayQuery = <TItem = void>(
+  queryName: string,
+  url: string,
+  refetchInterval?: number,
+  queryParams?: Record<string, string | number | undefined>,
+  enabled?: boolean,
+) =>
+  useApiArrayQuery<TItem>(
+    queryName,
+    `/prs${url}`,
+    refetchInterval,
+    queryParams,
+    enabled,
+  );
+
 /**
  * Get all pull requests across the network
  * Returns all PRs regardless of miner registration status
  */
-export const useAllPrs = () => usePrsQuery<CommitLog[]>('useAllPrs', '');
+export const useAllPrs = () => usePrsArrayQuery<CommitLog>('useAllPrs', '');
 
 // Shared cache key for the pull requests dataset.
 export const getAllPrsQueryKey = () =>
@@ -58,7 +73,7 @@ export const usePullRequestDetails = (
  * @param number - Pull request number
  */
 export const usePullRequestComments = (repo: string, number: number) =>
-  usePrsQuery<PullRequestComment[]>(
+  usePrsArrayQuery<PullRequestComment>(
     'usePullRequestComments',
     '/comments',
     undefined,

--- a/src/api/ReposApi.ts
+++ b/src/api/ReposApi.ts
@@ -1,5 +1,5 @@
 // Repository API hooks - uses /repos endpoints
-import { useApiQuery } from './ApiUtils';
+import { useApiArrayQuery, useApiQuery } from './ApiUtils';
 import { type RepositoryMaintainer, type RepositoryIssue } from './models';
 import { type Repository } from './models/Dashboard';
 
@@ -13,6 +13,19 @@ const useReposQuery = <TResponse = void, TSelect = TResponse>(
   queryParams?: Record<string, string | number | undefined>,
 ) =>
   useApiQuery<TResponse, TSelect>(
+    queryName,
+    `/repos${url}`,
+    refetchInterval,
+    queryParams,
+  );
+
+const useReposArrayQuery = <TItem = void>(
+  queryName: string,
+  url: string,
+  refetchInterval?: number,
+  queryParams?: Record<string, string | number | undefined>,
+) =>
+  useApiArrayQuery<TItem>(
     queryName,
     `/repos${url}`,
     refetchInterval,
@@ -34,7 +47,7 @@ export const useRepositoryConfig = (repo: string) =>
  * @param repo - Full repository name (e.g., "opentensor/btcli")
  */
 export const useRepositoryMaintainers = (repo: string) =>
-  useReposQuery<RepositoryMaintainer[]>(
+  useReposArrayQuery<RepositoryMaintainer>(
     'useRepositoryMaintainers',
     `/${encodeURIComponent(repo)}/maintainers`,
   );
@@ -44,7 +57,7 @@ export const useRepositoryMaintainers = (repo: string) =>
  * @param repo - Full repository name (e.g., "opentensor/btcli")
  */
 export const useRepositoryIssues = (repo: string) =>
-  useReposQuery<RepositoryIssue[]>(
+  useReposArrayQuery<RepositoryIssue>(
     'useRepositoryIssues',
     `/${encodeURIComponent(repo)}/issues`,
   );

--- a/src/api/SearchApi.ts
+++ b/src/api/SearchApi.ts
@@ -3,7 +3,7 @@
  * Composes cached miners, repositories, PRs, and issues datasets in place of a dedicated search endpoint.
  */
 import { useQueryClient } from '@tanstack/react-query';
-import { useApiQuery } from './ApiUtils';
+import { normalizeArrayResponse, useApiArrayQuery } from './ApiUtils';
 import { getReposQueryKey } from './DashboardApi';
 import { getIssuesQueryKey } from './IssuesApi';
 import { getAllMinersQueryKey } from './MinerApi';
@@ -35,7 +35,7 @@ const useCachedSearchDataset = <T>(
   cachedData: T[] | undefined,
   shouldFetch: boolean,
 ): DatasetState<T> => {
-  const datasetQuery = useApiQuery<T[]>(
+  const datasetQuery = useApiArrayQuery<T>(
     queryName,
     url,
     undefined,
@@ -44,7 +44,7 @@ const useCachedSearchDataset = <T>(
   );
 
   return {
-    data: datasetQuery.data ?? cachedData ?? [],
+    data: normalizeArrayResponse<T>(datasetQuery.data ?? cachedData),
     isLoading: isDatasetLoading(
       shouldFetch,
       cachedData,

--- a/src/tests/ApiUtils.test.ts
+++ b/src/tests/ApiUtils.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeArrayResponse } from '../api/ApiUtils';
+
+describe('normalizeArrayResponse', () => {
+  it('returns the payload when already an array', () => {
+    expect(normalizeArrayResponse<number>([1, 2, 3])).toEqual([1, 2, 3]);
+  });
+
+  it('unwraps common array envelope keys', () => {
+    expect(normalizeArrayResponse<number>({ items: [1, 2] })).toEqual([1, 2]);
+    expect(normalizeArrayResponse<number>({ results: [3, 4] })).toEqual([3, 4]);
+    expect(normalizeArrayResponse<number>({ data: [5] })).toEqual([5]);
+    expect(normalizeArrayResponse<number>({ rows: [6] })).toEqual([6]);
+  });
+
+  it('returns an empty array for non-array payloads', () => {
+    expect(normalizeArrayResponse<number>({ total: 10 })).toEqual([]);
+    expect(normalizeArrayResponse<number>(null)).toEqual([]);
+    expect(normalizeArrayResponse<number>('not-array')).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes #454 by normalizing array-like API payloads in shared API boundary hooks instead of adding defensive UI callsite guards.
- Adds `normalizeArrayResponse` and `useApiArrayQuery` in `src/api/ApiUtils.ts` to accept direct arrays and common envelope forms (`items`, `results`, `data`, `rows`) while safely degrading malformed payloads to `[]`.
- Applies the array-boundary helper to array-returning API hooks (`dashboard`, `issues`, `miners`, `prs`, `repos`, and search dataset hydration) so downstream `.map()` consumers stay stable.
- Adds focused tests for the normalizer behavior in `src/tests/ApiUtils.test.ts`.

## Why this approach
- Previous attempts were rejected for adding protections in page/components.
- This keeps the fix centralized at the API boundary, making behavior consistent and easier to maintain.

## Test plan
- [x] `npm run test`
- [x] `npm run lint`
- [x] `npm run build`