### PR TITLE
Feat/miner card badge layout

### DIFF
--- a/src/components/leaderboard/MinerCard.tsx
+++ b/src/components/leaderboard/MinerCard.tsx
@@ -168,7 +168,14 @@ export const MinerCard: React.FC<MinerCardProps> = ({
             }}
           >
             {/* Name + rank on the same line */}
-            <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 0.75, minWidth: 0 }}>
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'baseline',
+                gap: 0.75,
+                minWidth: 0,
+              }}
+            >
               <Typography
                 sx={(theme) => ({
                   fontFamily: FONTS.mono,

--- a/src/components/leaderboard/MinerCard.tsx
+++ b/src/components/leaderboard/MinerCard.tsx
@@ -161,128 +161,133 @@ export const MinerCard: React.FC<MinerCardProps> = ({
           <Box
             sx={{
               minWidth: 0,
-              minHeight: 36,
               display: 'flex',
               flexDirection: 'column',
-              justifyContent: 'space-between',
+              gap: 0.4,
               overflow: 'hidden',
             }}
           >
-            <Typography
-              sx={(theme) => ({
-                fontFamily: FONTS.mono,
-                fontSize: '1rem',
-                fontWeight: 700,
-                color: isEligible
-                  ? theme.palette.text.primary
-                  : theme.palette.text.tertiary,
-                opacity: isEligible ? 1 : INACTIVE_OPACITY,
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
-                whiteSpace: 'nowrap',
-              })}
+            {/* Name + rank on the same line */}
+            <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 0.75, minWidth: 0 }}>
+              <Typography
+                sx={(theme) => ({
+                  fontFamily: FONTS.mono,
+                  fontSize: '1rem',
+                  fontWeight: 700,
+                  color: isEligible
+                    ? theme.palette.text.primary
+                    : theme.palette.text.tertiary,
+                  opacity: isEligible ? 1 : INACTIVE_OPACITY,
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                })}
+              >
+                {username}
+              </Typography>
+              <Typography
+                sx={(theme) => ({
+                  fontFamily: FONTS.mono,
+                  fontSize: '0.72rem',
+                  fontWeight: 700,
+                  color: isEligible
+                    ? theme.palette.status.merged
+                    : theme.palette.text.tertiary,
+                  opacity: isEligible ? 1 : INACTIVE_OPACITY,
+                  lineHeight: 1,
+                  flexShrink: 0,
+                })}
+              >
+                #{miner.rank}
+              </Typography>
+            </Box>
+            {/* Badges under the name */}
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 0.5,
+                flexWrap: 'wrap',
+                mt: 0.25,
+              }}
             >
-              {username}
-            </Typography>
-            <Typography
-              sx={(theme) => ({
-                fontFamily: FONTS.mono,
-                fontSize: '0.72rem',
-                fontWeight: 700,
-                color: isEligible
-                  ? theme.palette.status.merged
-                  : theme.palette.text.tertiary,
-                opacity: isEligible ? 1 : INACTIVE_OPACITY,
-                lineHeight: 1,
-                mt: 0.1,
-              })}
-            >
-              #{miner.rank}
-            </Typography>
+              {showDualEligibilityBadges ? (
+                <>
+                  <Typography
+                    sx={(theme) => ({
+                      fontFamily: FONTS.mono,
+                      fontSize: '0.65rem',
+                      fontWeight: 700,
+                      textTransform: 'uppercase',
+                      border: `1px solid ${
+                        ossEligible
+                          ? alpha(theme.palette.status.merged, 0.45)
+                          : theme.palette.border.subtle
+                      }`,
+                      borderRadius: 1,
+                      px: 0.75,
+                      py: 0.25,
+                      letterSpacing: '0.06em',
+                      color: ossEligible
+                        ? theme.palette.status.merged
+                        : theme.palette.text.secondary,
+                      backgroundColor: ossEligible
+                        ? alpha(theme.palette.status.merged, 0.08)
+                        : theme.palette.surface.subtle,
+                    })}
+                  >
+                    OSS {ossEligible ? 'Eligible' : 'Ineligible'}
+                  </Typography>
+                  <Typography
+                    sx={(theme) => ({
+                      fontFamily: FONTS.mono,
+                      fontSize: '0.65rem',
+                      fontWeight: 700,
+                      textTransform: 'uppercase',
+                      border: `1px solid ${
+                        discoveriesEligible
+                          ? alpha(theme.palette.status.merged, 0.45)
+                          : theme.palette.border.subtle
+                      }`,
+                      borderRadius: 1,
+                      px: 0.75,
+                      py: 0.25,
+                      letterSpacing: '0.06em',
+                      color: discoveriesEligible
+                        ? theme.palette.status.merged
+                        : theme.palette.text.secondary,
+                      backgroundColor: discoveriesEligible
+                        ? alpha(theme.palette.status.merged, 0.08)
+                        : theme.palette.surface.subtle,
+                    })}
+                  >
+                    Issues {discoveriesEligible ? 'Eligible' : 'Ineligible'}
+                  </Typography>
+                </>
+              ) : !isEligible ? (
+                <Typography
+                  sx={(theme) => ({
+                    fontFamily: FONTS.mono,
+                    fontSize: '0.65rem',
+                    fontWeight: 700,
+                    color: theme.palette.text.secondary,
+                    textTransform: 'uppercase',
+                    border: `1px solid ${theme.palette.border.subtle}`,
+                    borderRadius: 1,
+                    px: 0.75,
+                    py: 0.25,
+                    letterSpacing: '0.06em',
+                    backgroundColor: theme.palette.surface.subtle,
+                  })}
+                >
+                  Ineligible
+                </Typography>
+              ) : null}
+            </Box>
           </Box>
         </Box>
-        <Box
-          sx={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: 0.5,
-            flexShrink: 0,
-            flexWrap: 'wrap',
-            justifyContent: 'flex-end',
-          }}
-        >
-          {showDualEligibilityBadges ? (
-            <>
-              <Typography
-                sx={(theme) => ({
-                  fontFamily: FONTS.mono,
-                  fontSize: '0.65rem',
-                  fontWeight: 700,
-                  textTransform: 'uppercase',
-                  border: `1px solid ${
-                    ossEligible
-                      ? alpha(theme.palette.status.merged, 0.45)
-                      : theme.palette.border.subtle
-                  }`,
-                  borderRadius: 1,
-                  px: 0.75,
-                  py: 0.25,
-                  letterSpacing: '0.06em',
-                  color: ossEligible
-                    ? theme.palette.status.merged
-                    : theme.palette.text.secondary,
-                  backgroundColor: ossEligible
-                    ? alpha(theme.palette.status.merged, 0.08)
-                    : theme.palette.surface.subtle,
-                })}
-              >
-                OSS {ossEligible ? 'Eligible' : 'Ineligible'}
-              </Typography>
-              <Typography
-                sx={(theme) => ({
-                  fontFamily: FONTS.mono,
-                  fontSize: '0.65rem',
-                  fontWeight: 700,
-                  textTransform: 'uppercase',
-                  border: `1px solid ${
-                    discoveriesEligible
-                      ? alpha(theme.palette.status.merged, 0.45)
-                      : theme.palette.border.subtle
-                  }`,
-                  borderRadius: 1,
-                  px: 0.75,
-                  py: 0.25,
-                  letterSpacing: '0.06em',
-                  color: discoveriesEligible
-                    ? theme.palette.status.merged
-                    : theme.palette.text.secondary,
-                  backgroundColor: discoveriesEligible
-                    ? alpha(theme.palette.status.merged, 0.08)
-                    : theme.palette.surface.subtle,
-                })}
-              >
-                Issues {discoveriesEligible ? 'Eligible' : 'Ineligible'}
-              </Typography>
-            </>
-          ) : !isEligible ? (
-            <Typography
-              sx={(theme) => ({
-                fontFamily: FONTS.mono,
-                fontSize: '0.65rem',
-                fontWeight: 700,
-                color: theme.palette.text.secondary,
-                textTransform: 'uppercase',
-                border: `1px solid ${theme.palette.border.subtle}`,
-                borderRadius: 1,
-                px: 0.75,
-                py: 0.25,
-                letterSpacing: '0.06em',
-                backgroundColor: theme.palette.surface.subtle,
-              })}
-            >
-              Ineligible
-            </Typography>
-          ) : null}
+        {/* Watchlist button stays top-right */}
+        <Box sx={{ flexShrink: 0 }}>
           {miner.githubId && (
             <WatchlistButton
               category="miners"


### PR DESCRIPTION
## Summary

Reorganized the miner card header layout in the Watchlist page so that eligibility badges appear beneath the miner's name and rank, rather than beside them on the right. The rank is now displayed inline next to the name (baseline-aligned), and the watchlist star button remains anchored to the top-right corner of the card.

## Related Issues
Resolves: https://github.com/entrius/gittensor-ui/issues/626

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

## Before:
<img width="1670" height="1004" alt="Screenshot 2026-04-26 at 7 07 38 AM" src="https://github.com/user-attachments/assets/42779fdb-cb1b-4c82-9a8d-a13f08131a45" />

## After:
<img width="1920" height="1004" alt="Screenshot 2026-04-26 at 7 08 11 AM" src="https://github.com/user-attachments/assets/0c1542d1-9530-4ba4-95b5-f4f57e2736b9" />

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes