### PR TITLE
feat: dashboard live activity relative time

### DIFF
--- a/src/pages/dashboard/views/LiveCommitLog.tsx
+++ b/src/pages/dashboard/views/LiveCommitLog.tsx
@@ -12,6 +12,7 @@ import {
   Chip,
   Tooltip,
 } from '@mui/material';
+import { formatDistanceToNow } from 'date-fns';
 import { LinkBox } from '../../../components/common/linkBehavior';
 import { useInfiniteCommitLog } from '../../../api';
 import theme, {
@@ -42,6 +43,12 @@ const formatUtcTimestamp = (iso: string): string => {
   const mm = String(d.getUTCMinutes()).padStart(2, '0');
   const ss = String(d.getUTCSeconds()).padStart(2, '0');
   return `${month} ${day}, ${hh}:${mm}:${ss} UTC`;
+};
+
+const formatRelativeActivityTime = (iso: string): string => {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '—';
+  return formatDistanceToNow(d, { addSuffix: true });
 };
 
 interface CommitLogEntry {
@@ -134,8 +141,8 @@ const CommitLogItem: React.FC<{
   else if (isClosed)
     status = { label: 'CLOSED', color: theme.palette.status.closed };
   const timestampRaw = entry.mergedAt || entry.prCreatedAt;
-  const timestamp = timestampRaw
-    ? formatUtcTimestamp(timestampRaw)
+  const relativeTime = timestampRaw
+    ? formatRelativeActivityTime(timestampRaw)
     : 'Loading...';
 
   const content = (
@@ -239,9 +246,25 @@ const CommitLogItem: React.FC<{
                 backgroundColor: alpha(status.color, 0.1),
               }}
             />
-            <Typography variant="caption" sx={{ color: 'text.secondary' }}>
-              {timestamp}
-            </Typography>
+            {timestampRaw ? (
+              <Tooltip
+                title={formatUtcTimestamp(timestampRaw)}
+                placement="top"
+                enterDelay={400}
+              >
+                <Typography
+                  component="span"
+                  variant="caption"
+                  sx={{ color: 'text.secondary' }}
+                >
+                  {relativeTime}
+                </Typography>
+              </Tooltip>
+            ) : (
+              <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+                {relativeTime}
+              </Typography>
+            )}
           </Stack>
           <Typography
             sx={{
@@ -353,8 +376,17 @@ const LiveCommitLog: React.FC = () => {
   const [statusFilter, setStatusFilter] = useState<CommitStatusFilter>('all');
   const [logEntries, setLogEntries] = useState<CommitLogEntry[]>([]);
   const [newEntryIds, setNewEntryIds] = useState<Set<string>>(new Set());
+  const [, setRelativeTimeTick] = useState(0);
   const logContainerRef = useRef<HTMLDivElement>(null);
   const loadMoreRef = useRef<HTMLAnchorElement>(null);
+
+  useEffect(() => {
+    const id = window.setInterval(
+      () => setRelativeTimeTick((n) => n + 1),
+      60_000,
+    );
+    return () => window.clearInterval(id);
+  }, []);
 
   const apiCommits = useMemo<CommitLogEntry[]>(
     () => data?.pages.flat() ?? [],


### PR DESCRIPTION
## Summary

Updates the Dashboard **Live Activity** feed (`LiveCommitLog`) so each PR row shows a **GitHub-style relative time** (e.g. `5 minutes ago`, `2 days ago`) instead of only an absolute UTC clock string. Hovering the time shows the **existing UTC tooltip** (`Jan 15, 14:32:00 UTC` style) for exact timestamps. A **60-second interval** re-renders the list so “X ago” stays accurate during long sessions.

Reference instant is unchanged: **`mergedAt || prCreatedAt`** (merge time when present, otherwise PR creation).

## Related Issues

Closes https://github.com/entrius/gittensor-ui/issues/768

## Screenshots
### Before
<img width="534" height="628" alt="image" src="https://github.com/user-attachments/assets/36f4a6ed-3ff9-4d67-be5f-86a15660edd2" />

### After
<img width="515" height="439" alt="image" src="https://github.com/user-attachments/assets/b6b94b67-0fda-467b-93e2-8ebdaf463e66" />

### When hover
<img width="559" height="449" alt="image" src="https://github.com/user-attachments/assets/345311e6-7fd7-48f0-97e7-76b66c35f945" />


## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Implementation

| Item | Detail |
|------|--------|
| Relative label | `date-fns` `formatDistanceToNow` with `addSuffix: true` |
| Absolute detail | MUI `Tooltip` + existing `formatUtcTimestamp` |
| Refresh | `setInterval` 60s in `LiveCommitLog` to bump state and refresh relative strings |
| Files | `src/pages/dashboard/views/LiveCommitLog.tsx` |

## Checklist

- [x] Uses existing theme / MUI patterns (`Tooltip`, `Typography`)
- [x] `npm run build` passes
- [x] `npm run lint` passes
- [ ] `npm run format` / `npm run lint:fix` (if required by team)
- [ ] Manual check: Dashboard → Live Activity → hover time for UTC tooltip; wait or mock time for relative refresh
- [ ] Screenshots attached for UI change
