### PR TITLE
feat(repo): issues search & filters, tab counts, and repo detail UX

### DIFF
--- a/src/components/repositories/RepositoryIssuesTable.tsx
+++ b/src/components/repositories/RepositoryIssuesTable.tsx
@@ -4,14 +4,19 @@ import {
   Card,
   Chip,
   CircularProgress,
+  IconButton,
+  InputAdornment,
   Stack,
+  TextField,
   Typography,
   alpha,
+  useMediaQuery,
   useTheme,
 } from '@mui/material';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import RadioButtonUncheckedIcon from '@mui/icons-material/RadioButtonUnchecked';
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
+import SearchIcon from '@mui/icons-material/Search';
 import {
   useRepositoryIssues,
   useRepoIssues,
@@ -26,6 +31,8 @@ import { formatTokenAmount } from '../../utils/format';
 import {
   getIssueStatusMeta,
   getBountyAmountColor,
+  isRepositoryIssueOpen,
+  dedupeRepositoryIssues,
 } from '../../utils/issueStatus';
 import { STATUS_COLORS, TEXT_OPACITY, scrollbarSx } from '../../theme';
 import FilterButton from '../FilterButton';
@@ -34,44 +41,158 @@ interface RepositoryIssuesTableProps {
   repositoryFullName: string;
 }
 
+type IssuesSearchLayout = 'desktop' | 'mdRange' | 'mobile';
+
+/** One search field for all breakpoints (avoids three `TextField` copies + extra `useMemo`s). */
+const IssuesSearchTextField: React.FC<{
+  value: string;
+  onChange: (next: string) => void;
+  layout: IssuesSearchLayout;
+  onMobileBlurCollapse?: () => void;
+}> = ({ value, onChange, layout, onMobileBlurCollapse }) => {
+  const theme = useTheme();
+  return (
+    <TextField
+      size="small"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      placeholder="Search issues"
+      autoComplete="off"
+      fullWidth={layout === 'mobile'}
+      autoFocus={layout === 'mobile'}
+      onBlur={
+        layout === 'mobile'
+          ? () => {
+              if (!value.trim()) onMobileBlurCollapse?.();
+            }
+          : undefined
+      }
+      sx={{
+        '& .MuiOutlinedInput-root': {
+          fontSize: '0.82rem',
+          borderRadius: '8px',
+          backgroundColor: 'surface.subtle',
+          '& fieldset': {
+            borderColor: theme.palette.border.light,
+          },
+        },
+        ...(layout === 'desktop'
+          ? { minWidth: 220, maxWidth: 340 }
+          : layout === 'mdRange'
+            ? { flex: '1 1 160px', minWidth: 160, maxWidth: 280 }
+            : {}),
+      }}
+      InputProps={{
+        endAdornment: (
+          <InputAdornment position="end">
+            <SearchIcon sx={{ color: 'text.secondary', fontSize: 16 }} />
+          </InputAdornment>
+        ),
+      }}
+    />
+  );
+};
+
 const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
   repositoryFullName,
 }) => {
   const theme = useTheme();
-  const { data: issues, isLoading } = useRepositoryIssues(repositoryFullName);
+  /** `md` and up (900px+): title row + filters + search field in one toolbar. */
+  const useWideIssuesToolbar = useMediaQuery(theme.breakpoints.up('md'), {
+    noSsr: true,
+  });
+  /** Below `sm` (<600px): title row + search icon; tap to expand field below. */
+  const isXsPhone = useMediaQuery(theme.breakpoints.down('sm'), {
+    noSsr: true,
+  });
+  const { data: issuesRaw, isLoading } =
+    useRepositoryIssues(repositoryFullName);
+  const issues = useMemo(
+    () => (issuesRaw ? dedupeRepositoryIssues(issuesRaw) : undefined),
+    [issuesRaw],
+  );
   const { data: bounties } = useRepoIssues(repositoryFullName);
   const [filter, setFilter] = useState<'all' | 'open' | 'closed'>('all');
+  const [searchQuery, setSearchQuery] = useState('');
+  const [isMobileSearchOpen, setIsMobileSearchOpen] = useState(false);
+
+  const showPhoneExpandedSearch =
+    isXsPhone && (isMobileSearchOpen || !!searchQuery.trim());
 
   const counts = useMemo(() => {
     if (!issues) return { total: 0, open: 0, closed: 0 };
-    return {
-      total: issues.length,
-      open: issues.filter((issue) => !issue.closedAt).length,
-      closed: issues.filter((issue) => issue.closedAt).length,
-    };
+    let open = 0;
+    for (const issue of issues) {
+      if (isRepositoryIssueOpen(issue)) open += 1;
+    }
+    const total = issues.length;
+    return { total, open, closed: total - open };
   }, [issues]);
 
-  const filteredIssues = useMemo(() => {
-    if (!issues) return [];
-    if (filter === 'open') return issues.filter((issue) => !issue.closedAt);
-    if (filter === 'closed') return issues.filter((issue) => issue.closedAt);
-    return issues;
-  }, [issues, filter]);
+  /** Avoid O(bounties × issues) `.find` per bounty row. */
+  const issueTitleByRepoAndNumber = useMemo(() => {
+    if (!issues) return null;
+    const m = new Map<string, string>();
+    for (const i of issues) {
+      m.set(`${i.repositoryFullName}:${i.number}`, i.title ?? '');
+    }
+    return m;
+  }, [issues]);
 
-  const sortedIssues = useMemo(
-    () =>
-      [...filteredIssues].sort((a, b) => {
-        // Sort by creation date, most recent first.
-        const dateA = a.createdAt ? new Date(a.createdAt).getTime() : 0;
-        const dateB = b.createdAt ? new Date(b.createdAt).getTime() : 0;
-        return dateB - dateA;
-      }),
-    [filteredIssues],
-  );
+  /** Denominator for the title ("n of m") matches `counts`, no extra filter pass. */
+  const statusMatchLength =
+    filter === 'open'
+      ? counts.open
+      : filter === 'closed'
+        ? counts.closed
+        : counts.total;
+
+  /** Single pipeline: status filter → search → sort (one copy + sort). */
+  const sortedVisibleIssues = useMemo(() => {
+    if (!issues) return [];
+    let list =
+      filter === 'open'
+        ? issues.filter((issue) => isRepositoryIssueOpen(issue))
+        : filter === 'closed'
+          ? issues.filter((issue) => !isRepositoryIssueOpen(issue))
+          : issues;
+
+    const trimmedQuery = searchQuery.trim().toLowerCase();
+    if (trimmedQuery) {
+      list = list.filter((issue) => {
+        const issueNumber = String(issue.number);
+        const title = issue.title?.toLowerCase() ?? '';
+        const author = issue.author?.toLowerCase() ?? '';
+        return (
+          issueNumber.includes(trimmedQuery) ||
+          title.includes(trimmedQuery) ||
+          author.includes(trimmedQuery)
+        );
+      });
+    }
+
+    return [...list].sort((a, b) => {
+      const dateA = a.createdAt ? new Date(a.createdAt).getTime() : 0;
+      const dateB = b.createdAt ? new Date(b.createdAt).getTime() : 0;
+      return dateB - dateA;
+    });
+  }, [issues, filter, searchQuery]);
+
+  const titleText = useMemo(() => {
+    if (!searchQuery.trim()) return `Issues (${statusMatchLength})`;
+    return `Issues (${sortedVisibleIssues.length} of ${statusMatchLength})`;
+  }, [searchQuery, sortedVisibleIssues.length, statusMatchLength]);
+
+  const emptyMessage = useMemo(() => {
+    if ((issues?.length ?? 0) > 0 && sortedVisibleIssues.length === 0) {
+      return searchQuery.trim()
+        ? 'No issues match your search'
+        : 'No issues match this filter';
+    }
+    return 'No issues found';
+  }, [issues?.length, sortedVisibleIssues.length, searchQuery]);
 
   const handleRowClick = useCallback((issue: RepositoryIssue) => {
-    // Row navigates to GitHub in a new tab; using onRowClick (not getRowHref)
-    // keeps nested <a> cells valid HTML.
     window.open(
       `https://github.com/${issue.repositoryFullName}/issues/${issue.number}`,
       '_blank',
@@ -79,145 +200,112 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
     );
   }, []);
 
-  if (isLoading) {
-    return (
-      <Card
-        sx={{
-          borderRadius: 3,
-          border: `1px solid ${theme.palette.border.light}`,
-          backgroundColor: 'transparent',
-          p: 4,
-          textAlign: 'center',
-        }}
-        elevation={0}
-      >
-        <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 3 }}>
-          <Typography variant="h6" sx={{ color: 'text.primary' }}>
-            Issues
-          </Typography>
-        </Box>
-        <CircularProgress size={40} sx={{ color: 'primary.main' }} />
-      </Card>
-    );
-  }
-
-  const columns: DataTableColumn<RepositoryIssue>[] = [
-    {
-      key: 'number',
-      header: 'Issue #',
-      renderCell: (issue) => (
-        <a
-          href={`https://github.com/${issue.repositoryFullName}/issues/${issue.number}`}
-          target="_blank"
-          rel="noopener noreferrer"
-          style={{
-            color: 'inherit',
-            textDecoration: 'none',
-            fontWeight: 500,
-          }}
-          onClick={(e) => e.stopPropagation()}
-        >
-          #{issue.number}
-        </a>
-      ),
-    },
-    {
-      key: 'title',
-      header: 'Title',
-      renderCell: (issue) => (
-        <Box
-          sx={{
-            maxWidth: '400px',
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
-            whiteSpace: 'nowrap',
-          }}
-        >
-          {issue.title}
-        </Box>
-      ),
-    },
-    {
-      key: 'status',
-      header: 'Status',
-      renderCell: (issue) => {
-        const isOpen = !issue.closedAt;
-        return (
-          <Chip
-            variant="status"
-            icon={isOpen ? <RadioButtonUncheckedIcon /> : <CheckCircleIcon />}
-            label={isOpen ? 'OPEN' : 'CLOSED'}
-            sx={{
-              color: isOpen ? STATUS_COLORS.open : STATUS_COLORS.merged,
-              borderColor: isOpen ? STATUS_COLORS.open : STATUS_COLORS.merged,
-              '& .MuiChip-icon': { color: 'inherit' },
-            }}
-          />
-        );
-      },
-    },
-    {
-      key: 'linkedPr',
-      header: 'Linked PR',
-      renderCell: (issue) =>
-        issue.prNumber ? (
+  const columns: DataTableColumn<RepositoryIssue>[] = useMemo(
+    () => [
+      {
+        key: 'number',
+        header: 'Issue #',
+        renderCell: (issue) => (
           <a
-            href={`https://github.com/${issue.repositoryFullName}/pull/${issue.prNumber}`}
+            href={`https://github.com/${issue.repositoryFullName}/issues/${issue.number}`}
             target="_blank"
             rel="noopener noreferrer"
             style={{
-              color: STATUS_COLORS.info,
+              color: 'inherit',
               textDecoration: 'none',
               fontWeight: 500,
             }}
             onClick={(e) => e.stopPropagation()}
           >
-            #{issue.prNumber}
+            #{issue.number}
           </a>
-        ) : (
-          <span
-            style={{
-              color: alpha(theme.palette.common.white, TEXT_OPACITY.faint),
+        ),
+      },
+      {
+        key: 'title',
+        header: 'Title',
+        renderCell: (issue) => (
+          <Box
+            sx={{
+              maxWidth: '400px',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
             }}
           >
-            -
-          </span>
+            {issue.title}
+          </Box>
         ),
-    },
-    {
-      key: 'created',
-      header: 'Created',
-      align: 'right',
-      renderCell: (issue) =>
-        issue.createdAt ? new Date(issue.createdAt).toLocaleDateString() : '-',
-    },
-    {
-      key: 'closed',
-      header: 'Closed',
-      align: 'right',
-      renderCell: (issue) =>
-        issue.closedAt ? new Date(issue.closedAt).toLocaleDateString() : '-',
-    },
-  ];
+      },
+      {
+        key: 'status',
+        header: 'Status',
+        renderCell: (issue) => {
+          const isOpen = isRepositoryIssueOpen(issue);
+          return (
+            <Chip
+              variant="status"
+              icon={isOpen ? <RadioButtonUncheckedIcon /> : <CheckCircleIcon />}
+              label={isOpen ? 'OPEN' : 'CLOSED'}
+              sx={{
+                color: isOpen ? STATUS_COLORS.open : STATUS_COLORS.merged,
+                borderColor: isOpen ? STATUS_COLORS.open : STATUS_COLORS.merged,
+                '& .MuiChip-icon': { color: 'inherit' },
+              }}
+            />
+          );
+        },
+      },
+      {
+        key: 'linkedPr',
+        header: 'Linked PR',
+        renderCell: (issue) =>
+          issue.prNumber ? (
+            <a
+              href={`https://github.com/${issue.repositoryFullName}/pull/${issue.prNumber}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{
+                color: STATUS_COLORS.info,
+                textDecoration: 'none',
+                fontWeight: 500,
+              }}
+              onClick={(e) => e.stopPropagation()}
+            >
+              #{issue.prNumber}
+            </a>
+          ) : (
+            <span
+              style={{
+                color: alpha(theme.palette.common.white, TEXT_OPACITY.faint),
+              }}
+            >
+              -
+            </span>
+          ),
+      },
+      {
+        key: 'created',
+        header: 'Created',
+        align: 'right',
+        renderCell: (issue) =>
+          issue.createdAt
+            ? new Date(issue.createdAt).toLocaleDateString()
+            : '-',
+      },
+      {
+        key: 'closed',
+        header: 'Closed',
+        align: 'right',
+        renderCell: (issue) =>
+          issue.closedAt ? new Date(issue.closedAt).toLocaleDateString() : '-',
+      },
+    ],
+    [theme],
+  );
 
-  const headerToolbar = (
-    <Box
-      sx={{
-        p: 3,
-        borderBottom: `1px solid ${theme.palette.border.light}`,
-        display: 'flex',
-        justifyContent: 'space-between',
-        alignItems: 'center',
-        flexWrap: 'wrap',
-        gap: 2,
-      }}
-    >
-      <Typography
-        variant="h6"
-        sx={{ color: 'text.primary', fontSize: '1.1rem', fontWeight: 500 }}
-      >
-        Issues ({sortedIssues.length})
-      </Typography>
+  const filterButtons = useMemo(
+    () => (
       <Stack direction="row" spacing={1}>
         <FilterButton
           label="All"
@@ -244,12 +332,185 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
           activeTextColor="text.primary"
         />
       </Stack>
+    ),
+    [filter, counts.total, counts.open, counts.closed],
+  );
+
+  if (isLoading) {
+    return (
+      <Card
+        sx={{
+          borderRadius: 3,
+          border: `1px solid ${theme.palette.border.light}`,
+          backgroundColor: 'transparent',
+          p: 4,
+          textAlign: 'center',
+        }}
+        elevation={0}
+      >
+        <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 3 }}>
+          <Typography variant="h6" sx={{ color: 'text.primary' }}>
+            Issues
+          </Typography>
+        </Box>
+        <CircularProgress size={40} sx={{ color: 'primary.main' }} />
+      </Card>
+    );
+  }
+
+  const mobileSearchIconButton = (
+    <IconButton
+      aria-label="Open issue search"
+      onClick={() => setIsMobileSearchOpen(true)}
+      sx={{
+        border: `1px solid ${theme.palette.border.light}`,
+        borderRadius: '8px',
+        backgroundColor: 'surface.subtle',
+        color: 'text.secondary',
+        width: 36,
+        height: 36,
+        flexShrink: 0,
+      }}
+    >
+      <SearchIcon sx={{ fontSize: 18 }} />
+    </IconButton>
+  );
+
+  const headerToolbar = (
+    <Box
+      sx={{
+        p: 3,
+        borderBottom: `1px solid ${theme.palette.border.light}`,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 2,
+      }}
+    >
+      {useWideIssuesToolbar ? (
+        <Box
+          sx={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            flexWrap: 'wrap',
+            gap: 2,
+          }}
+        >
+          <Typography
+            variant="h6"
+            sx={{ color: 'text.primary', fontSize: '1.1rem', fontWeight: 500 }}
+          >
+            {titleText}
+          </Typography>
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              flexWrap: 'wrap',
+              gap: 1.5,
+            }}
+          >
+            {filterButtons}
+            <IssuesSearchTextField
+              value={searchQuery}
+              onChange={setSearchQuery}
+              layout="desktop"
+            />
+          </Box>
+        </Box>
+      ) : isXsPhone ? (
+        <>
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              gap: 1,
+              width: '100%',
+            }}
+          >
+            <Typography
+              variant="h6"
+              sx={{
+                color: 'text.primary',
+                fontSize: '1.1rem',
+                fontWeight: 500,
+              }}
+            >
+              {titleText}
+            </Typography>
+            {!showPhoneExpandedSearch ? mobileSearchIconButton : null}
+          </Box>
+          <Box
+            sx={{
+              width: '100%',
+              overflowX: 'auto',
+              WebkitOverflowScrolling: 'touch',
+              ...scrollbarSx,
+            }}
+          >
+            <Box sx={{ width: 'max-content' }}>{filterButtons}</Box>
+          </Box>
+          {showPhoneExpandedSearch ? (
+            <IssuesSearchTextField
+              value={searchQuery}
+              onChange={setSearchQuery}
+              layout="mobile"
+              onMobileBlurCollapse={() => setIsMobileSearchOpen(false)}
+            />
+          ) : null}
+        </>
+      ) : (
+        <>
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              gap: 1.5,
+              width: '100%',
+              minWidth: 0,
+            }}
+          >
+            <Typography
+              variant="h6"
+              sx={{
+                color: 'text.primary',
+                fontSize: '1.1rem',
+                fontWeight: 500,
+                flexShrink: 0,
+                minWidth: 0,
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+                pr: 1,
+              }}
+            >
+              {titleText}
+            </Typography>
+            <IssuesSearchTextField
+              value={searchQuery}
+              onChange={setSearchQuery}
+              layout="mdRange"
+            />
+          </Box>
+          <Box
+            sx={{
+              width: '100%',
+              overflowX: 'auto',
+              WebkitOverflowScrolling: 'touch',
+              ...scrollbarSx,
+            }}
+          >
+            <Box sx={{ width: 'max-content' }}>{filterButtons}</Box>
+          </Box>
+        </>
+      )}
     </Box>
   );
 
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
-      {/* Bounties Section — list of LinkBox cards, separate from the table. */}
       {bounties && bounties.length > 0 && (
         <Card
           sx={{
@@ -284,6 +545,10 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
           <Box sx={{ p: 2, display: 'flex', flexDirection: 'column', gap: 1 }}>
             {bounties.map((bounty) => {
               const meta = getIssueStatusMeta(bounty.status);
+              const titleKey = `${bounty.repositoryFullName}:${bounty.issueNumber}`;
+              const linkedTitle =
+                issueTitleByRepoAndNumber?.get(titleKey) ??
+                `${repositoryFullName}#${bounty.issueNumber}`;
               return (
                 <LinkBox
                   key={bounty.id}
@@ -345,11 +610,7 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
                         whiteSpace: 'nowrap',
                       }}
                     >
-                      {issues?.find(
-                        (i) =>
-                          i.number === bounty.issueNumber &&
-                          i.repositoryFullName === bounty.repositoryFullName,
-                      )?.title || `${repositoryFullName}#${bounty.issueNumber}`}
+                      {linkedTitle}
                     </Typography>
                   </Box>
                   <Box
@@ -389,7 +650,6 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
         </Card>
       )}
 
-      {/* Issues Table */}
       <Card
         sx={{
           borderRadius: 3,
@@ -399,7 +659,6 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
           display: 'flex',
           flexDirection: 'column',
           overflow: 'hidden',
-          // Bounded scroll ancestor for the sticky header inside DataTable.
           '& .MuiTableContainer-root': {
             maxHeight: '500px',
             overflow: 'auto',
@@ -410,8 +669,8 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
       >
         <DataTable<RepositoryIssue>
           columns={columns}
-          rows={sortedIssues}
-          getRowKey={(issue) => `${issue.number}-${issue.repositoryFullName}`}
+          rows={sortedVisibleIssues}
+          getRowKey={(issue) => `${issue.repositoryFullName}:${issue.number}`}
           stickyHeader
           size="medium"
           header={headerToolbar}
@@ -426,7 +685,7 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
                   fontSize: '0.9rem',
                 }}
               >
-                No issues found
+                {emptyMessage}
               </Typography>
             </Box>
           }

--- a/src/pages/RepositoryDetailsPage.tsx
+++ b/src/pages/RepositoryDetailsPage.tsx
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { useMemo, useCallback } from 'react';
 import { useSearchParams, useNavigate } from 'react-router-dom';
-import { formatDate } from '../utils/format';
+import { formatDate, formatCompactCountBadge } from '../utils/format';
+import { dedupeRepositoryIssues } from '../utils/issueStatus';
 import {
   Alert,
   Box,
@@ -24,7 +25,12 @@ import VolunteerActivismIcon from '@mui/icons-material/VolunteerActivism';
 import FactCheckIcon from '@mui/icons-material/FactCheck';
 import { RANK_COLORS, STATUS_COLORS } from '../theme';
 import { Page } from '../components/layout';
-import { useReposAndWeights, useRepoBountySummary } from '../api';
+import {
+  useReposAndWeights,
+  useRepoBountySummary,
+  useRepositoryIssues,
+  useAllPrs,
+} from '../api';
 import {
   RepositoryContributorsTable,
   RepositoryPRsTable,
@@ -44,6 +50,33 @@ interface TabPanelProps {
   children?: React.ReactNode;
   index: number;
   value: number;
+}
+
+function RepositoryTabCountPill({ children }: { children: React.ReactNode }) {
+  return (
+    <Box
+      component="span"
+      sx={(theme) => ({
+        ml: 0.5,
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        px: 1,
+        py: 0.25,
+        minHeight: 20,
+        borderRadius: '999px',
+        fontSize: '0.75rem',
+        fontWeight: 600,
+        lineHeight: 1,
+        fontVariantNumeric: 'tabular-nums',
+        backgroundColor: theme.palette.surface.elevated,
+        border: 'none',
+        color: theme.palette.text.primary,
+      })}
+    >
+      {children}
+    </Box>
+  );
 }
 
 function CustomTabPanel(props: TabPanelProps) {
@@ -85,12 +118,52 @@ const RepositoryDetailsPage: React.FC = () => {
   const tabValue = tabIndexFromSearchParam(searchParams.get('tab'));
   const { data: repos, isLoading: isLoadingRepos } = useReposAndWeights();
   const { data: bountySummary } = useRepoBountySummary(repo || '');
+  const { data: allMinerPRs } = useAllPrs();
+  const { data: repoIssuesForBadge } = useRepositoryIssues(repo || '');
   const trackedRepo = repos?.find(
     (r) => r.fullName.toLowerCase() === (repo ?? '').toLowerCase(),
   );
   const isTrackedRepository = Boolean(trackedRepo);
 
   const owner = repo ? repo.split('/')[0] : '';
+
+  const repoLower = repo?.toLowerCase() ?? '';
+
+  const issuesTabBadge = useMemo(() => {
+    if (repoIssuesForBadge === undefined) return null;
+    return formatCompactCountBadge(
+      dedupeRepositoryIssues(repoIssuesForBadge).length,
+    );
+  }, [repoIssuesForBadge]);
+
+  const prTabBadge = useMemo(() => {
+    if (allMinerPRs === undefined || !repoLower) return null;
+    let n = 0;
+    for (const pr of allMinerPRs) {
+      if (pr.repository.toLowerCase() === repoLower) n += 1;
+    }
+    return formatCompactCountBadge(n);
+  }, [allMinerPRs, repoLower]);
+
+  const handleTabChange = useCallback(
+    (_event: React.SyntheticEvent, newValue: number) => {
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          if (!repo) return next;
+          next.set('name', repo);
+          if (newValue === 0) {
+            next.delete('tab');
+          } else {
+            next.set('tab', REPO_TAB_KEYS[newValue]);
+          }
+          return next;
+        },
+        { replace: true },
+      );
+    },
+    [repo, setSearchParams],
+  );
 
   // If no repo is provided, redirect to repository list (registered route)
   if (!repo) {
@@ -142,23 +215,6 @@ const RepositoryDetailsPage: React.FC = () => {
       </Page>
     );
   }
-
-  const handleTabChange = (_event: React.SyntheticEvent, newValue: number) => {
-    setSearchParams(
-      (prev) => {
-        const next = new URLSearchParams(prev);
-        if (!repo) return next;
-        next.set('name', repo);
-        if (newValue === 0) {
-          next.delete('tab');
-        } else {
-          next.set('tab', REPO_TAB_KEYS[newValue]);
-        }
-        return next;
-      },
-      { replace: true },
-    );
-  };
 
   return (
     <Page title={`Repository - ${repo} `}>
@@ -313,8 +369,20 @@ const RepositoryDetailsPage: React.FC = () => {
                 icon={<BugReportIcon sx={{ fontSize: 16, mb: 0, mr: 1 }} />}
                 iconPosition="start"
                 label={
-                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                  <Box
+                    sx={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 1,
+                      flexWrap: 'wrap',
+                    }}
+                  >
                     Issues
+                    {issuesTabBadge != null && (
+                      <RepositoryTabCountPill>
+                        {issuesTabBadge}
+                      </RepositoryTabCountPill>
+                    )}
                     {bountySummary &&
                       bountySummary.totalBounties -
                         bountySummary.completedBounties >
@@ -350,7 +418,16 @@ const RepositoryDetailsPage: React.FC = () => {
               <Tab
                 icon={<MergeTypeIcon sx={{ fontSize: 16, mb: 0, mr: 1 }} />}
                 iconPosition="start"
-                label="Pull Requests"
+                label={
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                    Pull Requests
+                    {prTabBadge != null && (
+                      <RepositoryTabCountPill>
+                        {prTabBadge}
+                      </RepositoryTabCountPill>
+                    )}
+                  </Box>
+                }
                 disableRipple
               />
               <Tab

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -79,6 +79,16 @@ export const formatAlphaToUsd = (
   return `~${usd.toLocaleString('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 })}`;
 };
 
+/**
+ * Compact numeric badge for tabs (exact below 1k; then 1k+ … 4k+; cap at 5k+).
+ */
+export const formatCompactCountBadge = (n: number): string => {
+  if (!Number.isFinite(n) || n < 0) return '0';
+  if (n < 1000) return String(Math.floor(n));
+  if (n >= 5000) return '5k+';
+  return `${Math.floor(n / 1000)}k+`;
+};
+
 export const credibilityColor = (cred: number): string => {
   if (cred >= 0.9) return CREDIBILITY_COLORS.excellent;
   if (cred >= 0.7) return CREDIBILITY_COLORS.good;

--- a/src/utils/issueStatus.ts
+++ b/src/utils/issueStatus.ts
@@ -1,5 +1,44 @@
 import { alpha } from '@mui/material/styles';
 import { STATUS_COLORS } from '../theme';
+import type { RepositoryIssue } from '../api/models/Miner';
+
+/** Prefer `state`, then `closedAt` (GitHub-style). */
+export const isRepositoryIssueOpen = (issue: RepositoryIssue): boolean => {
+  const s = issue.state?.toLowerCase();
+  if (s === 'closed') return false;
+  if (s === 'open') return true;
+  return !issue.closedAt;
+};
+
+/**
+ * API can return duplicate `repo:number` rows. React row keys must be unique
+ * or the table body can show the wrong issue for a filter.
+ */
+export const dedupeRepositoryIssues = (
+  list: RepositoryIssue[],
+): RepositoryIssue[] => {
+  const byKey = new Map<string, RepositoryIssue>();
+  for (const issue of list) {
+    const k = `${issue.repositoryFullName}:${issue.number}`;
+    const existing = byKey.get(k);
+    if (existing === undefined) {
+      byKey.set(k, issue);
+    } else {
+      byKey.set(k, pickConsistentIssueDuplicate(existing, issue));
+    }
+  }
+  return Array.from(byKey.values());
+};
+
+function pickConsistentIssueDuplicate(
+  a: RepositoryIssue,
+  b: RepositoryIssue,
+): RepositoryIssue {
+  const aOpen = isRepositoryIssueOpen(a);
+  const bOpen = isRepositoryIssueOpen(b);
+  if (aOpen === bOpen) return a;
+  return aOpen ? b : a;
+}
 
 export interface IssueStatusMeta {
   bgColor: string;


### PR DESCRIPTION
## Summary

1. **Numbers in titles** — Show compact issue / PR counts next to the **Issues** and **Pull Requests** tabs on the repository details page.
2. **Search** — Client-side search on the repository issues table (issue number, title, author).
3. **Filter buttons** — Fix label + count alignment so the pills read cleanly (vertical center / consistent typography).
4. **Mobile** — Responsive issues toolbar: search + filters behave correctly on small screens (e.g. icon vs full search field, stacked layout).


## Type of Change

- [x] New feature
- [x] Bug fix
- [x] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

### Before

[1.webm](https://github.com/user-attachments/assets/087fbedb-1d17-4019-98fc-9e883da1dfb9)

-----------------------------------------------------------

### After

[gorec-2026-04-22-23-36-04.webm](https://github.com/user-attachments/assets/27655a09-772a-4957-b966-77ae2ec8ef2d)

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes