### PR TITLE
feat(watchlist): auto-show PRs from watched miners and repos on PR tab (#784)

### DIFF
--- a/src/api/MinerApi.ts
+++ b/src/api/MinerApi.ts
@@ -57,6 +57,9 @@ export const useMinerPRs = (githubId: string, enabled?: boolean) =>
     enabled,
   );
 
+export const getMinerPRsQueryKey = (githubId: string) =>
+  ['useMinerPRs', `/miners/${githubId}/prs`, undefined] as const;
+
 /**
  * Get GitHub profile data for a specific miner
  * @param githubId - Numeric GitHub ID (e.g., "583231"), NOT username

--- a/src/components/common/MinerWatchlistButton.tsx
+++ b/src/components/common/MinerWatchlistButton.tsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import { IconButton, Tooltip, type SxProps, type Theme } from '@mui/material';
+import StarIcon from '@mui/icons-material/Star';
+import StarBorderIcon from '@mui/icons-material/StarBorder';
+import axios from 'axios';
+import { useQueryClient } from '@tanstack/react-query';
+import { useWatchlist, serializePRKey } from '../../hooks/useWatchlist';
+import {
+  getAllPrsQueryKey,
+  getMinerPRsQueryKey,
+  type CommitLog,
+} from '../../api';
+
+interface MinerWatchlistButtonProps {
+  githubId: string;
+  hotkey?: string;
+  size?: 'small' | 'medium';
+  sx?: SxProps<Theme>;
+}
+
+function fanOutKeys(prs: CommitLog[]): string[] {
+  return prs.map((pr) => serializePRKey(pr.repository, pr.pullRequestNumber));
+}
+
+function filterPrsByHotkey(prs: CommitLog[], hotkey: string): CommitLog[] {
+  return prs.filter((pr) => pr.hotkey === hotkey);
+}
+
+async function fetchMinerPRsViaCache(
+  queryClient: ReturnType<typeof useQueryClient>,
+  githubId: string,
+): Promise<CommitLog[]> {
+  return queryClient.fetchQuery<CommitLog[]>({
+    queryKey: getMinerPRsQueryKey(githubId),
+    queryFn: async () => {
+      const baseUrl = import.meta.env.VITE_REACT_APP_BASE_URL;
+      const url = `${baseUrl ?? ''}/miners/${githubId}/prs`;
+      const { data } = await axios.get<CommitLog[]>(url);
+      return data;
+    },
+  });
+}
+
+export const MinerWatchlistButton: React.FC<MinerWatchlistButtonProps> = ({
+  githubId,
+  hotkey,
+  size = 'small',
+  sx,
+}) => {
+  const { isWatched, toggle } = useWatchlist('miners');
+  const { addMany: addManyPrs } = useWatchlist('prs');
+  const queryClient = useQueryClient();
+
+  const watched = githubId ? isWatched(githubId) : false;
+  const label = watched ? 'Remove from watchlist' : 'Add to watchlist';
+
+  const handleClick = async (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+    e.preventDefault();
+    if (!githubId) return;
+
+    const willBeWatched = !watched;
+    toggle(githubId);
+    if (!willBeWatched) return;
+
+    if (hotkey) {
+      const cached = queryClient.getQueryData<CommitLog[]>(getAllPrsQueryKey());
+      if (cached) {
+        addManyPrs(fanOutKeys(filterPrsByHotkey(cached, hotkey)));
+        return;
+      }
+    }
+
+    try {
+      const prs = await fetchMinerPRsViaCache(queryClient, githubId);
+      addManyPrs(fanOutKeys(prs ?? []));
+    } catch {
+      // noop
+    }
+  };
+
+  return (
+    <Tooltip title={label} placement="top" arrow>
+      <IconButton
+        size={size}
+        onClick={handleClick}
+        aria-label={label}
+        aria-pressed={watched}
+        sx={{
+          color: watched ? 'warning.main' : 'text.tertiary',
+          transition: 'color 0.15s, transform 0.15s',
+          '&:hover': {
+            color: 'warning.light',
+            transform: 'scale(1.08)',
+            backgroundColor: 'rgba(255,255,255,0.06)',
+          },
+          ...sx,
+        }}
+      >
+        {watched ? (
+          <StarIcon fontSize={size === 'medium' ? 'medium' : 'small'} />
+        ) : (
+          <StarBorderIcon fontSize={size === 'medium' ? 'medium' : 'small'} />
+        )}
+      </IconButton>
+    </Tooltip>
+  );
+};

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -1,4 +1,5 @@
 export * from './SearchInput';
 export * from './linkBehavior';
 export * from './WatchlistButton';
+export * from './MinerWatchlistButton';
 export * from './DataTable';

--- a/src/components/leaderboard/MinerCard.tsx
+++ b/src/components/leaderboard/MinerCard.tsx
@@ -6,7 +6,7 @@ import { useMinerGithubData, useMinerPRs } from '../../api';
 import { CHART_COLORS, STATUS_COLORS } from '../../theme';
 import { getGithubAvatarSrc } from '../../utils/ExplorerUtils';
 import { linkResetSx, useLinkBehavior } from '../common/linkBehavior';
-import { WatchlistButton } from '../common';
+import { MinerWatchlistButton } from '../common';
 import { type MinerStats, type LeaderboardVariant, FONTS } from './types';
 
 interface MinerCardProps {
@@ -296,9 +296,9 @@ export const MinerCard: React.FC<MinerCardProps> = ({
         {/* Watchlist button stays top-right */}
         <Box sx={{ flexShrink: 0 }}>
           {miner.githubId && (
-            <WatchlistButton
-              category="miners"
-              itemKey={miner.githubId}
+            <MinerWatchlistButton
+              githubId={miner.githubId}
+              hotkey={miner.hotkey}
               size="small"
             />
           )}

