### PR TITLE
Repositories page: move highlights to right sidebar and widen table

### DIFF
--- a/src/components/leaderboard/TopRepositoriesTable.tsx
+++ b/src/components/leaderboard/TopRepositoriesTable.tsx
@@ -38,6 +38,7 @@ import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
 import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
 import FilterButton from '../FilterButton';
 import { RepositoryCard } from './RepositoryCard';
+import { SectionCard } from './SectionCard';
 import {
   REPOSITORIES_CARD_ROWS,
   REPOSITORIES_DEFAULT_CARD_ROWS,
@@ -709,7 +710,7 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
         startAdornment: searchAdornment,
       }}
       sx={{
-        width: '200px',
+        width: '100%',
         ...(isMobileSearchVisible
           ? {
               flexBasis: { xs: '100%', sm: 'auto' },
@@ -1021,471 +1022,503 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
   }
 
   return (
-    <Card
-      sx={{
-        borderRadius: 3,
-        border: '1px solid',
-        borderColor: 'border.light',
-        backgroundColor: 'transparent',
-        overflow: 'hidden',
-        display: 'flex',
-        flexDirection: 'column',
-      }}
-      elevation={0}
-    >
-      <Box
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+      {/* Header Card — matches OSS contributions layout (title + search, then filters) */}
+      <SectionCard
         sx={{
-          borderBottom: '1px solid',
-          borderColor: 'border.light',
+          position: 'sticky',
+          top: 0,
+          zIndex: 100,
+          backgroundColor: (theme) =>
+            alpha(theme.palette.background.default, 0.65),
+          backdropFilter: 'blur(12px)',
+          borderBottom: (theme) => `1px solid ${theme.palette.border.light}`,
+          boxShadow: 'none',
         }}
       >
-        {/* Row 1: All Controls */}
-        <Box
-          sx={{
-            p: { xs: 1.5, md: 2 },
-            display: 'flex',
-            flexDirection: { xs: 'column', md: 'row' },
-            alignItems: { xs: 'stretch', md: 'center' },
-            gap: { xs: 1.25, md: 2 },
-          }}
-        >
-          <Box
-            sx={{
-              display: 'flex',
-              gap: 0.5,
-              alignItems: 'center',
-              flexWrap: 'wrap',
-              width: { xs: '100%', md: 'auto' },
-            }}
-          >
-            <FilterButton
-              label="All"
-              count={rankedRepositories.length}
-              color={STATUS_COLORS.neutral}
-              isActive={statusFilter === 'all'}
-              onClick={() => {
-                setStatusFilter('all');
-                setPage(0);
-                syncToUrl({ status: 'all', page: '0' });
-              }}
-            />
-            <FilterButton
-              label="Active"
-              count={rankedRepositories.filter((r) => !r.inactiveAt).length}
-              color={STATUS_COLORS.success}
-              isActive={statusFilter === 'active'}
-              onClick={() => {
-                setStatusFilter('active');
-                setPage(0);
-                syncToUrl({ status: 'active', page: '0' });
-              }}
-            />
-            <FilterButton
-              label="Inactive"
-              count={rankedRepositories.filter((r) => !!r.inactiveAt).length}
-              color={STATUS_COLORS.closed}
-              isActive={statusFilter === 'inactive'}
-              onClick={() => {
-                setStatusFilter('inactive');
-                setPage(0);
-                syncToUrl({ status: 'inactive', page: '0' });
-              }}
-            />
-          </Box>
-
+        <Box sx={{ p: 2, display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+          {/* Row 1: Title + Search */}
           <Box
             sx={{
               display: 'flex',
               alignItems: 'center',
-              justifyContent: { xs: 'space-between', md: 'flex-end' },
-              gap: 1,
-              flexWrap: 'wrap',
-              width: { xs: '100%', md: 'auto' },
-            }}
-          >
-            <Tooltip title={showChart ? 'Hide Chart' : 'Show Chart'}>
-              <IconButton
-                onClick={() => setShowChart(!showChart)}
-                size="small"
-                sx={{
-                  color: showChart ? 'text.primary' : 'text.tertiary',
-                  border: '1px solid',
-                  borderColor: 'border.light',
-                  borderRadius: 2,
-                  padding: '6px',
-                  '&:hover': {
-                    backgroundColor: 'surface.light',
-                    borderColor: 'border.medium',
-                  },
-                }}
-              >
-                {showChart ? (
-                  <TableChartIcon fontSize="small" />
-                ) : (
-                  <BarChartIcon fontSize="small" />
-                )}
-              </IconButton>
-            </Tooltip>
-
-            {showChart && (
-              <FormControlLabel
-                control={
-                  <Switch
-                    checked={useLogScale}
-                    onChange={(e) => setUseLogScale(e.target.checked)}
-                    size="small"
-                    sx={{
-                      '& .MuiSwitch-switchBase.Mui-checked': {
-                        color: 'primary.main',
-                      },
-                      '& .MuiSwitch-track': {
-                        backgroundColor: 'border.medium',
-                      },
-                    }}
-                  />
-                }
-                label={
-                  <Typography
-                    variant="body2"
-                    sx={{
-                      fontSize: '0.8rem',
-                      color: 'text.secondary',
-                    }}
-                  >
-                    Log Scale
-                  </Typography>
-                }
-              />
-            )}
-
-            <FormControl size="small">
-              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                <Typography
-                  variant="body2"
-                  sx={{
-                    color: 'text.secondary',
-                    fontSize: '0.8rem',
-                  }}
-                >
-                  Rows:
-                </Typography>
-                <Select
-                  value={rowsPerPage}
-                  onChange={(e) => {
-                    const newRows = e.target.value as number;
-                    setRowsPerPage(newRows);
-                    setPage(0);
-                    syncToUrl({ rows: String(newRows), page: '0' });
-                  }}
-                  sx={{
-                    color: 'text.primary',
-                    backgroundColor: 'background.default',
-                    fontSize: '0.8rem',
-                    height: '36px',
-                    borderRadius: 2,
-                    minWidth: '80px',
-                    '& fieldset': { borderColor: 'border.light' },
-                    '&:hover fieldset': {
-                      borderColor: 'border.medium',
-                    },
-                    '&.Mui-focused fieldset': { borderColor: 'primary.main' },
-                    '& .MuiSelect-select': { py: 0.75 },
-                  }}
-                >
-                  {(viewMode === 'cards'
-                    ? REPOSITORIES_CARD_ROWS
-                    : REPOSITORIES_LIST_ROWS
-                  ).map((n) => (
-                    <MenuItem key={n} value={n}>
-                      {n}
-                    </MenuItem>
-                  ))}
-                </Select>
-              </Box>
-            </FormControl>
-
-            {isMobileSearchVisible ? (
-              searchInput
-            ) : isMobile ? (
-              <IconButton
-                size="small"
-                onClick={() => setIsMobileSearchOpen(true)}
-                sx={{
-                  color: 'text.tertiary',
-                  border: '1px solid',
-                  borderColor: 'border.light',
-                  borderRadius: 2,
-                  width: 36,
-                  height: 36,
-                  '&:hover': {
-                    backgroundColor: 'surface.light',
-                    borderColor: 'border.medium',
-                  },
-                }}
-              >
-                <SearchIcon sx={{ fontSize: '1rem' }} />
-              </IconButton>
-            ) : (
-              searchInput
-            )}
-
-            <Box sx={{ ml: { xs: 0, md: 'auto' } }}>
-              <ViewModeToggle
-                viewMode={viewMode}
-                onChange={handleViewModeChange}
-              />
-            </Box>
-          </Box>
-        </Box>
-
-        {/* Row 2: Sort controls (card view only) */}
-        {viewMode === 'cards' && (
-          <Box
-            sx={{
-              px: 2,
-              pb: 2,
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'flex-end',
-              gap: 1,
+              gap: 2,
+              flexWrap: { xs: 'wrap', sm: 'nowrap' },
             }}
           >
             <Typography
-              variant="body2"
-              sx={{ color: 'text.secondary', fontSize: '0.8rem' }}
+              variant="h6"
+              sx={{ fontSize: '1.25rem', fontWeight: 600, flexShrink: 0 }}
             >
-              Sort:
+              Repositories ({filteredRepositories.length})
             </Typography>
-            <Select
-              size="small"
-              value={sortColumn}
-              onChange={(e) => handleSort(e.target.value as SortColumn)}
+            <Box
+              sx={{ flex: 1, minWidth: 0, width: { xs: '100%', sm: 'auto' } }}
+            >
+              {isMobileSearchVisible ? (
+                searchInput
+              ) : isMobile ? (
+                <IconButton
+                  size="small"
+                  onClick={() => setIsMobileSearchOpen(true)}
+                  sx={{
+                    color: 'text.tertiary',
+                    border: '1px solid',
+                    borderColor: 'border.light',
+                    borderRadius: 2,
+                    width: 36,
+                    height: 36,
+                    '&:hover': {
+                      backgroundColor: 'surface.light',
+                      borderColor: 'border.medium',
+                    },
+                  }}
+                >
+                  <SearchIcon sx={{ fontSize: '1rem' }} />
+                </IconButton>
+              ) : (
+                searchInput
+              )}
+            </Box>
+          </Box>
+
+          {/* Row 2: Filters + Controls */}
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              gap: 1,
+              flexWrap: 'wrap',
+            }}
+          >
+            <Box
               sx={{
-                color: 'text.primary',
-                backgroundColor: 'background.default',
-                fontSize: '0.8rem',
-                height: '36px',
-                borderRadius: 2,
-                minWidth: '140px',
-                '& fieldset': { borderColor: 'border.light' },
-                '&:hover fieldset': { borderColor: 'border.medium' },
-                '&.Mui-focused fieldset': { borderColor: 'primary.main' },
-                '& .MuiSelect-select': { py: 0.75 },
+                display: 'flex',
+                gap: 0.5,
+                alignItems: 'center',
+                flexWrap: 'wrap',
               }}
             >
-              {cardSortSelectOptions.map((opt) => (
-                <MenuItem key={opt.value} value={opt.value}>
-                  {opt.label}
-                </MenuItem>
-              ))}
-            </Select>
-            <Tooltip
-              title={sortDirection === 'asc' ? 'Ascending' : 'Descending'}
-            >
-              <IconButton
-                onClick={() => handleSort(sortColumn)}
-                size="small"
-                aria-label={
-                  sortDirection === 'asc' ? 'Sort descending' : 'Sort ascending'
-                }
-                sx={{
-                  color: 'text.primary',
-                  border: '1px solid',
-                  borderColor: 'border.light',
-                  borderRadius: 2,
-                  padding: '6px',
-                  '&:hover': {
-                    backgroundColor: 'surface.light',
-                    borderColor: 'border.medium',
-                  },
+              <FilterButton
+                label="All"
+                count={rankedRepositories.length}
+                color={STATUS_COLORS.neutral}
+                isActive={statusFilter === 'all'}
+                onClick={() => {
+                  setStatusFilter('all');
+                  setPage(0);
+                  syncToUrl({ status: 'all', page: '0' });
                 }}
-              >
-                {sortDirection === 'asc' ? (
-                  <ArrowUpwardIcon fontSize="small" />
-                ) : (
-                  <ArrowDownwardIcon fontSize="small" />
-                )}
-              </IconButton>
-            </Tooltip>
-          </Box>
-        )}
-      </Box>
+              />
+              <FilterButton
+                label="Active"
+                count={rankedRepositories.filter((r) => !r.inactiveAt).length}
+                color={STATUS_COLORS.success}
+                isActive={statusFilter === 'active'}
+                onClick={() => {
+                  setStatusFilter('active');
+                  setPage(0);
+                  syncToUrl({ status: 'active', page: '0' });
+                }}
+              />
+              <FilterButton
+                label="Inactive"
+                count={rankedRepositories.filter((r) => !!r.inactiveAt).length}
+                color={STATUS_COLORS.closed}
+                isActive={statusFilter === 'inactive'}
+                onClick={() => {
+                  setStatusFilter('inactive');
+                  setPage(0);
+                  syncToUrl({ status: 'inactive', page: '0' });
+                }}
+              />
+            </Box>
 
-      <Collapse in={showChart}>
-        <Box
-          sx={{
-            p: 2,
-            borderBottom: '1px solid',
-            borderColor: 'border.light',
-            height: '500px',
-            backgroundColor: 'surface.subtle',
-          }}
-        >
-          {showChart && filteredRepositories.length > 0 && (
-            <ReactECharts
-              option={getChartOption()}
-              style={{ height: '100%', width: '100%' }}
-            />
-          )}
-        </Box>
-      </Collapse>
-
-      {viewMode === 'cards' && (
-        <Box
-          sx={{
-            p: 2,
-            overflowY: 'auto',
-            ...scrollbarSx,
-          }}
-        >
-          {isLoading ? (
-            <Grid container spacing={2}>
-              {Array.from({ length: rowsPerPage }).map((_, i) => (
-                <Grid item xs={12} sm={6} md={4} lg={4} key={i}>
-                  <Skeleton
-                    variant="rounded"
-                    height={220}
-                    sx={{
-                      bgcolor: (t) => alpha(t.palette.text.primary, 0.06),
-                    }}
-                  />
-                </Grid>
-              ))}
-            </Grid>
-          ) : pagedRepositories.length > 0 ? (
-            <Grid container spacing={2}>
-              {pagedRepositories.map((repo) => (
-                <Grid item xs={12} sm={6} md={4} lg={4} key={repo.repository}>
-                  <RepositoryCard
-                    repo={repo}
-                    maxWeight={maxWeight}
-                    href={getRepositoryHref(repo.repository || '')}
-                    linkState={linkState}
-                  />
-                </Grid>
-              ))}
-            </Grid>
-          ) : trimmedSearch && isDirectRepoInput ? (
             <Box
               sx={{
                 display: 'flex',
                 alignItems: 'center',
-                justifyContent: 'space-between',
-                gap: 2,
-                p: 2,
+                justifyContent: 'flex-end',
+                gap: 1,
+                flexWrap: 'wrap',
               }}
             >
-              <Typography sx={{ color: 'text.secondary' }}>
-                Repository not in tracked list. Open details for{' '}
-                <Typography
-                  component="span"
-                  sx={{ fontFamily: '"JetBrains Mono", monospace' }}
-                >
-                  {trimmedSearch}
-                </Typography>
-                ?
-              </Typography>
-              <Button
-                size="small"
-                variant="outlined"
-                onClick={() =>
-                  navigate(getRepositoryHref(trimmedSearch), {
-                    state: linkState,
-                  })
-                }
-                sx={{ textTransform: 'none' }}
-              >
-                Open repository
-              </Button>
-            </Box>
-          ) : (
-            <Typography
-              sx={{
-                color: 'text.secondary',
-                textAlign: 'center',
-                py: 4,
-              }}
-            >
-              No repositories match the current filters.
-            </Typography>
-          )}
-        </Box>
-      )}
-
-      {viewMode === 'list' && (
-        <Box sx={{ overflowY: 'auto', ...scrollbarSx }}>
-          <DataTable<RepoStats, SortColumn>
-            columns={listColumns}
-            rows={pagedRepositories}
-            isLoading={isLoading}
-            getRowKey={(repo) => repo.repository || ''}
-            getRowHref={(repo) => getRepositoryHref(repo.repository || '')}
-            linkState={linkState}
-            getRowSx={(repo) => ({
-              opacity: repo.inactiveAt ? 0.5 : 1,
-              '&:hover': { backgroundColor: 'border.subtle' },
-              transition: 'all 0.2s',
-              borderBottom: '1px solid',
-              borderColor: 'surface.light',
-            })}
-            minWidth="1280px"
-            stickyHeader
-            emptyState={
-              !filteredRepositories.length &&
-              trimmedSearch &&
-              isDirectRepoInput ? (
-                <Box
+              <Tooltip title={showChart ? 'Hide Chart' : 'Show Chart'}>
+                <IconButton
+                  onClick={() => setShowChart(!showChart)}
+                  size="small"
                   sx={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'space-between',
-                    gap: 2,
-                    px: 2,
-                    py: 2,
-                    borderBottom: '1px solid',
-                    borderColor: 'surface.light',
+                    color: showChart ? 'text.primary' : 'text.tertiary',
+                    border: '1px solid',
+                    borderColor: 'border.light',
+                    borderRadius: 2,
+                    padding: '6px',
+                    '&:hover': {
+                      backgroundColor: 'surface.light',
+                      borderColor: 'border.medium',
+                    },
                   }}
                 >
-                  <Typography sx={{ color: 'text.secondary' }}>
-                    Repository not in tracked list. Open details for{' '}
-                    <Typography component="span">{trimmedSearch}</Typography>?
-                  </Typography>
-                  <Button
-                    size="small"
-                    variant="outlined"
-                    onClick={() =>
-                      navigate(getRepositoryHref(trimmedSearch), {
-                        state: linkState,
-                      })
-                    }
-                    sx={{ textTransform: 'none' }}
+                  {showChart ? (
+                    <TableChartIcon fontSize="small" />
+                  ) : (
+                    <BarChartIcon fontSize="small" />
+                  )}
+                </IconButton>
+              </Tooltip>
+
+              {showChart && (
+                <FormControlLabel
+                  control={
+                    <Switch
+                      checked={useLogScale}
+                      onChange={(e) => setUseLogScale(e.target.checked)}
+                      size="small"
+                      sx={{
+                        '& .MuiSwitch-switchBase.Mui-checked': {
+                          color: 'primary.main',
+                        },
+                        '& .MuiSwitch-track': {
+                          backgroundColor: 'border.medium',
+                        },
+                      }}
+                    />
+                  }
+                  label={
+                    <Typography
+                      variant="body2"
+                      sx={{
+                        fontSize: '0.8rem',
+                        color: 'text.secondary',
+                      }}
+                    >
+                      Log Scale
+                    </Typography>
+                  }
+                />
+              )}
+
+              <FormControl size="small">
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                  <Typography
+                    variant="body2"
+                    sx={{
+                      color: 'text.secondary',
+                      fontSize: '0.8rem',
+                    }}
                   >
-                    Open repository
-                  </Button>
+                    Rows:
+                  </Typography>
+                  <Select
+                    value={rowsPerPage}
+                    onChange={(e) => {
+                      const newRows = e.target.value as number;
+                      setRowsPerPage(newRows);
+                      setPage(0);
+                      syncToUrl({ rows: String(newRows), page: '0' });
+                    }}
+                    sx={{
+                      color: 'text.primary',
+                      backgroundColor: 'background.default',
+                      fontSize: '0.8rem',
+                      height: '36px',
+                      borderRadius: 2,
+                      minWidth: '80px',
+                      '& fieldset': { borderColor: 'border.light' },
+                      '&:hover fieldset': {
+                        borderColor: 'border.medium',
+                      },
+                      '&.Mui-focused fieldset': { borderColor: 'primary.main' },
+                      '& .MuiSelect-select': { py: 0.75 },
+                    }}
+                  >
+                    {(viewMode === 'cards'
+                      ? REPOSITORIES_CARD_ROWS
+                      : REPOSITORIES_LIST_ROWS
+                    ).map((n) => (
+                      <MenuItem key={n} value={n}>
+                        {n}
+                      </MenuItem>
+                    ))}
+                  </Select>
                 </Box>
-              ) : undefined
-            }
-          />
+              </FormControl>
+
+              <Box sx={{ ml: { xs: 0, md: 'auto' } }}>
+                <ViewModeToggle
+                  viewMode={viewMode}
+                  onChange={handleViewModeChange}
+                />
+              </Box>
+            </Box>
+          </Box>
+
+          {/* Row 3: Sort controls (card view only) */}
+          {viewMode === 'cards' && (
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'flex-end',
+                gap: 1,
+                flexWrap: 'wrap',
+              }}
+            >
+              <Typography
+                variant="body2"
+                sx={{ color: 'text.secondary', fontSize: '0.8rem' }}
+              >
+                Sort:
+              </Typography>
+              <Select
+                size="small"
+                value={sortColumn}
+                onChange={(e) => handleSort(e.target.value as SortColumn)}
+                sx={{
+                  color: 'text.primary',
+                  backgroundColor: 'background.default',
+                  fontSize: '0.8rem',
+                  height: '36px',
+                  borderRadius: 2,
+                  minWidth: '140px',
+                  '& fieldset': { borderColor: 'border.light' },
+                  '&:hover fieldset': { borderColor: 'border.medium' },
+                  '&.Mui-focused fieldset': { borderColor: 'primary.main' },
+                  '& .MuiSelect-select': { py: 0.75 },
+                }}
+              >
+                {cardSortSelectOptions.map((opt) => (
+                  <MenuItem key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </MenuItem>
+                ))}
+              </Select>
+              <Tooltip
+                title={sortDirection === 'asc' ? 'Ascending' : 'Descending'}
+              >
+                <IconButton
+                  onClick={() => handleSort(sortColumn)}
+                  size="small"
+                  aria-label={
+                    sortDirection === 'asc'
+                      ? 'Sort descending'
+                      : 'Sort ascending'
+                  }
+                  sx={{
+                    color: 'text.primary',
+                    border: '1px solid',
+                    borderColor: 'border.light',
+                    borderRadius: 2,
+                    padding: '6px',
+                    '&:hover': {
+                      backgroundColor: 'surface.light',
+                      borderColor: 'border.medium',
+                    },
+                  }}
+                >
+                  {sortDirection === 'asc' ? (
+                    <ArrowUpwardIcon fontSize="small" />
+                  ) : (
+                    <ArrowDownwardIcon fontSize="small" />
+                  )}
+                </IconButton>
+              </Tooltip>
+            </Box>
+          )}
         </Box>
-      )}
-      <TablePagination
-        rowsPerPageOptions={[]}
-        component="div"
-        count={filteredRepositories.length}
-        rowsPerPage={rowsPerPage}
-        page={page}
-        onPageChange={handleChangePage}
-        onRowsPerPageChange={handleChangeRowsPerPage}
-        showFirstButton
-        showLastButton
+      </SectionCard>
+
+      {/* Table Card */}
+      <Card
         sx={{
-          borderTop: '1px solid',
+          borderRadius: 3,
+          border: '1px solid',
           borderColor: 'border.light',
-          color: 'text.secondary',
-          '.MuiTablePagination-displayedRows': {},
+          backgroundColor: 'transparent',
+          overflow: 'hidden',
+          display: 'flex',
+          flexDirection: 'column',
         }}
-      />
-    </Card>
+        elevation={0}
+      >
+        <Collapse in={showChart}>
+          <Box
+            sx={{
+              p: 2,
+              borderBottom: '1px solid',
+              borderColor: 'border.light',
+              height: '500px',
+              backgroundColor: 'surface.subtle',
+            }}
+          >
+            {showChart && filteredRepositories.length > 0 && (
+              <ReactECharts
+                option={getChartOption()}
+                style={{ height: '100%', width: '100%' }}
+              />
+            )}
+          </Box>
+        </Collapse>
+
+        {viewMode === 'cards' && (
+          <Box
+            sx={{
+              p: 2,
+              overflowY: 'auto',
+              ...scrollbarSx,
+            }}
+          >
+            {isLoading ? (
+              <Grid container spacing={2}>
+                {Array.from({ length: rowsPerPage }).map((_, i) => (
+                  <Grid item xs={12} sm={6} md={4} lg={4} key={i}>
+                    <Skeleton
+                      variant="rounded"
+                      height={220}
+                      sx={{
+                        bgcolor: (t) => alpha(t.palette.text.primary, 0.06),
+                      }}
+                    />
+                  </Grid>
+                ))}
+              </Grid>
+            ) : pagedRepositories.length > 0 ? (
+              <Grid container spacing={2}>
+                {pagedRepositories.map((repo) => (
+                  <Grid item xs={12} sm={6} md={4} lg={4} key={repo.repository}>
+                    <RepositoryCard
+                      repo={repo}
+                      maxWeight={maxWeight}
+                      href={getRepositoryHref(repo.repository || '')}
+                      linkState={linkState}
+                    />
+                  </Grid>
+                ))}
+              </Grid>
+            ) : trimmedSearch && isDirectRepoInput ? (
+              <Box
+                sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'space-between',
+                  gap: 2,
+                  p: 2,
+                }}
+              >
+                <Typography sx={{ color: 'text.secondary' }}>
+                  Repository not in tracked list. Open details for{' '}
+                  <Typography
+                    component="span"
+                    sx={{ fontFamily: '"JetBrains Mono", monospace' }}
+                  >
+                    {trimmedSearch}
+                  </Typography>
+                  ?
+                </Typography>
+                <Button
+                  size="small"
+                  variant="outlined"
+                  onClick={() =>
+                    navigate(getRepositoryHref(trimmedSearch), {
+                      state: linkState,
+                    })
+                  }
+                  sx={{ textTransform: 'none' }}
+                >
+                  Open repository
+                </Button>
+              </Box>
+            ) : (
+              <Typography
+                sx={{
+                  color: 'text.secondary',
+                  textAlign: 'center',
+                  py: 4,
+                }}
+              >
+                No repositories match the current filters.
+              </Typography>
+            )}
+          </Box>
+        )}
+
+        {viewMode === 'list' && (
+          <Box sx={{ overflowY: 'auto', ...scrollbarSx }}>
+            <DataTable<RepoStats, SortColumn>
+              columns={listColumns}
+              rows={pagedRepositories}
+              isLoading={isLoading}
+              getRowKey={(repo) => repo.repository || ''}
+              getRowHref={(repo) => getRepositoryHref(repo.repository || '')}
+              linkState={linkState}
+              getRowSx={(repo) => ({
+                opacity: repo.inactiveAt ? 0.5 : 1,
+                '&:hover': { backgroundColor: 'border.subtle' },
+                transition: 'all 0.2s',
+                borderBottom: '1px solid',
+                borderColor: 'surface.light',
+              })}
+              minWidth="1280px"
+              stickyHeader
+              emptyState={
+                !filteredRepositories.length &&
+                trimmedSearch &&
+                isDirectRepoInput ? (
+                  <Box
+                    sx={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'space-between',
+                      gap: 2,
+                      px: 2,
+                      py: 2,
+                      borderBottom: '1px solid',
+                      borderColor: 'surface.light',
+                    }}
+                  >
+                    <Typography sx={{ color: 'text.secondary' }}>
+                      Repository not in tracked list. Open details for{' '}
+                      <Typography component="span">{trimmedSearch}</Typography>?
+                    </Typography>
+                    <Button
+                      size="small"
+                      variant="outlined"
+                      onClick={() =>
+                        navigate(getRepositoryHref(trimmedSearch), {
+                          state: linkState,
+                        })
+                      }
+                      sx={{ textTransform: 'none' }}
+                    >
+                      Open repository
+                    </Button>
+                  </Box>
+                ) : undefined
+              }
+            />
+          </Box>
+        )}
+
+        <TablePagination
+          rowsPerPageOptions={[]}
+          component="div"
+          count={filteredRepositories.length}
+          rowsPerPage={rowsPerPage}
+          page={page}
+          onPageChange={handleChangePage}
+          onRowsPerPageChange={handleChangeRowsPerPage}
+          showFirstButton
+          showLastButton
+          sx={{
+            borderTop: '1px solid',
+            borderColor: 'border.light',
+            color: 'text.secondary',
+            '.MuiTablePagination-displayedRows': {},
+          }}
+        />
+      </Card>
+    </Box>
   );
 };
 

--- a/src/pages/RepositoriesPage.tsx
+++ b/src/pages/RepositoriesPage.tsx
@@ -340,286 +340,309 @@ const RepositoriesPage: React.FC = () => {
       <Box
         sx={{
           width: '100%',
-          maxWidth: 1200,
+          maxWidth: 1560,
           mx: 'auto',
           py: { xs: 2, sm: 3 },
           px: { xs: 2, sm: 3 },
         }}
       >
-        {/* ── Highlight Sections ─────────────────────────────────────── */}
         <Box
           sx={{
             display: 'grid',
-            gridTemplateColumns: { xs: '1fr', lg: '1fr 1fr 1fr' },
-            gap: 2,
-            mb: 3,
-            alignItems: 'stretch',
+            gridTemplateColumns: { xs: '1fr', lg: 'minmax(0, 1fr) 1px 360px' },
+            gap: { xs: 3, lg: 3 },
+            alignItems: 'start',
           }}
         >
-          {/* Trending This Week */}
-          <Card sx={cardSx}>
-            {isLoading || trendingRepos.length > 0 ? (
-              <>
-                <SectionHeader>Trending This Week</SectionHeader>
-                <Box sx={{ display: 'flex', flexDirection: 'column' }}>
-                  {trendingRepos.length === 0 && !isLoading ? (
-                    <Typography
-                      sx={(theme) => ({
-                        color: alpha(theme.palette.text.primary, 0.3),
-                        fontSize: '0.8rem',
-                        fontStyle: 'italic',
-                        p: 1,
-                      })}
-                    >
-                      No data available
-                    </Typography>
-                  ) : (
-                    trendingRepos.map((repo) => (
-                      <HighlightRow
-                        key={repo.name}
-                        href={getRepoHref(repo.name)}
-                        linkState={REPO_LINK_STATE}
-                        avatar={`https://avatars.githubusercontent.com/${repo.name.split('/')[0]}`}
-                        avatarBg={getAvatarBg(repo.name)}
-                        label={
-                          <Tooltip title={repo.name} arrow placement="top">
-                            <Typography
-                              sx={{
-                                fontFamily: FONTS.mono,
-                                fontSize: '0.82rem',
-                                color: 'text.primary',
-                                overflow: 'hidden',
-                                textOverflow: 'ellipsis',
-                                whiteSpace: 'nowrap',
-                              }}
-                            >
-                              {repo.name}
-                            </Typography>
-                          </Tooltip>
-                        }
-                        right={
-                          <Typography
-                            sx={(theme) => ({
-                              fontFamily: FONTS.mono,
-                              fontSize: '0.75rem',
-                              fontWeight: 600,
-                              color: theme.palette.status.success,
-                              flexShrink: 0,
-                              backgroundColor: alpha(
-                                theme.palette.status.success,
-                                0.1,
-                              ),
-                              px: 0.75,
-                              py: 0.25,
-                              borderRadius: '4px',
-                            })}
-                          >
-                            +{repo.pctIncrease.toFixed(0)}%
-                          </Typography>
-                        }
-                      />
-                    ))
-                  )}
-                </Box>
-              </>
-            ) : null}
+          {/* ── Main Table ────────────────────────────────────────────── */}
+          <Card
+            sx={(theme) => ({
+              borderRadius: 3,
+              border: '1px solid',
+              borderColor: theme.palette.border.light,
+              backgroundColor: theme.palette.surface.transparent,
+              overflow: 'hidden',
+              width: '100%',
+            })}
+            elevation={0}
+          >
+            <TopRepositoriesTable
+              repositories={repoStats}
+              isLoading={isLoading}
+              getRepositoryHref={getRepoHref}
+              linkState={REPO_LINK_STATE}
+            />
           </Card>
 
-          {/* Most Collateral Staked */}
-          <Card sx={cardSx}>
-            {isLoading || topCollateralRepos.length > 0 ? (
-              <>
-                <SectionHeader>Most Collateral Staked</SectionHeader>
-                <Box sx={{ display: 'flex', flexDirection: 'column' }}>
-                  {topCollateralRepos.length === 0 && !isLoading ? (
-                    <Typography
-                      sx={(theme) => ({
-                        color: alpha(theme.palette.text.primary, 0.3),
-                        fontSize: '0.8rem',
-                        fontStyle: 'italic',
-                        p: 1,
-                      })}
-                    >
-                      No collateral data available
-                    </Typography>
-                  ) : (
-                    topCollateralRepos.map((repo) => (
-                      <HighlightRow
-                        key={repo.name}
-                        href={getRepoHref(repo.name)}
-                        linkState={REPO_LINK_STATE}
-                        avatar={`https://avatars.githubusercontent.com/${repo.name.split('/')[0]}`}
-                        avatarBg={getAvatarBg(repo.name)}
-                        label={
-                          <Tooltip title={repo.name} arrow placement="top">
-                            <Typography
-                              sx={{
-                                fontFamily: FONTS.mono,
-                                fontSize: '0.82rem',
-                                color: 'text.primary',
-                                overflow: 'hidden',
-                                textOverflow: 'ellipsis',
-                                whiteSpace: 'nowrap',
-                              }}
-                            >
-                              {repo.name}
-                            </Typography>
-                          </Tooltip>
-                        }
-                        right={
-                          <Typography
-                            sx={{
-                              fontFamily: FONTS.mono,
-                              fontSize: '0.72rem',
-                              color: 'text.secondary',
-                              flexShrink: 0,
-                              whiteSpace: 'nowrap',
-                            }}
-                          >
-                            {repo.collateral.toFixed(1)} ({repo.openPRs} PR
-                            {repo.openPRs !== 1 ? 's' : ''})
-                          </Typography>
-                        }
-                      />
-                    ))
-                  )}
-                </Box>
-              </>
-            ) : null}
-          </Card>
+          {/* Divider (desktop only) */}
+          <Box
+            aria-hidden="true"
+            sx={(theme) => ({
+              display: { xs: 'none', lg: 'block' },
+              alignSelf: 'stretch',
+              backgroundColor: theme.palette.border.subtle,
+              borderRadius: 999,
+              opacity: 0.9,
+            })}
+          />
 
-          {/* Recent PRs */}
-          <Card sx={cardSx}>
-            {isLoading || recentPrs.length > 0 ? (
-              <>
-                <SectionHeader>Recent Pull Requests</SectionHeader>
-                <Box sx={{ display: 'flex', flexDirection: 'column' }}>
-                  {recentPrs.length === 0 && !isLoading ? (
-                    <Typography
-                      sx={(theme) => ({
-                        color: alpha(theme.palette.text.primary, 0.3),
-                        fontSize: '0.8rem',
-                        fontStyle: 'italic',
-                        p: 1,
-                      })}
-                    >
-                      No data available
-                    </Typography>
-                  ) : (
-                    recentPrs.map((pr) => (
-                      <HighlightRow
-                        key={`${pr.name}-${pr.number}`}
-                        href={getPrHref(pr.name, pr.number)}
-                        linkState={REPO_LINK_STATE}
-                        avatar={`https://avatars.githubusercontent.com/${pr.name.split('/')[0]}`}
-                        avatarBg={getAvatarBg(pr.name)}
-                        label={
-                          <Box
-                            sx={{
-                              minWidth: 0,
-                              display: 'flex',
-                              flexDirection: 'column',
-                              justifyContent: 'center',
-                            }}
-                          >
-                            <Tooltip title={pr.name} arrow placement="top">
+          {/* ── Sidebar highlight cards ───────────────────────────────── */}
+          <Box
+            sx={{
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 2,
+              width: '100%',
+              position: { xs: 'static', lg: 'sticky' },
+              top: { lg: 88 },
+            }}
+          >
+            {/* Trending This Week */}
+            <Card sx={cardSx}>
+              {isLoading || trendingRepos.length > 0 ? (
+                <>
+                  <SectionHeader>Trending This Week</SectionHeader>
+                  <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+                    {trendingRepos.length === 0 && !isLoading ? (
+                      <Typography
+                        sx={(theme) => ({
+                          color: alpha(theme.palette.text.primary, 0.3),
+                          fontSize: '0.8rem',
+                          fontStyle: 'italic',
+                          p: 1,
+                        })}
+                      >
+                        No data available
+                      </Typography>
+                    ) : (
+                      trendingRepos.map((repo) => (
+                        <HighlightRow
+                          key={repo.name}
+                          href={getRepoHref(repo.name)}
+                          linkState={REPO_LINK_STATE}
+                          avatar={`https://avatars.githubusercontent.com/${repo.name.split('/')[0]}`}
+                          avatarBg={getAvatarBg(repo.name)}
+                          label={
+                            <Tooltip title={repo.name} arrow placement="top">
                               <Typography
                                 sx={{
                                   fontFamily: FONTS.mono,
-                                  fontSize: '0.68rem',
-                                  color: 'text.tertiary',
-                                  overflow: 'hidden',
-                                  textOverflow: 'ellipsis',
-                                  whiteSpace: 'nowrap',
-                                  lineHeight: 1.2,
-                                }}
-                              >
-                                {pr.name}
-                              </Typography>
-                            </Tooltip>
-                            <Tooltip title={pr.title} arrow placement="top">
-                              <Typography
-                                sx={{
-                                  fontFamily: FONTS.mono,
-                                  fontSize: '0.78rem',
+                                  fontSize: '0.82rem',
                                   color: 'text.primary',
                                   overflow: 'hidden',
                                   textOverflow: 'ellipsis',
                                   whiteSpace: 'nowrap',
-                                  lineHeight: 1.3,
                                 }}
                               >
-                                {pr.title}
+                                {repo.name}
                               </Typography>
                             </Tooltip>
-                          </Box>
-                        }
-                        right={
-                          <Typography
-                            sx={(theme) => ({
-                              fontFamily: FONTS.mono,
-                              fontSize: '0.68rem',
-                              color: alpha(theme.palette.text.primary, 0.35),
-                              flexShrink: 0,
-                              whiteSpace: 'nowrap',
-                              ml: 1,
-                            })}
-                          >
-                            {formatRelativeTime(pr.createdAt)}
-                          </Typography>
-                        }
-                      />
-                    ))
-                  )}
-                </Box>
-              </>
-            ) : null}
-            {!isLoading && recentPrs.length === 0 ? (
-              <>
-                <SectionHeader>Recent Pull Requests</SectionHeader>
-                <Box
-                  sx={{
-                    flex: 1,
-                    minHeight: ROW_HEIGHT * 5,
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                  }}
-                >
-                  <Typography
-                    sx={(theme) => ({
-                      color: alpha(theme.palette.text.primary, 0.3),
-                      fontSize: '0.8rem',
-                      p: 1,
-                      textAlign: 'center',
-                    })}
-                  >
-                    No merged PRs today
-                  </Typography>
-                </Box>
-              </>
-            ) : null}
-          </Card>
-        </Box>
+                          }
+                          right={
+                            <Typography
+                              sx={(theme) => ({
+                                fontFamily: FONTS.mono,
+                                fontSize: '0.75rem',
+                                fontWeight: 600,
+                                color: theme.palette.status.success,
+                                flexShrink: 0,
+                                backgroundColor: alpha(
+                                  theme.palette.status.success,
+                                  0.1,
+                                ),
+                                px: 0.75,
+                                py: 0.25,
+                                borderRadius: '4px',
+                              })}
+                            >
+                              +{repo.pctIncrease.toFixed(0)}%
+                            </Typography>
+                          }
+                        />
+                      ))
+                    )}
+                  </Box>
+                </>
+              ) : null}
+            </Card>
 
-        {/* ── Main Table ────────────────────────────────────────────── */}
-        <Card
-          sx={(theme) => ({
-            borderRadius: 3,
-            border: '1px solid',
-            borderColor: theme.palette.border.light,
-            backgroundColor: theme.palette.surface.transparent,
-            overflow: 'hidden',
-          })}
-          elevation={0}
-        >
-          <TopRepositoriesTable
-            repositories={repoStats}
-            isLoading={isLoading}
-            getRepositoryHref={getRepoHref}
-            linkState={REPO_LINK_STATE}
-          />
-        </Card>
+            {/* Most Collateral Staked */}
+            <Card sx={cardSx}>
+              {isLoading || topCollateralRepos.length > 0 ? (
+                <>
+                  <SectionHeader>Most Collateral Staked</SectionHeader>
+                  <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+                    {topCollateralRepos.length === 0 && !isLoading ? (
+                      <Typography
+                        sx={(theme) => ({
+                          color: alpha(theme.palette.text.primary, 0.3),
+                          fontSize: '0.8rem',
+                          fontStyle: 'italic',
+                          p: 1,
+                        })}
+                      >
+                        No collateral data available
+                      </Typography>
+                    ) : (
+                      topCollateralRepos.map((repo) => (
+                        <HighlightRow
+                          key={repo.name}
+                          href={getRepoHref(repo.name)}
+                          linkState={REPO_LINK_STATE}
+                          avatar={`https://avatars.githubusercontent.com/${repo.name.split('/')[0]}`}
+                          avatarBg={getAvatarBg(repo.name)}
+                          label={
+                            <Tooltip title={repo.name} arrow placement="top">
+                              <Typography
+                                sx={{
+                                  fontFamily: FONTS.mono,
+                                  fontSize: '0.82rem',
+                                  color: 'text.primary',
+                                  overflow: 'hidden',
+                                  textOverflow: 'ellipsis',
+                                  whiteSpace: 'nowrap',
+                                }}
+                              >
+                                {repo.name}
+                              </Typography>
+                            </Tooltip>
+                          }
+                          right={
+                            <Typography
+                              sx={{
+                                fontFamily: FONTS.mono,
+                                fontSize: '0.72rem',
+                                color: 'text.secondary',
+                                flexShrink: 0,
+                                whiteSpace: 'nowrap',
+                              }}
+                            >
+                              {repo.collateral.toFixed(1)} ({repo.openPRs} PR
+                              {repo.openPRs !== 1 ? 's' : ''})
+                            </Typography>
+                          }
+                        />
+                      ))
+                    )}
+                  </Box>
+                </>
+              ) : null}
+            </Card>
+
+            {/* Recent PRs */}
+            <Card sx={cardSx}>
+              {isLoading || recentPrs.length > 0 ? (
+                <>
+                  <SectionHeader>Recent Pull Requests</SectionHeader>
+                  <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+                    {recentPrs.length === 0 && !isLoading ? (
+                      <Typography
+                        sx={(theme) => ({
+                          color: alpha(theme.palette.text.primary, 0.3),
+                          fontSize: '0.8rem',
+                          fontStyle: 'italic',
+                          p: 1,
+                        })}
+                      >
+                        No data available
+                      </Typography>
+                    ) : (
+                      recentPrs.map((pr) => (
+                        <HighlightRow
+                          key={`${pr.name}-${pr.number}`}
+                          href={getPrHref(pr.name, pr.number)}
+                          linkState={REPO_LINK_STATE}
+                          avatar={`https://avatars.githubusercontent.com/${pr.name.split('/')[0]}`}
+                          avatarBg={getAvatarBg(pr.name)}
+                          label={
+                            <Box
+                              sx={{
+                                minWidth: 0,
+                                display: 'flex',
+                                flexDirection: 'column',
+                                justifyContent: 'center',
+                              }}
+                            >
+                              <Tooltip title={pr.name} arrow placement="top">
+                                <Typography
+                                  sx={{
+                                    fontFamily: FONTS.mono,
+                                    fontSize: '0.68rem',
+                                    color: 'text.tertiary',
+                                    overflow: 'hidden',
+                                    textOverflow: 'ellipsis',
+                                    whiteSpace: 'nowrap',
+                                    lineHeight: 1.2,
+                                  }}
+                                >
+                                  {pr.name}
+                                </Typography>
+                              </Tooltip>
+                              <Tooltip title={pr.title} arrow placement="top">
+                                <Typography
+                                  sx={{
+                                    fontFamily: FONTS.mono,
+                                    fontSize: '0.78rem',
+                                    color: 'text.primary',
+                                    overflow: 'hidden',
+                                    textOverflow: 'ellipsis',
+                                    whiteSpace: 'nowrap',
+                                    lineHeight: 1.3,
+                                  }}
+                                >
+                                  {pr.title}
+                                </Typography>
+                              </Tooltip>
+                            </Box>
+                          }
+                          right={
+                            <Typography
+                              sx={(theme) => ({
+                                fontFamily: FONTS.mono,
+                                fontSize: '0.68rem',
+                                color: alpha(theme.palette.text.primary, 0.35),
+                                flexShrink: 0,
+                                whiteSpace: 'nowrap',
+                                ml: 1,
+                              })}
+                            >
+                              {formatRelativeTime(pr.createdAt)}
+                            </Typography>
+                          }
+                        />
+                      ))
+                    )}
+                  </Box>
+                </>
+              ) : null}
+              {!isLoading && recentPrs.length === 0 ? (
+                <>
+                  <SectionHeader>Recent Pull Requests</SectionHeader>
+                  <Box
+                    sx={{
+                      flex: 1,
+                      minHeight: ROW_HEIGHT * 5,
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                    }}
+                  >
+                    <Typography
+                      sx={(theme) => ({
+                        color: alpha(theme.palette.text.primary, 0.3),
+                        fontSize: '0.8rem',
+                        p: 1,
+                        textAlign: 'center',
+                      })}
+                    >
+                      No merged PRs today
+                    </Typography>
+                  </Box>
+                </>
+              ) : null}
+            </Card>
+          </Box>
+        </Box>
       </Box>
     </Page>
   );

--- a/src/pages/RepositoriesPage.tsx
+++ b/src/pages/RepositoriesPage.tsx
@@ -1,6 +1,13 @@
 import React, { useMemo } from 'react';
 
-import { Avatar, Box, Card, Tooltip, Typography } from '@mui/material';
+import {
+  Avatar,
+  Box,
+  Card,
+  Tooltip,
+  Typography,
+  useMediaQuery,
+} from '@mui/material';
 import { alpha, type Theme } from '@mui/material/styles';
 
 import { LinkBox } from '../components/common/linkBehavior';
@@ -10,6 +17,7 @@ import { useAllPrs, useAllMiners, useReposAndWeights } from '../api';
 import { type CommitLog } from '../api/models/Dashboard';
 import { buildRepoDiscoveryRollupFromMiners } from '../utils/ExplorerUtils';
 import { isMergedPr } from '../utils/prStatus';
+import theme, { scrollbarSx } from '../theme';
 
 const FONTS = { mono: '"JetBrains Mono", monospace' } as const;
 
@@ -122,6 +130,16 @@ const getPrHref = (name: string, number: number) =>
   `/miners/pr?repo=${encodeURIComponent(name)}&number=${number}`;
 
 const RepositoriesPage: React.FC = () => {
+  // Dashboard-like responsive logic (aligns with OSS contributions page layout)
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+  const isTablet = useMediaQuery(theme.breakpoints.between('sm', 'md'));
+  const isLargeScreen = useMediaQuery(theme.breakpoints.up('xl'));
+  const showSidebarRight = useMediaQuery(theme.breakpoints.up('xl'));
+
+  // Dynamic sidebar width based on screen size (matching TopMinersPage)
+  const sidebarWidth =
+    isMobile || isTablet ? '100%' : isLargeScreen ? '360px' : '340px';
+
   const formatRelativeTime = (date: Date) => {
     const now = new Date();
     if (date > now) return 'just now';
@@ -340,308 +358,296 @@ const RepositoriesPage: React.FC = () => {
       <Box
         sx={{
           width: '100%',
-          maxWidth: 1560,
-          mx: 'auto',
-          py: { xs: 2, sm: 3 },
-          px: { xs: 2, sm: 3 },
+          height: showSidebarRight ? 'calc(100vh - 64px)' : 'auto',
+          display: 'flex',
+          flexDirection: showSidebarRight ? 'row' : 'column',
+          gap: { xs: 2, sm: 2, md: 2.5, lg: 3 },
+          py: { xs: 2, sm: 2, md: 2.5, lg: 3 },
+          px: { xs: 2, sm: 2, md: 2.5, lg: 3 },
+          overflow: 'hidden',
         }}
       >
+        {/* Main Content Area */}
         <Box
           sx={{
-            display: 'grid',
-            gridTemplateColumns: { xs: '1fr', lg: 'minmax(0, 1fr) 1px 360px' },
-            gap: { xs: 3, lg: 3 },
-            alignItems: 'start',
+            flex: 1,
+            display: 'flex',
+            flexDirection: 'column',
+            gap: { xs: 2, sm: 1.5 },
+            minHeight: 0,
+            overflow: showSidebarRight ? 'auto' : 'visible',
+            minWidth: 0,
+            pr: showSidebarRight ? 1 : 0,
+            ...scrollbarSx,
           }}
         >
-          {/* ── Main Table ────────────────────────────────────────────── */}
-          <Card
-            sx={(theme) => ({
-              borderRadius: 3,
-              border: '1px solid',
-              borderColor: theme.palette.border.light,
-              backgroundColor: theme.palette.surface.transparent,
-              overflow: 'hidden',
-              width: '100%',
-            })}
-            elevation={0}
-          >
+          <Box sx={{ width: '100%' }}>
             <TopRepositoriesTable
               repositories={repoStats}
               isLoading={isLoading}
               getRepositoryHref={getRepoHref}
               linkState={REPO_LINK_STATE}
             />
-          </Card>
+          </Box>
+        </Box>
 
-          {/* Divider (desktop only) */}
-          <Box
-            aria-hidden="true"
-            sx={(theme) => ({
-              display: { xs: 'none', lg: 'block' },
-              alignSelf: 'stretch',
-              backgroundColor: theme.palette.border.subtle,
-              borderRadius: 999,
-              opacity: 0.9,
-            })}
-          />
-
-          {/* ── Sidebar highlight cards ───────────────────────────────── */}
-          <Box
-            sx={{
-              display: 'flex',
-              flexDirection: 'column',
-              gap: 2,
-              width: '100%',
-              position: { xs: 'static', lg: 'sticky' },
-              top: { lg: 88 },
-            }}
-          >
-            {/* Trending This Week */}
-            <Card sx={cardSx}>
-              {isLoading || trendingRepos.length > 0 ? (
-                <>
-                  <SectionHeader>Trending This Week</SectionHeader>
-                  <Box sx={{ display: 'flex', flexDirection: 'column' }}>
-                    {trendingRepos.length === 0 && !isLoading ? (
-                      <Typography
-                        sx={(theme) => ({
-                          color: alpha(theme.palette.text.primary, 0.3),
-                          fontSize: '0.8rem',
-                          fontStyle: 'italic',
-                          p: 1,
-                        })}
-                      >
-                        No data available
-                      </Typography>
-                    ) : (
-                      trendingRepos.map((repo) => (
-                        <HighlightRow
-                          key={repo.name}
-                          href={getRepoHref(repo.name)}
-                          linkState={REPO_LINK_STATE}
-                          avatar={`https://avatars.githubusercontent.com/${repo.name.split('/')[0]}`}
-                          avatarBg={getAvatarBg(repo.name)}
-                          label={
-                            <Tooltip title={repo.name} arrow placement="top">
-                              <Typography
-                                sx={{
-                                  fontFamily: FONTS.mono,
-                                  fontSize: '0.82rem',
-                                  color: 'text.primary',
-                                  overflow: 'hidden',
-                                  textOverflow: 'ellipsis',
-                                  whiteSpace: 'nowrap',
-                                }}
-                              >
-                                {repo.name}
-                              </Typography>
-                            </Tooltip>
-                          }
-                          right={
-                            <Typography
-                              sx={(theme) => ({
-                                fontFamily: FONTS.mono,
-                                fontSize: '0.75rem',
-                                fontWeight: 600,
-                                color: theme.palette.status.success,
-                                flexShrink: 0,
-                                backgroundColor: alpha(
-                                  theme.palette.status.success,
-                                  0.1,
-                                ),
-                                px: 0.75,
-                                py: 0.25,
-                                borderRadius: '4px',
-                              })}
-                            >
-                              +{repo.pctIncrease.toFixed(0)}%
-                            </Typography>
-                          }
-                        />
-                      ))
-                    )}
-                  </Box>
-                </>
-              ) : null}
-            </Card>
-
-            {/* Most Collateral Staked */}
-            <Card sx={cardSx}>
-              {isLoading || topCollateralRepos.length > 0 ? (
-                <>
-                  <SectionHeader>Most Collateral Staked</SectionHeader>
-                  <Box sx={{ display: 'flex', flexDirection: 'column' }}>
-                    {topCollateralRepos.length === 0 && !isLoading ? (
-                      <Typography
-                        sx={(theme) => ({
-                          color: alpha(theme.palette.text.primary, 0.3),
-                          fontSize: '0.8rem',
-                          fontStyle: 'italic',
-                          p: 1,
-                        })}
-                      >
-                        No collateral data available
-                      </Typography>
-                    ) : (
-                      topCollateralRepos.map((repo) => (
-                        <HighlightRow
-                          key={repo.name}
-                          href={getRepoHref(repo.name)}
-                          linkState={REPO_LINK_STATE}
-                          avatar={`https://avatars.githubusercontent.com/${repo.name.split('/')[0]}`}
-                          avatarBg={getAvatarBg(repo.name)}
-                          label={
-                            <Tooltip title={repo.name} arrow placement="top">
-                              <Typography
-                                sx={{
-                                  fontFamily: FONTS.mono,
-                                  fontSize: '0.82rem',
-                                  color: 'text.primary',
-                                  overflow: 'hidden',
-                                  textOverflow: 'ellipsis',
-                                  whiteSpace: 'nowrap',
-                                }}
-                              >
-                                {repo.name}
-                              </Typography>
-                            </Tooltip>
-                          }
-                          right={
-                            <Typography
-                              sx={{
-                                fontFamily: FONTS.mono,
-                                fontSize: '0.72rem',
-                                color: 'text.secondary',
-                                flexShrink: 0,
-                                whiteSpace: 'nowrap',
-                              }}
-                            >
-                              {repo.collateral.toFixed(1)} ({repo.openPRs} PR
-                              {repo.openPRs !== 1 ? 's' : ''})
-                            </Typography>
-                          }
-                        />
-                      ))
-                    )}
-                  </Box>
-                </>
-              ) : null}
-            </Card>
-
-            {/* Recent PRs */}
-            <Card sx={cardSx}>
-              {isLoading || recentPrs.length > 0 ? (
-                <>
-                  <SectionHeader>Recent Pull Requests</SectionHeader>
-                  <Box sx={{ display: 'flex', flexDirection: 'column' }}>
-                    {recentPrs.length === 0 && !isLoading ? (
-                      <Typography
-                        sx={(theme) => ({
-                          color: alpha(theme.palette.text.primary, 0.3),
-                          fontSize: '0.8rem',
-                          fontStyle: 'italic',
-                          p: 1,
-                        })}
-                      >
-                        No data available
-                      </Typography>
-                    ) : (
-                      recentPrs.map((pr) => (
-                        <HighlightRow
-                          key={`${pr.name}-${pr.number}`}
-                          href={getPrHref(pr.name, pr.number)}
-                          linkState={REPO_LINK_STATE}
-                          avatar={`https://avatars.githubusercontent.com/${pr.name.split('/')[0]}`}
-                          avatarBg={getAvatarBg(pr.name)}
-                          label={
-                            <Box
-                              sx={{
-                                minWidth: 0,
-                                display: 'flex',
-                                flexDirection: 'column',
-                                justifyContent: 'center',
-                              }}
-                            >
-                              <Tooltip title={pr.name} arrow placement="top">
-                                <Typography
-                                  sx={{
-                                    fontFamily: FONTS.mono,
-                                    fontSize: '0.68rem',
-                                    color: 'text.tertiary',
-                                    overflow: 'hidden',
-                                    textOverflow: 'ellipsis',
-                                    whiteSpace: 'nowrap',
-                                    lineHeight: 1.2,
-                                  }}
-                                >
-                                  {pr.name}
-                                </Typography>
-                              </Tooltip>
-                              <Tooltip title={pr.title} arrow placement="top">
-                                <Typography
-                                  sx={{
-                                    fontFamily: FONTS.mono,
-                                    fontSize: '0.78rem',
-                                    color: 'text.primary',
-                                    overflow: 'hidden',
-                                    textOverflow: 'ellipsis',
-                                    whiteSpace: 'nowrap',
-                                    lineHeight: 1.3,
-                                  }}
-                                >
-                                  {pr.title}
-                                </Typography>
-                              </Tooltip>
-                            </Box>
-                          }
-                          right={
-                            <Typography
-                              sx={(theme) => ({
-                                fontFamily: FONTS.mono,
-                                fontSize: '0.68rem',
-                                color: alpha(theme.palette.text.primary, 0.35),
-                                flexShrink: 0,
-                                whiteSpace: 'nowrap',
-                                ml: 1,
-                              })}
-                            >
-                              {formatRelativeTime(pr.createdAt)}
-                            </Typography>
-                          }
-                        />
-                      ))
-                    )}
-                  </Box>
-                </>
-              ) : null}
-              {!isLoading && recentPrs.length === 0 ? (
-                <>
-                  <SectionHeader>Recent Pull Requests</SectionHeader>
-                  <Box
-                    sx={{
-                      flex: 1,
-                      minHeight: ROW_HEIGHT * 5,
-                      display: 'flex',
-                      alignItems: 'center',
-                      justifyContent: 'center',
-                    }}
-                  >
+        {/* Right Sidebar highlight cards */}
+        <Box
+          sx={{
+            width: showSidebarRight ? sidebarWidth : '100%',
+            height: showSidebarRight ? '100%' : 'auto',
+            maxHeight: showSidebarRight ? '100%' : 'none',
+            flexShrink: 0,
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 2,
+            position: showSidebarRight ? 'static' : 'static',
+          }}
+        >
+          {/* Trending This Week */}
+          <Card sx={cardSx}>
+            {isLoading || trendingRepos.length > 0 ? (
+              <>
+                <SectionHeader>Trending This Week</SectionHeader>
+                <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+                  {trendingRepos.length === 0 && !isLoading ? (
                     <Typography
                       sx={(theme) => ({
                         color: alpha(theme.palette.text.primary, 0.3),
                         fontSize: '0.8rem',
+                        fontStyle: 'italic',
                         p: 1,
-                        textAlign: 'center',
                       })}
                     >
-                      No merged PRs today
+                      No data available
                     </Typography>
-                  </Box>
-                </>
-              ) : null}
-            </Card>
-          </Box>
+                  ) : (
+                    trendingRepos.map((repo) => (
+                      <HighlightRow
+                        key={repo.name}
+                        href={getRepoHref(repo.name)}
+                        linkState={REPO_LINK_STATE}
+                        avatar={`https://avatars.githubusercontent.com/${repo.name.split('/')[0]}`}
+                        avatarBg={getAvatarBg(repo.name)}
+                        label={
+                          <Tooltip title={repo.name} arrow placement="top">
+                            <Typography
+                              sx={{
+                                fontFamily: FONTS.mono,
+                                fontSize: '0.82rem',
+                                color: 'text.primary',
+                                overflow: 'hidden',
+                                textOverflow: 'ellipsis',
+                                whiteSpace: 'nowrap',
+                              }}
+                            >
+                              {repo.name}
+                            </Typography>
+                          </Tooltip>
+                        }
+                        right={
+                          <Typography
+                            sx={(theme) => ({
+                              fontFamily: FONTS.mono,
+                              fontSize: '0.75rem',
+                              fontWeight: 600,
+                              color: theme.palette.status.success,
+                              flexShrink: 0,
+                              backgroundColor: alpha(
+                                theme.palette.status.success,
+                                0.1,
+                              ),
+                              px: 0.75,
+                              py: 0.25,
+                              borderRadius: '4px',
+                            })}
+                          >
+                            +{repo.pctIncrease.toFixed(0)}%
+                          </Typography>
+                        }
+                      />
+                    ))
+                  )}
+                </Box>
+              </>
+            ) : null}
+          </Card>
+
+          {/* Most Collateral Staked */}
+          <Card sx={cardSx}>
+            {isLoading || topCollateralRepos.length > 0 ? (
+              <>
+                <SectionHeader>Most Collateral Staked</SectionHeader>
+                <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+                  {topCollateralRepos.length === 0 && !isLoading ? (
+                    <Typography
+                      sx={(theme) => ({
+                        color: alpha(theme.palette.text.primary, 0.3),
+                        fontSize: '0.8rem',
+                        fontStyle: 'italic',
+                        p: 1,
+                      })}
+                    >
+                      No collateral data available
+                    </Typography>
+                  ) : (
+                    topCollateralRepos.map((repo) => (
+                      <HighlightRow
+                        key={repo.name}
+                        href={getRepoHref(repo.name)}
+                        linkState={REPO_LINK_STATE}
+                        avatar={`https://avatars.githubusercontent.com/${repo.name.split('/')[0]}`}
+                        avatarBg={getAvatarBg(repo.name)}
+                        label={
+                          <Tooltip title={repo.name} arrow placement="top">
+                            <Typography
+                              sx={{
+                                fontFamily: FONTS.mono,
+                                fontSize: '0.82rem',
+                                color: 'text.primary',
+                                overflow: 'hidden',
+                                textOverflow: 'ellipsis',
+                                whiteSpace: 'nowrap',
+                              }}
+                            >
+                              {repo.name}
+                            </Typography>
+                          </Tooltip>
+                        }
+                        right={
+                          <Typography
+                            sx={{
+                              fontFamily: FONTS.mono,
+                              fontSize: '0.72rem',
+                              color: 'text.secondary',
+                              flexShrink: 0,
+                              whiteSpace: 'nowrap',
+                            }}
+                          >
+                            {repo.collateral.toFixed(1)} ({repo.openPRs} PR
+                            {repo.openPRs !== 1 ? 's' : ''})
+                          </Typography>
+                        }
+                      />
+                    ))
+                  )}
+                </Box>
+              </>
+            ) : null}
+          </Card>
+
+          {/* Recent PRs */}
+          <Card sx={cardSx}>
+            {isLoading || recentPrs.length > 0 ? (
+              <>
+                <SectionHeader>Recent Pull Requests</SectionHeader>
+                <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+                  {recentPrs.length === 0 && !isLoading ? (
+                    <Typography
+                      sx={(theme) => ({
+                        color: alpha(theme.palette.text.primary, 0.3),
+                        fontSize: '0.8rem',
+                        fontStyle: 'italic',
+                        p: 1,
+                      })}
+                    >
+                      No data available
+                    </Typography>
+                  ) : (
+                    recentPrs.map((pr) => (
+                      <HighlightRow
+                        key={`${pr.name}-${pr.number}`}
+                        href={getPrHref(pr.name, pr.number)}
+                        linkState={REPO_LINK_STATE}
+                        avatar={`https://avatars.githubusercontent.com/${pr.name.split('/')[0]}`}
+                        avatarBg={getAvatarBg(pr.name)}
+                        label={
+                          <Box
+                            sx={{
+                              minWidth: 0,
+                              display: 'flex',
+                              flexDirection: 'column',
+                              justifyContent: 'center',
+                            }}
+                          >
+                            <Tooltip title={pr.name} arrow placement="top">
+                              <Typography
+                                sx={{
+                                  fontFamily: FONTS.mono,
+                                  fontSize: '0.68rem',
+                                  color: 'text.tertiary',
+                                  overflow: 'hidden',
+                                  textOverflow: 'ellipsis',
+                                  whiteSpace: 'nowrap',
+                                  lineHeight: 1.2,
+                                }}
+                              >
+                                {pr.name}
+                              </Typography>
+                            </Tooltip>
+                            <Tooltip title={pr.title} arrow placement="top">
+                              <Typography
+                                sx={{
+                                  fontFamily: FONTS.mono,
+                                  fontSize: '0.78rem',
+                                  color: 'text.primary',
+                                  overflow: 'hidden',
+                                  textOverflow: 'ellipsis',
+                                  whiteSpace: 'nowrap',
+                                  lineHeight: 1.3,
+                                }}
+                              >
+                                {pr.title}
+                              </Typography>
+                            </Tooltip>
+                          </Box>
+                        }
+                        right={
+                          <Typography
+                            sx={(theme) => ({
+                              fontFamily: FONTS.mono,
+                              fontSize: '0.68rem',
+                              color: alpha(theme.palette.text.primary, 0.35),
+                              flexShrink: 0,
+                              whiteSpace: 'nowrap',
+                              ml: 1,
+                            })}
+                          >
+                            {formatRelativeTime(pr.createdAt)}
+                          </Typography>
+                        }
+                      />
+                    ))
+                  )}
+                </Box>
+              </>
+            ) : null}
+            {!isLoading && recentPrs.length === 0 ? (
+              <>
+                <SectionHeader>Recent Pull Requests</SectionHeader>
+                <Box
+                  sx={{
+                    flex: 1,
+                    minHeight: ROW_HEIGHT * 5,
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                  }}
+                >
+                  <Typography
+                    sx={(theme) => ({
+                      color: alpha(theme.palette.text.primary, 0.3),
+                      fontSize: '0.8rem',
+                      p: 1,
+                      textAlign: 'center',
+                    })}
+                  >
+                    No merged PRs today
+                  </Typography>
+                </Box>
+              </>
+            ) : null}
+          </Card>
         </Box>
       </Box>
     </Page>


### PR DESCRIPTION
## Summary

- Moved the three Repositories highlight cards (Trending This Week, Most Collateral Staked, Recent Pull Requests) into a right-side sidebar on desktop.
- Added a subtle vertical divider between the main table and the sidebar to improve visual separation.
- Expanded the available space for the repositories table by increasing the page container width and tuning the desktop grid layout.
- Preserved mobile-first behavior: content stacks in a single column on smaller screens; sidebar is sticky only on large screens.

## Related Issues

Closes #757

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

<img width="1845" height="912" alt="image" src="https://github.com/user-attachments/assets/52d0a9c1-8c10-418d-8e96-bd7af86b0f19" />


## Checklist

- [ ] New components are modularized/separated where sensible
- [ ] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
