### PR TITLE
feat(sidebar): respect eligibility filter on contributions, discoveries, and watchlist

### DIFF
--- a/src/components/leaderboard/ActivitySidebarCards.tsx
+++ b/src/components/leaderboard/ActivitySidebarCards.tsx
@@ -5,14 +5,16 @@ import { SectionCard } from './SectionCard';
 import { STATUS_COLORS, DIFF_COLORS, CREDIBILITY_COLORS } from '../../theme';
 import { credibilityColor } from '../../utils/format';
 import { type MinerStats, FONTS } from './types';
+import { useEligibilityFilteredMiners } from './useEligibilityFilteredMiners';
 
 interface ActivitySidebarCardsProps {
   miners: MinerStats[];
 }
 
 export const ActivitySidebarCards: React.FC<ActivitySidebarCardsProps> = ({
-  miners,
+  miners: allMiners,
 }) => {
+  const miners = useEligibilityFilteredMiners(allMiners);
   const minerActivityStats = useMemo(() => {
     const all = miners.length;
     const eligiblePr = miners.filter((m) => m.ossIsEligible).length;
@@ -46,8 +48,8 @@ export const ActivitySidebarCards: React.FC<ActivitySidebarCardsProps> = ({
     const merged = miners.reduce((acc, m) => acc + (m.totalMergedPrs || 0), 0);
     const open = miners.reduce((acc, m) => acc + (m.totalOpenPrs || 0), 0);
     const closed = miners.reduce((acc, m) => acc + (m.totalClosedPrs || 0), 0);
-    const total = merged + open + closed;
-    const mergeRate = total > 0 ? Math.round((merged / total) * 100) : 0;
+    const resolved = merged + closed;
+    const mergeRate = resolved > 0 ? Math.round((merged / resolved) * 100) : 0;
     return { merged, open, closed, mergeRate };
   }, [miners]);
 
@@ -61,8 +63,8 @@ export const ActivitySidebarCards: React.FC<ActivitySidebarCardsProps> = ({
       (acc, m) => acc + (m.totalClosedIssues || 0),
       0,
     );
-    const total = solved + open + closed;
-    const solveRate = total > 0 ? Math.round((solved / total) * 100) : 0;
+    const resolved = solved + closed;
+    const solveRate = resolved > 0 ? Math.round((solved / resolved) * 100) : 0;
     return { solved, open, closed, solveRate };
   }, [miners]);
 

--- a/src/components/leaderboard/LeaderboardSidebar.tsx
+++ b/src/components/leaderboard/LeaderboardSidebar.tsx
@@ -7,6 +7,7 @@ import { getGithubAvatarSrc } from '../../utils/ExplorerUtils';
 import { LinkBox } from '../common/linkBehavior';
 import { type MinerStats, FONTS } from './types';
 import { ActivitySidebarCards } from './ActivitySidebarCards';
+import { useEligibilityFilteredMiners } from './useEligibilityFilteredMiners';
 
 // Re-export MinerStats for backward compatibility
 export type { MinerStats } from './types';
@@ -29,25 +30,26 @@ export const LeaderboardSidebar: React.FC<LeaderboardSidebarProps> = ({
     'earners',
   );
 
-  // Stats (Use original unfiltered list for stats)
+  const filteredMiners = useEligibilityFilteredMiners(miners);
+
   const topEarners = useMemo(
     () =>
-      [...miners]
+      [...filteredMiners]
         .sort((a, b) => (b.usdPerDay || 0) - (a.usdPerDay || 0))
         .slice(0, 5),
-    [miners],
+    [filteredMiners],
   );
 
   const mostActive = useMemo(
     () =>
-      [...miners]
+      [...filteredMiners]
         .sort((a, b) =>
           variant === 'discoveries'
             ? (b.totalIssues || 0) - (a.totalIssues || 0)
             : (b.totalPRs || 0) - (a.totalPRs || 0),
         )
         .slice(0, 5),
-    [miners, variant],
+    [filteredMiners, variant],
   );
 
   return (

--- a/src/components/leaderboard/useEligibilityFilteredMiners.ts
+++ b/src/components/leaderboard/useEligibilityFilteredMiners.ts
@@ -1,0 +1,22 @@
+import { useMemo } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { type MinerStats } from './types';
+
+const ELIGIBLE_PARAM = 'eligible';
+
+export function useEligibilityFilteredMiners(
+  miners: MinerStats[],
+): MinerStats[] {
+  const [searchParams] = useSearchParams();
+  const eligibleParam = searchParams.get(ELIGIBLE_PARAM);
+
+  return useMemo(() => {
+    if (eligibleParam === 'true') {
+      return miners.filter((m) => m.isEligible);
+    }
+    if (eligibleParam === 'false') {
+      return miners.filter((m) => !m.isEligible);
+    }
+    return miners;
+  }, [miners, eligibleParam]);
+}


### PR DESCRIPTION
## Summary

The right sidebar on the Contributions, Discoveries, and Watchlist pages now respects the existing All / Eligible / Ineligible filter toggle in the main table. Previously the sidebar stats (Top Earners, Most Active, PR Activity, Issue Activity, Code Impact) were computed from the full miner list and did not change when the filter was toggled.

Also fixes the Merge Rate and Solve Rate denominators to exclude open PRs/issues:

- Merge Rate: `merged / (merged + closed)` (was `merged / (merged + open + closed)`)
- Solve Rate: `solved / (solved + closed)` (was `solved / (solved + open + closed)`)

## Related Issues

Closes #752

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Approach

Added a small shared hook `useEligibilityFilteredMiners` that reads the `?eligible=true|false` URL param written by `TopMinersTable`'s filter toggle and returns the filtered miner list. Both `LeaderboardSidebar` (Contributions, Discoveries) and `ActivitySidebarCards` (Watchlist mounts this directly) consume the hook, so all three pages stay in sync with the main table's filter. Filtering is idempotent, so nested consumers are safe.

## Screenshots

https://github.com/user-attachments/assets/fe0935cb-26b0-4a74-8ede-b99139e861f4


## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
