### PR TITLE
feat(repo): OSS vs Issue Discovery tabs on Top Miner Contributors

### DIFF
--- a/src/components/repositories/RepositoryContributorsTable.tsx
+++ b/src/components/repositories/RepositoryContributorsTable.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import {
   Box,
   Typography,
@@ -6,6 +6,7 @@ import {
   CircularProgress,
   alpha,
   useTheme,
+  Tooltip,
 } from '@mui/material';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
@@ -13,11 +14,14 @@ import { useAllPrs, useAllMiners } from '../../api';
 import { LinkBox } from '../common/linkBehavior';
 import { STATUS_COLORS } from '../../theme';
 import { isMergedPr } from '../../utils/prStatus';
+import { parseNumber } from '../../utils/ExplorerUtils';
 import { DataTable, type DataTableColumn } from '../common/DataTable';
 
 interface RepositoryContributorsTableProps {
   repositoryFullName: string;
 }
+
+type ContributorsProgramTab = 'oss' | 'issues';
 
 interface ContributorRow {
   rank: number;
@@ -26,7 +30,14 @@ interface ContributorRow {
   prs: number;
   score: number;
   minerRank?: number;
+  issueMinerRank?: number;
   isEligible?: boolean;
+  isIssueEligible?: boolean;
+  /** From GET /miners (miner-wide issue discovery stats). */
+  discoverySolved: number;
+  discoveryOpen: number;
+  discoveryClosed: number;
+  issueDiscoveryScore: number;
 }
 
 const numericCellSx = { fontVariantNumeric: 'tabular-nums' as const };
@@ -35,13 +46,17 @@ const RepositoryContributorsTable: React.FC<
   RepositoryContributorsTableProps
 > = ({ repositoryFullName }) => {
   const theme = useTheme();
-  const { data: allPRs, isLoading } = useAllPrs();
-  const { data: allMinersStats } = useAllMiners();
+  const { data: allPRs, isLoading: isPrsLoading } = useAllPrs();
+  const { data: allMinersStats, isLoading: isMinersLoading } = useAllMiners();
 
-  // State for how many items to show. Minimum 7.
   const [visibleCount, setVisibleCount] = useState(7);
+  const [programTab, setProgramTab] =
+    useState<ContributorsProgramTab>('oss');
 
-  // Build githubId -> miner rank/eligibility map
+  useEffect(() => {
+    setVisibleCount(7);
+  }, [programTab]);
+
   const minerDataMap = useMemo(() => {
     const map = new Map<string, { rank: number; isEligible?: boolean }>();
     if (Array.isArray(allMinersStats)) {
@@ -58,7 +73,47 @@ const RepositoryContributorsTable: React.FC<
     return map;
   }, [allMinersStats]);
 
-  // Get contributors for this repository - only count merged PRs
+  const issueLeaderboardRankById = useMemo(() => {
+    const map = new Map<string, number>();
+    if (Array.isArray(allMinersStats)) {
+      const sorted = [...allMinersStats].sort(
+        (a, b) =>
+          parseNumber(b.issueDiscoveryScore) -
+          parseNumber(a.issueDiscoveryScore),
+      );
+      sorted.forEach((m, index) => {
+        if (m.githubId) map.set(m.githubId, index + 1);
+      });
+    }
+    return map;
+  }, [allMinersStats]);
+
+  const minerDiscoveryById = useMemo(() => {
+    const map = new Map<
+      string,
+      {
+        discoverySolved: number;
+        discoveryOpen: number;
+        discoveryClosed: number;
+        issueDiscoveryScore: number;
+        isIssueEligible?: boolean;
+      }
+    >();
+    if (Array.isArray(allMinersStats)) {
+      for (const m of allMinersStats) {
+        if (!m.githubId) continue;
+        map.set(m.githubId, {
+          discoverySolved: parseNumber(m.totalSolvedIssues),
+          discoveryOpen: parseNumber(m.totalOpenIssues),
+          discoveryClosed: parseNumber(m.totalClosedIssues),
+          issueDiscoveryScore: parseNumber(m.issueDiscoveryScore),
+          isIssueEligible: m.isIssueEligible,
+        });
+      }
+    }
+    return map;
+  }, [allMinersStats]);
+
   const contributors = useMemo<ContributorRow[]>(() => {
     if (!allPRs) return [];
 
@@ -75,7 +130,7 @@ const RepositoryContributorsTable: React.FC<
     >();
 
     allRepoPRs.forEach((pr) => {
-      if (!pr.githubId) return; // Skip PRs without githubId
+      if (!pr.githubId) return;
       const existing = contributorsMap.get(pr.githubId) || {
         author: pr.author,
         githubId: pr.githubId,
@@ -87,129 +142,208 @@ const RepositoryContributorsTable: React.FC<
       contributorsMap.set(pr.githubId, existing);
     });
 
-    // Default sort by score descending
     return Array.from(contributorsMap.values())
       .sort((a, b) => b.score - a.score)
       .map((c, index) => {
         const minerData = minerDataMap.get(c.githubId);
+        const disc = minerDiscoveryById.get(c.githubId);
         return {
           ...c,
           rank: index + 1,
           minerRank: minerData?.rank,
+          issueMinerRank: issueLeaderboardRankById.get(c.githubId),
           isEligible: minerData?.isEligible,
+          isIssueEligible: disc?.isIssueEligible,
+          discoverySolved: disc?.discoverySolved ?? 0,
+          discoveryOpen: disc?.discoveryOpen ?? 0,
+          discoveryClosed: disc?.discoveryClosed ?? 0,
+          issueDiscoveryScore: disc?.issueDiscoveryScore ?? 0,
         };
       });
-  }, [allPRs, repositoryFullName, minerDataMap]);
+  }, [
+    allPRs,
+    repositoryFullName,
+    minerDataMap,
+    minerDiscoveryById,
+    issueLeaderboardRankById,
+  ]);
 
-  const displayedContributors = contributors.slice(0, visibleCount);
-  const totalContributors = contributors.length;
+  const discoveryOrderedContributors = useMemo(() => {
+    const totalIssues = (r: ContributorRow) =>
+      r.discoverySolved + r.discoveryOpen + r.discoveryClosed;
+    return [...contributors]
+      .sort((a, b) => {
+        const ds = b.issueDiscoveryScore - a.issueDiscoveryScore;
+        if (ds !== 0) return ds;
+        return totalIssues(b) - totalIssues(a);
+      })
+      .map((c, index) => ({ ...c, rank: index + 1 }));
+  }, [contributors]);
+
+  const activeContributors =
+    programTab === 'oss' ? contributors : discoveryOrderedContributors;
+
+  const displayedContributors = activeContributors.slice(0, visibleCount);
+  const totalContributors = activeContributors.length;
   const hasMore = visibleCount < totalContributors;
 
   const handleShowMore = () => setVisibleCount(totalContributors);
   const handleShowLess = () => setVisibleCount(7);
 
-  const columns = useMemo<DataTableColumn<ContributorRow>[]>(
-    () => [
-      {
-        key: 'rank',
-        header: '#',
-        width: '32px',
-        cellSx: (c) => ({
-          color: c.rank <= 3 ? 'text.primary' : STATUS_COLORS.open,
-          fontWeight: c.rank <= 3 ? 600 : 400,
-        }),
-        renderCell: (c) => c.rank,
-      },
-      {
-        key: 'miner',
-        header: 'Miner',
-        cellSx: { minWidth: 0 },
-        renderCell: (c) => (
-          <LinkBox
-            href={`/miners/details?githubId=${c.githubId}`}
-            linkState={{
-              backLabel: `Back to ${repositoryFullName}`,
+  const rankColumn = useMemo<DataTableColumn<ContributorRow>>(
+    () => ({
+      key: 'rank',
+      header: '#',
+      width: '32px',
+      cellSx: (c) => ({
+        color: c.rank <= 3 ? 'text.primary' : STATUS_COLORS.open,
+        fontWeight: c.rank <= 3 ? 600 : 400,
+      }),
+      renderCell: (c) => c.rank,
+    }),
+    [],
+  );
+
+  const minerColumn = useMemo<DataTableColumn<ContributorRow>>(
+    () => ({
+      key: 'miner',
+      header: 'Miner',
+      cellSx: { minWidth: 0 },
+      renderCell: (c) => (
+        <LinkBox
+          href={`/miners/details?githubId=${encodeURIComponent(c.githubId)}&mode=${programTab === 'issues' ? 'issues' : 'prs'}`}
+          linkState={{
+            backLabel: `Back to ${repositoryFullName}`,
+          }}
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 1.5,
+            overflow: 'hidden',
+            cursor: 'pointer',
+            '&:hover .contributor-name': {
+              color: STATUS_COLORS.info,
+              textDecoration: 'underline',
+            },
+          }}
+        >
+          <Avatar
+            src={`https://avatars.githubusercontent.com/${c.author}`}
+            sx={{
+              width: 20,
+              height: 20,
+              border: `1px solid ${theme.palette.border.light}`,
+              flexShrink: 0,
             }}
+          />
+          <Box
             sx={{
               display: 'flex',
-              alignItems: 'center',
-              gap: 1.5,
-              overflow: 'hidden',
-              cursor: 'pointer',
-              '&:hover .contributor-name': {
-                color: STATUS_COLORS.info,
-                textDecoration: 'underline',
-              },
+              flexDirection: 'column',
+              minWidth: 0,
             }}
           >
-            <Avatar
-              src={`https://avatars.githubusercontent.com/${c.author}`}
+            <Typography
+              className="contributor-name"
               sx={{
-                width: 20,
-                height: 20,
-                border: `1px solid ${theme.palette.border.light}`,
-                flexShrink: 0,
-              }}
-            />
-            <Box
-              sx={{
-                display: 'flex',
-                flexDirection: 'column',
-                minWidth: 0,
+                fontSize: '13px',
+                fontWeight: 500,
+                color: 'text.primary',
+                whiteSpace: 'nowrap',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                transition: 'color 0.1s',
               }}
             >
+              {c.author}
+            </Typography>
+            {programTab === 'oss' && c.minerRank != null && (
               <Typography
-                className="contributor-name"
                 sx={{
-                  fontSize: '13px',
-                  fontWeight: 500,
-                  color: 'text.primary',
+                  fontSize: '10px',
+                  color: STATUS_COLORS.open,
                   whiteSpace: 'nowrap',
                   overflow: 'hidden',
                   textOverflow: 'ellipsis',
-                  transition: 'color 0.1s',
                 }}
               >
-                {c.author}
+                OSS Rank #{c.minerRank}
               </Typography>
-              {c.minerRank != null && (
-                <Typography
-                  sx={{
-                    fontSize: '10px',
-                    color: STATUS_COLORS.open,
-                    whiteSpace: 'nowrap',
-                    overflow: 'hidden',
-                    textOverflow: 'ellipsis',
-                  }}
-                >
-                  Global Rank #{c.minerRank}
-                </Typography>
-              )}
-            </Box>
-          </LinkBox>
-        ),
-      },
-      {
-        key: 'prs',
-        header: 'PRs',
-        width: '3rem',
-        align: 'right',
-        headerSx: numericCellSx,
-        cellSx: numericCellSx,
-        renderCell: (c) => c.prs,
-      },
-      {
-        key: 'score',
-        header: 'Score',
-        width: '4.5rem',
-        align: 'right',
-        headerSx: numericCellSx,
-        cellSx: numericCellSx,
-        renderCell: (c) => c.score.toFixed(2),
-      },
-    ],
-    [repositoryFullName, theme.palette.border.light],
+            )}
+            {programTab === 'issues' && c.issueMinerRank != null && (
+              <Typography
+                sx={{
+                  fontSize: '10px',
+                  color: STATUS_COLORS.open,
+                  whiteSpace: 'nowrap',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                }}
+              >
+                Discovery rank #{c.issueMinerRank}
+              </Typography>
+            )}
+          </Box>
+        </LinkBox>
+      ),
+    }),
+    [programTab, repositoryFullName, theme.palette.border.light],
   );
+
+  const columns = useMemo<DataTableColumn<ContributorRow>[]>(() => {
+    if (programTab === 'oss') {
+      return [
+        rankColumn,
+        minerColumn,
+        {
+          key: 'prs',
+          header: 'PRs',
+          width: '3rem',
+          align: 'right',
+          headerSx: numericCellSx,
+          cellSx: numericCellSx,
+          renderCell: (c) => c.prs,
+        },
+        {
+          key: 'score',
+          header: 'Score',
+          width: '4.5rem',
+          align: 'right',
+          headerSx: numericCellSx,
+          cellSx: numericCellSx,
+          renderCell: (c) => c.score.toFixed(2),
+        },
+      ];
+    }
+    return [
+      rankColumn,
+      minerColumn,
+      {
+        key: 'discoverySolved',
+        header: (
+          <Tooltip title="Solved issues (Issue Discovery — from Gittensor /miners; miner-wide, not limited to this repo)">
+            <span>Issues</span>
+          </Tooltip>
+        ),
+        width: '3.25rem',
+        align: 'right',
+        headerSx: numericCellSx,
+        cellSx: numericCellSx,
+        renderCell: (c) => c.discoverySolved,
+      },
+      {
+        key: 'issueDiscoveryScore',
+        header: 'Score',
+        width: '4rem',
+        align: 'right',
+        headerSx: numericCellSx,
+        cellSx: numericCellSx,
+        renderCell: (c) => c.issueDiscoveryScore.toFixed(2),
+      },
+    ];
+  }, [programTab, rankColumn, minerColumn]);
+
+  const isLoading = isPrsLoading || isMinersLoading;
 
   if (isLoading) {
     return (
@@ -224,14 +358,7 @@ const RepositoryContributorsTable: React.FC<
   }
 
   const header = (
-    <Box
-      sx={{
-        display: 'flex',
-        justifyContent: 'space-between',
-        alignItems: 'center',
-        mb: 2,
-      }}
-    >
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5, mb: 0 }}>
       <Typography
         variant="subtitle2"
         sx={{
@@ -243,13 +370,74 @@ const RepositoryContributorsTable: React.FC<
           component="span"
           sx={{ color: STATUS_COLORS.open, fontSize: '0.8em' }}
         >
-          ({contributors.length})
+          ({totalContributors})
         </Typography>
       </Typography>
+      <Box
+        sx={{
+          display: 'flex',
+          width: '100%',
+          gap: 0.5,
+          backgroundColor: 'surface.subtle',
+          p: 0.5,
+          borderRadius: 2,
+        }}
+      >
+        {(
+          [
+            { label: 'OSS Contributions', value: 'oss' as const },
+            { label: 'Issue Discovery', value: 'issues' as const },
+          ] as const
+        ).map((option) => {
+          const isActive = programTab === option.value;
+          return (
+            <Box
+              key={option.value}
+              component="button"
+              type="button"
+              aria-pressed={isActive}
+              onClick={() => setProgramTab(option.value)}
+              sx={{
+                px: 1,
+                py: 0.65,
+                border: 0,
+                borderRadius: 1.5,
+                cursor: 'pointer',
+                minWidth: 0,
+                flex: 1,
+                fontFamily: 'inherit',
+                backgroundColor: isActive
+                  ? 'surface.elevated'
+                  : 'transparent',
+                color: isActive
+                  ? 'text.primary'
+                  : (t) => alpha(t.palette.text.primary, 0.5),
+                transition: 'all 0.2s',
+                '&:hover': {
+                  backgroundColor: 'surface.elevated',
+                  color: 'text.primary',
+                },
+              }}
+            >
+              <Typography
+                sx={{
+                  fontSize: '0.72rem',
+                  fontWeight: 600,
+                  textAlign: 'center',
+                  whiteSpace: 'nowrap',
+                  lineHeight: 1.2,
+                }}
+              >
+                {option.label}
+              </Typography>
+            </Box>
+          );
+        })}
+      </Box>
     </Box>
   );
 
-  const showMoreRow = contributors.length > 7 && (
+  const showMoreRow = activeContributors.length > 7 && (
     <Box
       onClick={hasMore ? handleShowMore : handleShowLess}
       sx={{
@@ -288,14 +476,20 @@ const RepositoryContributorsTable: React.FC<
         getRowKey={(c) => c.githubId}
         header={header}
         pagination={showMoreRow || undefined}
-        getRowSx={(c) => ({
-          opacity: c.isEligible ? 1 : 0.5,
-          '&:hover': {
-            backgroundColor: alpha(theme.palette.common.white, 0.04),
-            opacity: 1,
-          },
-          transition: 'all 0.1s',
-        })}
+        getRowSx={(c) => {
+          const eligible =
+            programTab === 'oss'
+              ? (c.isEligible ?? false)
+              : (c.isIssueEligible ?? false);
+          return {
+            opacity: eligible ? 1 : 0.5,
+            '&:hover': {
+              backgroundColor: alpha(theme.palette.common.white, 0.04),
+              opacity: 1,
+            },
+            transition: 'all 0.1s',
+          };
+        }}
       />
     </Box>
   );

--- a/src/components/repositories/RepositoryContributorsTable.tsx
+++ b/src/components/repositories/RepositoryContributorsTable.tsx
@@ -50,8 +50,7 @@ const RepositoryContributorsTable: React.FC<
   const { data: allMinersStats, isLoading: isMinersLoading } = useAllMiners();
 
   const [visibleCount, setVisibleCount] = useState(7);
-  const [programTab, setProgramTab] =
-    useState<ContributorsProgramTab>('oss');
+  const [programTab, setProgramTab] = useState<ContributorsProgramTab>('oss');
 
   useEffect(() => {
     setVisibleCount(7);
@@ -406,9 +405,7 @@ const RepositoryContributorsTable: React.FC<
                 minWidth: 0,
                 flex: 1,
                 fontFamily: 'inherit',
-                backgroundColor: isActive
-                  ? 'surface.elevated'
-                  : 'transparent',
+                backgroundColor: isActive ? 'surface.elevated' : 'transparent',
                 color: isActive
                   ? 'text.primary'
                   : (t) => alpha(t.palette.text.primary, 0.5),


### PR DESCRIPTION
## Summary

Repository details already listed top contributors from merged PRs using Gittensor **`/prs`**, enriched with **`/miners`** for rank and eligibility. This keeps that data path (no direct GitHub API for this block) and adds a second view for the same contributor set:

- **OSS Contributions** — existing columns (PR count, summed PR score for the repo). Miner subtitle label set to **OSS Rank** to match `totalScore`-based ordering from `/miners`.
- **Issue Discovery** — same miners, reordered by `issueDiscoveryScore` from `/miners` (tie-break on miner-wide issue counts), with **Issues** (solved count) and **Score**, row dimming via `isIssueEligible`, and miner links using `mode=issues` vs `mode=prs`.

Scope is limited to the contributors sidebar; expanding “show more” resets when switching tabs.

## Related issues

Fixed #780

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Screenshots

-Before Fix

<img width="1899" height="821" alt="image" src="https://github.com/user-attachments/assets/e194c2d6-483e-463f-a71a-367129493b88" />

-After Fix
<img width="1886" height="938" alt="image" src="https://github.com/user-attachments/assets/8fa08df9-4cf6-4678-8715-f9698ab34cf8" />
<img width="243" height="312" alt="image" src="https://github.com/user-attachments/assets/2e08261b-3e92-4864-bced-ef817fd3a9c5" />


## Testing

- `npm run build` passes.
- Manually verified on repository details with the test API (per [CONTRIBUTING.md](https://github.com/entrius/gittensor-ui/blob/test/CONTRIBUTING.md)): tabs, ordering, miner detail links with correct `mode`, loading state.

## Checklist

- [x] Scoped to contributors UI; follows existing `DataTable` / API patterns
- [x] Theme tokens only (no new hardcoded colors)
- [x] Tested against test API
- [x] `npm run format` and `npm run lint:fix`
- [x] `npm run build` passes
- [ ] Screenshots for UI changes

