### PR TITLE
feat(ux): persist last selected tab per page across reloads

### DIFF
--- a/src/components/issues/IssuesList.tsx
+++ b/src/components/issues/IssuesList.tsx
@@ -38,8 +38,10 @@ import { STATUS_COLORS, TEXT_OPACITY } from '../../theme';
 import { DataTable, type DataTableColumn } from '../common/DataTable';
 import BountyProgress from './BountyProgress';
 import FilterButton from '../FilterButton';
+import { usePersistedTab } from '../../hooks/usePersistedTab';
 
 type FilterType = 'all' | 'available' | 'pending' | 'history';
+const FILTER_TABS = ['all', 'available', 'pending', 'history'] as const;
 type SortDirection = 'asc' | 'desc';
 type SortKey =
   | 'id'
@@ -75,13 +77,13 @@ const IssuesList: React.FC<IssuesListProps> = ({
   const theme = useTheme();
   const [searchParams, setSearchParams] = useSearchParams();
 
-  // Derive filterType directly from URL — single source of truth so that
-  // redirects from /bounties/:tab and browser back/forward both work correctly.
-  const filterType = useMemo<FilterType>(() => {
-    const f = searchParams.get('filter');
-    if (f === 'available' || f === 'pending' || f === 'history') return f;
-    return 'all';
-  }, [searchParams]);
+  // Prefer URL param → stored preference → 'all'.
+  const filterParam = searchParams.get('filter');
+  const [filterType, persistFilter] = usePersistedTab(
+    'bounties-filter',
+    FILTER_TABS,
+    filterParam,
+  );
 
   const [sortKey, setSortKey] = useState<SortKey>('id');
   const [sortDirection, setSortDirection] = useState<SortDirection>('desc');
@@ -94,13 +96,14 @@ const IssuesList: React.FC<IssuesListProps> = ({
 
   const handleFilterChange = useCallback(
     (f: FilterType) => {
+      persistFilter(f);
       if (f === 'all') {
         setSearchParams({}, { replace: true });
       } else {
         setSearchParams({ filter: f }, { replace: true });
       }
     },
-    [setSearchParams],
+    [setSearchParams, persistFilter],
   );
 
   const counts = useMemo(

--- a/src/hooks/usePersistedTab.ts
+++ b/src/hooks/usePersistedTab.ts
@@ -2,7 +2,10 @@ import { useCallback, useEffect, useState } from 'react';
 
 const STORAGE_PREFIX = 'tab:';
 
-function readStored<T extends string>(key: string, valid: readonly T[]): T | null {
+function readStored<T extends string>(
+  key: string,
+  valid: readonly T[],
+): T | null {
   try {
     const v = localStorage.getItem(key);
     if (v !== null && (valid as readonly string[]).includes(v)) return v as T;
@@ -76,7 +79,6 @@ export function usePersistedTab<T extends string>(
   // Re-sync when the URL value changes (back/forward navigation, direct links).
   // `validTabs` is intentionally omitted from deps — it must be a stable
   // module-level const; including it would fire on every render for inline arrays.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
     setTab(resolve(key, validTabs, urlValue));
   }, [key, urlValue]); // eslint-disable-line react-hooks/exhaustive-deps

--- a/src/hooks/usePersistedTab.ts
+++ b/src/hooks/usePersistedTab.ts
@@ -1,0 +1,105 @@
+import { useCallback, useEffect, useState } from 'react';
+
+const STORAGE_PREFIX = 'tab:';
+
+function readStored<T extends string>(key: string, valid: readonly T[]): T | null {
+  try {
+    const v = localStorage.getItem(key);
+    if (v !== null && (valid as readonly string[]).includes(v)) return v as T;
+  } catch {
+    // localStorage unavailable (SSR, private-mode restrictions, etc.)
+  }
+  return null;
+}
+
+function writeStored(key: string, value: string): void {
+  try {
+    localStorage.setItem(key, value);
+  } catch {
+    // Ignore write failures silently.
+  }
+}
+
+function resolve<T extends string>(
+  key: string,
+  validTabs: readonly T[],
+  urlValue?: string | null,
+): T {
+  // 1. URL param always wins — also refreshes the stored preference so that
+  //    a direct link (e.g. ?tab=activity) becomes the new "remembered" tab.
+  if (urlValue && (validTabs as readonly string[]).includes(urlValue)) {
+    writeStored(key, urlValue);
+    return urlValue as T;
+  }
+  // 2. Stored preference (validated against the current tab list).
+  const stored = readStored(key, validTabs);
+  if (stored !== null) return stored;
+  // 3. Hard fallback.
+  return validTabs[0];
+}
+
+/**
+ * Persists the most-recently-selected tab in `localStorage` so each
+ * multi-tab page remembers the user's "home tab" across reloads and
+ * browser sessions, without requiring any user action.
+ *
+ * Priority (highest → lowest):
+ *  1. `urlValue` — the raw tab value from the URL (always wins; also saves
+ *     the choice, so direct links teach the preference).
+ *  2. Stored `localStorage` value, validated against the current `validTabs`
+ *     list (guards against stale / renamed tabs).
+ *  3. `validTabs[0]` as the hard fallback.
+ *
+ * Cross-tab sync: if the user selects a different tab in another browser
+ * window the active tab in this window updates automatically via the
+ * `storage` event.
+ *
+ * @param storageKey  A stable, unique key per page/mode
+ *                    (e.g. `'miner-details-prs'`, `'pr-details'`)
+ * @param validTabs   All valid tab identifiers for this page/mode. Define
+ *                    this array **outside** the component (module-level const)
+ *                    so its reference is stable across renders.
+ * @param urlValue    The raw tab string from the URL query param; pass
+ *                    `undefined` or omit for purely state-driven pages.
+ * @returns           `[activeTab, persistTab]` — call `persistTab(tab)`
+ *                    whenever the user selects a new tab.
+ */
+export function usePersistedTab<T extends string>(
+  storageKey: string,
+  validTabs: readonly T[],
+  urlValue?: string | null,
+): [T, (tab: T) => void] {
+  const key = `${STORAGE_PREFIX}${storageKey}`;
+
+  const [tab, setTab] = useState<T>(() => resolve(key, validTabs, urlValue));
+
+  // Re-sync when the URL value changes (back/forward navigation, direct links).
+  // `validTabs` is intentionally omitted from deps — it must be a stable
+  // module-level const; including it would fire on every render for inline arrays.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => {
+    setTab(resolve(key, validTabs, urlValue));
+  }, [key, urlValue]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Sync selections made in other browser windows / tabs.
+  useEffect(() => {
+    const handler = (e: StorageEvent) => {
+      if (e.key !== key || !e.newValue) return;
+      if ((validTabs as readonly string[]).includes(e.newValue)) {
+        setTab(e.newValue as T);
+      }
+    };
+    window.addEventListener('storage', handler);
+    return () => window.removeEventListener('storage', handler);
+  }, [key, validTabs]);
+
+  const persistTab = useCallback(
+    (next: T) => {
+      writeStored(key, next);
+      setTab(next);
+    },
+    [key],
+  );
+
+  return [tab, persistTab];
+}

--- a/src/pages/MinerDetailsPage.tsx
+++ b/src/pages/MinerDetailsPage.tsx
@@ -14,6 +14,7 @@ import {
   SEO,
 } from '../components';
 import { WatchlistButton } from '../components/common';
+import { usePersistedTab } from '../hooks/usePersistedTab';
 
 type ViewMode = 'prs' | 'issues';
 
@@ -63,16 +64,20 @@ const MinerDetailsPage: React.FC = () => {
 
   const tabs = viewMode === 'issues' ? ISSUE_TABS : PR_TABS;
 
+  // Prefer URL param → stored preference → first tab.
+  // Per-mode storage key keeps OSS and Issue Discovery memories independent.
   const tabParam = searchParams.get('tab');
-  const activeTab: MinerDetailsTab =
-    tabParam && (tabs as readonly string[]).includes(tabParam)
-      ? (tabParam as MinerDetailsTab)
-      : 'overview';
+  const [activeTab, persistTab] = usePersistedTab(
+    `miner-details-${viewMode}`,
+    tabs,
+    tabParam,
+  );
 
   const handleTabChange = (
     _event: React.SyntheticEvent,
     newValue: MinerDetailsTab,
   ) => {
+    persistTab(newValue);
     const p = new URLSearchParams(searchParams);
     p.set('tab', newValue);
     setSearchParams(p, { replace: true });

--- a/src/pages/PRDetailsPage.tsx
+++ b/src/pages/PRDetailsPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { useSearchParams, useNavigate } from 'react-router-dom';
 import { Box, Tabs, Tab, CircularProgress, Typography } from '@mui/material';
 import { Page } from '../components/layout';
@@ -17,13 +17,19 @@ import { STATUS_COLORS } from '../theme';
 import VisibilityIcon from '@mui/icons-material/Visibility';
 import CodeIcon from '@mui/icons-material/Code';
 import ChatBubbleOutlineIcon from '@mui/icons-material/ChatBubbleOutline';
+import { usePersistedTab } from '../hooks/usePersistedTab';
+
+const PR_DETAIL_TABS = ['overview', 'files-changed', 'conversation'] as const;
+type PRDetailTab = (typeof PR_DETAIL_TABS)[number];
 
 const PRDetailsPage: React.FC = () => {
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
   const repository = searchParams.get('repo');
   const pullRequestNumber = searchParams.get('number');
-  const [tabValue, setTabValue] = useState(0);
+
+  const [activeTab, persistTab] = usePersistedTab('pr-details', PR_DETAIL_TABS);
+  const tabValue = PR_DETAIL_TABS.indexOf(activeTab);
 
   // Call hook unconditionally (React rules of hooks)
   const { data: prDetails, isLoading } = usePullRequestDetails(
@@ -40,7 +46,7 @@ const PRDetailsPage: React.FC = () => {
   }
 
   const handleTabChange = (_event: React.SyntheticEvent, newValue: number) => {
-    setTabValue(newValue);
+    persistTab(PR_DETAIL_TABS[newValue] as PRDetailTab);
   };
 
   return (


### PR DESCRIPTION
## Summary

Adds a `usePersistedTab` hook that remembers the last selected tab on each multi-tab page using `localStorage`. The next time a user opens the page, their preferred tab is restored automatically — no user action required.

**Pages covered:**
- **Bounties** (`IssuesList`) — Available / Pending / History filter
- **PR Details** — Overview / Files Changed / Conversation
- **Miner Details** — Overview / Activity / Pull Requests / Repositories (OSS and Issue Discovery modes remembered independently)

**Priority order inside the hook:**
1. URL param always wins (direct links / back-forward navigation), and also writes the preference so direct links teach the remembered tab
2. `localStorage` value, validated against the current tab list (guards against stale or renamed tabs)
3. `validTabs[0]` as a hard fallback

**Additional behaviour:**
- Cross-window sync via the `storage` event — switching tabs in one window updates other open windows automatically
- `localStorage` access is wrapped in try/catch for private-mode / SSR safety
- Miner Details uses per-mode keys (`miner-details-prs` / `miner-details-issues`) so OSS and Issue Discovery each remember their own last tab independently

## Related Issues

Resolves #508 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

# Before:
https://github.com/user-attachments/assets/e62b11f1-2e47-44a7-9b3a-b661e34a669d


# After

https://github.com/user-attachments/assets/f8a90611-4434-421c-90a2-2fc349c7c9db


## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes