### PR TITLE
Fix #550: show owner initials when avatar image fails

### DIFF
--- a/src/components/leaderboard/TopRepositoriesTable.tsx
+++ b/src/components/leaderboard/TopRepositoriesTable.tsx
@@ -100,6 +100,11 @@ const VALID_SORT_COLUMNS: SortColumn[] = [
   'contributors',
 ];
 
+const getOwnerInitial = (repositoryFullName: string) => {
+  const owner = repositoryFullName.split('/')[0]?.trim();
+  return owner ? owner.charAt(0).toUpperCase() : '?';
+};
+
 const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
   repositories,
   isLoading,
@@ -697,19 +702,31 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
             },
           }}
         >
-          <Avatar
-            src={`https://avatars.githubusercontent.com/${(repo.repository || '').split('/')[0]}`}
-            alt={(repo.repository || '').split('/')[0]}
-            sx={{
-              width: 20,
-              height: 20,
-              border: '1px solid',
-              borderColor: 'border.medium',
-              backgroundColor: getRepositoryOwnerAvatarBackground(
-                (repo.repository || '').split('/')[0],
-              ),
-            }}
-          />
+          {(() => {
+            const owner = (repo.repository || '').split('/')[0];
+            const ownerAvatarBg = getRepositoryOwnerAvatarBackground(owner);
+            return (
+              <Avatar
+                src={`https://avatars.githubusercontent.com/${owner}`}
+                alt={owner}
+                sx={(theme) => ({
+                  width: 20,
+                  height: 20,
+                  border: '1px solid',
+                  borderColor: 'border.medium',
+                  backgroundColor: ownerAvatarBg,
+                  color:
+                    ownerAvatarBg === theme.palette.surface.transparent
+                      ? theme.palette.text.primary
+                      : theme.palette.getContrastText(ownerAvatarBg),
+                  fontSize: '0.62rem',
+                  fontWeight: 600,
+                })}
+              >
+                {getOwnerInitial(repo.repository || '')}
+              </Avatar>
+            );
+          })()}
           <Tooltip title={repo.repository || ''} placement="top">
             <Typography
               component="span"

--- a/src/pages/RepositoriesPage.tsx
+++ b/src/pages/RepositoriesPage.tsx
@@ -18,10 +18,21 @@ const HighlightRow: React.FC<{
   href: string;
   linkState?: Record<string, unknown>;
   avatar: string;
+  avatarAlt?: string;
+  avatarFallback?: string;
   avatarBg?: (theme: Theme) => string;
   label: React.ReactNode;
   right: React.ReactNode;
-}> = ({ href, linkState, avatar, avatarBg = 'transparent', label, right }) => {
+}> = ({
+  href,
+  linkState,
+  avatar,
+  avatarAlt,
+  avatarFallback,
+  avatarBg = 'transparent',
+  label,
+  right,
+}) => {
   return (
     <LinkBox
       href={href}
@@ -52,14 +63,19 @@ const HighlightRow: React.FC<{
       >
         <Avatar
           src={avatar}
+          alt={avatarAlt}
           sx={{
             width: 24,
             height: 24,
             flexShrink: 0,
             border: '1px solid rgba(255,255,255,0.1)',
             backgroundColor: avatarBg,
+            fontSize: '0.72rem',
+            fontWeight: 600,
           }}
-        />
+        >
+          {avatarFallback}
+        </Avatar>
         {label}
       </Box>
       {right}
@@ -74,6 +90,11 @@ const getAvatarBg = (name: string) => {
   if (owner === 'bitcoin')
     return (theme: Theme) => theme.palette.status.warningOrange;
   return (theme: Theme) => theme.palette.surface.transparent;
+};
+
+const getRepoOwnerInitial = (name: string) => {
+  const owner = name.split('/')[0]?.trim();
+  return owner ? owner.charAt(0).toUpperCase() : '?';
 };
 
 const SectionHeader: React.FC<{ children: React.ReactNode }> = ({
@@ -368,6 +389,8 @@ const RepositoriesPage: React.FC = () => {
                         href={getRepoHref(repo.name)}
                         linkState={REPO_LINK_STATE}
                         avatar={`https://avatars.githubusercontent.com/${repo.name.split('/')[0]}`}
+                        avatarAlt={repo.name.split('/')[0]}
+                        avatarFallback={getRepoOwnerInitial(repo.name)}
                         avatarBg={getAvatarBg(repo.name)}
                         label={
                           <Tooltip title={repo.name} arrow placement="top">
@@ -437,6 +460,8 @@ const RepositoriesPage: React.FC = () => {
                         href={getRepoHref(repo.name)}
                         linkState={REPO_LINK_STATE}
                         avatar={`https://avatars.githubusercontent.com/${repo.name.split('/')[0]}`}
+                        avatarAlt={repo.name.split('/')[0]}
+                        avatarFallback={getRepoOwnerInitial(repo.name)}
                         avatarBg={getAvatarBg(repo.name)}
                         label={
                           <Tooltip title={repo.name} arrow placement="top">
@@ -500,6 +525,8 @@ const RepositoriesPage: React.FC = () => {
                         href={getPrHref(pr.name, pr.number)}
                         linkState={REPO_LINK_STATE}
                         avatar={`https://avatars.githubusercontent.com/${pr.name.split('/')[0]}`}
+                        avatarAlt={pr.name.split('/')[0]}
+                        avatarFallback={getRepoOwnerInitial(pr.name)}
                         avatarBg={getAvatarBg(pr.name)}
                         label={
                           <Box

--- a/src/pages/RepositoriesPage.tsx
+++ b/src/pages/RepositoriesPage.tsx
@@ -21,7 +21,6 @@ const HighlightRow: React.FC<{
   avatarAlt?: string;
   avatarFallback?: string;
   avatarBg?: (theme: Theme) => string;
-  avatarColor?: (theme: Theme) => string;
   label: React.ReactNode;
   right: React.ReactNode;
 }> = ({
@@ -31,7 +30,6 @@ const HighlightRow: React.FC<{
   avatarAlt,
   avatarFallback,
   avatarBg = 'transparent',
-  avatarColor = 'text.primary',
   label,
   right,
 }) => {
@@ -66,15 +64,25 @@ const HighlightRow: React.FC<{
         <Avatar
           src={avatar}
           alt={avatarAlt}
-          sx={{
-            width: 24,
-            height: 24,
-            flexShrink: 0,
-            border: '1px solid rgba(255,255,255,0.1)',
-            backgroundColor: avatarBg,
-            color: avatarColor,
-            fontSize: '0.72rem',
-            fontWeight: 600,
+          sx={(theme) => {
+            const resolvedAvatarBg =
+              typeof avatarBg === 'function'
+                ? avatarBg(theme)
+                : theme.palette.surface.transparent;
+            const resolvedColor =
+              resolvedAvatarBg === theme.palette.surface.transparent
+                ? theme.palette.text.primary
+                : theme.palette.getContrastText(resolvedAvatarBg);
+            return {
+              width: 24,
+              height: 24,
+              flexShrink: 0,
+              border: '1px solid rgba(255,255,255,0.1)',
+              backgroundColor: resolvedAvatarBg,
+              color: resolvedColor,
+              fontSize: '0.72rem',
+              fontWeight: 600,
+            };
           }}
         >
           {avatarFallback}
@@ -98,14 +106,6 @@ const getAvatarBg = (name: string) => {
 const getRepoOwnerInitial = (name: string) => {
   const owner = name.split('/')[0]?.trim();
   return owner ? owner.charAt(0).toUpperCase() : '?';
-};
-
-const getRepoOwnerInitialColor = (name: string) => {
-  const owner = name.split('/')[0];
-  if (owner === 'opentensor' || owner === 'bitcoin') {
-    return (theme: Theme) => theme.palette.common.black;
-  }
-  return (theme: Theme) => theme.palette.text.primary;
 };
 
 const SectionHeader: React.FC<{ children: React.ReactNode }> = ({
@@ -403,7 +403,6 @@ const RepositoriesPage: React.FC = () => {
                         avatarAlt={repo.name.split('/')[0]}
                         avatarFallback={getRepoOwnerInitial(repo.name)}
                         avatarBg={getAvatarBg(repo.name)}
-                        avatarColor={getRepoOwnerInitialColor(repo.name)}
                         label={
                           <Tooltip title={repo.name} arrow placement="top">
                             <Typography
@@ -475,7 +474,6 @@ const RepositoriesPage: React.FC = () => {
                         avatarAlt={repo.name.split('/')[0]}
                         avatarFallback={getRepoOwnerInitial(repo.name)}
                         avatarBg={getAvatarBg(repo.name)}
-                        avatarColor={getRepoOwnerInitialColor(repo.name)}
                         label={
                           <Tooltip title={repo.name} arrow placement="top">
                             <Typography
@@ -541,7 +539,6 @@ const RepositoriesPage: React.FC = () => {
                         avatarAlt={pr.name.split('/')[0]}
                         avatarFallback={getRepoOwnerInitial(pr.name)}
                         avatarBg={getAvatarBg(pr.name)}
-                        avatarColor={getRepoOwnerInitialColor(pr.name)}
                         label={
                           <Box
                             sx={{

--- a/src/pages/RepositoriesPage.tsx
+++ b/src/pages/RepositoriesPage.tsx
@@ -21,6 +21,7 @@ const HighlightRow: React.FC<{
   avatarAlt?: string;
   avatarFallback?: string;
   avatarBg?: (theme: Theme) => string;
+  avatarColor?: (theme: Theme) => string;
   label: React.ReactNode;
   right: React.ReactNode;
 }> = ({
@@ -30,6 +31,7 @@ const HighlightRow: React.FC<{
   avatarAlt,
   avatarFallback,
   avatarBg = 'transparent',
+  avatarColor = 'text.primary',
   label,
   right,
 }) => {
@@ -70,6 +72,7 @@ const HighlightRow: React.FC<{
             flexShrink: 0,
             border: '1px solid rgba(255,255,255,0.1)',
             backgroundColor: avatarBg,
+            color: avatarColor,
             fontSize: '0.72rem',
             fontWeight: 600,
           }}
@@ -95,6 +98,14 @@ const getAvatarBg = (name: string) => {
 const getRepoOwnerInitial = (name: string) => {
   const owner = name.split('/')[0]?.trim();
   return owner ? owner.charAt(0).toUpperCase() : '?';
+};
+
+const getRepoOwnerInitialColor = (name: string) => {
+  const owner = name.split('/')[0];
+  if (owner === 'opentensor' || owner === 'bitcoin') {
+    return (theme: Theme) => theme.palette.common.black;
+  }
+  return (theme: Theme) => theme.palette.text.primary;
 };
 
 const SectionHeader: React.FC<{ children: React.ReactNode }> = ({
@@ -392,6 +403,7 @@ const RepositoriesPage: React.FC = () => {
                         avatarAlt={repo.name.split('/')[0]}
                         avatarFallback={getRepoOwnerInitial(repo.name)}
                         avatarBg={getAvatarBg(repo.name)}
+                        avatarColor={getRepoOwnerInitialColor(repo.name)}
                         label={
                           <Tooltip title={repo.name} arrow placement="top">
                             <Typography
@@ -463,6 +475,7 @@ const RepositoriesPage: React.FC = () => {
                         avatarAlt={repo.name.split('/')[0]}
                         avatarFallback={getRepoOwnerInitial(repo.name)}
                         avatarBg={getAvatarBg(repo.name)}
+                        avatarColor={getRepoOwnerInitialColor(repo.name)}
                         label={
                           <Tooltip title={repo.name} arrow placement="top">
                             <Typography
@@ -528,6 +541,7 @@ const RepositoriesPage: React.FC = () => {
                         avatarAlt={pr.name.split('/')[0]}
                         avatarFallback={getRepoOwnerInitial(pr.name)}
                         avatarBg={getAvatarBg(pr.name)}
+                        avatarColor={getRepoOwnerInitialColor(pr.name)}
                         label={
                           <Box
                             sx={{

--- a/src/pages/dashboard/views/LiveCommitLog.tsx
+++ b/src/pages/dashboard/views/LiveCommitLog.tsx
@@ -121,6 +121,13 @@ const getOwnerInitial = (repository: string) => {
   return owner ? owner.charAt(0).toUpperCase() : '?';
 };
 
+const getOwnerInitialColor = (owner: string) => {
+  if (owner === 'opentensor' || owner === 'bitcoin') {
+    return theme.palette.common.black;
+  }
+  return theme.palette.text.primary;
+};
+
 const CommitLogItem: React.FC<{
   entry: CommitLogEntry;
   isNew: boolean;
@@ -130,6 +137,7 @@ const CommitLogItem: React.FC<{
   const isTablet = useMediaQuery(theme.breakpoints.between('sm', 'md'));
   const repositoryOwner = entry.repository.split('/')[0];
   const repositoryOwnerInitial = getOwnerInitial(entry.repository);
+  const repositoryOwnerInitialColor = getOwnerInitialColor(repositoryOwner);
 
   const isMerged = !!entry.mergedAt;
   const isClosed = entry.prState === 'CLOSED' && !entry.mergedAt;
@@ -208,7 +216,8 @@ const CommitLogItem: React.FC<{
                     : repositoryOwner === 'bitcoin'
                       ? REPO_OWNER_AVATAR_BACKGROUNDS.bitcoin
                       : theme.palette.surface.transparent,
-                fontSize: '0.55rem',
+                color: repositoryOwnerInitialColor,
+                fontSize: '0.62rem',
                 fontWeight: 600,
               }}
             >

--- a/src/pages/dashboard/views/LiveCommitLog.tsx
+++ b/src/pages/dashboard/views/LiveCommitLog.tsx
@@ -121,11 +121,30 @@ const getOwnerInitial = (repository: string) => {
   return owner ? owner.charAt(0).toUpperCase() : '?';
 };
 
-const getOwnerInitialColor = (owner: string) => {
-  if (owner === 'opentensor' || owner === 'bitcoin') {
-    return theme.palette.common.black;
+const getOwnerAvatarBg = (owner: string) => {
+  if (owner === 'opentensor') {
+    return REPO_OWNER_AVATAR_BACKGROUNDS.opentensor;
   }
-  return theme.palette.text.primary;
+  if (owner === 'bitcoin') {
+    return REPO_OWNER_AVATAR_BACKGROUNDS.bitcoin;
+  }
+  return theme.palette.surface.transparent;
+};
+
+const getAvatarFallbackColor = (avatarBg: string) => {
+  if (avatarBg === theme.palette.surface.transparent) {
+    return theme.palette.text.primary;
+  }
+  return theme.palette.getContrastText(avatarBg);
+};
+
+const getOwnerAvatarStyles = (owner: string) => {
+  const avatarBg = getOwnerAvatarBg(owner);
+  // Keep fallback text readable regardless of background color choice.
+  return {
+    backgroundColor: avatarBg,
+    color: getAvatarFallbackColor(avatarBg),
+  };
 };
 
 const CommitLogItem: React.FC<{
@@ -137,7 +156,7 @@ const CommitLogItem: React.FC<{
   const isTablet = useMediaQuery(theme.breakpoints.between('sm', 'md'));
   const repositoryOwner = entry.repository.split('/')[0];
   const repositoryOwnerInitial = getOwnerInitial(entry.repository);
-  const repositoryOwnerInitialColor = getOwnerInitialColor(repositoryOwner);
+  const ownerAvatarStyles = getOwnerAvatarStyles(repositoryOwner);
 
   const isMerged = !!entry.mergedAt;
   const isClosed = entry.prState === 'CLOSED' && !entry.mergedAt;
@@ -210,13 +229,7 @@ const CommitLogItem: React.FC<{
                 width: 16,
                 height: 16,
                 border: `1px solid ${theme.palette.border.medium}`,
-                backgroundColor:
-                  repositoryOwner === 'opentensor'
-                    ? REPO_OWNER_AVATAR_BACKGROUNDS.opentensor
-                    : repositoryOwner === 'bitcoin'
-                      ? REPO_OWNER_AVATAR_BACKGROUNDS.bitcoin
-                      : theme.palette.surface.transparent,
-                color: repositoryOwnerInitialColor,
+                ...ownerAvatarStyles,
                 fontSize: '0.62rem',
                 fontWeight: 600,
               }}

--- a/src/pages/dashboard/views/LiveCommitLog.tsx
+++ b/src/pages/dashboard/views/LiveCommitLog.tsx
@@ -116,6 +116,11 @@ const getScoreColor = (score: string) => {
   return theme.palette.text.secondary;
 };
 
+const getOwnerInitial = (repository: string) => {
+  const owner = repository.split('/')[0]?.trim();
+  return owner ? owner.charAt(0).toUpperCase() : '?';
+};
+
 const CommitLogItem: React.FC<{
   entry: CommitLogEntry;
   isNew: boolean;
@@ -123,6 +128,8 @@ const CommitLogItem: React.FC<{
 }> = ({ entry, isNew, innerRef }) => {
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
   const isTablet = useMediaQuery(theme.breakpoints.between('sm', 'md'));
+  const repositoryOwner = entry.repository.split('/')[0];
+  const repositoryOwnerInitial = getOwnerInitial(entry.repository);
 
   const isMerged = !!entry.mergedAt;
   const isClosed = entry.prState === 'CLOSED' && !entry.mergedAt;
@@ -189,19 +196,24 @@ const CommitLogItem: React.FC<{
         >
           <Stack direction="row" alignItems="center" spacing={1}>
             <Avatar
-              src={`https://avatars.githubusercontent.com/${entry.repository.split('/')[0]}`}
+              src={`https://avatars.githubusercontent.com/${repositoryOwner}`}
+              alt={repositoryOwner}
               sx={{
                 width: 16,
                 height: 16,
                 border: `1px solid ${theme.palette.border.medium}`,
                 backgroundColor:
-                  entry.repository.split('/')[0] === 'opentensor'
+                  repositoryOwner === 'opentensor'
                     ? REPO_OWNER_AVATAR_BACKGROUNDS.opentensor
-                    : entry.repository.split('/')[0] === 'bitcoin'
+                    : repositoryOwner === 'bitcoin'
                       ? REPO_OWNER_AVATAR_BACKGROUNDS.bitcoin
                       : theme.palette.surface.transparent,
+                fontSize: '0.55rem',
+                fontWeight: 600,
               }}
-            />
+            >
+              {repositoryOwnerInitial}
+            </Avatar>
             <Typography
               variant="caption"
               sx={{


### PR DESCRIPTION
## Summary
- Fixes #550 by adding Avatar children fallbacks (owner initial) where repository-owner avatars are rendered from GitHub image URLs.
- Applies the fix to the two affected UI paths called out by the issue:
  - `src/pages/dashboard/views/LiveCommitLog.tsx`
  - `src/pages/RepositoriesPage.tsx` (highlight rows)
- Keeps behavior unchanged when avatar images load successfully; fallback appears only when image loading fails.

## Root cause
`<Avatar src=... />` was rendered without fallback children, so failed image requests produced blank/broken avatar blocks instead of an identifiable owner initial.

## Repro / verification
1. Open Dashboard Live Activity and Repositories highlights.
2. Simulate avatar request failure (e.g. block `avatars.githubusercontent.com` in browser devtools).
3. Confirm owner initial fallback is shown instead of blank avatar.

## Test plan
- [x] `npm run lint`
- [x] `npm run test`
- [x] `npm run build`