### PR TITLE
fix(discoveries): show credibility in list view by mapping issueCredibility to credibility field

### DIFF
--- a/src/pages/DiscoveriesPage.tsx
+++ b/src/pages/DiscoveriesPage.tsx
@@ -9,7 +9,7 @@ import {
 } from '../components';
 import { useAllMiners } from '../api';
 import theme, { scrollbarSx } from '../theme';
-import { parseNumber } from '../utils/ExplorerUtils';
+import { mapIssueDiscoveryMinerStats } from '../utils/minerMapper';
 
 const MINER_LINK_STATE = { backLabel: 'Back to Discoveries' } as const;
 const getMinerHref = (miner: MinerStats) =>
@@ -20,38 +20,13 @@ const DiscoveriesPage: React.FC = () => {
   const allMinersStats = allMinerStatsQuery?.data;
   const isLoadingMinerStats = allMinerStatsQuery?.isLoading;
 
-  // Process miner stats for TopMinersTable, using issue discovery fields
-  const minerStats = useMemo(() => {
-    if (!Array.isArray(allMinersStats)) return [];
-    return allMinersStats.map((stat) => ({
-      id: String(stat.id),
-      githubId: stat.githubId || '',
-      author: stat.githubUsername || undefined,
-      totalScore: parseNumber(stat.issueDiscoveryScore),
-      baseTotalScore: parseNumber(stat.baseTotalScore),
-      totalPRs: parseNumber(stat.totalPrs),
-      totalIssues:
-        parseNumber(stat.totalSolvedIssues) +
-        parseNumber(stat.totalOpenIssues) +
-        parseNumber(stat.totalClosedIssues),
-      linesChanged: parseNumber(stat.totalNodesScored),
-      linesAdded: parseNumber(stat.totalAdditions),
-      linesDeleted: parseNumber(stat.totalDeletions),
-      hotkey: stat.hotkey || 'N/A',
-      uniqueReposCount: parseNumber(stat.uniqueReposCount),
-      issueCredibility: parseNumber(stat.issueCredibility),
-      isEligible: stat.isIssueEligible ?? false,
-      ossIsEligible: stat.isEligible ?? false,
-      discoveriesIsEligible: stat.isIssueEligible ?? false,
-      usdPerDay: parseNumber(stat.usdPerDay),
-      totalMergedPrs: parseNumber(stat.totalMergedPrs),
-      totalOpenPrs: parseNumber(stat.totalOpenPrs),
-      totalClosedPrs: parseNumber(stat.totalClosedPrs),
-      totalSolvedIssues: parseNumber(stat.totalSolvedIssues),
-      totalOpenIssues: parseNumber(stat.totalOpenIssues),
-      totalClosedIssues: parseNumber(stat.totalClosedIssues),
-    }));
-  }, [allMinersStats]);
+  const minerStats = useMemo(
+    () =>
+      Array.isArray(allMinersStats)
+        ? mapIssueDiscoveryMinerStats(allMinersStats)
+        : [],
+    [allMinersStats],
+  );
 
   // Sort miners by issue discovery score
   const sortedMinerStats = useMemo(

--- a/src/pages/TopMinersPage.tsx
+++ b/src/pages/TopMinersPage.tsx
@@ -78,6 +78,7 @@ const TopMinersPage: React.FC = () => {
       hotkey: stat.hotkey || 'N/A',
       uniqueReposCount: parseNumber(stat.uniqueReposCount),
       issueCredibility: parseNumber(stat.issueCredibility),
+      credibility: parseNumber(stat.issueCredibility),
       isEligible: stat.isIssueEligible ?? false,
       ossIsEligible: stat.isEligible ?? false,
       discoveriesIsEligible: stat.isIssueEligible ?? false,

--- a/src/utils/minerMapper.ts
+++ b/src/utils/minerMapper.ts
@@ -2,6 +2,40 @@ import { type MinerEvaluation } from '../api/models/Dashboard';
 import { type MinerStats } from '../components/leaderboard/types';
 import { parseNumber } from './ExplorerUtils';
 
+export function mapIssueDiscoveryMinerStats(
+  allMinersStats: MinerEvaluation[],
+): MinerStats[] {
+  return allMinersStats.map((stat) => ({
+    id: String(stat.id),
+    githubId: stat.githubId || '',
+    author: stat.githubUsername || undefined,
+    totalScore: parseNumber(stat.issueDiscoveryScore),
+    baseTotalScore: parseNumber(stat.baseTotalScore),
+    totalPRs: parseNumber(stat.totalPrs),
+    totalIssues:
+      parseNumber(stat.totalSolvedIssues) +
+      parseNumber(stat.totalOpenIssues) +
+      parseNumber(stat.totalClosedIssues),
+    linesChanged: parseNumber(stat.totalNodesScored),
+    linesAdded: parseNumber(stat.totalAdditions),
+    linesDeleted: parseNumber(stat.totalDeletions),
+    hotkey: stat.hotkey || 'N/A',
+    uniqueReposCount: parseNumber(stat.uniqueReposCount),
+    credibility: parseNumber(stat.issueCredibility),
+    issueCredibility: parseNumber(stat.issueCredibility),
+    isEligible: stat.isIssueEligible ?? false,
+    ossIsEligible: stat.isEligible ?? false,
+    discoveriesIsEligible: stat.isIssueEligible ?? false,
+    usdPerDay: parseNumber(stat.usdPerDay),
+    totalMergedPrs: parseNumber(stat.totalMergedPrs),
+    totalOpenPrs: parseNumber(stat.totalOpenPrs),
+    totalClosedPrs: parseNumber(stat.totalClosedPrs),
+    totalSolvedIssues: parseNumber(stat.totalSolvedIssues),
+    totalOpenIssues: parseNumber(stat.totalOpenIssues),
+    totalClosedIssues: parseNumber(stat.totalClosedIssues),
+  }));
+}
+
 export const mapAllMinersToStats = (
   allMinersStats: MinerEvaluation[],
 ): MinerStats[] => {


### PR DESCRIPTION
## Summary

Fixes the Credibility column showing `0%` for every miner in the **list view** on the Discoveries page. The card view was already correct.

Root cause: `DiscoveriesPage` was mapping the API's `issueCredibility` field but leaving the generic `credibility` field unset. The list view (`MinersList`) reads `miner.credibility`, so it always rendered 0% on this page. The card view branched on variant and read `issueCredibility` directly, masking the issue.

Fix: extracted `mapIssueDiscoveryMinerStats` into `src/utils/minerMapper.ts` (mirroring the existing `mapAllMinersToStats` pattern) and set `credibility: parseNumber(stat.issueCredibility)` inside it. `DiscoveriesPage` now calls the shared mapper. As a side effect, sorting the list view by Credibility on `/discoveries` also works correctly now (the sort comparator reads the same `credibility` field).

## Related Issues

Fixes #763

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots
**Before**
<img width="1856" height="798" alt="image" src="https://github.com/user-attachments/assets/7b368cee-9cfb-4337-9d30-0b8d5d572569" />
<img width="1879" height="680" alt="image" src="https://github.com/user-attachments/assets/79e8054a-ff4c-431b-9f4f-27eb6e815c08" />

**After**
<img width="1868" height="839" alt="image" src="https://github.com/user-attachments/assets/b7bfe5d1-3ef1-40d9-9e7c-70bd54ca4ac1" />

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
