### PR TITLE
feat: centralized dashboard for reported github issues

### DIFF
--- a/src/api/models/Miner.ts
+++ b/src/api/models/Miner.ts
@@ -7,6 +7,8 @@ export interface RepositoryIssue {
   closedAt: string | null;
   state?: string;
   author?: string;
+  /** When present, preferred over `author` for matching the reporter. */
+  authorLogin?: string | null;
   url?: string;
 }
 

--- a/src/components/miners/MinerOpenDiscoveryIssuesByRepo.tsx
+++ b/src/components/miners/MinerOpenDiscoveryIssuesByRepo.tsx
@@ -1,9 +1,12 @@
 import React, { useMemo, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import axios from 'axios';
 import {
   Accordion,
   AccordionDetails,
   AccordionSummary,
   Alert,
+  Avatar,
   Box,
   Button,
   Card,
@@ -37,6 +40,64 @@ const githubIssueUrl = (issue: RepositoryIssue) =>
 const githubSearchOpenByAuthor = (login: string) =>
   `https://github.com/search?q=${encodeURIComponent(`is:issue is:open author:${login}`)}&type=issues`;
 
+interface GithubSearchIssueItem {
+  number: number;
+  title: string;
+  html_url: string;
+  repository_url: string;
+  created_at: string | null;
+  closed_at: string | null;
+  user?: { login?: string | null } | null;
+  pull_request?: unknown;
+}
+
+interface GithubSearchIssuesResponse {
+  items: GithubSearchIssueItem[];
+}
+
+const parseRepoFromRepositoryUrl = (repositoryUrl: string): string | null => {
+  const marker = '/repos/';
+  const idx = repositoryUrl.indexOf(marker);
+  if (idx < 0) return null;
+  const repo = repositoryUrl.slice(idx + marker.length);
+  return repo || null;
+};
+
+const fetchGithubOpenIssuesByAuthor = async (
+  login: string,
+): Promise<RepositoryIssue[]> => {
+  const { data } = await axios.get<GithubSearchIssuesResponse>(
+    'https://api.github.com/search/issues',
+    {
+      params: {
+        q: `is:issue is:open author:${login}`,
+        per_page: 100,
+      },
+    },
+  );
+
+  return (data.items || [])
+    .filter((item) => !item.pull_request)
+    .map((item) => {
+      const repositoryFullName = parseRepoFromRepositoryUrl(
+        item.repository_url,
+      );
+      return {
+        number: item.number,
+        repositoryFullName: repositoryFullName ?? '',
+        prNumber: null,
+        title: item.title,
+        createdAt: item.created_at ?? null,
+        closedAt: item.closed_at ?? null,
+        state: item.closed_at ? 'closed' : 'open',
+        author: item.user?.login ?? login,
+        authorLogin: item.user?.login ?? login,
+        url: item.html_url,
+      } satisfies RepositoryIssue;
+    })
+    .filter((issue) => !!issue.repositoryFullName);
+};
+
 interface MinerOpenDiscoveryIssuesByRepoProps {
   githubId: string;
 }
@@ -53,13 +114,33 @@ const MinerOpenDiscoveryIssuesByRepo: React.FC<
     useMinerRepositoriesOpenIssues(scanRepos, !isLoadingPrs);
 
   const login = githubProfile?.login ?? '';
+  const {
+    data: githubAuthoredIssues = [],
+    isLoading: isLoadingAuthoredIssues,
+    isFetching: isFetchingAuthoredIssues,
+    isError: isAuthorFallbackError,
+  } = useQuery({
+    queryKey: ['githubAuthorOpenIssues', login],
+    queryFn: () => fetchGithubOpenIssuesByAuthor(login),
+    enabled: !!login,
+    staleTime: 60_000,
+    retry: 1,
+  });
 
   const { mineByRepo, otherByRepo, mineTotal, otherTotal } = useMemo(() => {
     const mine = new Map<string, RepositoryIssue[]>();
     const other = new Map<string, RepositoryIssue[]>();
-    let m = 0;
-    let o = 0;
+    const mineKeys = new Set<string>();
     const loginLower = login.toLowerCase();
+    const addToMap = (
+      target: Map<string, RepositoryIssue[]>,
+      repo: string,
+      issue: RepositoryIssue,
+    ) => {
+      const arr = target.get(repo) ?? [];
+      arr.push(issue);
+      target.set(repo, arr);
+    };
 
     scanRepos.forEach((repo) => {
       const list = issuesByRepo.get(repo) ?? [];
@@ -68,14 +149,28 @@ const MinerOpenDiscoveryIssuesByRepo: React.FC<
         const author = getIssueAuthor(issue);
         const isMine =
           !!author && !!loginLower && author.toLowerCase() === loginLower;
-        const target = isMine ? mine : other;
-        const arr = target.get(repo) ?? [];
-        arr.push(issue);
-        target.set(repo, arr);
-        if (isMine) m += 1;
-        else o += 1;
+        if (isMine) {
+          const key = `${repo}#${issue.number}`;
+          mineKeys.add(key);
+          addToMap(mine, repo, issue);
+        } else {
+          addToMap(other, repo, issue);
+        }
       });
     });
+
+    githubAuthoredIssues.forEach((issue) => {
+      if (!isIssueOpen(issue)) return;
+      const repo = issue.repositoryFullName;
+      if (!repo) return;
+      const key = `${repo}#${issue.number}`;
+      if (mineKeys.has(key)) return;
+      mineKeys.add(key);
+      addToMap(mine, repo, issue);
+    });
+
+    const m = [...mine.values()].reduce((sum, items) => sum + items.length, 0);
+    const o = [...other.values()].reduce((sum, items) => sum + items.length, 0);
 
     return {
       mineByRepo: mine,
@@ -83,7 +178,7 @@ const MinerOpenDiscoveryIssuesByRepo: React.FC<
       mineTotal: m,
       otherTotal: o,
     };
-  }, [issuesByRepo, login, scanRepos]);
+  }, [githubAuthoredIssues, issuesByRepo, login, scanRepos]);
 
   const [showOtherTracked, setShowOtherTracked] = useState(true);
 
