### PR TITLE
feat: Bounties table tooltips(repository + date)

### DIFF
--- a/src/components/issues/IssuesList.tsx
+++ b/src/components/issues/IssuesList.tsx
@@ -26,6 +26,7 @@ import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import SearchIcon from '@mui/icons-material/Search';
 import TableChartIcon from '@mui/icons-material/TableChart';
 import ReactECharts from 'echarts-for-react';
+import { format } from 'date-fns';
 import { IssueBounty } from '../../api/models/Issues';
 import { usePrices } from '../../hooks/usePrices';
 import {
@@ -366,25 +367,34 @@ const IssuesList: React.FC<IssuesListProps> = ({
       sortKey: 'repository',
       cellSx: { overflow: 'hidden' },
       renderCell: (issue) => (
-        <Box
-          sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 0 }}
-        >
-          <Avatar
-            src={`https://avatars.githubusercontent.com/${issue.repositoryFullName.split('/')[0]}`}
-            sx={{ width: 24, height: 24, borderRadius: 1, flexShrink: 0 }}
-          />
-          <Typography
+        <Tooltip title={issue.repositoryFullName} arrow>
+          <Box
             sx={{
-              fontSize: '0.85rem',
-              color: STATUS_COLORS.info,
-              overflow: 'hidden',
-              textOverflow: 'ellipsis',
-              whiteSpace: 'nowrap',
+              display: 'flex',
+              alignItems: 'center',
+              gap: 1,
+              minWidth: 0,
+              maxWidth: '100%',
             }}
           >
-            {issue.repositoryFullName}
-          </Typography>
-        </Box>
+            <Avatar
+              src={`https://avatars.githubusercontent.com/${issue.repositoryFullName.split('/')[0]}`}
+              sx={{ width: 24, height: 24, borderRadius: 1, flexShrink: 0 }}
+            />
+            <Typography
+              component="span"
+              sx={{
+                fontSize: '0.85rem',
+                color: STATUS_COLORS.info,
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+              }}
+            >
+              {issue.repositoryFullName}
+            </Typography>
+          </Box>
+        </Tooltip>
       ),
     };
 
@@ -548,19 +558,33 @@ const IssuesList: React.FC<IssuesListProps> = ({
     const dateColumn: DataTableColumn<IssueBounty, SortKey> = {
       key: 'date',
       header: 'Date',
-      width: '110px',
+      width: '132px',
       align: 'center',
       sortKey: 'date',
-      renderCell: (issue) => (
-        <Typography
-          sx={{
-            fontSize: '0.8rem',
-            color: alpha(theme.palette.common.white, 0.6),
-          }}
-        >
-          {formatDate(issue.completedAt || issue.updatedAt)}
-        </Typography>
-      ),
+      renderCell: (issue) => {
+        const raw = issue.completedAt || issue.updatedAt;
+        const label = formatDate(raw);
+        const tooltipTitle = (() => {
+          if (!raw) return label;
+          const d = new Date(raw);
+          if (Number.isNaN(d.getTime())) return label;
+          return format(d, 'PPpp');
+        })();
+        return (
+          <Tooltip title={tooltipTitle} arrow>
+            <Typography
+              component="span"
+              sx={{
+                fontSize: '0.8rem',
+                color: alpha(theme.palette.common.white, 0.6),
+                whiteSpace: 'nowrap',
+              }}
+            >
+              {label}
+            </Typography>
+          </Tooltip>
+        );
+      },
     };
 
     if (filterType === 'pending') {


### PR DESCRIPTION
## Summary

Improves the **Bounties** page table (`IssuesList` on `IssuesPage`) by adding **MUI tooltips** for **truncated repository names** (full `owner/repo` on hover, consistent with the existing **Solver** hotkey column) and for the **Date** column (short cell label plus **`PPpp`** datetime on hover when the timestamp is valid). The date cell uses **`whiteSpace: 'nowrap'`** and a slightly **wider** column (**132px**) so the formatted date stays on **one line**.

## Related issues / specs

Closes #773

## Type of change

- [x] Bug fix (UX: missing tooltip, awkward wrapping)
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Implementation

| Item | Detail |
|------|--------|
| Repository | `Tooltip title={issue.repositoryFullName}` around avatar + ellipsized `Typography`; `component="span"` on label |
| Date | `formatDate` for visible text; `Tooltip` with `date-fns` `format(..., 'PPpp')` when `completedAt` / `updatedAt` parses |
| Layout | Date column `width: '132px'` (was `110px`); `whiteSpace: 'nowrap'` on date `Typography` |
| Files | `src/components/issues/IssuesList.tsx` |

## Screenshots

### Before
https://github.com/user-attachments/assets/ce08a62a-b67a-4d70-aa46-121d9e9c0575

### After
https://github.com/user-attachments/assets/75f14710-6009-4559-bcb4-feef24d1c8ce


## Checklist

- [x] Matches existing MUI patterns (`Tooltip`, `arrow`, solver column precedent)
- [x] `npm run build` passes
- [x] `npm run lint` passes
- [ ] Manual check: Bounties → hover truncated repo name; hover date for `PPpp` tooltip
- [ ] Screenshots attached if required by team process
