### PR TITLE
Top Repositories: show full search placeholder text

### DIFF
--- a/src/components/leaderboard/TopRepositoriesTable.tsx
+++ b/src/components/leaderboard/TopRepositoriesTable.tsx
@@ -625,7 +625,7 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
         startAdornment: searchAdornment,
       }}
       sx={{
-        width: '200px',
+        width: { xs: '100%', sm: 280 },
         ...(isMobileSearchVisible
           ? {
               flexBasis: { xs: '100%', sm: 'auto' },


### PR DESCRIPTION
## Summary
Fixes the Top Repositories search input so the placeholder text is fully visible.

## Problem
The search field was too narrow, causing the placeholder text `Search or enter owner/repo...` to be truncated.

## Changes
- Increased the desktop width of the search input
- Kept the mobile behavior responsive by using full width on small screens

## Result
Users can now see the full placeholder text, which makes the search input clearer and easier to use.

## Testing
- Opened the Top Repositories page
- Verified the placeholder text is fully visible on desktop
- Verified the input still behaves correctly on mobile layouts


<img width="1644" height="795" alt="Screenshot 2026-04-22 131202" src="https://github.com/user-attachments/assets/4bfb7755-ad46-4249-85d7-ebf3e0b0c9b0" />
<img width="1763" height="745" alt="Screenshot 2026-04-22 131047" src="https://github.com/user-attachments/assets/1bdec715-5016-4695-8bcb-54238e9a2b8a" />
