### PR TITLE
fix(dashboard): keep live activity "by user" on one row and clip long usernames

### DIFF
--- a/src/pages/dashboard/views/LiveCommitLog.tsx
+++ b/src/pages/dashboard/views/LiveCommitLog.tsx
@@ -262,15 +262,26 @@ const CommitLogItem: React.FC<{
           direction="row"
           justifyContent="space-between"
           alignItems="center"
+          gap={1}
           sx={{
             pt: 1,
+            minWidth: 0,
             borderTop: `1px solid ${theme.palette.border.subtle}`,
           }}
         >
-          <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+          <Typography
+            variant="caption"
+            sx={{
+              color: 'text.secondary',
+              minWidth: 0,
+              whiteSpace: 'nowrap',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+            }}
+          >
             by {entry.author}
           </Typography>
-          <Stack direction="row" spacing={2}>
+          <Stack direction="row" spacing={2} sx={{ flexShrink: 0 }}>
             <Stack direction="row" spacing={0.5} alignItems="center">
               <Typography
                 variant="caption"

--- a/src/pages/dashboard/views/LiveCommitLog.tsx
+++ b/src/pages/dashboard/views/LiveCommitLog.tsx
@@ -10,6 +10,7 @@ import {
   alpha,
   Avatar,
   Chip,
+  Tooltip,
 } from '@mui/material';
 import { LinkBox } from '../../../components/common/linkBehavior';
 import { useInfiniteCommitLog } from '../../../api';
@@ -258,64 +259,89 @@ const CommitLogItem: React.FC<{
           </Typography>
         </Box>
 
-        <Stack
-          direction="row"
-          justifyContent="space-between"
-          alignItems="center"
-          gap={1}
-          sx={{
-            pt: 1,
-            minWidth: 0,
-            borderTop: `1px solid ${theme.palette.border.subtle}`,
-          }}
-        >
-          <Typography
-            variant="caption"
-            sx={{
-              color: 'text.secondary',
-              minWidth: 0,
-              whiteSpace: 'nowrap',
-              overflow: 'hidden',
-              textOverflow: 'ellipsis',
-            }}
-          >
-            by {entry.author}
-          </Typography>
-          <Stack direction="row" spacing={2} sx={{ flexShrink: 0 }}>
-            <Stack direction="row" spacing={0.5} alignItems="center">
-              <Typography
-                variant="caption"
-                sx={{ color: theme.palette.diff.additions, fontWeight: 600 }}
-              >
-                +{entry.additions}
-              </Typography>
-              <Typography variant="caption" sx={{ color: 'text.secondary' }}>
-                /
-              </Typography>
-              <Typography
-                variant="caption"
-                sx={{ color: theme.palette.diff.deletions, fontWeight: 600 }}
-              >
-                -{entry.deletions}
-              </Typography>
-            </Stack>
-            <Typography
-              variant="caption"
-              sx={{
-                color: getScoreColor(entry.score),
-                fontWeight: 600,
-              }}
-            >
-              SCORE: {parseFloat(entry.score).toFixed(2)}
-            </Typography>
-          </Stack>
-        </Stack>
+        <LiveCommitFooter
+          author={entry.author}
+          additions={entry.additions}
+          deletions={entry.deletions}
+          score={entry.score}
+        />
       </Stack>
     </LinkBox>
   );
 
   return content;
 };
+
+interface LiveCommitFooterProps {
+  author: string;
+  additions: number;
+  deletions: number;
+  score: string;
+}
+
+function LiveCommitFooter({
+  author,
+  additions,
+  deletions,
+  score,
+}: LiveCommitFooterProps) {
+  return (
+    <Stack
+      direction="row"
+      justifyContent="space-between"
+      alignItems="center"
+      gap={1}
+      sx={{
+        pt: 1,
+        minWidth: 0,
+        borderTop: `1px solid ${theme.palette.border.subtle}`,
+      }}
+    >
+      <Tooltip title={author} placement="top" arrow>
+        <Typography
+          variant="caption"
+          sx={{
+            color: 'text.secondary',
+            minWidth: 0,
+            whiteSpace: 'nowrap',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+          }}
+        >
+          by {author}
+        </Typography>
+      </Tooltip>
+      <Stack direction="row" spacing={2} sx={{ flexShrink: 0 }}>
+        <Stack direction="row" spacing={0.5} alignItems="center">
+          <Typography
+            variant="caption"
+            sx={{ color: theme.palette.diff.additions, fontWeight: 600 }}
+          >
+            +{additions}
+          </Typography>
+          <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+            /
+          </Typography>
+          <Typography
+            variant="caption"
+            sx={{ color: theme.palette.diff.deletions, fontWeight: 600 }}
+          >
+            -{deletions}
+          </Typography>
+        </Stack>
+        <Typography
+          variant="caption"
+          sx={{
+            color: getScoreColor(score),
+            fontWeight: 600,
+          }}
+        >
+          SCORE: {parseFloat(score).toFixed(2)}
+        </Typography>
+      </Stack>
+    </Stack>
+  );
+}
 
 const LiveCommitLog: React.FC = () => {
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));


### PR DESCRIPTION
## Summary

On the Dashboard Live Activity cards, the "by {username}" label wraps onto a second row when the username is long, pushing the card contents around. Fixes this so the username stays on one row and clips with an ellipsis.

Change is CSS-only on `src/pages/dashboard/views/LiveCommitLog.tsx`:

- Outer footer `<Stack>`: added `minWidth: 0` (so the flex child can shrink below its intrinsic width) and `gap={1}` (guarantees a small gap when the username ellipses up against the stats).
- "by {author}" `<Typography>`: added `minWidth: 0`, `whiteSpace: 'nowrap'`, `overflow: 'hidden'`, `textOverflow: 'ellipsis'`.
- Right-side additions / deletions / score `<Stack>`: added `flexShrink: 0` so only the username side shrinks.

## Related Issues

Closes #765

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots
**Before**
<img width="343" height="191" alt="image" src="https://github.com/user-attachments/assets/661deba2-806e-4624-8b0e-3e54e46d2364" />

<!-- before/after of the Live Activity card with a long username -->
**After**
<img width="448" height="558" alt="image" src="https://github.com/user-attachments/assets/56f7c70a-e4b2-4aaa-8247-b448fccd7e20" />
**When hover**
<img width="452" height="203" alt="image" src="https://github.com/user-attachments/assets/4be20388-55e6-4414-9063-5f653ee294c5" />


## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
