### PR TITLE
fix(dashboard): prevent donut chart tooltip clipping

### DIFF
--- a/src/pages/dashboard/views/DashboardOverview.tsx
+++ b/src/pages/dashboard/views/DashboardOverview.tsx
@@ -62,6 +62,19 @@ const buildStatusChartOption = (
     },
     tooltip: {
       trigger: 'item',
+      appendToBody: true,
+      confine: false,
+      transitionDuration: 0,
+      position: (
+        point: [number, number],
+        _params: unknown,
+        _dom: HTMLElement,
+        _rect: unknown,
+        size: { contentSize: [number, number]; viewSize: [number, number] },
+      ) => {
+        const [tipW, tipH] = size.contentSize;
+        return [point[0] - tipW / 2, point[1] - tipH - 12];
+      },
       formatter: ({
         name,
         value,


### PR DESCRIPTION
## Summary
**1.**
On the dashboard page, hovering over the donut charts in the OSS Contributions and Issue Discoveries cards caused the tooltip to be cut off by parent container boundaries on both of desktop view and mobile view.

This PR fixes issue so the tooltip is fully visible and consistently appears next to the hovered/tapped segment on every viewport.

## Related Issues

<!-- Link to related issues: Fixes #123, Closes #456 -->

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots
### 1.
**Before**
<img width="376" height="666" alt="Screenshot_7" src="https://github.com/user-attachments/assets/ac18dd48-a276-4df6-a486-6d07bfbd849e" />
<img width="1920" height="946" alt="Screenshot_1" src="https://github.com/user-attachments/assets/6cb91a7b-604a-4902-bb6b-67a7b75a48cb" />
<img width="1920" height="946" alt="Screenshot_2" src="https://github.com/user-attachments/assets/c8d6be6a-5428-46a5-92cc-9dfe51a7f1b9" />
<img width="378" height="669" alt="Screenshot_6" src="https://github.com/user-attachments/assets/12cf644b-5062-41fc-a87d-cd71d47ef599" />



**Now**
<img width="1918" height="945" alt="Screenshot_4" src="https://github.com/user-attachments/assets/d4672b87-621c-4624-8061-e90dfbb9d95e" />
<img width="1320" height="647" alt="Screenshot_10" src="https://github.com/user-attachments/assets/a0d0203b-d5a6-4116-b21f-11cce6307c80" />
<img width="312" height="558" alt="Screenshot_1" src="https://github.com/user-attachments/assets/fb3ab481-9e3d-467c-802b-6aafdd40c779" />
<img width="363" height="646" alt="Screenshot_2" src="https://github.com/user-attachments/assets/55170837-5e75-4dfd-b4f0-a652d561cada" />