@@ -167,6 +262,7 @@ const MinerOpenDiscoveryIssuesByRepo: React.FC<
               border: '1px solid',
               borderColor: 'border.light',
               borderRadius: 2,
+              bgcolor: (t) => alpha(t.palette.background.paper, 0.35),
               '&:before': { display: 'none' },
               overflow: 'hidden',
             }}
@@ -182,24 +278,49 @@ const MinerOpenDiscoveryIssuesByRepo: React.FC<
                   pr: 1,
                 }}
               >
-                <LinkBox
-                  href={`/miners/repository?name=${encodeURIComponent(repo)}`}
+                <Box
                   sx={{
-                    color: 'primary.main',
-                    fontWeight: 600,
-                    fontSize: '0.9rem',
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 1,
                     minWidth: 0,
-                    '&:hover': { textDecoration: 'underline' },
                   }}
                 >
-                  {repo}
-                </LinkBox>
+                  <Avatar
+                    src={`https://avatars.githubusercontent.com/${repo.split('/')[0]}`}
+                    sx={{
+                      width: 22,
+                      height: 22,
+                      borderRadius: '50%',
+                      flexShrink: 0,
+                    }}
+                  />
+                  <LinkBox
+                    href={`/miners/repository?name=${encodeURIComponent(repo)}`}
+                    sx={{
+                      color: (t) => alpha(t.palette.common.white, 0.9),
+                      fontWeight: 600,
+                      fontSize: '0.9rem',
+                      minWidth: 0,
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
+                      '&:hover': {
+                        textDecoration: 'underline',
+                        color: 'text.primary',
+                      },
+                    }}
+                  >
+                    {repo}
+                  </LinkBox>
+                </Box>
                 <Chip
                   size="small"
                   label={`${issues.length} open`}
                   sx={{
-                    borderColor: STATUS_COLORS.open,
+                    borderColor: alpha(STATUS_COLORS.open, 0.4),
                     color: STATUS_COLORS.open,
+                    bgcolor: alpha(STATUS_COLORS.open, 0.12),
                     flexShrink: 0,
                   }}
                   variant="outlined"
@@ -251,14 +372,22 @@ const MinerOpenDiscoveryIssuesByRepo: React.FC<
                           {issue.title}
                         </Typography>
                       </Link>
