### PR TITLE
fix: stabilize Live Activity pagination (#685)

### DIFF
--- a/src/api/DashboardApi.ts
+++ b/src/api/DashboardApi.ts
@@ -47,11 +47,23 @@ export const useCommitLog = (
     { page, limit },
   );
 
+export const COMMIT_LOG_PAGE_LIMIT = 15;
+
+export const getNextCommitLogPageParam = (
+  lastPage: CommitLog[],
+  lastPageParam: number,
+) => {
+  if (lastPage.length < COMMIT_LOG_PAGE_LIMIT) {
+    return undefined;
+  }
+
+  return lastPageParam + 1;
+};
+
 export const useInfiniteCommitLog = (options?: {
   refetchInterval?: number;
 }) => {
   const baseUrl = import.meta.env.VITE_REACT_APP_BASE_URL;
-  const limit = 15;
 
   return useInfiniteQuery({
     queryKey: ['useInfiniteCommitLog'],
@@ -59,18 +71,15 @@ export const useInfiniteCommitLog = (options?: {
       const url = '/dash/commits';
       const requestUrl = baseUrl ? `${baseUrl}${url}` : url;
       const { data } = await axios.get<CommitLog[]>(requestUrl, {
-        params: { page: pageParam, limit },
+        params: { page: pageParam, limit: COMMIT_LOG_PAGE_LIMIT },
       });
       return data;
     },
-    getNextPageParam: (lastPage: CommitLog[], allPages: CommitLog[][]) => {
-      // If the last page has fewer items than the limit, we've reached the end
-      if (lastPage.length < limit) {
-        return undefined;
-      }
-      // Otherwise, return the next page number
-      return allPages.length + 1;
-    },
+    getNextPageParam: (
+      lastPage: CommitLog[],
+      _allPages: CommitLog[][],
+      lastPageParam: number,
+    ) => getNextCommitLogPageParam(lastPage, lastPageParam),
     initialPageParam: 1,
     refetchInterval: options?.refetchInterval,
     retry: false,

--- a/src/pages/dashboard/views/LiveCommitLog.tsx
+++ b/src/pages/dashboard/views/LiveCommitLog.tsx
@@ -1,4 +1,10 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import {
   Card,
   CardContent,
@@ -318,6 +324,10 @@ const LiveCommitLog: React.FC = () => {
   const [newEntryIds, setNewEntryIds] = useState<Set<string>>(new Set());
   const logContainerRef = useRef<HTMLDivElement>(null);
   const loadMoreRef = useRef<HTMLAnchorElement>(null);
+  const fetchNextPagePendingRef = useRef(false);
+  const loadMoreVisibleRef = useRef(false);
+  const scrollGenerationRef = useRef(0);
+  const lastFetchScrollGenerationRef = useRef(0);
 
   const apiCommits = useMemo<CommitLogEntry[]>(
     () => data?.pages.flat() ?? [],
@@ -375,6 +385,29 @@ const LiveCommitLog: React.FC = () => {
   const showWaitingForActivity = !showInitialLoading && !hasAnyEntries;
   const showFilteredEmptyState = hasAnyEntries && visibleEntries.length === 0;
 
+  const fetchNextPageAfterScroll = useCallback(() => {
+    if (
+      !loadMoreVisibleRef.current ||
+      !hasNextPage ||
+      isFetchingNextPage ||
+      fetchNextPagePendingRef.current ||
+      scrollGenerationRef.current === lastFetchScrollGenerationRef.current
+    ) {
+      return;
+    }
+
+    lastFetchScrollGenerationRef.current = scrollGenerationRef.current;
+    fetchNextPagePendingRef.current = true;
+    void fetchNextPage().finally(() => {
+      fetchNextPagePendingRef.current = false;
+    });
+  }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
+
+  const handleLogScroll = useCallback(() => {
+    scrollGenerationRef.current += 1;
+    fetchNextPageAfterScroll();
+  }, [fetchNextPageAfterScroll]);
+
   // Intersection observer for infinite scroll
   useEffect(() => {
     const scrollContainer = logContainerRef.current;
@@ -383,9 +416,9 @@ const LiveCommitLog: React.FC = () => {
 
     const observer = new IntersectionObserver(
       (entries) => {
-        if (entries[0].isIntersecting && hasNextPage && !isFetchingNextPage) {
-          fetchNextPage();
-        }
+        const entry = entries[0];
+        loadMoreVisibleRef.current = !!entry?.isIntersecting;
+        fetchNextPageAfterScroll();
       },
       {
         root: scrollContainer,
@@ -396,7 +429,7 @@ const LiveCommitLog: React.FC = () => {
     observer.observe(loadMoreElement);
 
     return () => observer.disconnect();
-  }, [fetchNextPage, hasNextPage, isFetchingNextPage, visibleEntries.length]);
+  }, [fetchNextPageAfterScroll]);
 
   return (
     <Card
@@ -532,6 +565,7 @@ const LiveCommitLog: React.FC = () => {
         ) : (
           <Box
             ref={logContainerRef}
+            onScroll={handleLogScroll}
             sx={{
               flex: 1,
               overflowY: 'auto',

--- a/src/pages/dashboard/views/LiveCommitLog.tsx
+++ b/src/pages/dashboard/views/LiveCommitLog.tsx
@@ -99,6 +99,7 @@ const COMMIT_STATUS_FILTERS: CommitStatusFilter[] = [
   'open',
   'closed',
 ];
+const SCROLL_FETCH_THRESHOLD_PX = 48;
 
 const getCommitId = (entry: CommitLogEntry) =>
   `${entry.repository}-${entry.pullRequestNumber}`;
@@ -323,11 +324,7 @@ const LiveCommitLog: React.FC = () => {
   const [logEntries, setLogEntries] = useState<CommitLogEntry[]>([]);
   const [newEntryIds, setNewEntryIds] = useState<Set<string>>(new Set());
   const logContainerRef = useRef<HTMLDivElement>(null);
-  const loadMoreRef = useRef<HTMLAnchorElement>(null);
   const fetchNextPagePendingRef = useRef(false);
-  const loadMoreVisibleRef = useRef(false);
-  const scrollGenerationRef = useRef(0);
-  const lastFetchScrollGenerationRef = useRef(0);
 
   const apiCommits = useMemo<CommitLogEntry[]>(
     () => data?.pages.flat() ?? [],
@@ -385,51 +382,38 @@ const LiveCommitLog: React.FC = () => {
   const showWaitingForActivity = !showInitialLoading && !hasAnyEntries;
   const showFilteredEmptyState = hasAnyEntries && visibleEntries.length === 0;
 
-  const fetchNextPageAfterScroll = useCallback(() => {
-    if (
-      !loadMoreVisibleRef.current ||
-      !hasNextPage ||
-      isFetchingNextPage ||
-      fetchNextPagePendingRef.current ||
-      scrollGenerationRef.current === lastFetchScrollGenerationRef.current
-    ) {
-      return;
-    }
+  const fetchNextPageIfNeeded = useCallback(
+    (scrollContainer: HTMLDivElement) => {
+      const distanceFromBottom =
+        scrollContainer.scrollHeight -
+        (scrollContainer.scrollTop + scrollContainer.clientHeight);
 
-    lastFetchScrollGenerationRef.current = scrollGenerationRef.current;
-    fetchNextPagePendingRef.current = true;
-    void fetchNextPage().finally(() => {
-      fetchNextPagePendingRef.current = false;
-    });
-  }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
+      if (distanceFromBottom > SCROLL_FETCH_THRESHOLD_PX) {
+        return;
+      }
 
-  const handleLogScroll = useCallback(() => {
-    scrollGenerationRef.current += 1;
-    fetchNextPageAfterScroll();
-  }, [fetchNextPageAfterScroll]);
+      if (
+        !hasNextPage ||
+        isFetchingNextPage ||
+        fetchNextPagePendingRef.current
+      ) {
+        return;
+      }
 
-  // Intersection observer for infinite scroll
-  useEffect(() => {
-    const scrollContainer = logContainerRef.current;
-    const loadMoreElement = loadMoreRef.current;
-    if (!scrollContainer || !loadMoreElement) return;
+      fetchNextPagePendingRef.current = true;
+      void fetchNextPage().finally(() => {
+        fetchNextPagePendingRef.current = false;
+      });
+    },
+    [fetchNextPage, hasNextPage, isFetchingNextPage],
+  );
 
-    const observer = new IntersectionObserver(
-      (entries) => {
-        const entry = entries[0];
-        loadMoreVisibleRef.current = !!entry?.isIntersecting;
-        fetchNextPageAfterScroll();
-      },
-      {
-        root: scrollContainer,
-        threshold: 0.1,
-      },
-    );
-
-    observer.observe(loadMoreElement);
-
-    return () => observer.disconnect();
-  }, [fetchNextPageAfterScroll]);
+  const handleLogScroll = useCallback(
+    (event: React.UIEvent<HTMLDivElement>) => {
+      fetchNextPageIfNeeded(event.currentTarget);
+    },
+    [fetchNextPageIfNeeded],
+  );
 
   return (
     <Card
@@ -614,8 +598,6 @@ const LiveCommitLog: React.FC = () => {
                 })}
               </Stack>
             )}
-
-            <Box ref={loadMoreRef} sx={{ height: 1 }} />
 
             {isFetchingNextPage && (
               <Box sx={{ display: 'flex', justifyContent: 'center', p: 2 }}>

--- a/src/tests/DashboardApi.test.ts
+++ b/src/tests/DashboardApi.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import {
+  COMMIT_LOG_PAGE_LIMIT,
+  getNextCommitLogPageParam,
+} from '../api/DashboardApi';
+import type { CommitLog } from '../api/models/Dashboard';
+
+const makePage = (length: number) =>
+  Array.from({ length }, () => ({}) as CommitLog);
+
+describe('getNextCommitLogPageParam', () => {
+  it('returns page 2 when the first page is full', () => {
+    expect(getNextCommitLogPageParam(makePage(COMMIT_LOG_PAGE_LIMIT), 1)).toBe(
+      2,
+    );
+  });
+
+  it('uses the last page param instead of the number of cached pages', () => {
+    expect(getNextCommitLogPageParam(makePage(COMMIT_LOG_PAGE_LIMIT), 5)).toBe(
+      6,
+    );
+  });
+
+  it('returns undefined when the last page is not full', () => {
+    expect(
+      getNextCommitLogPageParam(makePage(COMMIT_LOG_PAGE_LIMIT - 1), 5),
+    ).toBeUndefined();
+  });
+
+  it('returns undefined for an empty page', () => {
+    expect(getNextCommitLogPageParam(makePage(0), 5)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the Dashboard Live Activity infinite-scroll loop reported in #685.

**Root Cause**
Live Activity used an `IntersectionObserver` sentinel for infinite scroll. When the sentinel stayed visible after loading a page, it kept triggering `fetchNextPage()` even after the user stopped scrolling.

**Changes**
- Removed the observer-based next-page trigger.
- Load the next page only from the scroll handler.
- Fetch only when the user scrolls near the bottom and no next-page request is already running.
- Keep existing requests, UI, filters, and polling behavior unchanged.

## Related Issues

Fixes #685 **Issue 1. Dashboard live activity infinite scroll**

**Issue 2. Repo table chart** cannot be reproduced on my side. It appears to be working normally.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing
- [x] npm run test
- [x] npm run lint
- [x] npm run format:check
- [x] npm run build

## Manual check:

- Open /dashboard
- Scroll Live Activity quickly
- Stop scrolling
- Confirm next-page /dash/commits requests do not continue indefinitely

## Screenshots

<!-- Include before/after screenshots for every UI/visual change. Remove this section if not applicable. -->

https://github.com/user-attachments/assets/beb7db18-4dd2-47c8-ba44-7e7da23cd0ad


## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [ ] Screenshots included for any UI/visual changes
