### PR TITLE
perf: correct navigation and add "View All" link for featured cards

### DIFF
--- a/src/pages/dashboard/DashboardPage.tsx
+++ b/src/pages/dashboard/DashboardPage.tsx
@@ -81,12 +81,15 @@ const DashboardFeaturePage: React.FC = () => {
             <DashboardTopContributors
               contributors={featuredContributors}
               isLoading={isLoading}
+              viewAllHref="/top-miners"
             />
 
             <DashboardTopContributors
               title="Featured Discoverers"
               contributors={featuredDiscoveryContributors}
               isLoading={isLoading}
+              mode="issues"
+              viewAllHref="/discoveries"
             />
           </Box>
 

--- a/src/pages/dashboard/views/DashboardTopContributors.tsx
+++ b/src/pages/dashboard/views/DashboardTopContributors.tsx
@@ -40,9 +40,12 @@ const DashboardTopContributors: React.FC<DashboardTopContributorsProps> = ({
 
   const openContributor = (githubId: string) => {
     const modeParam = mode !== 'prs' ? `&mode=${mode}` : '';
-    navigate(`/miners/details?githubId=${encodeURIComponent(githubId)}${modeParam}`, {
-      state: { backTo: '/dashboard' },
-    });
+    navigate(
+      `/miners/details?githubId=${encodeURIComponent(githubId)}${modeParam}`,
+      {
+        state: { backTo: '/dashboard' },
+      },
+    );
   };
 
   return (

--- a/src/pages/dashboard/views/DashboardTopContributors.tsx
+++ b/src/pages/dashboard/views/DashboardTopContributors.tsx
@@ -80,10 +80,8 @@ const DashboardTopContributors: React.FC<DashboardTopContributorsProps> = ({
           <Typography
             onClick={() => navigate(viewAllHref)}
             sx={{
+              ...theme.typography.tooltipLabel,
               color: alpha(theme.palette.text.primary, 0.45),
-              fontFamily: monoFontFamily,
-              fontSize: '0.72rem',
-              fontWeight: 600,
               cursor: 'pointer',
               letterSpacing: '0.02em',
               transition: 'color 0.15s ease',

--- a/src/pages/dashboard/views/DashboardTopContributors.tsx
+++ b/src/pages/dashboard/views/DashboardTopContributors.tsx
@@ -15,6 +15,8 @@ interface DashboardTopContributorsProps {
   contributors: DashboardFeaturedContributor[];
   isLoading?: boolean;
   title?: string;
+  mode?: 'prs' | 'issues';
+  viewAllHref?: string;
 }
 
 const getInitials = (name: string) =>
@@ -29,13 +31,16 @@ const DashboardTopContributors: React.FC<DashboardTopContributorsProps> = ({
   contributors,
   isLoading = false,
   title = 'Featured Contributors',
+  mode = 'prs',
+  viewAllHref,
 }) => {
   const theme = useTheme();
   const navigate = useNavigate();
   const monoFontFamily = theme.typography.fontFamily;
 
   const openContributor = (githubId: string) => {
-    navigate(`/miners/details?githubId=${encodeURIComponent(githubId)}`, {
+    const modeParam = mode === 'issues' ? '&mode=issues' : '';
+    navigate(`/miners/details?githubId=${encodeURIComponent(githubId)}${modeParam}`, {
       state: { backTo: '/dashboard' },
     });
   };
@@ -50,7 +55,14 @@ const DashboardTopContributors: React.FC<DashboardTopContributorsProps> = ({
         backgroundColor: 'transparent',
       }}
     >
-      <Box sx={{ mb: 1.35 }}>
+      <Box
+        sx={{
+          mb: 1.35,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+        }}
+      >
         <Typography
           sx={{
             color: theme.palette.text.primary,
@@ -61,6 +73,25 @@ const DashboardTopContributors: React.FC<DashboardTopContributorsProps> = ({
         >
           {title}
         </Typography>
+        {viewAllHref && (
+          <Typography
+            onClick={() => navigate(viewAllHref)}
+            sx={{
+              color: alpha(theme.palette.text.primary, 0.45),
+              fontFamily: monoFontFamily,
+              fontSize: '0.72rem',
+              fontWeight: 600,
+              cursor: 'pointer',
+              letterSpacing: '0.02em',
+              transition: 'color 0.15s ease',
+              '&:hover': {
+                color: theme.palette.text.primary,
+              },
+            }}
+          >
+            view all →
+          </Typography>
+        )}
       </Box>
 
       {isLoading ? (

--- a/src/pages/dashboard/views/DashboardTopContributors.tsx
+++ b/src/pages/dashboard/views/DashboardTopContributors.tsx
@@ -39,7 +39,7 @@ const DashboardTopContributors: React.FC<DashboardTopContributorsProps> = ({
   const monoFontFamily = theme.typography.fontFamily;
 
   const openContributor = (githubId: string) => {
-    const modeParam = mode === 'issues' ? '&mode=issues' : '';
+    const modeParam = mode !== 'prs' ? `&mode=${mode}` : '';
     navigate(`/miners/details?githubId=${encodeURIComponent(githubId)}${modeParam}`, {
       state: { backTo: '/dashboard' },
     });


### PR DESCRIPTION
## Closes: #750

## Summary

- Fix Featured Discoverers card to navigate to the Issue Discovery tab (`?mode=issues`) instead of defaulting to the OSS Contributions (PRs) tab
- Add `viewAllHref` prop to `DashboardTopContributors` component and wire up "view all →" links on both featured cards

## Changes

### `DashboardTopContributors.tsx`
- Add optional `mode?: 'prs' | 'issues'` prop — when `'issues'`, appends `&mode=issues` to the miner details navigation URL
- Add optional `viewAllHref?: string` prop — when provided, renders a "view all →" link in the card header that navigates to the given route

### `DashboardPage.tsx`
- Pass `mode="issues"` to the Featured Discoverers card
- Pass `viewAllHref="/top-miners"` to Featured Contributors
- Pass `viewAllHref="/discoveries"` to Featured Discoverers

## Test plan

- [ ] Click a card under **Featured Contributors** → lands on miner details, PRs tab active
- [ ] Click a card under **Featured Discoverers** → lands on miner details, Issue Discovery tab active
- [ ] Click "view all →" on Featured Contributors → navigates to `/top-miners`
- [ ] Click "view all →" on Featured Discoverers → navigates to `/discoveries`
- [ ] "view all →" link is not rendered when `viewAllHref` is omitted


https://github.com/user-attachments/assets/43d5c5b2-6f69-4ac8-a71a-dfeca1651e31

