### PR TITLE
feat(watchlist): repo avatar on pull requests tab

### DIFF
--- a/src/pages/WatchlistPage.tsx
+++ b/src/pages/WatchlistPage.tsx
@@ -1889,19 +1889,38 @@ const buildPrColumns = (
     width: '20%',
     sortKey: 'repo',
     cellSx: prCellSx,
-    renderCell: (pr) => (
-      <Typography
-        sx={{
-          fontSize: '0.75rem',
-          color: 'text.secondary',
-          overflow: 'hidden',
-          textOverflow: 'ellipsis',
-          whiteSpace: 'nowrap',
-        }}
-      >
-        {pr.repository}
-      </Typography>
-    ),
+    renderCell: (pr) => {
+      const owner = pr.repository.split('/')[0] || '';
+      return (
+        <Box
+          sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 0 }}
+        >
+          <Avatar
+            src={`https://avatars.githubusercontent.com/${owner}`}
+            alt={owner}
+            sx={{
+              width: 20,
+              height: 20,
+              flexShrink: 0,
+              border: '1px solid',
+              borderColor: 'border.medium',
+              backgroundColor: getRepositoryOwnerAvatarBackground(owner),
+            }}
+          />
+          <Typography
+            sx={{
+              fontSize: '0.75rem',
+              color: 'text.secondary',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {pr.repository}
+          </Typography>
+        </Box>
+      );
+    },
   },
   {
     key: 'author',


### PR DESCRIPTION
## Summary

Enhances the Watchlist **Pull Requests** tab so each pinned repo shows its avatar.

## Related Issues

Closes #771 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

### before
<img width="1586" height="1034" alt="image" src="https://github.com/user-attachments/assets/d5915af9-2bbe-4bee-9c0f-7f7d6a32b40d" />
### after
<img width="1593" height="1020" alt="image" src="https://github.com/user-attachments/assets/b9ad01a7-24f5-4834-8507-40412561f6f5" />
## Checklist

- [ ] New components are modularized/separated where sensible
- [ ] Uses predefined theme (e.g. no hardcoded colors)
- [ ] Responsive/mobile checked
- [ ] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
