### PR TITLE
fix(watchlist): populate totalIssues so Issues sort actually orders by issue count

### DIFF
--- a/src/utils/minerMapper.ts
+++ b/src/utils/minerMapper.ts
@@ -35,6 +35,10 @@ export const mapAllMinersToStats = (
     totalSolvedIssues: parseNumber(stat.totalSolvedIssues),
     totalOpenIssues: parseNumber(stat.totalOpenIssues),
     totalClosedIssues: parseNumber(stat.totalClosedIssues),
+    totalIssues:
+      parseNumber(stat.totalSolvedIssues) +
+      parseNumber(stat.totalOpenIssues) +
+      parseNumber(stat.totalClosedIssues),
     issueDiscoveryScore: parseNumber(stat.issueDiscoveryScore),
     issueCredibility: parseNumber(stat.issueCredibility),
     isIssueEligible: stat.isIssueEligible ?? false,


### PR DESCRIPTION
```
## Summary

Closes #638.

`mapAllMinersToStats` in `src/utils/minerMapper.ts` was setting `totalSolvedIssues`, `totalOpenIssues`, `totalClosedIssues` individually but never the aggregate `totalIssues`. The miners-table comparator in `TopMinersTable.tsx:95-96` sorts by `totalIssues`, so every pair compared `0 - 0 = 0` and the **Issues** sort tab silently left rows in their input order.

Visible on `/watchlist` (and any view that uses `mapAllMinersToStats` + `TopMinersTable` with the Issues sort exposed): clicking the Issues sort tab does not actually reorder the cards/rows by issue volume.

## Fix

Set `totalIssues = parseNumber(totalSolvedIssues) + parseNumber(totalOpenIssues) + parseNumber(totalClosedIssues)` — the same formula `DiscoveriesPage.tsx:33-36` already uses for its own mapper. No type change (`totalIssues?: number` already exists on `MinerStats`), no API change, no per-bucket display change.

## Verification

- `MinerStats.totalIssues` was already declared optional in `src/components/leaderboard/types.ts`
- `DiscoveriesPage.tsx:33-36` mapper has the same formula — fix is pattern-consistent
- `prettier --check src/utils/minerMapper.ts` → passes after the change
- `git diff --stat`: 1 file changed, 4 insertions(+), 0 deletions(-)
- Behaviour for any view that doesn't sort by `totalIssues` is unchanged
```