--- a/src/components/leaderboard/MinersList.tsx
+++ b/src/components/leaderboard/MinersList.tsx
@@ -3,7 +3,11 @@ import { Avatar, Box, Card, Tooltip, Typography } from '@mui/material';
 import { useMinerGithubData, useMinerPRs } from '../../api';
 import { CHART_COLORS, scrollbarSx } from '../../theme';
 import { getGithubAvatarSrc, type SortOrder } from '../../utils/ExplorerUtils';
-import { DataTable, type DataTableColumn, WatchlistButton } from '../common';
+import {
+  DataTable,
+  type DataTableColumn,
+  MinerWatchlistButton,
+} from '../common';
 import { RankIcon } from './RankIcon';
 import {
   type LeaderboardVariant,
@@ -119,9 +123,9 @@ export const MinersList: React.FC<MinersListProps> = ({
       cellSx: { p: 0 },
       renderCell: (miner) =>
         miner.githubId ? (
-          <WatchlistButton
-            category="miners"
-            itemKey={miner.githubId}
+          <MinerWatchlistButton
+            githubId={miner.githubId}
+            hotkey={miner.hotkey}
             size="small"
           />
         ) : null,

--- a/src/hooks/useWatchedPRs.ts
+++ b/src/hooks/useWatchedPRs.ts
@@ -1,0 +1,69 @@
+import { useMemo } from 'react';
+import { useAllMiners, useAllPrs, type CommitLog } from '../api';
+import { useWatchlist, serializePRKey } from './useWatchlist';
+
+export interface UseWatchedPRsResult {
+  items: CommitLog[];
+  isLoading: boolean;
+}
+
+interface MinerLike {
+  githubId?: string;
+  hotkey?: string;
+}
+
+export function resolveWatchedMinerHotkeys(
+  allMiners: MinerLike[] | undefined,
+  watchedMinerIds: string[],
+): Set<string> {
+  if (!allMiners || watchedMinerIds.length === 0) return new Set<string>();
+  const watchedSet = new Set(watchedMinerIds);
+  const hotkeys = new Set<string>();
+  for (const m of allMiners) {
+    if (m.githubId && watchedSet.has(m.githubId) && m.hotkey) {
+      hotkeys.add(m.hotkey);
+    }
+  }
+  return hotkeys;
+}
+
+export function matchesWatchedSet(
+  pr: CommitLog,
+  starredKeys: Set<string>,
+  watchedRepos: Set<string>,
+  watchedMinerHotkeys: Set<string>,
+): boolean {
+  return (
+    starredKeys.has(serializePRKey(pr.repository, pr.pullRequestNumber)) ||
+    watchedRepos.has(pr.repository.toLowerCase()) ||
+    watchedMinerHotkeys.has(pr.hotkey)
+  );
+}
+
+export function useWatchedPRs(starredKeyList: string[]): UseWatchedPRsResult {
+  const { data: allPrs, isLoading } = useAllPrs();
+  const { ids: watchedMinerIds } = useWatchlist('miners');
+  const { ids: watchedRepoIds } = useWatchlist('repos');
+  const { data: allMiners } = useAllMiners();
+
+  const watchedMinerHotkeys = useMemo(
+    () => resolveWatchedMinerHotkeys(allMiners, watchedMinerIds),
+    [allMiners, watchedMinerIds],
+  );
+
+  const watchedRepoSet = useMemo(
+    () => new Set(watchedRepoIds.map((r) => r.toLowerCase())),
+    [watchedRepoIds],
+  );
+
+  const starredKeys = useMemo(() => new Set(starredKeyList), [starredKeyList]);
+
+  const items = useMemo(() => {
+    if (!allPrs) return [] as CommitLog[];
+    return allPrs.filter((pr) =>
+      matchesWatchedSet(pr, starredKeys, watchedRepoSet, watchedMinerHotkeys),
+    );
+  }, [allPrs, starredKeys, watchedRepoSet, watchedMinerHotkeys]);
+
+  return { items, isLoading };
+}

--- a/src/hooks/useWatchlist.ts
+++ b/src/hooks/useWatchlist.ts
@@ -128,6 +128,7 @@ interface UseWatchlist {
   count: number;
   isWatched: (id: string) => boolean;
   add: (id: string) => void;
+  addMany: (ids: string[]) => void;
   remove: (id: string) => void;
   toggle: (id: string) => void;
   clear: () => void;
@@ -156,6 +157,26 @@ export const useWatchlist = (
     (id: string) => {
       if (!id || snapshot[category].includes(id)) return;
       setSnapshot({ ...snapshot, [category]: [...snapshot[category], id] });
+    },
+    [category],
+  );
+
+  const addMany = useCallback(
+    (incoming: string[]) => {
+      if (!incoming || incoming.length === 0) return;
+      const existing = snapshot[category];
+      const existingSet = new Set(existing);
+      const additions: string[] = [];
+      for (const id of incoming) {
+        if (!id || existingSet.has(id)) continue;
+        existingSet.add(id);
+        additions.push(id);
+      }
+      if (additions.length === 0) return;
+      setSnapshot({
+        ...snapshot,
+        [category]: [...existing, ...additions],
+      });
     },
     [category],
   );
@@ -195,6 +216,7 @@ export const useWatchlist = (
     count: ids.length,
     isWatched,
     add,
+    addMany,
     remove,
     toggle,
     clear,

--- a/src/pages/MinerDetailsPage.tsx
+++ b/src/pages/MinerDetailsPage.tsx
@@ -13,7 +13,7 @@ import {
   MinerScoreCard,
   SEO,
 } from '../components';
-import { WatchlistButton } from '../components/common';
+import { MinerWatchlistButton } from '../components/common';
 
 type ViewMode = 'prs' | 'issues';
 
@@ -125,11 +125,7 @@ const MinerDetailsPage: React.FC = () => {
               }}
             >
               <BackButton to="/top-miners" mb={0} />
-              <WatchlistButton
-                category="miners"
-                itemKey={githubId}
-                size="medium"
-              />
+              <MinerWatchlistButton githubId={githubId} size="medium" />
             </Box>
             <Box
               sx={{

--- a/src/pages/WatchlistPage.tsx
+++ b/src/pages/WatchlistPage.tsx
@@ -5,14 +5,11 @@ import {
   Card,
   Chip,
   FormControl,
-  Grid,
-  IconButton,
   InputAdornment,
   MenuItem,
   Select,
   TablePagination,
   TextField,
-  Tooltip,
   Typography,
   Button,
   alpha,
@@ -26,8 +23,6 @@ import {
   useMediaQuery,
 } from '@mui/material';
 import SearchIcon from '@mui/icons-material/Search';
-import ViewModuleIcon from '@mui/icons-material/ViewModule';
-import ViewListIcon from '@mui/icons-material/ViewList';
 import { Link as RouterLink, useSearchParams } from 'react-router-dom';
 import { Page } from '../components/layout';
 import {
@@ -41,7 +36,7 @@ import {
   type DataTableColumn,
 } from '../components/common/DataTable';
 import { LinkBox } from '../components/common/linkBehavior';
-import { useAllMiners, useAllPrs, useReposAndWeights, useIssues } from '../api';
+import { useAllMiners, useReposAndWeights, useIssues } from '../api';
 import { mapAllMinersToStats } from '../utils/minerMapper';
 import {
   useWatchlist,
@@ -49,16 +44,12 @@ import {
   serializePRKey,
   type WatchlistCategory,
 } from '../hooks/useWatchlist';
-import {
-  isMergedPr,
-  isClosedUnmergedPr,
-  getPrStatusCounts,
-} from '../utils/prStatus';
+import { useWatchedPRs } from '../hooks/useWatchedPRs';
+import { isMergedPr, isClosedUnmergedPr } from '../utils/prStatus';
 import { filterPrs, type PrStatusFilter } from '../utils/prTable';
 import { getIssueStatusMeta } from '../utils/issueStatus';
 import { formatTokenAmount } from '../utils/format';
 import theme, { STATUS_COLORS, scrollbarSx } from '../theme';
-import FilterButton from '../components/FilterButton';
 import type { CommitLog } from '../api/models/Dashboard';
 
 const TAB_ORDER: readonly WatchlistCategory[] = [
@@ -282,7 +273,9 @@ const WatchlistPage: React.FC = () => {
             </Tabs>
           </Box>
 
-          {isEmpty ? (
+          {activeTab === 'prs' ? (
+            <PRsList itemKeys={ids} />
+          ) : isEmpty ? (
             <Box
               sx={{
                 py: 8,
@@ -321,10 +314,8 @@ const WatchlistPage: React.FC = () => {
             <MinersList itemKeys={ids} />
           ) : activeTab === 'repos' ? (
             <ReposList itemKeys={ids} />
-          ) : activeTab === 'bounties' ? (
-            <BountiesList itemKeys={ids} />
           ) : (
-            <PRsList itemKeys={ids} />
+            <BountiesList itemKeys={ids} />
           )}
         </Box>
 
@@ -743,253 +734,17 @@ const prColumns: DataTableColumn<CommitLog, PrSortKey>[] = [
   },
 ];
 
-type PRsViewMode = 'list' | 'cards';
-
-const PRsViewModeToggle: React.FC<{
-  viewMode: PRsViewMode;
-  onChange: (mode: PRsViewMode) => void;
-}> = ({ viewMode, onChange }) => {
-  const options: {
-    value: PRsViewMode;
-    label: string;
-    Icon: typeof ViewListIcon;
-  }[] = [
-    { value: 'list', label: 'List view', Icon: ViewListIcon },
-    { value: 'cards', label: 'Card view', Icon: ViewModuleIcon },
-  ];
-
-  return (
-    <Box
-      sx={(t) => ({
-        display: 'inline-flex',
-        alignItems: 'center',
-        borderRadius: 2,
-        border: '1px solid',
-        borderColor: t.palette.border.light,
-        overflow: 'hidden',
-      })}
-      role="group"
-      aria-label="Toggle view mode"
-    >
-      {options.map(({ value, label, Icon }) => {
-        const isActive = viewMode === value;
-        return (
-          <Tooltip key={value} title={label} placement="top" arrow>
-            <IconButton
-              onClick={() => onChange(value)}
-              size="small"
-              aria-label={label}
-              aria-pressed={isActive}
-              sx={(t) => ({
-                borderRadius: 0,
-                padding: '6px 10px',
-                color: isActive
-                  ? t.palette.text.primary
-                  : t.palette.text.tertiary,
-                backgroundColor: isActive
-                  ? t.palette.surface.light
-                  : 'transparent',
-                '&:hover': {
-                  backgroundColor: t.palette.surface.light,
-                  color: t.palette.text.primary,
-                },
-              })}
-            >
-              <Icon fontSize="small" />
-            </IconButton>
-          </Tooltip>
-        );
-      })}
-    </Box>
-  );
-};
-
 const getPrHref = (pr: CommitLog) =>
   `/miners/pr?repo=${encodeURIComponent(pr.repository)}&number=${pr.pullRequestNumber}`;
-
-const PRCard: React.FC<{ pr: CommitLog }> = ({ pr }) => {
-  const { label, color } = prStatusMeta(pr);
-  const key = serializePRKey(pr.repository, pr.pullRequestNumber);
-  return (
-    <Card
-      elevation={0}
-      sx={(t) => ({
-        p: 1,
-        backgroundColor: t.palette.background.default,
-        backdropFilter: 'blur(12px)',
-        border: '1px solid',
-        borderColor: alpha(color, 0.3),
-        borderRadius: 2,
-        cursor: 'pointer',
-        transition: 'all 0.2s cubic-bezier(0.4, 0, 0.2, 1)',
-        height: '100%',
-        display: 'flex',
-        flexDirection: 'column',
-        gap: 1,
-        boxShadow: `0 2px 8px ${alpha(t.palette.background.default, 0.1)}`,
-        '&:hover': {
-          backgroundColor: t.palette.surface.elevated,
-          borderColor: alpha(color, 0.5),
-          transform: 'translateY(-2px)',
-          boxShadow: `0 8px 24px -6px ${alpha(t.palette.background.default, 0.6)}`,
-        },
-      })}
-    >
-      {/* Row 1: repo + status + star */}
-      <Box
-        sx={{
-          display: 'flex',
-          justifyContent: 'space-between',
-          alignItems: 'flex-start',
-        }}
-      >
-        <Stack
-          direction="row"
-          alignItems="center"
-          spacing={1}
-          sx={{ minWidth: 0 }}
-        >
-          <Avatar
-            src={`https://avatars.githubusercontent.com/${pr.repository.split('/')[0]}`}
-            sx={{
-              width: 20,
-              height: 20,
-              flexShrink: 0,
-              border: '1px solid',
-              borderColor: 'border.medium',
-            }}
-          />
-          <Typography
-            sx={{
-              fontSize: '0.72rem',
-              color: 'text.secondary',
-              overflow: 'hidden',
-              textOverflow: 'ellipsis',
-              whiteSpace: 'nowrap',
-            }}
-          >
-            {pr.repository}
-          </Typography>
-        </Stack>
-        <Stack
-          direction="row"
-          alignItems="center"
-          spacing={0.5}
-          sx={{ flexShrink: 0 }}
-        >
-          <Chip
-            variant="status"
-            label={label}
-            size="small"
-            sx={{
-              color,
-              borderColor: alpha(color, 0.3),
-              backgroundColor: alpha(color, 0.08),
-            }}
-          />
-          <WatchlistButton category="prs" itemKey={key} size="small" />
-        </Stack>
-      </Box>
-
-      {/* Row 2: title (linkable) */}
-      <LinkBox
-        href={getPrHref(pr)}
-        linkState={{ backLabel: 'Back to Watchlist' }}
-        sx={{ display: 'flex', flexDirection: 'column', gap: 1, flex: 1 }}
-      >
-        <Typography
-          sx={{
-            fontSize: '0.85rem',
-            fontWeight: 600,
-            color: 'text.primary',
-            lineHeight: 1.4,
-            display: '-webkit-box',
-            WebkitLineClamp: 2,
-            WebkitBoxOrient: 'vertical',
-            overflow: 'hidden',
-          }}
-        >
-          #{pr.pullRequestNumber} {pr.pullRequestTitle}
-        </Typography>
-
-        {/* Row 3: footer stats */}
-        <Box
-          sx={(t) => ({
-            mt: 'auto',
-            backgroundColor: alpha(t.palette.background.default, 0.2),
-            borderRadius: 1.5,
-            p: 1,
-            display: 'flex',
-            justifyContent: 'space-between',
-            alignItems: 'center',
-          })}
-        >
-          <Stack direction="row" alignItems="center" spacing={1}>
-            <Avatar
-              src={`https://avatars.githubusercontent.com/${pr.author}`}
-              sx={{ width: 18, height: 18 }}
-            />
-            <Typography
-              sx={{
-                fontSize: '0.72rem',
-                color: 'text.secondary',
-              }}
-            >
-              {pr.author}
-            </Typography>
-          </Stack>
-          <Stack direction="row" spacing={1.5} alignItems="center">
-            <Stack direction="row" spacing={0.5} alignItems="center">
-              <Typography
-                sx={{
-                  fontSize: '0.7rem',
-                  color: 'diff.additions',
-                  fontWeight: 600,
-                }}
-              >
-                +{pr.additions}
-              </Typography>
-              <Typography
-                sx={{
-                  fontSize: '0.7rem',
-                  color: 'text.tertiary',
-                }}
-              >
-                /
-              </Typography>
-              <Typography
-                sx={{
-                  fontSize: '0.7rem',
-                  color: 'diff.deletions',
-                  fontWeight: 600,
-                }}
-              >
-                -{pr.deletions}
-              </Typography>
-            </Stack>
-            <Typography
-              sx={{
-                fontSize: '0.75rem',
-                fontWeight: 700,
-                color: 'text.primary',
-              }}
-            >
-              {parseFloat(pr.score || '0').toFixed(2)}
-            </Typography>
-          </Stack>
-        </Box>
-      </LinkBox>
-    </Card>
-  );
-};
 
 const PR_ROWS_OPTIONS = [10, 25, 50] as const;
 
 const PRsList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
-  const { data: allPrs } = useAllPrs();
+  const { items } = useWatchedPRs(itemKeys);
+
   const [searchQuery, setSearchQuery] = useState('');
   const [statusFilter, setStatusFilter] = useState<PrStatusFilter>('all');
-  const [viewMode, setViewMode] = useState<PRsViewMode>('list');
+  const [authorFilter, setAuthorFilter] = useState<string>('all');
   const [rowsPerPage, setRowsPerPage] = useState(10);
   const [page, setPage] = useState(0);
   const [sortField, setSortField] = useState<PrSortKey>('score');
@@ -1009,25 +764,24 @@ const PRsList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
     setPage(0);
   };
 
-  const items = useMemo(() => {
-    if (!allPrs) return [];
-    const set = new Set(itemKeys);
-    return allPrs.filter((pr) =>
-      set.has(serializePRKey(pr.repository, pr.pullRequestNumber)),
-    );
-  }, [allPrs, itemKeys]);
-
-  const counts = useMemo(() => getPrStatusCounts(items), [items]);
+  const authorOptions = useMemo(() => {
+    const seen = new Set<string>();
+    for (const pr of items) {
+      if (pr.author) seen.add(pr.author);
+    }
+    return Array.from(seen).sort((a, b) => a.localeCompare(b));
+  }, [items]);
 
   const filtered = useMemo(() => {
     const result = filterPrs(items, {
       statusFilter,
+      author: authorFilter === 'all' ? null : authorFilter,
       searchQuery,
       includeNumber: true,
     });
     setPage(0);
     return result;
-  }, [items, statusFilter, searchQuery]);
+  }, [items, statusFilter, authorFilter, searchQuery]);
 
   const sorted = useMemo(() => {
     const dir = sortOrder === 'asc' ? 1 : -1;
@@ -1084,38 +838,132 @@ const PRsList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
           gap: 2,
           borderBottom: '1px solid',
           borderColor: 'border.light',
+          flexWrap: 'wrap',
         }}
       >
-        <Box sx={{ display: 'flex', gap: 0.5, alignItems: 'center' }}>
-          <FilterButton
-            label="All"
-            count={counts.all}
-            color={STATUS_COLORS.neutral}
-            isActive={statusFilter === 'all'}
-            onClick={() => setStatusFilter('all')}
-          />
-          <FilterButton
-            label="Open"
-            count={counts.open}
-            color={STATUS_COLORS.open}
-            isActive={statusFilter === 'open'}
-            onClick={() => setStatusFilter('open')}
-          />
-          <FilterButton
-            label="Merged"
-            count={counts.merged}
-            color={STATUS_COLORS.merged}
-            isActive={statusFilter === 'merged'}
-            onClick={() => setStatusFilter('merged')}
-          />
-          <FilterButton
-            label="Closed"
-            count={counts.closed}
-            color={STATUS_COLORS.closed}
-            isActive={statusFilter === 'closed'}
-            onClick={() => setStatusFilter('closed')}
-          />
-        </Box>
+        <FormControl size="small">
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <Typography
+              variant="body2"
+              sx={{ color: 'text.secondary', fontSize: '0.8rem' }}
+            >
+              State:
+            </Typography>
+            <Select
+              value={statusFilter}
+              onChange={(e) =>
+                setStatusFilter(e.target.value as PrStatusFilter)
+              }
+              sx={{
+                color: 'text.primary',
+                backgroundColor: 'background.default',
+                fontSize: '0.8rem',
+                height: '36px',
+                borderRadius: 2,
+                minWidth: '96px',
+                '& fieldset': { borderColor: 'border.light' },
+                '&:hover fieldset': { borderColor: 'border.medium' },
+                '&.Mui-focused fieldset': { borderColor: 'primary.main' },
+                '& .MuiSelect-select': { py: 0.75, pr: '28px !important' },
+              }}
+            >
+              <MenuItem value="all">All</MenuItem>
+              <MenuItem value="open">Open</MenuItem>
+              <MenuItem value="merged">Merged</MenuItem>
+              <MenuItem value="closed">Closed</MenuItem>
+            </Select>
+          </Box>
+        </FormControl>
+        <FormControl size="small">
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <Typography
+              variant="body2"
+              sx={{ color: 'text.secondary', fontSize: '0.8rem' }}
+            >
+              Author:
+            </Typography>
+            <Select
+              value={authorFilter}
+              onChange={(e) => setAuthorFilter(e.target.value as string)}
+              sx={{
+                color: 'text.primary',
+                backgroundColor: 'background.default',
+                fontSize: '0.8rem',
+                height: '36px',
+                borderRadius: 2,
+                minWidth: '180px',
+                maxWidth: '240px',
+                '& fieldset': { borderColor: 'border.light' },
+                '&:hover fieldset': { borderColor: 'border.medium' },
+                '&.Mui-focused fieldset': { borderColor: 'primary.main' },
+                '& .MuiSelect-select': {
+                  py: 0.75,
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 0.75,
+                },
+              }}
+              MenuProps={{ PaperProps: { sx: { maxHeight: 360 } } }}
+              renderValue={(value) =>
+                value === 'all' ? (
+                  'All authors'
+                ) : (
+                  <Box
+                    sx={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 0.75,
+                      minWidth: 0,
+                    }}
+                  >
+                    <Avatar
+                      src={`https://avatars.githubusercontent.com/${value}`}
+                      sx={{ width: 18, height: 18, flexShrink: 0 }}
+                    />
+                    <Box
+                      component="span"
+                      sx={{
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        whiteSpace: 'nowrap',
+                      }}
+                    >
+                      {value}
+                    </Box>
+                  </Box>
+                )
+              }
+            >
+              <MenuItem value="all">All authors</MenuItem>
+              {authorOptions.map((author) => (
+                <MenuItem
+                  key={author}
+                  value={author}
+                  sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 0.75,
+                  }}
+                >
+                  <Avatar
+                    src={`https://avatars.githubusercontent.com/${author}`}
+                    sx={{ width: 20, height: 20, flexShrink: 0 }}
+                  />
+                  <Box
+                    component="span"
+                    sx={{
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
+                    }}
+                  >
+                    {author}
+                  </Box>
+                </MenuItem>
+              ))}
+            </Select>
+          </Box>
+        </FormControl>
         <FormControl size="small">
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
             <Typography
@@ -1164,7 +1012,8 @@ const PRsList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
             ),
           }}
           sx={{
-            width: '220px',
+            flex: 1,
+            minWidth: '180px',
             '& .MuiOutlinedInput-root': {
               color: 'text.primary',
               backgroundColor: 'background.default',
@@ -1177,69 +1026,23 @@ const PRsList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
             },
           }}
         />
-        <Box sx={{ ml: 'auto' }}>
-          <PRsViewModeToggle viewMode={viewMode} onChange={setViewMode} />
-        </Box>
       </Box>
 
-      {/* Content */}
-      {viewMode === 'list' ? (
-        <DataTable<CommitLog, PrSortKey>
-          columns={prColumns}
-          rows={paged}
-          getRowKey={(pr) =>
-            serializePRKey(pr.repository, pr.pullRequestNumber)
-          }
-          getRowHref={getPrHref}
-          linkState={{ backLabel: 'Back to Watchlist' }}
-          minWidth="750px"
-          stickyHeader
-          emptyLabel="No watched pull requests found."
-          sort={{
-            field: sortField,
-            order: sortOrder,
-            onChange: handleSort,
-          }}
-        />
-      ) : (
-        <Box
-          sx={{
-            p: 2,
-            overflowY: 'auto',
-            ...scrollbarSx,
-          }}
-        >
-          {paged.length === 0 ? (
-            <Typography
-              sx={{
-                color: 'text.secondary',
-                textAlign: 'center',
-                py: 4,
-                fontSize: '0.85rem',
-              }}
-            >
-              No watched pull requests found.
-            </Typography>
-          ) : (
-            <Grid container spacing={2} alignItems="stretch">
-              {paged.map((pr) => (
-                <Grid
-                  item
-                  xs={12}
-                  sm={6}
-                  md={4}
-                  key={serializePRKey(pr.repository, pr.pullRequestNumber)}
-                  sx={{ display: 'flex' }}
-                >
-                  <Box sx={{ width: '100%' }}>
-                    <PRCard pr={pr} />
-                  </Box>
-                </Grid>
-              ))}
-            </Grid>
-          )}
-        </Box>
-      )}
+      <DataTable<CommitLog, PrSortKey>
+        columns={prColumns}
+        rows={paged}
+        getRowKey={(pr) => serializePRKey(pr.repository, pr.pullRequestNumber)}
+        getRowHref={getPrHref}
+        linkState={{ backLabel: 'Back to Watchlist' }}
+        minWidth="750px"
+        stickyHeader
+        emptyLabel="No watched pull requests found."
+        sort={{
+          field: sortField,
+          order: sortOrder,
+          onChange: handleSort,
+        }}
+      />
       <TablePagination
         rowsPerPageOptions={[]}
         component="div"

--- a/src/tests/useWatchedPRs.test.ts
+++ b/src/tests/useWatchedPRs.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import {
+  resolveWatchedMinerHotkeys,
+  matchesWatchedSet,
+} from '../hooks/useWatchedPRs';
+import { type CommitLog } from '../api';
+
+function makePr(overrides: Partial<CommitLog> = {}): CommitLog {
+  return {
+    pullRequestNumber: 1,
+    hotkey: 'hk_default',
+    pullRequestTitle: 'PR title',
+    additions: 0,
+    deletions: 0,
+    commitCount: 1,
+    repository: 'owner/repo',
+    mergedAt: null,
+    closedAt: null,
+    prCreatedAt: '2026-01-01T00:00:00Z',
+    prState: 'open',
+    author: 'someone',
+    score: '0',
+    ...overrides,
+  };
+}
+
+describe('resolveWatchedMinerHotkeys', () => {
+  it('returns an empty set when no miners are watched', () => {
+    const result = resolveWatchedMinerHotkeys(
+      [{ githubId: '1', hotkey: 'hk_a' }],
+      [],
+    );
+    expect(result.size).toBe(0);
+  });
+
+  it('returns an empty set when the miners cache is undefined', () => {
+    const result = resolveWatchedMinerHotkeys(undefined, ['1']);
+    expect(result.size).toBe(0);
+  });
+
+  it('maps watched githubIds to their hotkeys', () => {
+    const miners = [
+      { githubId: '1', hotkey: 'hk_a' },
+      { githubId: '2', hotkey: 'hk_b' },
+      { githubId: '3', hotkey: 'hk_c' },
+    ];
+    const result = resolveWatchedMinerHotkeys(miners, ['1', '3']);
+    expect(Array.from(result).sort()).toEqual(['hk_a', 'hk_c']);
+  });
+
+  it('skips miners that lack a hotkey', () => {
+    const miners = [
+      { githubId: '1', hotkey: undefined },
+      { githubId: '2', hotkey: 'hk_b' },
+    ];
+    const result = resolveWatchedMinerHotkeys(miners, ['1', '2']);
+    expect(Array.from(result)).toEqual(['hk_b']);
+  });
+});
+
+describe('matchesWatchedSet', () => {
+  const empty = new Set<string>();
+
+  it('matches when the PR key is starred', () => {
+    const pr = makePr({ repository: 'owner/repo', pullRequestNumber: 42 });
+    const starred = new Set(['owner/repo#42']);
+    expect(matchesWatchedSet(pr, starred, empty, empty)).toBe(true);
+  });
+
+  it('matches when the repository is watched, case-insensitive', () => {
+    const pr = makePr({ repository: 'Owner/Repo' });
+    const repos = new Set(['owner/repo']);
+    expect(matchesWatchedSet(pr, empty, repos, empty)).toBe(true);
+  });
+
+  it('matches when the miner hotkey is watched', () => {
+    const pr = makePr({ hotkey: 'hk_xyz' });
+    const hotkeys = new Set(['hk_xyz']);
+    expect(matchesWatchedSet(pr, empty, empty, hotkeys)).toBe(true);
+  });
+
+  it('returns false when nothing matches', () => {
+    const pr = makePr();
+    expect(matchesWatchedSet(pr, empty, empty, empty)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Watchlist → Pull Requests tab now auto-displays every PR from any watched miner or repository, in addition to PRs starred individually. The tab is rendered even when no individual PRs are starred, with its own empty state when nothing matches.

## Related Issues

Closes #784

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots


https://github.com/user-attachments/assets/384d0b2d-8f48-40d0-a25a-66e28ad4ed3c



## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes

