### PR TITLE
refactor: unused or misleading exported symbols

### DIFF
--- a/src/api/DashboardApi.ts
+++ b/src/api/DashboardApi.ts
@@ -8,7 +8,7 @@ import {
   type CommitLog,
 } from './models/Dashboard';
 
-export const useDashboardQuery = <TResponse = void, TSelect = TResponse>(
+const useDashboardQuery = <TResponse = void, TSelect = TResponse>(
   queryName: string,
   url: string,
   refetchInterval?: number,
@@ -34,18 +34,6 @@ export const useReposAndWeights = () =>
 
 export const useLanguagesAndWeights = () =>
   useDashboardQuery<LanguageWeight[]>('useLanguagesAndWeights', '/languages');
-
-export const useCommitLog = (
-  options?: { refetchInterval?: number },
-  page?: number,
-  limit?: number,
-) =>
-  useDashboardQuery<CommitLog[]>(
-    'useCommitLog',
-    '/commits',
-    options?.refetchInterval,
-    { page, limit },
-  );
 
 export const useInfiniteCommitLog = (options?: {
   refetchInterval?: number;

--- a/src/components/leaderboard/ActivitySidebarCards.tsx
+++ b/src/components/leaderboard/ActivitySidebarCards.tsx
@@ -304,17 +304,13 @@ export const ActivitySidebarCards: React.FC<ActivitySidebarCardsProps> = ({
 
 // ── Shared sub-components ────────────────────────────────────────
 
-export interface StatRowProps {
+interface StatRowProps {
   label: string;
   value: number | string;
   valueColor?: string;
 }
 
-export const StatRow: React.FC<StatRowProps> = ({
-  label,
-  value,
-  valueColor,
-}) => (
+const StatRow: React.FC<StatRowProps> = ({ label, value, valueColor }) => (
   <Box
     sx={{
       display: 'flex',

--- a/src/components/leaderboard/index.ts
+++ b/src/components/leaderboard/index.ts
@@ -2,7 +2,7 @@
 export { default as TopMinersTable } from './TopMinersTable';
 export { default as TopRepositoriesTable } from './TopRepositoriesTable';
 export { LeaderboardSidebar } from './LeaderboardSidebar';
-export { ActivitySidebarCards, StatRow } from './ActivitySidebarCards';
+export { ActivitySidebarCards } from './ActivitySidebarCards';
 export { MinerCard } from './MinerCard';
 export { MinersList } from './MinersList';
 export { RankIcon } from './RankIcon';

--- a/src/components/miners/TrustBadge.tsx
+++ b/src/components/miners/TrustBadge.tsx
@@ -25,7 +25,7 @@ interface RiskAssessment {
 
 const ICON_SIZE = { fontSize: 18 };
 
-export const getRiskAssessment = (
+const getRiskAssessment = (
   credibility: number,
   totalPRs: number,
 ): RiskAssessment => {

--- a/src/components/miners/index.ts
+++ b/src/components/miners/index.ts
@@ -10,4 +10,4 @@ export { default as MinerScoreCard } from './MinerScoreCard';
 export { default as PerformanceRadar } from './PerformanceRadar';
 export { default as RankBadge } from './RankBadge';
 export { default as TablePagination } from './TablePagination';
-export { default as TrustBadge, getRiskAssessment } from './TrustBadge';
+export { default as TrustBadge } from './TrustBadge';

--- a/src/components/repositories/index.ts
+++ b/src/components/repositories/index.ts
@@ -8,4 +8,3 @@ export { default as ReadmeViewer } from './ReadmeViewer';
 export { default as RepositoryCodeBrowser } from './RepositoryCodeBrowser';
 export { default as RepositoryMaintainers } from './RepositoryMaintainers';
 export { default as RepositoryCheckTab } from './RepositoryCheckTab';
-export { resolveRelativeUrl } from './MarkdownRenderers';

--- a/src/pages/dashboard/useDashboardData.ts
+++ b/src/pages/dashboard/useDashboardData.ts
@@ -29,7 +29,7 @@ type DashboardDatasets = {
   issues: DatasetState<IssueBounty>;
 };
 
-export const useDashboardData = (range: TrendTimeRange) => {
+const useDashboardData = (range: TrendTimeRange) => {
   const prsQuery = useAllPrs();
   const minersQuery = useAllMiners();
   const issuesQuery = useIssues();

--- a/src/pages/search/SearchResultsCard.tsx
+++ b/src/pages/search/SearchResultsCard.tsx
@@ -50,7 +50,7 @@ const paginationSx: SxProps<Theme> = (theme) => ({
   },
 });
 
-export const SearchResultsCard = <T,>({
+const SearchResultsCard = <T,>({
   columns,
   rows,
   totalCount,

--- a/src/utils/ExplorerUtils.ts
+++ b/src/utils/ExplorerUtils.ts
@@ -190,7 +190,7 @@ export const sortMinerRepoStats = (
 // Scoring window staleness check
 // ---------------------------------------------------------------------------
 
-export const SCORING_WINDOW_DAYS = 35;
+const SCORING_WINDOW_DAYS = 35;
 
 export const isOutsideScoringWindow = (
   date: string | null | undefined,


### PR DESCRIPTION
## Summary

Tightens the public module surface by removing or privatizing symbols that were exported but unused outside their defining files, and by dropping a dead dashboard hook. Aligns with the hygiene issues described in `bug-report-unused-exports-public-api-surface.md` (overlapping themes with [#739](https://github.com/entrius/gittensor-ui/issues/739), but includes additional items such as `StatRow`, duplicate named/default exports, and the `repositories` barrel re-export).

## Related Issues

Closes #761 

## Type of Change

- [x] Bug fix (maintainability / misleading API surface)
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## What Changed

| Area | Change |
|------|--------|
| `src/utils/ExplorerUtils.ts` | `SCORING_WINDOW_DAYS` is no longer exported; remains an internal constant for `isOutsideScoringWindow`. |
| `src/api/DashboardApi.ts` | `useDashboardQuery` is module-private. **`useCommitLog` removed** (zero in-repo callers; `useInfiniteCommitLog` unchanged). |
| `src/components/miners/TrustBadge.tsx` | `getRiskAssessment` is module-private. |
| `src/components/miners/index.ts` | Stop re-exporting `getRiskAssessment`. |
| `src/components/leaderboard/ActivitySidebarCards.tsx` | `StatRow` / `StatRowProps` are file-private. |
| `src/components/leaderboard/index.ts` | Export only `ActivitySidebarCards` (drop `StatRow` from barrel). |
| `src/components/repositories/index.ts` | Remove unused `resolveRelativeUrl` re-export (callers use `./MarkdownRenderers`). |
| `src/pages/search/SearchResultsCard.tsx` | Single export path: `const` + `export default` only. |
| `src/pages/dashboard/useDashboardData.ts` | Single export path: `const` + `export default` only. |

## Behavior / Risk

- **No UI or runtime behavior changes** intended for screens users interact with.
- **Breaking risk (external only):** Any code **outside this repo** that imported `useCommitLog` from the app’s API module would need to migrate (in-repo grep found no usages).

## Checklist

- [x] Scoped to dead / redundant exports and one unused hook
- [x] `npm run lint` passes
- [x] `npm run build` passes
- [ ] `npm run format` / `npm run lint:fix` run (if required by team policy)
- [ ] Screenshots N/A confirmed with reviewers