-                      <OpenInNewIcon
-                        sx={{
-                          fontSize: '1rem',
-                          color: (t) =>
-                            alpha(t.palette.common.white, TEXT_OPACITY.muted),
-                          flexShrink: 0,
-                        }}
-                      />
+                      <Link
+                        href={githubIssueUrl(issue)}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        underline="none"
+                        sx={{ display: 'inline-flex', flexShrink: 0 }}
+                        aria-label={`Open issue #${issue.number} on GitHub`}
+                      >
+                        <OpenInNewIcon
+                          sx={{
+                            fontSize: '1rem',
+                            color: (t) =>
+                              alpha(t.palette.common.white, TEXT_OPACITY.faint),
+                          }}
+                        />
+                      </Link>
                     </Box>
                     <Box
                       sx={{
@@ -274,9 +403,9 @@ const MinerOpenDiscoveryIssuesByRepo: React.FC<
                           target="_blank"
                           rel="noopener noreferrer"
                           variant="caption"
-                          sx={{ color: STATUS_COLORS.info }}
+                          sx={{ color: 'primary.main' }}
                         >
-                          Linked PR #{issue.prNumber}
+                          PR #{issue.prNumber}
                         </Link>
                       ) : (
                         <Typography variant="caption" color="text.secondary">
@@ -302,7 +431,18 @@ const MinerOpenDiscoveryIssuesByRepo: React.FC<
 
   return (
     <Stack spacing={2}>
-      <Alert severity="info" sx={{ borderRadius: 2 }}>
+      <Alert
+        severity="info"
+        sx={{
+          borderRadius: 2,
+          bgcolor: (t) => alpha(t.palette.warning.main, 0.08),
+          border: '1px solid',
+          borderColor: (t) => alpha(t.palette.warning.main, 0.22),
+          '& .MuiAlert-icon': {
+            color: (t) => alpha(t.palette.warning.light, 0.95),
+          },
+        }}
+      >
         Open issues are loaded from Gittensor’s per-repository issue index for
         up to {repoFetchLimit} repositories where you have scored PRs (most
         recent first). When the API includes an issue author, issues you opened
@@ -317,7 +457,16 @@ const MinerOpenDiscoveryIssuesByRepo: React.FC<
               rel="noopener noreferrer"
               size="small"
               variant="outlined"
+              color="inherit"
               endIcon={<OpenInNewIcon fontSize="small" />}
+              sx={{
+                borderColor: (t) => alpha(t.palette.warning.main, 0.45),
+                color: (t) => alpha(t.palette.warning.light, 0.95),
+                '&:hover': {
+                  borderColor: (t) => alpha(t.palette.warning.main, 0.65),
+                  bgcolor: (t) => alpha(t.palette.warning.main, 0.14),
+                },
+              }}
             >
               View all open issues by @{login} on GitHub
             </Button>
@@ -338,12 +487,18 @@ const MinerOpenDiscoveryIssuesByRepo: React.FC<
         </Alert>
       ) : null}
 
-      {isLoading ? (
+      {isLoading || isLoadingAuthoredIssues || isFetchingAuthoredIssues ? (
         <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
           <CircularProgress size={36} />
         </Box>
       ) : (
         <>
+          {isAuthorFallbackError ? (
+            <Alert severity="warning" sx={{ borderRadius: 2 }}>
+              Could not load all authored open issues from GitHub right now.
+              Showing indexed results only.
+            </Alert>
+          ) : null}
           <Card
             elevation={0}
             sx={{

--- a/src/components/miners/MinerOpenDiscoveryIssuesByRepo.tsx
+++ b/src/components/miners/MinerOpenDiscoveryIssuesByRepo.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import axios from 'axios';
 import {
@@ -28,9 +28,6 @@ import {
 } from '../../hooks/useMinerRepositoriesOpenIssues';
 import { type RepositoryIssue } from '../../api/models/Miner';
 
-const getIssueAuthor = (issue: RepositoryIssue) =>
-  issue.authorLogin ?? issue.author ?? null;
-
 const isIssueOpen = (issue: RepositoryIssue) => !issue.closedAt;
 
 const githubIssueUrl = (issue: RepositoryIssue) =>
@@ -55,12 +52,57 @@ interface GithubSearchIssuesResponse {
   items: GithubSearchIssueItem[];
 }
 
+const parsePullNumberFromUrl = (url: string): number | null => {
+  const match = url.match(/\/pull\/(\d+)(?:$|[/?#])/);
+  if (!match?.[1]) return null;
+  const n = Number(match[1]);
+  return Number.isFinite(n) ? n : null;
+};
+
 const parseRepoFromRepositoryUrl = (repositoryUrl: string): string | null => {
   const marker = '/repos/';
   const idx = repositoryUrl.indexOf(marker);
   if (idx < 0) return null;
   const repo = repositoryUrl.slice(idx + marker.length);
   return repo || null;
+};
+
+interface GithubIssueTimelineEvent {
+  event?: string;
+  source?: {
+    issue?: {
+      pull_request?: {
+        html_url?: string;
+      } | null;
+    } | null;
+  } | null;
+}
+
+const fetchLinkedPrNumberForIssue = async (
+  repositoryFullName: string,
+  issueNumber: number,
+): Promise<number | null> => {
+  try {
+    const { data } = await axios.get<GithubIssueTimelineEvent[]>(
+      `https://api.github.com/repos/${repositoryFullName}/issues/${issueNumber}/timeline`,
+      {
+        headers: {
+          Accept: 'application/vnd.github+json',
+          'X-GitHub-Api-Version': '2022-11-28',
+        },
+      },
+    );
+
+    for (const event of data ?? []) {
+      const prUrl = event.source?.issue?.pull_request?.html_url;
+      if (!prUrl) continue;
+      const prNumber = parsePullNumberFromUrl(prUrl);
+      if (prNumber != null) return prNumber;
+    }
+  } catch {
+    // Ignore timeline fetch failures and fall back to "No linked PR yet".
+  }
+  return null;
 };
 
 const fetchGithubOpenIssuesByAuthor = async (
@@ -76,7 +118,7 @@ const fetchGithubOpenIssuesByAuthor = async (
     },
   );
 
-  return (data.items || [])
+  const mapped = (data.items || [])
     .filter((item) => !item.pull_request)
     .map((item) => {
       const repositoryFullName = parseRepoFromRepositoryUrl(
@@ -96,6 +138,21 @@ const fetchGithubOpenIssuesByAuthor = async (
       } satisfies RepositoryIssue;
     })
     .filter((issue) => !!issue.repositoryFullName);
+
+  const enriched = await Promise.all(
+    mapped.map(async (issue) => {
+      const prNumber = await fetchLinkedPrNumberForIssue(
+        issue.repositoryFullName,
+        issue.number,
+      );
+      return {
+        ...issue,
+        prNumber,
+      } satisfies RepositoryIssue;
+    }),
+  );
+
+  return enriched;
 };
 
 interface MinerOpenDiscoveryIssuesByRepoProps {
@@ -110,9 +167,6 @@ const MinerOpenDiscoveryIssuesByRepo: React.FC<
     useMinerGithubData(githubId);
 
   const scanRepos = useMemo(() => selectMinerIssueScanRepos(prs), [prs]);
-  const { issuesByRepo, isLoading, isError, repoFetchLimit } =
-    useMinerRepositoriesOpenIssues(scanRepos, !isLoadingPrs);
-
   const login = githubProfile?.login ?? '';
   const {
     data: githubAuthoredIssues = [],
@@ -126,12 +180,35 @@ const MinerOpenDiscoveryIssuesByRepo: React.FC<
     staleTime: 60_000,
     retry: 1,
   });
+  const authoredRepos = useMemo(
+    () =>
+      [
+        ...new Set(githubAuthoredIssues.map((i) => i.repositoryFullName)),
+      ].filter(Boolean),
+    [githubAuthoredIssues],
+  );
+
+  const { issuesByRepo, isLoading, isError, repoFetchLimit } =
+    useMinerRepositoriesOpenIssues(scanRepos, !isLoadingPrs);
+  const {
+    issuesByRepo: authoredReposIssuesByRepo,
+    isLoading: isLoadingAuthoredRepoIssues,
+    isError: isAuthoredRepoIssuesError,
+  } = useMinerRepositoriesOpenIssues(
+    authoredRepos,
+    !isLoadingPrs && !isLoadingAuthoredIssues && authoredRepos.length > 0,
+  );
+
+  const reposForGrouping = useMemo(
+    () => [...new Set([...scanRepos, ...authoredRepos])],
+    [authoredRepos, scanRepos],
+  );
 
   const { mineByRepo, otherByRepo, mineTotal, otherTotal } = useMemo(() => {
     const mine = new Map<string, RepositoryIssue[]>();
     const other = new Map<string, RepositoryIssue[]>();
     const mineKeys = new Set<string>();
-    const loginLower = login.toLowerCase();
+    const indexedIssueByKey = new Map<string, RepositoryIssue>();
     const addToMap = (
       target: Map<string, RepositoryIssue[]>,
       repo: string,
@@ -142,23 +219,25 @@ const MinerOpenDiscoveryIssuesByRepo: React.FC<
       target.set(repo, arr);
     };
 
-    scanRepos.forEach((repo) => {
-      const list = issuesByRepo.get(repo) ?? [];
+    reposForGrouping.forEach((repo) => {
+      const fromScan = issuesByRepo.get(repo) ?? [];
+      const fromAuthoredRepoFetch = authoredReposIssuesByRepo.get(repo) ?? [];
+      const listByNumber = new Map<number, RepositoryIssue>();
+      [...fromScan, ...fromAuthoredRepoFetch].forEach((issue) => {
+        listByNumber.set(issue.number, issue);
+      });
+      const list = [...listByNumber.values()];
       list.forEach((issue) => {
         if (!isIssueOpen(issue)) return;
-        const author = getIssueAuthor(issue);
-        const isMine =
-          !!author && !!loginLower && author.toLowerCase() === loginLower;
-        if (isMine) {
-          const key = `${repo}#${issue.number}`;
-          mineKeys.add(key);
-          addToMap(mine, repo, issue);
-        } else {
-          addToMap(other, repo, issue);
-        }
+        const key = `${repo}#${issue.number}`;
+        indexedIssueByKey.set(key, issue);
+        addToMap(other, repo, issue);
       });
     });
 
+    // Canonical "mine" source: GitHub open issues authored by this miner.
+    // We still overlay indexed records when available to preserve enriched fields
+    // such as linked PR numbers in the row metadata.
     githubAuthoredIssues.forEach((issue) => {
       if (!isIssueOpen(issue)) return;
       const repo = issue.repositoryFullName;
@@ -166,21 +245,43 @@ const MinerOpenDiscoveryIssuesByRepo: React.FC<
       const key = `${repo}#${issue.number}`;
       if (mineKeys.has(key)) return;
       mineKeys.add(key);
-      addToMap(mine, repo, issue);
+      const indexedIssue = indexedIssueByKey.get(key);
+      addToMap(mine, repo, indexedIssue ?? issue);
+    });
+
+    // Remove authored issues from "other" buckets in the same repos.
+    const filteredOtherRaw = new Map<string, RepositoryIssue[]>();
+    other.forEach((issues, repo) => {
+      const filtered = issues.filter(
+        (issue) => !mineKeys.has(`${repo}#${issue.number}`),
+      );
+      if (filtered.length) filteredOtherRaw.set(repo, filtered);
+    });
+
+    const mineRepos = new Set(mine.keys());
+    const filteredOther = new Map<string, RepositoryIssue[]>();
+    filteredOtherRaw.forEach((issues, repo) => {
+      if (mineRepos.has(repo)) filteredOther.set(repo, issues);
     });
 
     const m = [...mine.values()].reduce((sum, items) => sum + items.length, 0);
-    const o = [...other.values()].reduce((sum, items) => sum + items.length, 0);
+    const o = [...filteredOther.values()].reduce(
+      (sum, items) => sum + items.length,
+      0,
+    );
 
     return {
       mineByRepo: mine,
-      otherByRepo: other,
+      otherByRepo: filteredOther,
       mineTotal: m,
       otherTotal: o,
     };
-  }, [githubAuthoredIssues, issuesByRepo, login, scanRepos]);
-
-  const [showOtherTracked, setShowOtherTracked] = useState(true);
+  }, [
+    authoredReposIssuesByRepo,
+    githubAuthoredIssues,
+    issuesByRepo,
+    reposForGrouping,
+  ]);
 
   if (isLoadingPrs || isLoadingGithub) {
     return (
@@ -481,13 +582,16 @@ const MinerOpenDiscoveryIssuesByRepo: React.FC<
         </Typography>
       ) : null}
 
-      {isError ? (
+      {isError || isAuthoredRepoIssuesError ? (
         <Alert severity="error" sx={{ borderRadius: 2 }}>
           Some issue lists could not be loaded. Try again later.
         </Alert>
       ) : null}
 
-      {isLoading || isLoadingAuthoredIssues || isFetchingAuthoredIssues ? (
+      {isLoading ||
+      isLoadingAuthoredIssues ||
+      isFetchingAuthoredIssues ||
+      isLoadingAuthoredRepoIssues ? (
         <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
           <CircularProgress size={36} />
         </Box>
@@ -509,7 +613,7 @@ const MinerOpenDiscoveryIssuesByRepo: React.FC<
             }}
           >
             <Typography variant="h6" sx={{ fontSize: '1.05rem', mb: 1 }}>
-              Your open reports
+              Your open discovery issues
               {mineTotal > 0 ? (
                 <Typography
                   component="span"
@@ -519,8 +623,13 @@ const MinerOpenDiscoveryIssuesByRepo: React.FC<
                 </Typography>
               ) : null}
             </Typography>
+            <Typography variant="body2" color="text.secondary" sx={{ mb: 1.5 }}>
+              Open issues authored by you in the scanned repositories (discovery
+              index plus GitHub fallback). Use this list to track your own
+              active reports.
+            </Typography>
             {mineTotal === 0 ? (
-              <Typography color="text.secondary" sx={{ mb: 1 }}>
+              <Typography color="text.secondary" sx={{ mb: 1.5 }}>
                 No open issues in this index matched your GitHub login as
                 author. That usually means the API response does not yet include
                 author fields, or you have no open reports in these
@@ -563,24 +672,15 @@ const MinerOpenDiscoveryIssuesByRepo: React.FC<
                   </Typography>
                 ) : null}
               </Typography>
-              <Button
-                size="small"
-                onClick={() => setShowOtherTracked((v) => !v)}
-                disabled={otherTotal === 0}
-              >
-                {showOtherTracked ? 'Hide' : 'Show'}
-              </Button>
             </Box>
             <Typography variant="body2" color="text.secondary" sx={{ mb: 1.5 }}>
               Other people’s open issues in the same repositories (still part of
               the discovery index). Useful for triage and collaboration.
             </Typography>
-            {showOtherTracked
-              ? renderRepoAccordionMap(
-                  otherByRepo,
-                  'No other open issues in the scanned repositories.',
-                )
-              : null}
+            {renderRepoAccordionMap(
+              otherByRepo,
+              'No other open issues in the scanned repositories.',
+            )}
           </Card>
         </>
       )}

--- a/src/components/miners/MinerOpenDiscoveryIssuesByRepo.tsx
+++ b/src/components/miners/MinerOpenDiscoveryIssuesByRepo.tsx
@@ -1,0 +1,436 @@
+import React, { useMemo, useState } from 'react';
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Alert,
+  Box,
+  Button,
+  Card,
+  Chip,
+  CircularProgress,
+  Link,
+  Stack,
+  Typography,
+  alpha,
+} from '@mui/material';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
+import { useMinerGithubData, useMinerPRs } from '../../api';
+import { LinkBox } from '../common/linkBehavior';
+import { STATUS_COLORS, TEXT_OPACITY } from '../../theme';
+import {
+  selectMinerIssueScanRepos,
+  useMinerRepositoriesOpenIssues,
+} from '../../hooks/useMinerRepositoriesOpenIssues';
+import { type RepositoryIssue } from '../../api/models/Miner';
+
+const getIssueAuthor = (issue: RepositoryIssue) =>
+  issue.authorLogin ?? issue.author ?? null;
+
+const isIssueOpen = (issue: RepositoryIssue) => !issue.closedAt;
+
+const githubIssueUrl = (issue: RepositoryIssue) =>
+  issue.url ??
+  `https://github.com/${issue.repositoryFullName}/issues/${issue.number}`;
+
+const githubSearchOpenByAuthor = (login: string) =>
+  `https://github.com/search?q=${encodeURIComponent(`is:issue is:open author:${login}`)}&type=issues`;
+
+interface MinerOpenDiscoveryIssuesByRepoProps {
+  githubId: string;
+}
+
+const MinerOpenDiscoveryIssuesByRepo: React.FC<
+  MinerOpenDiscoveryIssuesByRepoProps
+> = ({ githubId }) => {
+  const { data: prs, isLoading: isLoadingPrs } = useMinerPRs(githubId);
+  const { data: githubProfile, isLoading: isLoadingGithub } =
+    useMinerGithubData(githubId);
+
+  const scanRepos = useMemo(() => selectMinerIssueScanRepos(prs), [prs]);
+  const { issuesByRepo, isLoading, isError, repoFetchLimit } =
+    useMinerRepositoriesOpenIssues(scanRepos, !isLoadingPrs);
+
+  const login = githubProfile?.login ?? '';
+
+  const { mineByRepo, otherByRepo, mineTotal, otherTotal } = useMemo(() => {
+    const mine = new Map<string, RepositoryIssue[]>();
+    const other = new Map<string, RepositoryIssue[]>();
+    let m = 0;
+    let o = 0;
+    const loginLower = login.toLowerCase();
+
+    scanRepos.forEach((repo) => {
+      const list = issuesByRepo.get(repo) ?? [];
+      list.forEach((issue) => {
+        if (!isIssueOpen(issue)) return;
+        const author = getIssueAuthor(issue);
+        const isMine =
+          !!author && !!loginLower && author.toLowerCase() === loginLower;
+        const target = isMine ? mine : other;
+        const arr = target.get(repo) ?? [];
+        arr.push(issue);
+        target.set(repo, arr);
+        if (isMine) m += 1;
+        else o += 1;
+      });
+    });
+
+    return {
+      mineByRepo: mine,
+      otherByRepo: other,
+      mineTotal: m,
+      otherTotal: o,
+    };
+  }, [issuesByRepo, login, scanRepos]);
+
+  const [showOtherTracked, setShowOtherTracked] = useState(true);
+
+  if (isLoadingPrs || isLoadingGithub) {
+    return (
+      <Card
+        elevation={0}
+        sx={{
+          borderRadius: 3,
+          border: '1px solid',
+          borderColor: 'border.light',
+          p: 4,
+          display: 'flex',
+          justifyContent: 'center',
+        }}
+      >
+        <CircularProgress size={36} />
+      </Card>
+    );
+  }
+
+  if (!prs?.length) {
+    return (
+      <Card
+        elevation={0}
+        sx={{
+          borderRadius: 3,
+          border: '1px solid',
+          borderColor: 'border.light',
+          p: 3,
+        }}
+      >
+        <Typography color="text.secondary">
+          No scored pull requests yet. Open issues are listed for repositories
+          where you already have PR activity, so this view will populate after
+          your first contributions are indexed.
+        </Typography>
+      </Card>
+    );
+  }
+
+  if (!scanRepos.length) {
+    return (
+      <Card
+        elevation={0}
+        sx={{
+          borderRadius: 3,
+          border: '1px solid',
+          borderColor: 'border.light',
+          p: 3,
+        }}
+      >
+        <Typography color="text.secondary">
+          No repositories found to scan for issues.
+        </Typography>
+      </Card>
+    );
+  }
+
+  const renderRepoAccordionMap = (
+    map: Map<string, RepositoryIssue[]>,
+    emptyHint: string,
+  ) => {
+    const entries = [...map.entries()].filter(([, issues]) => issues.length);
+    if (!entries.length) {
+      return (
+        <Typography color="text.secondary" sx={{ py: 1 }}>
+          {emptyHint}
+        </Typography>
+      );
+    }
+
+    return (
+      <Stack spacing={1}>
+        {entries.map(([repo, issues]) => (
+          <Accordion
+            key={repo}
+            disableGutters
+            elevation={0}
+            sx={{
+              border: '1px solid',
+              borderColor: 'border.light',
+              borderRadius: 2,
+              '&:before': { display: 'none' },
+              overflow: 'hidden',
+            }}
+          >
+            <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+              <Box
+                sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'space-between',
+                  width: '100%',
+                  gap: 1,
+                  pr: 1,
+                }}
+              >
+                <LinkBox
+                  href={`/miners/repository?name=${encodeURIComponent(repo)}`}
+                  sx={{
+                    color: 'primary.main',
+                    fontWeight: 600,
+                    fontSize: '0.9rem',
+                    minWidth: 0,
+                    '&:hover': { textDecoration: 'underline' },
+                  }}
+                >
+                  {repo}
+                </LinkBox>
+                <Chip
+                  size="small"
+                  label={`${issues.length} open`}
+                  sx={{
+                    borderColor: STATUS_COLORS.open,
+                    color: STATUS_COLORS.open,
+                    flexShrink: 0,
+                  }}
+                  variant="outlined"
+                />
+              </Box>
+            </AccordionSummary>
+            <AccordionDetails sx={{ pt: 0, px: 2, pb: 2 }}>
+              <Stack spacing={1.25}>
+                {issues.map((issue) => (
+                  <Box
+                    key={`${repo}-${issue.number}`}
+                    sx={{
+                      display: 'flex',
+                      flexDirection: 'column',
+                      gap: 0.5,
+                      py: 1,
+                      borderTop: '1px solid',
+                      borderColor: 'border.light',
+                      '&:first-of-type': {
+                        borderTop: 'none',
+                        pt: 0,
+                      },
+                    }}
+                  >
+                    <Box
+                      sx={{
+                        display: 'flex',
+                        alignItems: 'flex-start',
+                        justifyContent: 'space-between',
+                        gap: 1,
+                      }}
+                    >
+                      <Link
+                        href={githubIssueUrl(issue)}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        underline="hover"
+                        sx={{
+                          color: 'text.primary',
+                          fontWeight: 500,
+                          fontSize: '0.85rem',
+                          minWidth: 0,
+                        }}
+                      >
+                        <Typography component="span" sx={{ fontWeight: 600 }}>
+                          #{issue.number}
+                        </Typography>{' '}
+                        <Typography component="span" sx={{ fontWeight: 400 }}>
+                          {issue.title}
+                        </Typography>
+                      </Link>
+                      <OpenInNewIcon
+                        sx={{
+                          fontSize: '1rem',
+                          color: (t) =>
+                            alpha(t.palette.common.white, TEXT_OPACITY.muted),
+                          flexShrink: 0,
+                        }}
+                      />
+                    </Box>
+                    <Box
+                      sx={{
+                        display: 'flex',
+                        flexWrap: 'wrap',
+                        gap: 1,
+                        alignItems: 'center',
+                      }}
+                    >
+                      {issue.prNumber != null ? (
+                        <Link
+                          href={`https://github.com/${issue.repositoryFullName}/pull/${issue.prNumber}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          variant="caption"
+                          sx={{ color: STATUS_COLORS.info }}
+                        >
+                          Linked PR #{issue.prNumber}
+                        </Link>
+                      ) : (
+                        <Typography variant="caption" color="text.secondary">
+                          No linked PR yet
+                        </Typography>
+                      )}
+                      {issue.createdAt ? (
+                        <Typography variant="caption" color="text.secondary">
+                          Opened{' '}
+                          {new Date(issue.createdAt).toLocaleDateString()}
+                        </Typography>
+                      ) : null}
+                    </Box>
+                  </Box>
+                ))}
+              </Stack>
+            </AccordionDetails>
+          </Accordion>
+        ))}
+      </Stack>
+    );
+  };
+
+  return (
+    <Stack spacing={2}>
+      <Alert severity="info" sx={{ borderRadius: 2 }}>
+        Open issues are loaded from Gittensor’s per-repository issue index for
+        up to {repoFetchLimit} repositories where you have scored PRs (most
+        recent first). When the API includes an issue author, issues you opened
+        are grouped separately. Use GitHub search for the canonical list of
+        everything you have opened publicly.
+        {login ? (
+          <Box sx={{ mt: 1.5 }}>
+            <Button
+              component="a"
+              href={githubSearchOpenByAuthor(login)}
+              target="_blank"
+              rel="noopener noreferrer"
+              size="small"
+              variant="outlined"
+              endIcon={<OpenInNewIcon fontSize="small" />}
+            >
+              View all open issues by @{login} on GitHub
+            </Button>
+          </Box>
+        ) : null}
+      </Alert>
+
+      {prs.length > repoFetchLimit ? (
+        <Typography variant="caption" color="text.secondary">
+          You have PRs in more than {repoFetchLimit} repositories; only the most
+          active {repoFetchLimit} are scanned here to limit load.
+        </Typography>
+      ) : null}
+
+      {isError ? (
+        <Alert severity="error" sx={{ borderRadius: 2 }}>
+          Some issue lists could not be loaded. Try again later.
+        </Alert>
+      ) : null}
+
+      {isLoading ? (
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+          <CircularProgress size={36} />
+        </Box>
+      ) : (
+        <>
+          <Card
+            elevation={0}
+            sx={{
+              borderRadius: 3,
+              border: '1px solid',
+              borderColor: 'border.light',
+              p: 2.5,
+            }}
+          >
+            <Typography variant="h6" sx={{ fontSize: '1.05rem', mb: 1 }}>
+              Your open reports
+              {mineTotal > 0 ? (
+                <Typography
+                  component="span"
+                  sx={{ ml: 1, color: 'text.secondary', fontSize: '0.85rem' }}
+                >
+                  ({mineTotal})
+                </Typography>
+              ) : null}
+            </Typography>
+            {mineTotal === 0 ? (
+              <Typography color="text.secondary" sx={{ mb: 1 }}>
+                No open issues in this index matched your GitHub login as
+                author. That usually means the API response does not yet include
+                author fields, or you have no open reports in these
+                repositories. Use the GitHub button above for a definitive list.
+              </Typography>
+            ) : null}
+            {renderRepoAccordionMap(
+              mineByRepo,
+              'No matching open issues in the scanned repositories.',
+            )}
+          </Card>
+
+          <Card
+            elevation={0}
+            sx={{
+              borderRadius: 3,
+              border: '1px solid',
+              borderColor: 'border.light',
+              p: 2.5,
+            }}
+          >
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                gap: 1,
+                flexWrap: 'wrap',
+                mb: 1,
+              }}
+            >
+              <Typography variant="h6" sx={{ fontSize: '1.05rem' }}>
+                Other open discovery issues
+                {otherTotal > 0 ? (
+                  <Typography
+                    component="span"
+                    sx={{ ml: 1, color: 'text.secondary', fontSize: '0.85rem' }}
+                  >
+                    ({otherTotal})
+                  </Typography>
+                ) : null}
+              </Typography>
+              <Button
+                size="small"
+                onClick={() => setShowOtherTracked((v) => !v)}
+                disabled={otherTotal === 0}
+              >
+                {showOtherTracked ? 'Hide' : 'Show'}
+              </Button>
+            </Box>
+            <Typography variant="body2" color="text.secondary" sx={{ mb: 1.5 }}>
+              Other people’s open issues in the same repositories (still part of
+              the discovery index). Useful for triage and collaboration.
+            </Typography>
+            {showOtherTracked
+              ? renderRepoAccordionMap(
+                  otherByRepo,
+                  'No other open issues in the scanned repositories.',
+                )
+              : null}
+          </Card>
+        </>
+      )}
+    </Stack>
+  );
+};
+
+export default MinerOpenDiscoveryIssuesByRepo;

--- a/src/components/miners/index.ts
+++ b/src/components/miners/index.ts
@@ -3,6 +3,7 @@ export { default as EmptyStateMessage } from './EmptyStateMessage';
 export { default as ExplorerFilterButton } from './ExplorerFilterButton';
 export { default as MinerActivity } from './MinerActivity';
 export { default as MinerInsightsCard } from './MinerInsightsCard';
+export { default as MinerOpenDiscoveryIssuesByRepo } from './MinerOpenDiscoveryIssuesByRepo';
 export { default as MinerPRsTable } from './MinerPRsTable';
 export { default as MinerRepositoriesTable } from './MinerRepositoriesTable';
 export { default as MinerScoreBreakdown } from './MinerScoreBreakdown';

--- a/src/hooks/useMinerRepositoriesOpenIssues.ts
+++ b/src/hooks/useMinerRepositoriesOpenIssues.ts
@@ -1,0 +1,86 @@
+import { useMemo } from 'react';
+import { useQueries } from '@tanstack/react-query';
+import axios from 'axios';
+import { type RepositoryIssue } from '../api/models/Miner';
+import { type CommitLog } from '../api/models/Dashboard';
+
+const REPO_FETCH_LIMIT = 50;
+
+const buildReposIssuesPath = (repoFullName: string) =>
+  `/repos/${encodeURIComponent(repoFullName)}/issues`;
+
+const fetchRepositoryIssues = async (
+  repoFullName: string,
+): Promise<RepositoryIssue[]> => {
+  const baseUrl = import.meta.env.VITE_REACT_APP_BASE_URL;
+  const path = buildReposIssuesPath(repoFullName);
+  const requestUrl = baseUrl ? `${baseUrl}${path}` : path;
+  const { data } = await axios.get<RepositoryIssue[]>(requestUrl);
+  return data;
+};
+
+/**
+ * Repositories where the miner has scored PR activity, ordered by most recent
+ * PR timestamp (merged or created), capped for parallel fetch limits.
+ */
+export const selectMinerIssueScanRepos = (prs: CommitLog[] | undefined) => {
+  if (!prs?.length) return [];
+  const latest = new Map<string, number>();
+  prs.forEach((pr) => {
+    const raw = pr.mergedAt || pr.prCreatedAt;
+    const t = raw ? new Date(raw).getTime() : 0;
+    const prev = latest.get(pr.repository) ?? 0;
+    if (t >= prev) latest.set(pr.repository, t);
+  });
+  return [...latest.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .map(([repo]) => repo)
+    .slice(0, REPO_FETCH_LIMIT);
+};
+
+/**
+ * Parallel fetch of `/repos/{repo}/issues` for each repository in `repos`.
+ * Shares query keys with `useRepositoryIssues` so navigation can reuse cache.
+ */
+export const useMinerRepositoriesOpenIssues = (
+  repos: string[],
+  enabled: boolean,
+) => {
+  const stableRepos = useMemo(
+    () => [...new Set(repos)].filter(Boolean),
+    [repos],
+  );
+
+  const queries = useQueries({
+    queries: stableRepos.map((repo) => {
+      const url = buildReposIssuesPath(repo);
+      return {
+        queryKey: ['useRepositoryIssues', url, undefined] as const,
+        queryFn: () => fetchRepositoryIssues(repo),
+        enabled: enabled && stableRepos.length > 0,
+        staleTime: 60_000,
+      };
+    }),
+  });
+
+  const isLoading = queries.some((q) => q.isLoading || q.isFetching);
+  const isError = queries.some((q) => q.isError);
+
+  const issuesByRepo = useMemo(() => {
+    const map = new Map<string, RepositoryIssue[]>();
+    stableRepos.forEach((repo, idx) => {
+      const data = queries[idx]?.data;
+      if (!data) return;
+      map.set(repo, data);
+    });
+    return map;
+  }, [queries, stableRepos]);
+
+  return {
+    repos: stableRepos,
+    issuesByRepo,
+    isLoading,
+    isError,
+    repoFetchLimit: REPO_FETCH_LIMIT,
+  };
+};

--- a/src/pages/DiscoveriesPage.tsx
+++ b/src/pages/DiscoveriesPage.tsx
@@ -13,7 +13,7 @@ import { parseNumber } from '../utils/ExplorerUtils';
 
 const MINER_LINK_STATE = { backLabel: 'Back to Discoveries' } as const;
 const getMinerHref = (miner: MinerStats) =>
-  `/miners/details?githubId=${miner.githubId}&mode=issues`;
+  `/miners/details?githubId=${miner.githubId}&mode=issues&tab=open-issues`;
 
 const DiscoveriesPage: React.FC = () => {
   const allMinerStatsQuery = useAllMiners();
@@ -110,6 +110,17 @@ const DiscoveriesPage: React.FC = () => {
           >
             Miners earn discovery rewards by filing quality issues that others
             solve via merged PRs. Rewarded separately from OSS contributions.
+          </Typography>
+          <Typography
+            sx={{
+              fontSize: '0.8rem',
+              color: (t) => alpha(t.palette.text.primary, 0.5),
+              lineHeight: 1.6,
+            }}
+          >
+            Open a miner, switch to Issue Discovery, then use the Open issues
+            tab to see open discovery-indexed issues grouped by repository (plus
+            a GitHub search link for everything you have opened publicly).
           </Typography>
           <Box sx={{ width: '100%' }}>
             <TopMinersTable

--- a/src/pages/MinerDetailsPage.tsx
+++ b/src/pages/MinerDetailsPage.tsx
@@ -7,6 +7,7 @@ import {
   BackButton,
   MinerActivity,
   MinerInsightsCard,
+  MinerOpenDiscoveryIssuesByRepo,
   MinerPRsTable,
   MinerRepositoriesTable,
   MinerScoreBreakdown,
@@ -23,7 +24,12 @@ const PR_TABS = [
   'pull-requests',
   'repositories',
 ] as const;
-const ISSUE_TABS = ['overview', 'activity', 'repositories'] as const;
+const ISSUE_TABS = [
+  'overview',
+  'activity',
+  'open-issues',
+  'repositories',
+] as const;
 type MinerDetailsTab = (typeof PR_TABS)[number] | (typeof ISSUE_TABS)[number];
 
 /**
@@ -200,6 +206,9 @@ const MinerDetailsPage: React.FC = () => {
             >
               <Tab value="overview" label="Overview" />
               <Tab value="activity" label="Activity" />
+              {viewMode === 'issues' && (
+                <Tab value="open-issues" label="Open issues" />
+              )}
               {viewMode === 'prs' && (
                 <Tab value="pull-requests" label="Pull Requests" />
               )}
@@ -217,6 +226,9 @@ const MinerDetailsPage: React.FC = () => {
 
             {activeTab === 'activity' && (
               <MinerActivity githubId={githubId} viewMode={viewMode} />
+            )}
+            {activeTab === 'open-issues' && viewMode === 'issues' && (
+              <MinerOpenDiscoveryIssuesByRepo githubId={githubId} />
             )}
             {activeTab === 'pull-requests' && (
               <MinerPRsTable githubId={githubId} />


### PR DESCRIPTION
## Summary

Adds an **Issue Discovery → Open issues** tab on the miner dashboard (`MinerDetailsPage`) so miners can see **open discovery-indexed issues grouped by repository** without opening each repo on GitHub first.

Implementation details:

- New hook `useMinerRepositoriesOpenIssues` (`src/hooks/useMinerRepositoriesOpenIssues.ts`) selects up to **50** repositories from the miner’s scored PRs (most recent activity first) and loads `/repos/{repo}/issues` in parallel via `useQueries`, reusing the same query keys as `useRepositoryIssues` for cache alignment.
- New UI component `MinerOpenDiscoveryIssuesByRepo` (`src/components/miners/MinerOpenDiscoveryIssuesByRepo.tsx`): accordions per repo, GitHub issue links, linked PR links when `prNumber` is set, opened date, info alert with **GitHub search** (`author:` + `is:issue` + `is:open`) for a definitive list of issues the user opened publicly.
- Splits **“Your open reports”** vs **“Other open discovery issues”** when `author` / `authorLogin` on `RepositoryIssue` matches the miner’s GitHub login from `useMinerGithubData` (model extended in `src/api/models/Miner.ts`).
- **Issue Discoveries** page (`src/pages/DiscoveriesPage.tsx`): miner links now include `tab=open-issues` so the leaderboard lands on the new tab; short explanatory copy added.
- Export: `src/components/miners/index.ts`.

## Related Issues

Fixes #749 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

### Before
<img width="2461" height="1878" alt="image" src="https://github.com/user-attachments/assets/3f42bf81-ab7c-4dee-a99f-1397789756fd" />

### After
<img width="2580" height="1900" alt="image" src="https://github.com/user-attachments/assets/6c20afcb-3fbf-4bad-9d79-7d231dcf0949" />


## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors) — MUI theme tokens (`border.light`, `text.secondary`, `primary.main`, etc.) and shared `STATUS_COLORS` / `TEXT_OPACITY` from `src/theme`
- [ ] Responsive/mobile checked
- [ ] Tested against the test API
- [ ] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [ ] Screenshots included for any UI/visual changes
