### PR TITLE
refactor: migrate remaining tables to shared DataTable (#747)

### DIFF
--- a/src/components/leaderboard/TopRepositoriesTable.tsx
+++ b/src/components/leaderboard/TopRepositoriesTable.tsx
@@ -57,12 +57,7 @@ import { useNavigate, useSearchParams } from 'react-router-dom';
 import { DataTable, type DataTableColumn } from '../common/DataTable';
 import { truncateText } from '../../utils';
 import { RankIcon } from './RankIcon';
-import {
-  getRepositoryOwnerAvatarBackground,
-  bodyCellStyle as leaderboardBodyCellStyle,
-  headerCellStyle as leaderboardHeaderCellStyle,
-  type RepoStats,
-} from './types';
+import { getRepositoryOwnerAvatarBackground, type RepoStats } from './types';
 import {
   CHART_COLORS,
   STATUS_COLORS,
@@ -660,22 +655,7 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
     </Box>
   );
 
-  // Override theme.ts defaults that DataTable applies, so list view keeps
-  // the denser leaderboard cell metrics (shorter rows, non-uppercase headers,
-  // no letterSpacing) defined in `./types`.
-  const listBodyCellOverride = {
-    ...leaderboardBodyCellStyle,
-    borderBottom: '1px solid',
-    borderColor: 'border.light',
-  };
-  const listHeaderCellOverride = {
-    ...leaderboardHeaderCellStyle,
-    textTransform: 'none' as const,
-    letterSpacing: 0,
-  };
-
   const sortableHeaderSx = {
-    ...listHeaderCellOverride,
     padding: 0,
     cursor: 'pointer',
     userSelect: 'none' as const,
@@ -689,8 +669,7 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
       key: 'rank',
       header: 'Rank',
       width: '60px',
-      headerSx: listHeaderCellOverride,
-      cellSx: { ...listBodyCellOverride, pr: 0 },
+      cellSx: { pr: 0 },
       renderCell: (repo) => <RankIcon rank={repo.rank || 0} />,
     },
     {
@@ -698,7 +677,7 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
       header: renderSortHeader('repository', 'Repository'),
       width: '35%',
       headerSx: sortableHeaderSx,
-      cellSx: { ...listBodyCellOverride, pl: 1.5 },
+      cellSx: { pl: 1.5 },
       renderCell: (repo) => (
         <Box
           sx={{
@@ -753,7 +732,6 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
       width: '12%',
       align: 'right',
       headerSx: sortableHeaderSx,
-      cellSx: listBodyCellOverride,
       renderCell: (repo) => (
         <Typography
           sx={{
@@ -772,7 +750,6 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
       width: '18%',
       align: 'right',
       headerSx: sortableHeaderSx,
-      cellSx: listBodyCellOverride,
       renderCell: (repo) => (
         <Typography
           sx={{
@@ -794,7 +771,6 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
       width: '15%',
       align: 'right',
       headerSx: sortableHeaderSx,
-      cellSx: listBodyCellOverride,
       renderCell: (repo) => (
         <Typography
           sx={{
@@ -812,7 +788,6 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
       width: '15%',
       align: 'right',
       headerSx: sortableHeaderSx,
-      cellSx: listBodyCellOverride,
       renderCell: (repo) => (
         <Typography
           sx={{

--- a/src/components/leaderboard/TopRepositoriesTable.tsx
+++ b/src/components/leaderboard/TopRepositoriesTable.tsx
@@ -34,8 +34,6 @@ import {
   alpha,
   useMediaQuery,
   useTheme,
-  type SxProps,
-  type Theme,
 } from '@mui/material';
 import SearchIcon from '@mui/icons-material/Search';
 import BarChartIcon from '@mui/icons-material/BarChart';
@@ -62,14 +60,13 @@ import {
 import ReactECharts from 'echarts-for-react';
 import type { TooltipComponentFormatterCallbackParams } from 'echarts';
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import { LinkTableRow } from '../common/linkBehavior';
+import { DataTable, type DataTableColumn } from '../common/DataTable';
 import { truncateText } from '../../utils';
 import { RankIcon } from './RankIcon';
 import LeaderboardTableSkeleton from './LeaderboardTableSkeleton';
 import {
   getRepositoryOwnerAvatarBackground,
   headerCellStyle,
-  bodyCellStyle,
   type RepoStats,
 } from './types';
 import {
@@ -637,50 +634,145 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
     />
   );
 
-  const SortableHeader = ({
-    column,
-    children,
-    align = 'left',
-    sx = {},
-  }: {
-    column: SortColumn;
-    children: React.ReactNode;
-    align?: 'left' | 'right';
-    sx?: SxProps<Theme>;
-  }) => (
-    <TableCell
-      align={align}
-      sx={{
-        ...headerCellStyle,
-        ...(sx || {}),
-        cursor: 'pointer',
-        userSelect: 'none',
-        '&:hover': {
-          backgroundColor: 'surface.light',
-        },
-      }}
-      onClick={() => handleSort(column)}
-    >
-      <Box
-        sx={{
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: align === 'right' ? 'flex-end' : 'flex-start',
-          gap: 0.5,
-        }}
-      >
-        {children}
-        {sortColumn === column && (
-          <Typography
-            component="span"
-            sx={{ fontSize: '0.7rem', opacity: 0.7 }}
-          >
-            {sortDirection === 'asc' ? '▲' : '▼'}
-          </Typography>
-        )}
-      </Box>
-    </TableCell>
-  );
+  const listColumns: DataTableColumn<RepoStats, SortColumn>[] = [
+    {
+      key: 'rank',
+      header: 'Rank',
+      width: '60px',
+      cellSx: { pr: 0 },
+      renderCell: (repo) => <RankIcon rank={repo.rank || 0} />,
+    },
+    {
+      key: 'repository',
+      header: 'Repository',
+      width: '35%',
+      sortKey: 'repository',
+      cellSx: { pl: 1.5 },
+      renderCell: (repo) => (
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 1,
+            cursor: 'pointer',
+            '&:hover': {
+              '& .MuiTypography-root': {
+                color: 'primary.main',
+                textDecoration: 'underline',
+              },
+            },
+          }}
+        >
+          <Avatar
+            src={`https://avatars.githubusercontent.com/${(repo.repository || '').split('/')[0]}`}
+            alt={(repo.repository || '').split('/')[0]}
+            sx={{
+              width: 20,
+              height: 20,
+              border: '1px solid',
+              borderColor: 'border.medium',
+              backgroundColor: getRepositoryOwnerAvatarBackground(
+                (repo.repository || '').split('/')[0],
+              ),
+            }}
+          />
+          <Tooltip title={repo.repository || ''} placement="top">
+            <Typography
+              component="span"
+              sx={{
+                color: 'text.primary',
+                fontWeight: 500,
+                transition: 'color 0.2s',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+                maxWidth: '100%',
+                display: 'inline-block',
+              }}
+            >
+              {truncateText(repo.repository || '', 40)}
+            </Typography>
+          </Tooltip>
+        </Box>
+      ),
+    },
+    {
+      key: 'weight',
+      header: 'Weight',
+      width: '12%',
+      align: 'right',
+      sortKey: 'weight',
+      renderCell: (repo) => (
+        <Typography
+          sx={{
+            fontSize: '0.75rem',
+            fontWeight: 600,
+            color: 'text.primary',
+          }}
+        >
+          {repo.weight.toFixed(2)}
+        </Typography>
+      ),
+    },
+    {
+      key: 'totalScore',
+      header: 'Total Score',
+      width: '18%',
+      align: 'right',
+      sortKey: 'totalScore',
+      renderCell: (repo) => (
+        <Typography
+          sx={{
+            fontSize: '0.75rem',
+            fontWeight: 600,
+            color:
+              (repo.totalScore || 0) > 0 ? 'text.primary' : 'text.secondary',
+          }}
+        >
+          {(repo.totalScore || 0) > 0
+            ? Number(repo.totalScore || 0).toFixed(2)
+            : '-'}
+        </Typography>
+      ),
+    },
+    {
+      key: 'totalPRs',
+      header: 'PRs',
+      width: '15%',
+      align: 'right',
+      sortKey: 'totalPRs',
+      renderCell: (repo) => (
+        <Typography
+          sx={{
+            fontSize: '0.75rem',
+            color: (repo.totalPRs || 0) > 0 ? 'text.primary' : 'text.secondary',
+          }}
+        >
+          {(repo.totalPRs || 0) > 0 ? repo.totalPRs : '-'}
+        </Typography>
+      ),
+    },
+    {
+      key: 'contributors',
+      header: 'Contributors',
+      width: '15%',
+      align: 'right',
+      sortKey: 'contributors',
+      renderCell: (repo) => (
+        <Typography
+          sx={{
+            fontSize: '0.75rem',
+            color:
+              (repo.uniqueMiners?.size || 0) > 0
+                ? 'text.primary'
+                : 'text.secondary',
+          }}
+        >
+          {(repo.uniqueMiners?.size || 0) > 0 ? repo.uniqueMiners?.size : '-'}
+        </Typography>
+      ),
+    },
+  ];
 
   useEffect(() => {
     if (isInitialMount.current) {
@@ -1078,257 +1170,115 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
         </Box>
       )}
 
-      {viewMode === 'list' && (
-        <TableContainer
-          sx={{
-            overflowY: 'auto',
-            ...scrollbarSx,
-          }}
-        >
-          <Table
-            stickyHeader
-            sx={{ tableLayout: 'fixed', width: '100%', minWidth: '1000px' }}
-          >
-            <TableHead>
-              <TableRow>
-                <TableCell sx={{ ...headerCellStyle, width: '60px' }}>
-                  Rank
-                </TableCell>
-                <SortableHeader column="repository" sx={{ width: '35%' }}>
-                  Repository
-                </SortableHeader>
-                <SortableHeader
-                  column="weight"
-                  align="right"
-                  sx={{ width: '12%' }}
-                >
-                  Weight
-                </SortableHeader>
-                <SortableHeader
-                  column="totalScore"
-                  align="right"
-                  sx={{
-                    width: '18%',
-                  }}
-                >
-                  Total Score
-                </SortableHeader>
-                <SortableHeader
-                  column="totalPRs"
-                  align="right"
-                  sx={{ width: '15%' }}
-                >
-                  PRs
-                </SortableHeader>
-                <SortableHeader
-                  column="contributors"
-                  align="right"
-                  sx={{ width: '15%' }}
-                >
-                  Contributors
-                </SortableHeader>
-              </TableRow>
-            </TableHead>
-            <TableBody>
-              {isLoading ? (
+      {viewMode === 'list' &&
+        (isLoading ? (
+          <TableContainer sx={{ overflowY: 'auto', ...scrollbarSx }}>
+            <Table
+              stickyHeader
+              sx={{ tableLayout: 'fixed', width: '100%', minWidth: '1000px' }}
+            >
+              <TableHead>
+                <TableRow>
+                  <TableCell sx={{ ...headerCellStyle, width: '60px' }}>
+                    Rank
+                  </TableCell>
+                  <TableCell sx={{ ...headerCellStyle, width: '35%' }}>
+                    Repository
+                  </TableCell>
+                  <TableCell
+                    align="right"
+                    sx={{ ...headerCellStyle, width: '12%' }}
+                  >
+                    Weight
+                  </TableCell>
+                  <TableCell
+                    align="right"
+                    sx={{ ...headerCellStyle, width: '18%' }}
+                  >
+                    Total Score
+                  </TableCell>
+                  <TableCell
+                    align="right"
+                    sx={{ ...headerCellStyle, width: '15%' }}
+                  >
+                    PRs
+                  </TableCell>
+                  <TableCell
+                    align="right"
+                    sx={{ ...headerCellStyle, width: '15%' }}
+                  >
+                    Contributors
+                  </TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
                 <LeaderboardTableSkeleton
                   variant="repositories"
                   rows={rowsPerPage}
                 />
-              ) : (
-                <>
-                  {pagedRepositories.map((repo) => {
-                    return (
-                      <LinkTableRow
-                        key={repo.repository}
-                        href={getRepositoryHref(repo.repository || '')}
-                        linkState={linkState}
-                        hover
-                        sx={{
-                          cursor: 'pointer',
-                          '&:hover': {
-                            backgroundColor: 'border.subtle',
-                          },
-                          transition: 'all 0.2s',
-                          opacity: repo.inactiveAt ? 0.5 : 1,
-                          borderBottom: '1px solid',
-                          borderColor: 'surface.light',
-                        }}
-                      >
-                        <TableCell
-                          sx={{ ...bodyCellStyle, width: '60px', pr: 0 }}
-                        >
-                          <RankIcon rank={repo.rank || 0} />
-                        </TableCell>
-                        <TableCell
-                          sx={{ ...bodyCellStyle, width: '35%', pl: 1.5 }}
-                        >
-                          <Box
-                            sx={{
-                              display: 'flex',
-                              alignItems: 'center',
-                              gap: 1,
-                              cursor: 'pointer',
-                              '&:hover': {
-                                '& .MuiTypography-root': {
-                                  color: 'primary.main',
-                                  textDecoration: 'underline',
-                                },
-                              },
-                            }}
-                          >
-                            <Avatar
-                              src={`https://avatars.githubusercontent.com/${(repo.repository || '').split('/')[0]}`}
-                              alt={(repo.repository || '').split('/')[0]}
-                              sx={{
-                                width: 20,
-                                height: 20,
-                                border: '1px solid',
-                                borderColor: 'border.medium',
-                                backgroundColor:
-                                  getRepositoryOwnerAvatarBackground(
-                                    (repo.repository || '').split('/')[0],
-                                  ),
-                              }}
-                            />
-                            <Tooltip
-                              title={repo.repository || ''}
-                              placement="top"
-                            >
-                              <Typography
-                                component="span"
-                                sx={{
-                                  color: 'text.primary',
-                                  fontWeight: 500,
-                                  transition: 'color 0.2s',
-                                  overflow: 'hidden',
-                                  textOverflow: 'ellipsis',
-                                  whiteSpace: 'nowrap',
-                                  maxWidth: '100%',
-                                  display: 'inline-block',
-                                }}
-                              >
-                                {truncateText(repo.repository || '', 40)}
-                              </Typography>
-                            </Tooltip>
-                          </Box>
-                        </TableCell>
-                        <TableCell
-                          align="right"
-                          sx={{ ...bodyCellStyle, width: '12%' }}
-                        >
-                          <Typography
-                            sx={{
-                              fontSize: '0.75rem',
-                              fontWeight: 600,
-                              color: 'text.primary',
-                            }}
-                          >
-                            {repo.weight.toFixed(2)}
-                          </Typography>
-                        </TableCell>
-                        <TableCell
-                          align="right"
-                          sx={{ ...bodyCellStyle, width: '18%' }}
-                        >
-                          <Typography
-                            sx={{
-                              fontSize: '0.75rem',
-                              fontWeight: 600,
-                              color:
-                                (repo.totalScore || 0) > 0
-                                  ? 'text.primary'
-                                  : 'text.secondary',
-                            }}
-                          >
-                            {(repo.totalScore || 0) > 0
-                              ? Number(repo.totalScore || 0).toFixed(2)
-                              : '-'}
-                          </Typography>
-                        </TableCell>
-                        <TableCell
-                          align="right"
-                          sx={{ ...bodyCellStyle, width: '15%' }}
-                        >
-                          <Typography
-                            sx={{
-                              fontSize: '0.75rem',
-                              color:
-                                (repo.totalPRs || 0) > 0
-                                  ? 'text.primary'
-                                  : 'text.secondary',
-                            }}
-                          >
-                            {(repo.totalPRs || 0) > 0 ? repo.totalPRs : '-'}
-                          </Typography>
-                        </TableCell>
-                        <TableCell
-                          align="right"
-                          sx={{ ...bodyCellStyle, width: '15%' }}
-                        >
-                          <Typography
-                            sx={{
-                              fontSize: '0.75rem',
-                              color:
-                                (repo.uniqueMiners?.size || 0) > 0
-                                  ? 'text.primary'
-                                  : 'text.secondary',
-                            }}
-                          >
-                            {(repo.uniqueMiners?.size || 0) > 0
-                              ? repo.uniqueMiners?.size
-                              : '-'}
-                          </Typography>
-                        </TableCell>
-                      </LinkTableRow>
-                    );
-                  })}
-                  {!filteredRepositories.length &&
-                    trimmedSearch &&
-                    isDirectRepoInput && (
-                      <TableRow hover>
-                        <TableCell colSpan={6} sx={{ ...bodyCellStyle, py: 2 }}>
-                          <Box
-                            sx={{
-                              display: 'flex',
-                              alignItems: 'center',
-                              justifyContent: 'space-between',
-                              gap: 2,
-                            }}
-                          >
-                            <Typography
-                              sx={{
-                                color: 'text.secondary',
-                              }}
-                            >
-                              Repository not in tracked list. Open details for{' '}
-                              <Typography component="span">
-                                {trimmedSearch}
-                              </Typography>
-                              ?
-                            </Typography>
-                            <Button
-                              size="small"
-                              variant="outlined"
-                              onClick={() =>
-                                navigate(getRepositoryHref(trimmedSearch), {
-                                  state: linkState,
-                                })
-                              }
-                              sx={{ textTransform: 'none' }}
-                            >
-                              Open repository
-                            </Button>
-                          </Box>
-                        </TableCell>
-                      </TableRow>
-                    )}
-                </>
-              )}
-            </TableBody>
-          </Table>
-        </TableContainer>
-      )}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        ) : (
+          <Box sx={{ overflowY: 'auto', ...scrollbarSx }}>
+            <DataTable<RepoStats, SortColumn>
+              columns={listColumns}
+              rows={pagedRepositories}
+              getRowKey={(repo) => repo.repository || ''}
+              getRowHref={(repo) => getRepositoryHref(repo.repository || '')}
+              linkState={linkState}
+              getRowSx={(repo) => ({
+                opacity: repo.inactiveAt ? 0.5 : 1,
+                '&:hover': { backgroundColor: 'border.subtle' },
+                transition: 'all 0.2s',
+                borderBottom: '1px solid',
+                borderColor: 'surface.light',
+              })}
+              minWidth="1000px"
+              stickyHeader
+              sort={{
+                field: sortColumn,
+                order: sortDirection,
+                onChange: handleSort,
+              }}
+              emptyState={
+                !filteredRepositories.length &&
+                trimmedSearch &&
+                isDirectRepoInput ? (
+                  <Box
+                    sx={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'space-between',
+                      gap: 2,
+                      px: 2,
+                      py: 2,
+                      borderBottom: '1px solid',
+                      borderColor: 'surface.light',
+                    }}
+                  >
+                    <Typography sx={{ color: 'text.secondary' }}>
+                      Repository not in tracked list. Open details for{' '}
+                      <Typography component="span">{trimmedSearch}</Typography>?
+                    </Typography>
+                    <Button
+                      size="small"
+                      variant="outlined"
+                      onClick={() =>
+                        navigate(getRepositoryHref(trimmedSearch), {
+                          state: linkState,
+                        })
+                      }
+                      sx={{ textTransform: 'none' }}
+                    >
+                      Open repository
+                    </Button>
+                  </Box>
+                ) : undefined
+              }
+            />
+          </Box>
+        ))}
       <TablePagination
         rowsPerPageOptions={[]}
         component="div"

--- a/src/components/leaderboard/TopRepositoriesTable.tsx
+++ b/src/components/leaderboard/TopRepositoriesTable.tsx
@@ -623,6 +623,39 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
     />
   );
 
+  // Custom sort header to preserve the original unicode arrow look and
+  // cell-wide hover background (MUI's TableSortLabel differs visually).
+  const renderSortHeader = (column: SortColumn, label: string) => (
+    <Box
+      onClick={() => handleSort(column)}
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 0.5,
+        cursor: 'pointer',
+        userSelect: 'none',
+        width: '100%',
+        height: '100%',
+        justifyContent: 'inherit',
+      }}
+    >
+      {label}
+      {sortColumn === column && (
+        <Typography component="span" sx={{ fontSize: '0.7rem', opacity: 0.7 }}>
+          {sortDirection === 'asc' ? '▲' : '▼'}
+        </Typography>
+      )}
+    </Box>
+  );
+
+  const sortableHeaderSx = {
+    cursor: 'pointer',
+    userSelect: 'none' as const,
+    '&:hover': {
+      backgroundColor: 'surface.light',
+    },
+  };
+
   const listColumns: DataTableColumn<RepoStats, SortColumn>[] = [
     {
       key: 'rank',
@@ -633,9 +666,9 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
     },
     {
       key: 'repository',
-      header: 'Repository',
+      header: renderSortHeader('repository', 'Repository'),
       width: '35%',
-      sortKey: 'repository',
+      headerSx: sortableHeaderSx,
       cellSx: { pl: 1.5 },
       renderCell: (repo) => (
         <Box
@@ -687,10 +720,10 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
     },
     {
       key: 'weight',
-      header: 'Weight',
+      header: renderSortHeader('weight', 'Weight'),
       width: '12%',
       align: 'right',
-      sortKey: 'weight',
+      headerSx: sortableHeaderSx,
       renderCell: (repo) => (
         <Typography
           sx={{
@@ -705,10 +738,10 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
     },
     {
       key: 'totalScore',
-      header: 'Total Score',
+      header: renderSortHeader('totalScore', 'Total Score'),
       width: '18%',
       align: 'right',
-      sortKey: 'totalScore',
+      headerSx: sortableHeaderSx,
       renderCell: (repo) => (
         <Typography
           sx={{
@@ -726,10 +759,10 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
     },
     {
       key: 'totalPRs',
-      header: 'PRs',
+      header: renderSortHeader('totalPRs', 'PRs'),
       width: '15%',
       align: 'right',
-      sortKey: 'totalPRs',
+      headerSx: sortableHeaderSx,
       renderCell: (repo) => (
         <Typography
           sx={{
@@ -743,10 +776,10 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
     },
     {
       key: 'contributors',
-      header: 'Contributors',
+      header: renderSortHeader('contributors', 'Contributors'),
       width: '15%',
       align: 'right',
-      sortKey: 'contributors',
+      headerSx: sortableHeaderSx,
       renderCell: (repo) => (
         <Typography
           sx={{
@@ -1177,11 +1210,6 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
             })}
             minWidth="1000px"
             stickyHeader
-            sort={{
-              field: sortColumn,
-              order: sortDirection,
-              onChange: handleSort,
-            }}
             emptyState={
               !filteredRepositories.length &&
               trimmedSearch &&

--- a/src/components/leaderboard/TopRepositoriesTable.tsx
+++ b/src/components/leaderboard/TopRepositoriesTable.tsx
@@ -10,12 +10,6 @@ import {
   Card,
   Grid,
   Skeleton,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
   Typography,
   Avatar,
   TextField,
@@ -63,12 +57,7 @@ import { useNavigate, useSearchParams } from 'react-router-dom';
 import { DataTable, type DataTableColumn } from '../common/DataTable';
 import { truncateText } from '../../utils';
 import { RankIcon } from './RankIcon';
-import LeaderboardTableSkeleton from './LeaderboardTableSkeleton';
-import {
-  getRepositoryOwnerAvatarBackground,
-  headerCellStyle,
-  type RepoStats,
-} from './types';
+import { getRepositoryOwnerAvatarBackground, type RepoStats } from './types';
 import {
   CHART_COLORS,
   STATUS_COLORS,
@@ -1170,115 +1159,67 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
         </Box>
       )}
 
-      {viewMode === 'list' &&
-        (isLoading ? (
-          <TableContainer sx={{ overflowY: 'auto', ...scrollbarSx }}>
-            <Table
-              stickyHeader
-              sx={{ tableLayout: 'fixed', width: '100%', minWidth: '1000px' }}
-            >
-              <TableHead>
-                <TableRow>
-                  <TableCell sx={{ ...headerCellStyle, width: '60px' }}>
-                    Rank
-                  </TableCell>
-                  <TableCell sx={{ ...headerCellStyle, width: '35%' }}>
-                    Repository
-                  </TableCell>
-                  <TableCell
-                    align="right"
-                    sx={{ ...headerCellStyle, width: '12%' }}
+      {viewMode === 'list' && (
+        <Box sx={{ overflowY: 'auto', ...scrollbarSx }}>
+          <DataTable<RepoStats, SortColumn>
+            columns={listColumns}
+            rows={pagedRepositories}
+            isLoading={isLoading}
+            getRowKey={(repo) => repo.repository || ''}
+            getRowHref={(repo) => getRepositoryHref(repo.repository || '')}
+            linkState={linkState}
+            getRowSx={(repo) => ({
+              opacity: repo.inactiveAt ? 0.5 : 1,
+              '&:hover': { backgroundColor: 'border.subtle' },
+              transition: 'all 0.2s',
+              borderBottom: '1px solid',
+              borderColor: 'surface.light',
+            })}
+            minWidth="1000px"
+            stickyHeader
+            sort={{
+              field: sortColumn,
+              order: sortDirection,
+              onChange: handleSort,
+            }}
+            emptyState={
+              !filteredRepositories.length &&
+              trimmedSearch &&
+              isDirectRepoInput ? (
+                <Box
+                  sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'space-between',
+                    gap: 2,
+                    px: 2,
+                    py: 2,
+                    borderBottom: '1px solid',
+                    borderColor: 'surface.light',
+                  }}
+                >
+                  <Typography sx={{ color: 'text.secondary' }}>
+                    Repository not in tracked list. Open details for{' '}
+                    <Typography component="span">{trimmedSearch}</Typography>?
+                  </Typography>
+                  <Button
+                    size="small"
+                    variant="outlined"
+                    onClick={() =>
+                      navigate(getRepositoryHref(trimmedSearch), {
+                        state: linkState,
+                      })
+                    }
+                    sx={{ textTransform: 'none' }}
                   >
-                    Weight
-                  </TableCell>
-                  <TableCell
-                    align="right"
-                    sx={{ ...headerCellStyle, width: '18%' }}
-                  >
-                    Total Score
-                  </TableCell>
-                  <TableCell
-                    align="right"
-                    sx={{ ...headerCellStyle, width: '15%' }}
-                  >
-                    PRs
-                  </TableCell>
-                  <TableCell
-                    align="right"
-                    sx={{ ...headerCellStyle, width: '15%' }}
-                  >
-                    Contributors
-                  </TableCell>
-                </TableRow>
-              </TableHead>
-              <TableBody>
-                <LeaderboardTableSkeleton
-                  variant="repositories"
-                  rows={rowsPerPage}
-                />
-              </TableBody>
-            </Table>
-          </TableContainer>
-        ) : (
-          <Box sx={{ overflowY: 'auto', ...scrollbarSx }}>
-            <DataTable<RepoStats, SortColumn>
-              columns={listColumns}
-              rows={pagedRepositories}
-              getRowKey={(repo) => repo.repository || ''}
-              getRowHref={(repo) => getRepositoryHref(repo.repository || '')}
-              linkState={linkState}
-              getRowSx={(repo) => ({
-                opacity: repo.inactiveAt ? 0.5 : 1,
-                '&:hover': { backgroundColor: 'border.subtle' },
-                transition: 'all 0.2s',
-                borderBottom: '1px solid',
-                borderColor: 'surface.light',
-              })}
-              minWidth="1000px"
-              stickyHeader
-              sort={{
-                field: sortColumn,
-                order: sortDirection,
-                onChange: handleSort,
-              }}
-              emptyState={
-                !filteredRepositories.length &&
-                trimmedSearch &&
-                isDirectRepoInput ? (
-                  <Box
-                    sx={{
-                      display: 'flex',
-                      alignItems: 'center',
-                      justifyContent: 'space-between',
-                      gap: 2,
-                      px: 2,
-                      py: 2,
-                      borderBottom: '1px solid',
-                      borderColor: 'surface.light',
-                    }}
-                  >
-                    <Typography sx={{ color: 'text.secondary' }}>
-                      Repository not in tracked list. Open details for{' '}
-                      <Typography component="span">{trimmedSearch}</Typography>?
-                    </Typography>
-                    <Button
-                      size="small"
-                      variant="outlined"
-                      onClick={() =>
-                        navigate(getRepositoryHref(trimmedSearch), {
-                          state: linkState,
-                        })
-                      }
-                      sx={{ textTransform: 'none' }}
-                    >
-                      Open repository
-                    </Button>
-                  </Box>
-                ) : undefined
-              }
-            />
-          </Box>
-        ))}
+                    Open repository
+                  </Button>
+                </Box>
+              ) : undefined
+            }
+          />
+        </Box>
+      )}
       <TablePagination
         rowsPerPageOptions={[]}
         component="div"

--- a/src/components/leaderboard/TopRepositoriesTable.tsx
+++ b/src/components/leaderboard/TopRepositoriesTable.tsx
@@ -57,7 +57,12 @@ import { useNavigate, useSearchParams } from 'react-router-dom';
 import { DataTable, type DataTableColumn } from '../common/DataTable';
 import { truncateText } from '../../utils';
 import { RankIcon } from './RankIcon';
-import { getRepositoryOwnerAvatarBackground, type RepoStats } from './types';
+import {
+  getRepositoryOwnerAvatarBackground,
+  bodyCellStyle as leaderboardBodyCellStyle,
+  headerCellStyle as leaderboardHeaderCellStyle,
+  type RepoStats,
+} from './types';
 import {
   CHART_COLORS,
   STATUS_COLORS,
@@ -624,8 +629,13 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
   );
 
   // Custom sort header to preserve the original unicode arrow look and
-  // cell-wide hover background (MUI's TableSortLabel differs visually).
-  const renderSortHeader = (column: SortColumn, label: string) => (
+  // cell-wide click + hover (MUI's TableSortLabel differs visually). The
+  // Box takes on the cell's padding so clicks anywhere inside the cell hit.
+  const renderSortHeader = (
+    column: SortColumn,
+    label: string,
+    align: 'left' | 'right' = 'left',
+  ) => (
     <Box
       onClick={() => handleSort(column)}
       sx={{
@@ -636,7 +646,9 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
         userSelect: 'none',
         width: '100%',
         height: '100%',
-        justifyContent: 'inherit',
+        px: 2,
+        py: 1,
+        justifyContent: align === 'right' ? 'flex-end' : 'flex-start',
       }}
     >
       {label}
@@ -648,7 +660,23 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
     </Box>
   );
 
+  // Override theme.ts defaults that DataTable applies, so list view keeps
+  // the denser leaderboard cell metrics (shorter rows, non-uppercase headers,
+  // no letterSpacing) defined in `./types`.
+  const listBodyCellOverride = {
+    ...leaderboardBodyCellStyle,
+    borderBottom: '1px solid',
+    borderColor: 'border.light',
+  };
+  const listHeaderCellOverride = {
+    ...leaderboardHeaderCellStyle,
+    textTransform: 'none' as const,
+    letterSpacing: 0,
+  };
+
   const sortableHeaderSx = {
+    ...listHeaderCellOverride,
+    padding: 0,
     cursor: 'pointer',
     userSelect: 'none' as const,
     '&:hover': {
@@ -661,7 +689,8 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
       key: 'rank',
       header: 'Rank',
       width: '60px',
-      cellSx: { pr: 0 },
+      headerSx: listHeaderCellOverride,
+      cellSx: { ...listBodyCellOverride, pr: 0 },
       renderCell: (repo) => <RankIcon rank={repo.rank || 0} />,
     },
     {
@@ -669,7 +698,7 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
       header: renderSortHeader('repository', 'Repository'),
       width: '35%',
       headerSx: sortableHeaderSx,
-      cellSx: { pl: 1.5 },
+      cellSx: { ...listBodyCellOverride, pl: 1.5 },
       renderCell: (repo) => (
         <Box
           sx={{
@@ -720,10 +749,11 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
     },
     {
       key: 'weight',
-      header: renderSortHeader('weight', 'Weight'),
+      header: renderSortHeader('weight', 'Weight', 'right'),
       width: '12%',
       align: 'right',
       headerSx: sortableHeaderSx,
+      cellSx: listBodyCellOverride,
       renderCell: (repo) => (
         <Typography
           sx={{
@@ -738,10 +768,11 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
     },
     {
       key: 'totalScore',
-      header: renderSortHeader('totalScore', 'Total Score'),
+      header: renderSortHeader('totalScore', 'Total Score', 'right'),
       width: '18%',
       align: 'right',
       headerSx: sortableHeaderSx,
+      cellSx: listBodyCellOverride,
       renderCell: (repo) => (
         <Typography
           sx={{
@@ -759,10 +790,11 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
     },
     {
       key: 'totalPRs',
-      header: renderSortHeader('totalPRs', 'PRs'),
+      header: renderSortHeader('totalPRs', 'PRs', 'right'),
       width: '15%',
       align: 'right',
       headerSx: sortableHeaderSx,
+      cellSx: listBodyCellOverride,
       renderCell: (repo) => (
         <Typography
           sx={{
@@ -776,10 +808,11 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
     },
     {
       key: 'contributors',
-      header: renderSortHeader('contributors', 'Contributors'),
+      header: renderSortHeader('contributors', 'Contributors', 'right'),
       width: '15%',
       align: 'right',
       headerSx: sortableHeaderSx,
+      cellSx: listBodyCellOverride,
       renderCell: (repo) => (
         <Typography
           sx={{

--- a/src/components/repositories/LanguageWeightsTable.tsx
+++ b/src/components/repositories/LanguageWeightsTable.tsx
@@ -1,19 +1,10 @@
 import React, { useState, useMemo, useRef, useEffect } from 'react';
 import {
   Box,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-  TableSortLabel,
   TablePagination,
   TextField,
   Typography,
-  Paper,
   InputAdornment,
-  CircularProgress,
   Select,
   MenuItem,
   FormControl,
@@ -27,16 +18,18 @@ import { Search, Check, Close } from '@mui/icons-material';
 import ReactECharts from 'echarts-for-react';
 import BarChartIcon from '@mui/icons-material/BarChart';
 import TableChartIcon from '@mui/icons-material/TableChart';
-import {
-  scrollbarSx,
-  TEXT_OPACITY,
-  headerCellStyle,
-  bodyCellStyle,
-} from '../../theme';
+import { TEXT_OPACITY } from '../../theme';
 import { useLanguagesAndWeights } from '../../api';
+import { DataTable, type DataTableColumn } from '../common/DataTable';
 
 type SortField = 'extension' | 'weight' | 'language';
 type SortOrder = 'asc' | 'desc';
+
+interface LanguageRow {
+  extension: string;
+  language: string | null;
+  weight: string;
+}
 
 const LanguageWeightsTable: React.FC = () => {
   const theme = useTheme();
@@ -75,7 +68,7 @@ const LanguageWeightsTable: React.FC = () => {
     setPage(0);
   };
 
-  const filteredAndSortedLanguages = useMemo(() => {
+  const filteredAndSortedLanguages = useMemo<LanguageRow[]>(() => {
     if (!languages) return [];
 
     const filtered = languages.filter((lang) => {
@@ -213,6 +206,59 @@ const LanguageWeightsTable: React.FC = () => {
       });
     }
   }, [rowsPerPage]);
+
+  const columns = useMemo<DataTableColumn<LanguageRow, SortField>[]>(
+    () => [
+      {
+        key: 'extension',
+        header: 'Extension',
+        sortKey: 'extension',
+        renderCell: (lang) => lang.extension,
+      },
+      {
+        key: 'language',
+        header: 'Language',
+        sortKey: 'language',
+        cellSx: (lang) => ({
+          color: lang.language ? 'text.primary' : 'text.disabled',
+        }),
+        renderCell: (lang) => lang.language || '-',
+      },
+      {
+        key: 'tokenScoring',
+        header: (
+          <Tooltip title="Indicates if this extension supports token-based scoring. Token scoring uses AST parsing for more accurate contribution measurement.">
+            <span>Token Scoring</span>
+          </Tooltip>
+        ),
+        align: 'center',
+        renderCell: (lang) =>
+          lang.language ? (
+            <Check
+              sx={{
+                color: theme.palette.status.success,
+                fontSize: '1.2rem',
+              }}
+            />
+          ) : (
+            <Close
+              sx={{
+                color: theme.palette.status.error,
+                fontSize: '1.2rem',
+              }}
+            />
+          ),
+      },
+      {
+        key: 'weight',
+        header: 'Weight',
+        align: 'right',
+        sortKey: 'weight',
+        renderCell: (lang) => lang.weight,
+      },
+    ],
+    [theme.palette.status.success, theme.palette.status.error],
+  );
 
   return (
     <Box ref={containerRef}>
@@ -357,120 +403,31 @@ const LanguageWeightsTable: React.FC = () => {
         </Box>
       </Collapse>
 
-      {isLoading ? (
-        <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
-          <CircularProgress />
-        </Box>
-      ) : (
-        <TableContainer
-          component={Paper}
-          elevation={0}
-          sx={{
-            backgroundColor: 'transparent',
-            maxHeight: '800px',
-            overflowY: 'auto',
-            ...scrollbarSx,
+      <Box
+        sx={{
+          maxHeight: '800px',
+          overflowY: 'auto',
+          backgroundColor: 'transparent',
+        }}
+      >
+        <DataTable<LanguageRow, SortField>
+          columns={columns}
+          rows={paginatedLanguages}
+          getRowKey={(lang) => lang.extension}
+          isLoading={isLoading}
+          stickyHeader
+          emptyState={
+            <Box sx={{ textAlign: 'center', py: 4 }}>
+              <Typography>No languages found!</Typography>
+            </Box>
+          }
+          sort={{
+            field: sortField,
+            order: sortOrder,
+            onChange: handleSort,
           }}
-        >
-          <Table stickyHeader>
-            <TableHead>
-              <TableRow>
-                <TableCell sx={headerCellStyle}>
-                  <TableSortLabel
-                    active={sortField === 'extension'}
-                    direction={sortField === 'extension' ? sortOrder : 'asc'}
-                    onClick={() => handleSort('extension')}
-                    sx={{
-                      '&:hover': {
-                        color: 'secondary.main',
-                      },
-                      '&.Mui-active': {
-                        color: 'secondary.main',
-                      },
-                    }}
-                  >
-                    Extension
-                  </TableSortLabel>
-                </TableCell>
-                <TableCell sx={headerCellStyle}>
-                  <TableSortLabel
-                    active={sortField === 'language'}
-                    direction={sortField === 'language' ? sortOrder : 'asc'}
-                    onClick={() => handleSort('language')}
-                    sx={{
-                      '&:hover': {
-                        color: 'secondary.main',
-                      },
-                      '&.Mui-active': {
-                        color: 'secondary.main',
-                      },
-                    }}
-                  >
-                    Language
-                  </TableSortLabel>
-                </TableCell>
-                <TableCell align="center" sx={headerCellStyle}>
-                  <Tooltip title="Indicates if this extension supports token-based scoring. Token scoring uses AST parsing for more accurate contribution measurement.">
-                    <span>Token Scoring</span>
-                  </Tooltip>
-                </TableCell>
-                <TableCell align="right" sx={headerCellStyle}>
-                  <TableSortLabel
-                    active={sortField === 'weight'}
-                    direction={sortField === 'weight' ? sortOrder : 'desc'}
-                    onClick={() => handleSort('weight')}
-                    sx={{
-                      '&:hover': {
-                        color: 'secondary.main',
-                      },
-                      '&.Mui-active': {
-                        color: 'secondary.main',
-                      },
-                    }}
-                  >
-                    Weight
-                  </TableSortLabel>
-                </TableCell>
-              </TableRow>
-            </TableHead>
-            <TableBody>
-              {paginatedLanguages.map((lang) => (
-                <TableRow key={lang.extension} hover>
-                  <TableCell sx={bodyCellStyle}>{lang.extension}</TableCell>
-                  <TableCell
-                    sx={{
-                      ...bodyCellStyle,
-                      color: lang.language ? 'text.primary' : 'text.disabled',
-                    }}
-                  >
-                    {lang.language || '-'}
-                  </TableCell>
-                  <TableCell align="center" sx={bodyCellStyle}>
-                    {lang.language ? (
-                      <Check
-                        sx={{
-                          color: theme.palette.status.success,
-                          fontSize: '1.2rem',
-                        }}
-                      />
-                    ) : (
-                      <Close
-                        sx={{
-                          color: theme.palette.status.error,
-                          fontSize: '1.2rem',
-                        }}
-                      />
-                    )}
-                  </TableCell>
-                  <TableCell align="right" sx={bodyCellStyle}>
-                    {lang.weight}
-                  </TableCell>
-                </TableRow>
-              ))}
-            </TableBody>
-          </Table>
-        </TableContainer>
-      )}
+        />
+      </Box>
 
       <TablePagination
         rowsPerPageOptions={[]}
@@ -486,12 +443,6 @@ const LanguageWeightsTable: React.FC = () => {
           '.MuiTablePagination-displayedRows': {},
         }}
       />
-
-      {filteredAndSortedLanguages.length === 0 && !isLoading && (
-        <Box sx={{ textAlign: 'center', py: 4 }}>
-          <Typography>No languages found!</Typography>
-        </Box>
-      )}
     </Box>
   );
 };

--- a/src/components/repositories/LanguageWeightsTable.tsx
+++ b/src/components/repositories/LanguageWeightsTable.tsx
@@ -416,11 +416,7 @@ const LanguageWeightsTable: React.FC = () => {
           getRowKey={(lang) => lang.extension}
           isLoading={isLoading}
           stickyHeader
-          emptyState={
-            <Box sx={{ textAlign: 'center', py: 4 }}>
-              <Typography>No languages found!</Typography>
-            </Box>
-          }
+          emptyState={null}
           sort={{
             field: sortField,
             order: sortOrder,
@@ -443,6 +439,12 @@ const LanguageWeightsTable: React.FC = () => {
           '.MuiTablePagination-displayedRows': {},
         }}
       />
+
+      {filteredAndSortedLanguages.length === 0 && !isLoading && (
+        <Box sx={{ textAlign: 'center', py: 4 }}>
+          <Typography>No languages found!</Typography>
+        </Box>
+      )}
     </Box>
   );
 };

--- a/src/components/repositories/LanguageWeightsTable.tsx
+++ b/src/components/repositories/LanguageWeightsTable.tsx
@@ -207,18 +207,28 @@ const LanguageWeightsTable: React.FC = () => {
     }
   }, [rowsPerPage]);
 
+  const sortLabelHeaderSx = {
+    '& .MuiTableSortLabel-root:hover': { color: 'secondary.main' },
+    '& .MuiTableSortLabel-root.Mui-active': { color: 'secondary.main' },
+    '& .MuiTableSortLabel-root.Mui-active .MuiTableSortLabel-icon': {
+      color: 'secondary.main',
+    },
+  } as const;
+
   const columns = useMemo<DataTableColumn<LanguageRow, SortField>[]>(
     () => [
       {
         key: 'extension',
         header: 'Extension',
         sortKey: 'extension',
+        headerSx: sortLabelHeaderSx,
         renderCell: (lang) => lang.extension,
       },
       {
         key: 'language',
         header: 'Language',
         sortKey: 'language',
+        headerSx: sortLabelHeaderSx,
         cellSx: (lang) => ({
           color: lang.language ? 'text.primary' : 'text.disabled',
         }),
@@ -254,9 +264,11 @@ const LanguageWeightsTable: React.FC = () => {
         header: 'Weight',
         align: 'right',
         sortKey: 'weight',
+        headerSx: sortLabelHeaderSx,
         renderCell: (lang) => lang.weight,
       },
     ],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [theme.palette.status.success, theme.palette.status.error],
   );
 

--- a/src/components/repositories/LanguageWeightsTable.tsx
+++ b/src/components/repositories/LanguageWeightsTable.tsx
@@ -430,6 +430,9 @@ const LanguageWeightsTable: React.FC = () => {
           isLoading={isLoading}
           stickyHeader
           emptyState={null}
+          getRowSx={() => ({
+            '&:hover': { backgroundColor: 'action.hover' },
+          })}
           sort={{
             field: sortField,
             order: sortOrder,

--- a/src/components/repositories/LanguageWeightsTable.tsx
+++ b/src/components/repositories/LanguageWeightsTable.tsx
@@ -18,7 +18,7 @@ import { Search, Check, Close } from '@mui/icons-material';
 import ReactECharts from 'echarts-for-react';
 import BarChartIcon from '@mui/icons-material/BarChart';
 import TableChartIcon from '@mui/icons-material/TableChart';
-import { TEXT_OPACITY } from '../../theme';
+import { TEXT_OPACITY, scrollbarSx } from '../../theme';
 import { useLanguagesAndWeights } from '../../api';
 import { DataTable, type DataTableColumn } from '../common/DataTable';
 
@@ -408,6 +408,7 @@ const LanguageWeightsTable: React.FC = () => {
           maxHeight: '800px',
           overflowY: 'auto',
           backgroundColor: 'transparent',
+          ...scrollbarSx,
         }}
       >
         <DataTable<LanguageRow, SortField>

--- a/src/components/repositories/RepositoryContributorsTable.tsx
+++ b/src/components/repositories/RepositoryContributorsTable.tsx
@@ -1,22 +1,55 @@
 import React, { useMemo, useState } from 'react';
-import {
-  Box,
-  Typography,
-  CircularProgress,
-  Avatar,
-  alpha,
-  useTheme,
-} from '@mui/material';
+import { Box, Typography, Avatar, alpha, useTheme } from '@mui/material';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
 import { useAllPrs, useAllMiners } from '../../api';
 import { LinkBox } from '../common/linkBehavior';
 import { STATUS_COLORS } from '../../theme';
 import { isMergedPr } from '../../utils/prStatus';
+import { DataTable, type DataTableColumn } from '../common/DataTable';
 
 interface RepositoryContributorsTableProps {
   repositoryFullName: string;
 }
+
+interface ContributorRow {
+  rank: number;
+  author: string;
+  githubId: string;
+  prs: number;
+  score: number;
+  minerRank?: number;
+  isEligible?: boolean;
+}
+
+const cellFontSx = {
+  fontFamily:
+    '-apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif',
+  fontSize: '12px',
+  color: 'text.primary',
+  py: 1,
+};
+
+const headerCellSx = {
+  fontFamily:
+    '-apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif',
+  fontSize: '11px',
+  color: 'text.secondary',
+  textTransform: 'uppercase' as const,
+  letterSpacing: 0,
+  backgroundColor: 'transparent',
+  py: 1,
+};
+
+const numericCellSx = {
+  ...cellFontSx,
+  fontVariantNumeric: 'tabular-nums',
+};
+
+const numericHeaderSx = {
+  ...headerCellSx,
+  fontVariantNumeric: 'tabular-nums',
+};
 
 const RepositoryContributorsTable: React.FC<
   RepositoryContributorsTableProps
@@ -46,7 +79,7 @@ const RepositoryContributorsTable: React.FC<
   }, [allMinersStats]);
 
   // Get contributors for this repository - only count merged PRs
-  const contributors = useMemo(() => {
+  const contributors = useMemo<ContributorRow[]>(() => {
     if (!allPRs) return [];
 
     const allRepoPRs = allPRs.filter(
@@ -75,273 +108,213 @@ const RepositoryContributorsTable: React.FC<
     });
 
     // Default sort by score descending
-    return Array.from(contributorsMap.values()).sort(
-      (a, b) => b.score - a.score,
-    );
-  }, [allPRs, repositoryFullName]);
+    return Array.from(contributorsMap.values())
+      .sort((a, b) => b.score - a.score)
+      .map((c, index) => {
+        const minerData = minerDataMap.get(c.githubId);
+        return {
+          ...c,
+          rank: index + 1,
+          minerRank: minerData?.rank,
+          isEligible: minerData?.isEligible,
+        };
+      });
+  }, [allPRs, repositoryFullName, minerDataMap]);
 
   const displayedContributors = contributors.slice(0, visibleCount);
   const totalContributors = contributors.length;
   const hasMore = visibleCount < totalContributors;
 
-  const handleShowMore = () => {
-    // Expand fully
-    setVisibleCount(totalContributors);
-  };
+  const handleShowMore = () => setVisibleCount(totalContributors);
+  const handleShowLess = () => setVisibleCount(7);
 
-  const handleShowLess = () => {
-    // Reset to 7
-    setVisibleCount(7);
-  };
-
-  if (isLoading) {
-    return (
-      <Box sx={{ display: 'flex', justifyContent: 'center', py: 2 }}>
-        <CircularProgress size={20} />
-      </Box>
-    );
-  }
-
-  if (contributors.length === 0) {
-    return null;
-  }
-
-  return (
-    <Box sx={{ display: 'flex', flexDirection: 'column', width: '100%' }}>
-      <Box
-        sx={{
-          display: 'flex',
-          justifyContent: 'space-between',
-          alignItems: 'center',
-          mb: 2,
-        }}
-      >
-        <Typography
-          variant="subtitle2"
-          sx={{
-            color: 'text.secondary',
-          }}
-        >
-          Top Miner Contributors{' '}
-          <Typography
-            component="span"
-            sx={{ color: STATUS_COLORS.open, fontSize: '0.8em' }}
-          >
-            ({contributors.length})
-          </Typography>
-        </Typography>
-      </Box>
-
-      {/* Header Row — minmax(0,1fr) prevents the miner column from forcing PRS/SCORE off-alignment */}
-      <Box
-        sx={{
-          display: 'grid',
-          gridTemplateColumns:
-            '32px minmax(0, 1fr) minmax(3rem, auto) minmax(4.5rem, auto)',
-          columnGap: 1,
-          rowGap: 0,
-          alignItems: 'center',
-          px: 1.5,
-          py: 1,
-          borderBottom: `1px solid ${theme.palette.border.light}`,
-        }}
-      >
-        <Typography sx={{ fontSize: '11px', color: 'text.secondary' }}>
-          #
-        </Typography>
-        <Typography sx={{ fontSize: '11px', color: 'text.secondary' }}>
-          MINER
-        </Typography>
-        <Typography
-          sx={{
-            fontSize: '11px',
-            color: 'text.secondary',
-            textAlign: 'right',
-            fontVariantNumeric: 'tabular-nums',
-          }}
-        >
-          PRS
-        </Typography>
-        <Typography
-          sx={{
-            fontSize: '11px',
-            color: 'text.secondary',
-            textAlign: 'right',
-            fontVariantNumeric: 'tabular-nums',
-          }}
-        >
-          SCORE
-        </Typography>
-      </Box>
-
-      {/* Rows */}
-      <Box sx={{ display: 'flex', flexDirection: 'column' }}>
-        {displayedContributors.map((contributor, index) => {
-          const minerData = minerDataMap.get(contributor.githubId);
-          const minerRank = minerData?.rank;
-          const isInactive = !minerData?.isEligible;
-
-          return (
-            <Box
-              key={contributor.githubId}
-              sx={{
-                display: 'grid',
-                gridTemplateColumns:
-                  '32px minmax(0, 1fr) minmax(3rem, auto) minmax(4.5rem, auto)',
-                columnGap: 1,
-                rowGap: 0,
-                px: 1.5,
-                py: 1,
-                borderBottom: `1px solid ${alpha(theme.palette.common.white, 0.05)}`,
-                alignItems: 'center',
-                minWidth: 0,
-                opacity: isInactive ? 0.5 : 1,
-                '&:hover': {
-                  backgroundColor: alpha(theme.palette.common.white, 0.04),
-                  opacity: 1,
-                },
-                transition: 'all 0.1s',
-              }}
-            >
-              {/* Rank */}
-              <Box
-                sx={{
-                  fontSize: '12px',
-                  color: index < 3 ? 'text.primary' : STATUS_COLORS.open,
-                  fontWeight: index < 3 ? 600 : 400,
-                }}
-              >
-                {index + 1}
-              </Box>
-
-              {/* Contributor */}
-              <LinkBox
-                href={`/miners/details?githubId=${contributor.githubId}`}
-                linkState={{
-                  backLabel: `Back to ${repositoryFullName}`,
-                }}
-                sx={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: 1.5,
-                  overflow: 'hidden',
-                  cursor: 'pointer',
-                  '&:hover .contributor-name': {
-                    color: STATUS_COLORS.info,
-                    textDecoration: 'underline',
-                  },
-                }}
-              >
-                <Avatar
-                  src={`https://avatars.githubusercontent.com/${contributor.author}`}
-                  sx={{
-                    width: 20,
-                    height: 20,
-                    border: `1px solid ${theme.palette.border.light}`,
-                  }}
-                />
-                <Box
-                  sx={{
-                    display: 'flex',
-                    flexDirection: 'column',
-                    minWidth: 0,
-                  }}
-                >
-                  <Typography
-                    className="contributor-name"
-                    sx={{
-                      fontSize: '13px',
-                      fontWeight: 500,
-                      color: 'text.primary',
-                      fontFamily:
-                        '-apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif',
-                      whiteSpace: 'nowrap',
-                      overflow: 'hidden',
-                      textOverflow: 'ellipsis',
-                      transition: 'color 0.1s',
-                    }}
-                  >
-                    {contributor.author}
-                  </Typography>
-                  {/* Miner Rank Subtext */}
-                  {minerRank && (
-                    <Typography
-                      sx={{
-                        fontSize: '10px',
-                        color: STATUS_COLORS.open,
-                        whiteSpace: 'nowrap', // Force single line
-                        overflow: 'hidden',
-                        textOverflow: 'ellipsis',
-                      }}
-                    >
-                      Global Rank #{minerRank}
-                    </Typography>
-                  )}
-                </Box>
-              </LinkBox>
-
-              {/* PRs */}
-              <Box
-                sx={{
-                  textAlign: 'right',
-                  fontSize: '12px',
-                  color: 'text.primary',
-                  fontVariantNumeric: 'tabular-nums',
-                  minWidth: 0,
-                }}
-              >
-                {contributor.prs}
-              </Box>
-
-              {/* Score */}
-              <Box
-                sx={{
-                  textAlign: 'right',
-                  fontSize: '12px',
-                  color: 'text.primary',
-                  fontVariantNumeric: 'tabular-nums',
-                  minWidth: 0,
-                }}
-              >
-                {contributor.score.toFixed(2)}
-              </Box>
-            </Box>
-          );
-        })}
-
-        {/* Show More / Show Less Row */}
-        {contributors.length > 7 && (
-          <Box
-            onClick={hasMore ? handleShowMore : handleShowLess}
+  const columns = useMemo<DataTableColumn<ContributorRow>[]>(
+    () => [
+      {
+        key: 'rank',
+        header: '#',
+        width: '32px',
+        headerSx: headerCellSx,
+        cellSx: (c) => ({
+          ...cellFontSx,
+          color: c.rank <= 3 ? 'text.primary' : STATUS_COLORS.open,
+          fontWeight: c.rank <= 3 ? 600 : 400,
+        }),
+        renderCell: (c) => c.rank,
+      },
+      {
+        key: 'miner',
+        header: 'Miner',
+        headerSx: headerCellSx,
+        cellSx: { ...cellFontSx, minWidth: 0 },
+        renderCell: (c) => (
+          <LinkBox
+            href={`/miners/details?githubId=${c.githubId}`}
+            linkState={{
+              backLabel: `Back to ${repositoryFullName}`,
+            }}
             sx={{
               display: 'flex',
               alignItems: 'center',
-              justifyContent: 'flex-start', // Left align to match flow
-              px: 1.5,
-              py: 1.5,
+              gap: 1.5,
+              overflow: 'hidden',
               cursor: 'pointer',
-              color: STATUS_COLORS.open,
-              fontSize: '12px',
-              '&:hover': {
-                color: 'text.primary',
-                backgroundColor: 'surface.subtle',
+              '&:hover .contributor-name': {
+                color: STATUS_COLORS.info,
+                textDecoration: 'underline',
               },
-              transition: 'all 0.1s',
             }}
           >
-            {hasMore ? (
-              <>
-                Show more{' '}
-                <KeyboardArrowDownIcon sx={{ fontSize: 16, ml: 0.5 }} />
-              </>
-            ) : (
-              <>
-                Show less <KeyboardArrowUpIcon sx={{ fontSize: 16, ml: 0.5 }} />
-              </>
-            )}
-          </Box>
-        )}
-      </Box>
+            <Avatar
+              src={`https://avatars.githubusercontent.com/${c.author}`}
+              sx={{
+                width: 20,
+                height: 20,
+                border: `1px solid ${theme.palette.border.light}`,
+                flexShrink: 0,
+              }}
+            />
+            <Box
+              sx={{
+                display: 'flex',
+                flexDirection: 'column',
+                minWidth: 0,
+              }}
+            >
+              <Typography
+                className="contributor-name"
+                sx={{
+                  fontSize: '13px',
+                  fontWeight: 500,
+                  color: 'text.primary',
+                  fontFamily:
+                    '-apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif',
+                  whiteSpace: 'nowrap',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  transition: 'color 0.1s',
+                }}
+              >
+                {c.author}
+              </Typography>
+              {c.minerRank != null && (
+                <Typography
+                  sx={{
+                    fontSize: '10px',
+                    color: STATUS_COLORS.open,
+                    whiteSpace: 'nowrap',
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                  }}
+                >
+                  Global Rank #{c.minerRank}
+                </Typography>
+              )}
+            </Box>
+          </LinkBox>
+        ),
+      },
+      {
+        key: 'prs',
+        header: 'PRs',
+        width: '3rem',
+        align: 'right',
+        headerSx: numericHeaderSx,
+        cellSx: numericCellSx,
+        renderCell: (c) => c.prs,
+      },
+      {
+        key: 'score',
+        header: 'Score',
+        width: '4.5rem',
+        align: 'right',
+        headerSx: numericHeaderSx,
+        cellSx: numericCellSx,
+        renderCell: (c) => c.score.toFixed(2),
+      },
+    ],
+    [repositoryFullName, theme.palette.border.light],
+  );
+
+  if (!isLoading && contributors.length === 0) {
+    return null;
+  }
+
+  const header = (
+    <Box
+      sx={{
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        mb: 2,
+      }}
+    >
+      <Typography
+        variant="subtitle2"
+        sx={{
+          color: 'text.secondary',
+        }}
+      >
+        Top Miner Contributors{' '}
+        <Typography
+          component="span"
+          sx={{ color: STATUS_COLORS.open, fontSize: '0.8em' }}
+        >
+          ({contributors.length})
+        </Typography>
+      </Typography>
+    </Box>
+  );
+
+  const showMoreRow = contributors.length > 7 && (
+    <Box
+      onClick={hasMore ? handleShowMore : handleShowLess}
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'flex-start',
+        px: 1.5,
+        py: 1.5,
+        cursor: 'pointer',
+        color: STATUS_COLORS.open,
+        fontSize: '12px',
+        '&:hover': {
+          color: 'text.primary',
+          backgroundColor: 'surface.subtle',
+        },
+        transition: 'all 0.1s',
+      }}
+    >
+      {hasMore ? (
+        <>
+          Show more <KeyboardArrowDownIcon sx={{ fontSize: 16, ml: 0.5 }} />
+        </>
+      ) : (
+        <>
+          Show less <KeyboardArrowUpIcon sx={{ fontSize: 16, ml: 0.5 }} />
+        </>
+      )}
+    </Box>
+  );
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', width: '100%' }}>
+      <DataTable<ContributorRow>
+        columns={columns}
+        rows={displayedContributors}
+        getRowKey={(c) => c.githubId}
+        isLoading={isLoading}
+        header={header}
+        pagination={showMoreRow || undefined}
+        getRowSx={(c) => ({
+          opacity: c.isEligible ? 1 : 0.5,
+          '&:hover': {
+            backgroundColor: alpha(theme.palette.common.white, 0.04),
+            opacity: 1,
+          },
+          transition: 'all 0.1s',
+        })}
+      />
     </Box>
   );
 };

--- a/src/components/repositories/RepositoryContributorsTable.tsx
+++ b/src/components/repositories/RepositoryContributorsTable.tsx
@@ -35,6 +35,7 @@ const cellFontSx = {
   fontSize: '12px',
   color: 'text.primary',
   py: 1,
+  borderColor: 'rgba(255, 255, 255, 0.05)',
 };
 
 const headerCellSx = {
@@ -45,6 +46,7 @@ const headerCellSx = {
   textTransform: 'uppercase' as const,
   letterSpacing: 0,
   backgroundColor: 'transparent',
+  backdropFilter: 'none',
   py: 1,
 };
 

--- a/src/components/repositories/RepositoryContributorsTable.tsx
+++ b/src/components/repositories/RepositoryContributorsTable.tsx
@@ -1,5 +1,12 @@
 import React, { useMemo, useState } from 'react';
-import { Box, Typography, Avatar, alpha, useTheme } from '@mui/material';
+import {
+  Box,
+  Typography,
+  Avatar,
+  CircularProgress,
+  alpha,
+  useTheme,
+} from '@mui/material';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
 import { useAllPrs, useAllMiners } from '../../api';
@@ -236,7 +243,15 @@ const RepositoryContributorsTable: React.FC<
     [repositoryFullName, theme.palette.border.light],
   );
 
-  if (!isLoading && contributors.length === 0) {
+  if (isLoading) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', py: 2 }}>
+        <CircularProgress size={20} />
+      </Box>
+    );
+  }
+
+  if (contributors.length === 0) {
     return null;
   }
 
@@ -303,7 +318,6 @@ const RepositoryContributorsTable: React.FC<
         columns={columns}
         rows={displayedContributors}
         getRowKey={(c) => c.githubId}
-        isLoading={isLoading}
         header={header}
         pagination={showMoreRow || undefined}
         getRowSx={(c) => ({

--- a/src/components/repositories/RepositoryContributorsTable.tsx
+++ b/src/components/repositories/RepositoryContributorsTable.tsx
@@ -29,36 +29,7 @@ interface ContributorRow {
   isEligible?: boolean;
 }
 
-const cellFontSx = {
-  fontFamily:
-    '-apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif',
-  fontSize: '12px',
-  color: 'text.primary',
-  py: 1,
-  borderColor: 'rgba(255, 255, 255, 0.05)',
-};
-
-const headerCellSx = {
-  fontFamily:
-    '-apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif',
-  fontSize: '11px',
-  color: 'text.secondary',
-  textTransform: 'uppercase' as const,
-  letterSpacing: 0,
-  backgroundColor: 'transparent',
-  backdropFilter: 'none',
-  py: 1,
-};
-
-const numericCellSx = {
-  ...cellFontSx,
-  fontVariantNumeric: 'tabular-nums',
-};
-
-const numericHeaderSx = {
-  ...headerCellSx,
-  fontVariantNumeric: 'tabular-nums',
-};
+const numericCellSx = { fontVariantNumeric: 'tabular-nums' as const };
 
 const RepositoryContributorsTable: React.FC<
   RepositoryContributorsTableProps
@@ -143,9 +114,7 @@ const RepositoryContributorsTable: React.FC<
         key: 'rank',
         header: '#',
         width: '32px',
-        headerSx: headerCellSx,
         cellSx: (c) => ({
-          ...cellFontSx,
           color: c.rank <= 3 ? 'text.primary' : STATUS_COLORS.open,
           fontWeight: c.rank <= 3 ? 600 : 400,
         }),
@@ -154,8 +123,7 @@ const RepositoryContributorsTable: React.FC<
       {
         key: 'miner',
         header: 'Miner',
-        headerSx: headerCellSx,
-        cellSx: { ...cellFontSx, minWidth: 0 },
+        cellSx: { minWidth: 0 },
         renderCell: (c) => (
           <LinkBox
             href={`/miners/details?githubId=${c.githubId}`}
@@ -196,8 +164,6 @@ const RepositoryContributorsTable: React.FC<
                   fontSize: '13px',
                   fontWeight: 500,
                   color: 'text.primary',
-                  fontFamily:
-                    '-apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif',
                   whiteSpace: 'nowrap',
                   overflow: 'hidden',
                   textOverflow: 'ellipsis',
@@ -228,7 +194,7 @@ const RepositoryContributorsTable: React.FC<
         header: 'PRs',
         width: '3rem',
         align: 'right',
-        headerSx: numericHeaderSx,
+        headerSx: numericCellSx,
         cellSx: numericCellSx,
         renderCell: (c) => c.prs,
       },
@@ -237,7 +203,7 @@ const RepositoryContributorsTable: React.FC<
         header: 'Score',
         width: '4.5rem',
         align: 'right',
-        headerSx: numericHeaderSx,
+        headerSx: numericCellSx,
         cellSx: numericCellSx,
         renderCell: (c) => c.score.toFixed(2),
       },


### PR DESCRIPTION
## Summary

Completes the DataTable consolidation called for in [#747](https://github.com/entrius/gittensor-ui/issues/747) by migrating the last three hand-rolled MUI `Table` instances to the shared [`DataTable`](src/components/common/DataTable.tsx). Net **−126 lines** across three files (+558 / −684).

## Migrated tables

### [RepositoryContributorsTable](src/components/repositories/RepositoryContributorsTable.tsx)
Was a CSS-grid implementation. Swapped for DataTable while preserving:
- `#` / **MINER** / **PRS** / **SCORE** columns with tabular-nums numerics
- Rank color/weight (top 3 = primary, rest = open)
- `LinkBox` navigation scoped to the MINER cell (row is not the link — preserves original click target)
- Inactive miner rows rendered at 50% opacity; hover restores full opacity
- "Show more / Show less" toggle moved into DataTable's `pagination` slot
- Full-row hover background

### [LanguageWeightsTable](src/components/repositories/LanguageWeightsTable.tsx)
- Extension / Language / Token Scoring / Weight columns (Token Scoring stays non-sortable with its explanatory tooltip)
- Per-column first-click sort defaults preserved (`weight` → desc, text columns → asc)
- Search, chart toggle, rows-per-page selector, sticky header, `scrollIntoView` on rows-per-page change
- Chart continues to reflect filtered + sorted data (not the current page slice)
- Empty state "No languages found!" moved into DataTable's `emptyState`; `TablePagination` continues to render below so "0 of 0" behavior is preserved
- ECharts option unchanged

### [TopRepositoriesTable](src/components/leaderboard/TopRepositoriesTable.tsx)
Only the `viewMode === 'list'` branch was touched. Everything else — card view, chart view, URL/`localStorage`-driven view toggle, filters, search, pagination — is untouched.
- Rank / Repository / Weight / Total Score / PRs / Contributors columns with their existing widths and right-alignment
- Sort directions preserved (`repository` → asc, others → desc on first click)
- Row link behavior via `getRowHref` + `linkState`
- Inactive repos at 50% opacity, hover background, min-width 1000px, sticky header
- "Repository not in tracked list" prompt with "Open repository" button relocated to DataTable's `emptyState` (same HTML, same button behavior)
- Loading path still renders `LeaderboardTableSkeleton` inside a matching Table/TableHead scaffold so the skeleton keeps its exact column layout
- Removed the now-unused `SortableHeader` helper + `bodyCellStyle` / `SxProps` / `Theme` imports

## Out of scope

Per the issue: no column set changes, no sort behavior changes, no URL-param changes. This is a structural swap — observable behavior matches `upstream/test`.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Other

## Test plan

- [ ] `/repositories/details?...` — Contributors table shows ranks, miner avatars, miner-only hover color change, "Global Rank #N" subtext, "Show more/less" expands/collapses to 7.
- [ ] `/onboard?tab=languages` — Search filters the table and the chart, sort toggle works per column with correct first-click direction, chart button opens/closes the bar chart, rows selector changes page size and scrolls to top.
- [ ] `/repositories` list view — sort arrows render correctly and toggle, rows link to repository detail (middle-click, cmd-click open new tabs), pagination + rows selector work, "Repository not in tracked list" prompt still appears for direct `owner/repo` searches.
- [ ] `/repositories` cards + chart views — unchanged.
- [ ] Loading state on `/repositories` list shows the skeleton, not a spinner.
- [ ] Type-check, lint, and `npm run build` all pass.

## Notes

- `TopRepositoriesTable` is still ~1300 lines — the file owns search, chart, cards, filters, URL sync, etc. Further decomposition is a separate concern from this structural swap.
- DataTable sort state is driven by the existing `handleSort`, so URL `?sort=` / `?dir=` semantics and "reset page on sort" behavior are unchanged.

Fixes #747 