### PR TITLE
fix(miners): plot actual solved issues on Performance Profile radar

### DIFF
--- a/src/components/miners/MinerActivity.tsx
+++ b/src/components/miners/MinerActivity.tsx
@@ -381,8 +381,8 @@ const MinerActivity: React.FC<MinerActivityProps> = ({
       ...allMinerStats.map((m) => m.totalNodesScored || 0),
       1,
     );
-    const maxMergedPrs = Math.max(
-      ...allMinerStats.map((m) => m.totalMergedPrs || 0),
+    const maxSolvedIssues = Math.max(
+      ...allMinerStats.map((m) => m.totalSolvedIssues || 0),
       1,
     );
     const maxUniqueRepos = Math.max(
@@ -412,7 +412,8 @@ const MinerActivity: React.FC<MinerActivityProps> = ({
     return {
       credibility: ((minerStats.credibility || 0) / maxCredibility) * 100,
       complexity: ((minerStats.totalNodesScored || 0) / maxComplexity) * 100,
-      issuesSolved: ((minerStats.totalMergedPrs || 0) / maxMergedPrs) * 100,
+      issuesSolved:
+        ((minerStats.totalSolvedIssues || 0) / maxSolvedIssues) * 100,
       uniqueRepos: ((minerStats.uniqueReposCount || 0) / maxUniqueRepos) * 100,
       totalPRs: ((minerStats.totalPrs || 0) / maxTotalPrs) * 100,
       avgRepoWeight: avgWeightVal,


### PR DESCRIPTION
```
## Summary

Closes #690.

The **Performance Profile** radar on the miner Activity tab (OSS Contributions mode) has six axes, one of which is labeled "Issues Solved". `prRadarValues` in `src/components/miners/MinerActivity.tsx` wired that slot with `minerStats.totalMergedPrs` normalised by `maxMergedPrs` — no issue data. Result: the axis stretched as far from centre as the miner's merged-PR count, regardless of how many issues they'd actually solved.

## Fix

- In `prRadarValues`, replace the `maxMergedPrs` local with `maxSolvedIssues` (computed the same way as every other max in the block), and switch the `issuesSolved` slot to `minerStats.totalSolvedIssues / maxSolvedIssues * 100`
- `maxMergedPrs` is removed entirely — it was only consumed by the misnamed `issuesSolved` line

This aligns the PR-mode radar with its own axis label AND with the sibling `issueRadarValues` useMemo in the same file (lines 423-460), which already reads `totalSolvedIssues` correctly when the user is in Issue Discovery mode.

## Before / After

Given a miner with `totalMergedPrs: 80`, `totalSolvedIssues: 3`, and a network where `max(totalMergedPrs) = 100` and `max(totalSolvedIssues) = 20`:

| Axis | Before | After |
|---|---|---|
| "Issues Solved" | **80** (drawn from merged PRs — misleading) | **15** (3 / 20 × 100 — actual issue contribution) |
| Other axes | unchanged | unchanged |

## Verification

- Read the issue carefully: the reporter already documented exact file paths and line numbers and named the offending field
- Confirmed the axis label string `"Issues\nSolved"` in `PerformanceRadar.tsx:32` is a compile-time constant — label is correct, only the wired value was wrong
- Confirmed `MinerEvaluation.totalSolvedIssues` is an optional field on the same API model that already provides `totalMergedPrs` (`src/api/models/Dashboard.ts:135,144`) — no backend change needed
- Confirmed sibling `issueRadarValues` (line 423) uses exactly this field with the same normalisation pattern — fix is pattern-consistent
- `prettier --check` on the modified file surfaces a pre-existing formatting warning on lines 493/500 that is unrelated to this change; my added lines are prettier-clean when checked in isolation (diff between `prettier` output and my additions is empty)

## Checklist

- [x] Bug fix (labeled `bug` on #690)
- [x] Root cause verified against the reporter's analysis
- [x] Sibling pattern confirms the fix shape
- [x] Zero behaviour change for the other five radar axes
- [x] Commit follows Conventional Commits (`fix(miners): …`)
```