### PR TITLE
refactor(search): remove unused matchMode from miner/repository helpers

### DIFF
--- a/src/pages/search/searchData.ts
+++ b/src/pages/search/searchData.ts
@@ -108,10 +108,9 @@ const buildMinerSearchData = (miners: MinerEvaluation[]): MinerSearchData[] => {
   }));
 };
 
-const getMinerSearchResults = (
+export const getMinerSearchResults = (
   miners: MinerSearchData[],
   query: string,
-  matchMode: SearchMatchMode,
   limit?: number,
 ) => {
   const results = sortByMatchThenTiebreaker(
@@ -182,10 +181,9 @@ const buildRepoSearchData = (
     }));
 };
 
-const getRepositorySearchResults = (
+export const getRepositorySearchResults = (
   repositories: RepoSearchData[],
   query: string,
-  matchMode: SearchMatchMode,
   limit?: number,
 ) => {
   const results = sortByMatchThenTiebreaker(
@@ -287,26 +285,18 @@ export const useSearchResults = (
     return getMinerSearchResults(
       minerSearchData,
       normalizedQuery,
-      matchMode,
       limits.miners,
     );
-  }, [hasQuery, limits.miners, matchMode, normalizedQuery, minerSearchData]);
+  }, [hasQuery, limits.miners, normalizedQuery, minerSearchData]);
 
   const repoResults = useMemo(() => {
     if (!hasQuery) return [];
     return getRepositorySearchResults(
       repoSearchData,
       normalizedQuery,
-      matchMode,
       limits.repositories,
     );
-  }, [
-    hasQuery,
-    limits.repositories,
-    matchMode,
-    normalizedQuery,
-    repoSearchData,
-  ]);
+  }, [hasQuery, limits.repositories, normalizedQuery, repoSearchData]);
 
   const prResults = useMemo(() => {
     if (!hasQuery) return [];

--- a/src/pages/search/searchData.ts
+++ b/src/pages/search/searchData.ts
@@ -108,7 +108,7 @@ const buildMinerSearchData = (miners: MinerEvaluation[]): MinerSearchData[] => {
   }));
 };
 
-export const getMinerSearchResults = (
+const getMinerSearchResults = (
   miners: MinerSearchData[],
   query: string,
   limit?: number,
@@ -181,7 +181,7 @@ const buildRepoSearchData = (
     }));
 };
 
-export const getRepositorySearchResults = (
+const getRepositorySearchResults = (
   repositories: RepoSearchData[],
   query: string,
   limit?: number,


### PR DESCRIPTION
## Summary

Removes unused `matchMode` plumbing in `src/pages/search/searchData.ts` for miner/repository search helpers:
- drop `matchMode` from `getMinerSearchResults` and `getRepositorySearchResults` signatures
- remove corresponding unused arguments at call sites
- remove related unnecessary `useMemo` dependencies

This is behavior-preserving for search results (PR/issues matching logic remains unchanged).

## Related Issues

Closes #744

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Checklist

- [x] New components are modularized/separated where sensible (N/A: no new components)
- [x] Uses predefined theme (e.g. no hardcoded colors) (N/A: no UI/theming changes)
- [x] Responsive/mobile checked (N/A: no UI changes)
- [x] Tested against the test API (N/A: no API behavior change)
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes (N/A: no UI/visual changes)
