### PR TITLE
feat: Make the right side bar respect the filter for all/eligible/ineligible

### DIFF
--- a/src/components/leaderboard/LeaderboardSidebar.tsx
+++ b/src/components/leaderboard/LeaderboardSidebar.tsx
@@ -43,8 +43,10 @@ export const LeaderboardSidebar: React.FC<LeaderboardSidebarProps> = ({
     useState<EligibilityFilter>('all');
 
   const filteredMiners = useMemo(() => {
-    if (eligibilityFilter === 'eligible') return miners.filter((m) => m.isEligible);
-    if (eligibilityFilter === 'ineligible') return miners.filter((m) => !m.isEligible);
+    if (eligibilityFilter === 'eligible')
+      return miners.filter((m) => m.isEligible);
+    if (eligibilityFilter === 'ineligible')
+      return miners.filter((m) => !m.isEligible);
     return miners;
   }, [miners, eligibilityFilter]);
 
@@ -107,10 +109,6 @@ export const LeaderboardSidebar: React.FC<LeaderboardSidebarProps> = ({
                   ? t.palette.text.primary
                   : alpha(option.color, 0.82),
                 cursor: 'pointer',
-                fontFamily: FONTS.mono,
-                fontSize: '0.72rem',
-                fontWeight: selected ? 600 : 500,
-                lineHeight: 1,
                 transition: 'all 0.2s ease',
                 '&:hover': {
                   backgroundColor: alpha(t.palette.text.primary, 0.1),
@@ -122,7 +120,16 @@ export const LeaderboardSidebar: React.FC<LeaderboardSidebarProps> = ({
                 },
               })}
             >
-              {option.label}
+              <Typography
+                sx={{
+                  fontSize: '0.72rem',
+                  fontWeight: selected ? 600 : 500,
+                  lineHeight: 1,
+                  color: 'inherit',
+                }}
+              >
+                {option.label}
+              </Typography>
             </Box>
           );
         })}

--- a/src/components/leaderboard/LeaderboardSidebar.tsx
+++ b/src/components/leaderboard/LeaderboardSidebar.tsx
@@ -5,7 +5,7 @@ import { SectionCard } from './SectionCard';
 import { STATUS_COLORS, scrollbarSx } from '../../theme';
 import { getGithubAvatarSrc } from '../../utils/ExplorerUtils';
 import { LinkBox } from '../common/linkBehavior';
-import { type MinerStats, FONTS } from './types';
+import { type MinerStats } from './types';
 import { ActivitySidebarCards } from './ActivitySidebarCards';
 
 // Re-export MinerStats for backward compatibility
@@ -225,7 +225,6 @@ const LeaderboardTabs: React.FC<LeaderboardTabsProps> = ({
       >
         <Typography
           sx={{
-            fontFamily: FONTS.mono,
             fontSize: '0.75rem',
             fontWeight: 600,
           }}
@@ -256,7 +255,6 @@ const LeaderboardHeader: React.FC<LeaderboardHeaderProps> = ({
   >
     <Typography
       sx={{
-        fontFamily: FONTS.mono,
         fontSize: '0.7rem',
         color: STATUS_COLORS.open,
         width: 24,
@@ -267,7 +265,6 @@ const LeaderboardHeader: React.FC<LeaderboardHeaderProps> = ({
     </Typography>
     <Typography
       sx={{
-        fontFamily: FONTS.mono,
         fontSize: '0.7rem',
         color: STATUS_COLORS.open,
         flex: 1,
@@ -278,7 +275,6 @@ const LeaderboardHeader: React.FC<LeaderboardHeaderProps> = ({
     </Typography>
     <Typography
       sx={{
-        fontFamily: FONTS.mono,
         fontSize: '0.7rem',
         color: STATUS_COLORS.open,
         textTransform: 'uppercase',
@@ -328,7 +324,6 @@ const LeaderboardRow: React.FC<LeaderboardRowProps> = ({
     >
       <Typography
         sx={{
-          fontFamily: FONTS.mono,
           fontSize: '0.85rem',
           color: STATUS_COLORS.open,
           width: 24,
@@ -351,7 +346,6 @@ const LeaderboardRow: React.FC<LeaderboardRowProps> = ({
         />
         <Typography
           sx={(theme) => ({
-            fontFamily: FONTS.mono,
             fontSize: '0.85rem',
             color: theme.palette.text.tertiary,
             overflow: 'hidden',
@@ -364,7 +358,6 @@ const LeaderboardRow: React.FC<LeaderboardRowProps> = ({
       </Box>
       <Typography
         sx={(theme) => ({
-          fontFamily: FONTS.mono,
           fontSize: '0.95rem',
           color:
             type === 'earners'

--- a/src/components/leaderboard/LeaderboardSidebar.tsx
+++ b/src/components/leaderboard/LeaderboardSidebar.tsx
@@ -11,6 +11,18 @@ import { ActivitySidebarCards } from './ActivitySidebarCards';
 // Re-export MinerStats for backward compatibility
 export type { MinerStats } from './types';
 
+type EligibilityFilter = 'all' | 'eligible' | 'ineligible';
+
+const ELIGIBILITY_FILTER_OPTIONS: Array<{
+  value: EligibilityFilter;
+  label: string;
+  color: string;
+}> = [
+  { value: 'all', label: 'All', color: STATUS_COLORS.open },
+  { value: 'eligible', label: 'Eligible', color: STATUS_COLORS.merged },
+  { value: 'ineligible', label: 'Ineligible', color: STATUS_COLORS.closed },
+];
+
 interface LeaderboardSidebarProps {
   miners: MinerStats[];
   getMinerHref: (miner: MinerStats) => string;
@@ -24,30 +36,36 @@ export const LeaderboardSidebar: React.FC<LeaderboardSidebarProps> = ({
   linkState,
   variant = 'oss',
 }) => {
-  // State for toggling lists
   const [leaderboardType, setLeaderboardType] = useState<'earners' | 'active'>(
     'earners',
   );
+  const [eligibilityFilter, setEligibilityFilter] =
+    useState<EligibilityFilter>('all');
 
-  // Stats (Use original unfiltered list for stats)
+  const filteredMiners = useMemo(() => {
+    if (eligibilityFilter === 'eligible') return miners.filter((m) => m.isEligible);
+    if (eligibilityFilter === 'ineligible') return miners.filter((m) => !m.isEligible);
+    return miners;
+  }, [miners, eligibilityFilter]);
+
   const topEarners = useMemo(
     () =>
-      [...miners]
+      [...filteredMiners]
         .sort((a, b) => (b.usdPerDay || 0) - (a.usdPerDay || 0))
         .slice(0, 5),
-    [miners],
+    [filteredMiners],
   );
 
   const mostActive = useMemo(
     () =>
-      [...miners]
+      [...filteredMiners]
         .sort((a, b) =>
           variant === 'discoveries'
             ? (b.totalIssues || 0) - (a.totalIssues || 0)
             : (b.totalPRs || 0) - (a.totalPRs || 0),
         )
         .slice(0, 5),
-    [miners, variant],
+    [filteredMiners, variant],
   );
 
   return (
@@ -55,8 +73,63 @@ export const LeaderboardSidebar: React.FC<LeaderboardSidebarProps> = ({
       spacing={2}
       sx={{ height: '100%', overflow: 'auto', pr: 1, ...scrollbarSx }}
     >
+      {/* Filter tabs */}
+      <Box
+        sx={(t) => ({
+          display: 'inline-flex',
+          alignSelf: 'center',
+          gap: 0.5,
+          p: 0.5,
+          borderRadius: 2,
+          backgroundColor: t.palette.surface.light,
+        })}
+      >
+        {ELIGIBILITY_FILTER_OPTIONS.map((option) => {
+          const selected = eligibilityFilter === option.value;
+          return (
+            <Box
+              key={option.value}
+              component="button"
+              type="button"
+              aria-pressed={selected}
+              onClick={() => setEligibilityFilter(option.value)}
+              sx={(t) => ({
+                px: 1.6,
+                height: 24,
+                display: 'flex',
+                alignItems: 'center',
+                border: 0,
+                borderRadius: 1.5,
+                backgroundColor: selected
+                  ? alpha(t.palette.text.primary, 0.15)
+                  : 'transparent',
+                color: selected
+                  ? t.palette.text.primary
+                  : alpha(option.color, 0.82),
+                cursor: 'pointer',
+                fontFamily: FONTS.mono,
+                fontSize: '0.72rem',
+                fontWeight: selected ? 600 : 500,
+                lineHeight: 1,
+                transition: 'all 0.2s ease',
+                '&:hover': {
+                  backgroundColor: alpha(t.palette.text.primary, 0.1),
+                  color: t.palette.text.primary,
+                },
+                '&:focus-visible': {
+                  outline: `1px solid ${option.color}`,
+                  outlineOffset: 1,
+                },
+              })}
+            >
+              {option.label}
+            </Box>
+          );
+        })}
+      </Box>
+
       {/* Activity Cards: PR Activity, Issue Activity, Code Impact */}
-      <ActivitySidebarCards miners={miners} />
+      <ActivitySidebarCards miners={filteredMiners} />
 
       {/* Leaderboard Lists (Tabs) */}
       <SectionCard


### PR DESCRIPTION
## Closes: #752 

## Summary

- Added All / Eligible / Ineligible filter tabs to the leaderboard right sidebar (`LeaderboardSidebar`), styled to match the Live Activity panel (pill container, colored inactive labels, highlighted active tab)
- Filter state is managed internally in the sidebar; switching tabs re-filters the miners array passed down to `ActivitySidebarCards` (PR Activity, Issue Activity, Code Impact, Miners Activity) and the Top Earners / Most Active lists
- Green for Eligible, red for Ineligible, gray for All — consistent with existing merged/closed status colors across the app

## Test plan

- [ ] On the OSS Contributions page, click **Eligible** in the sidebar filter — all stat cards and top earners list should update to reflect only eligible miners
- [ ] Click **Ineligible** — stats should reflect only ineligible miners
- [ ] Click **All** — stats should return to the full miner set
- [ ] Confirm the sidebar filter is independent from the main table's All/Eligible/Ineligible toggle
- [ ] Repeat on the Discoveries page (same sidebar component, `variant="discoveries"`)
- [ ] Confirm filter tabs are horizontally centered in the sidebar



https://github.com/user-attachments/assets/628c0016-ed58-406b-8985-8a08a969de79

