### PR TITLE
style(onboard): make section tabs sticky while scrolling

### DIFF
--- a/src/pages/OnboardPage.tsx
+++ b/src/pages/OnboardPage.tsx
@@ -60,9 +60,13 @@ const OnboardPage: React.FC = () => {
       >
         <Box
           sx={(theme) => ({
+            position: 'sticky',
+            top: 0,
+            zIndex: 2,
             maxWidth: 1200,
             width: '100%',
             mb: 4,
+            backgroundColor: theme.palette.background.default,
             borderBottom: '1px solid',
             borderColor: theme.palette.border.light,
           })}


### PR DESCRIPTION
## Summary

Makes the section-tab bar on the Onboard page (**About / Getting Started / Scoring / Languages / FAQ**) stick to the top of the viewport while the user scrolls content below it, so the user never loses access to navigation on long pages like Scoring and Languages.

## Motivation

Several onboard sections (Scoring, Languages, FAQ) are tall enough to scroll. Once the user scrolls past the tab bar, they have to scroll all the way back up to switch sections — a common complaint from new miners reading through the docs.

## Change

[src/pages/OnboardPage.tsx](src/pages/OnboardPage.tsx) — added four CSS properties to the existing tab-wrapper `Box`:

```tsx
position: 'sticky',
top: 0,
zIndex: 2,
backgroundColor: theme.palette.background.default,
```

No structural changes, no new components, no prop or route changes. The sticky behavior is relative to the existing scroll container (`<main>` in `AppLayout`), so no layout rework was needed.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / UX improvement
- [ ] Documentation
- [ ] Other

## Test plan

- [ ] Visit `/onboard`, scroll each tab content — tab bar remains glued to top of scroll viewport.
- [ ] Switching tabs while scrolled keeps the tab bar in place and resets content scroll.
- [ ] Visually verify the bar's `background.default` masks content scrolling behind it (no bleed-through).
- [ ] Mobile and desktop both behave correctly.
- [ ] Sidebar/top-nav remain above the sticky bar (`zIndex: 2` is below the app shell's higher z-index).

## Notes

- Orthogonal to [#725](https://github.com/entrius/gittensor-ui/pull/725) (onboard mobile layout). If both merge, expect a trivial adjacent-line rebase — they change different properties on the same `sx` object.
