### PR TITLE
feat(watchlist): show issue discovery counts in Miners list view

### DIFF
--- a/src/components/leaderboard/MinersList.tsx
+++ b/src/components/leaderboard/MinersList.tsx
@@ -11,6 +11,8 @@ import {
   type SortOption,
 } from './types';
 
+type ActivityMode = 'prs' | 'issues';
+
 const SEGMENT_COLORS = [
   CHART_COLORS.merged,
   CHART_COLORS.open,
@@ -41,9 +43,49 @@ export const MinersList: React.FC<MinersListProps> = ({
   getHref,
   linkState,
 }) => {
+  const isWatchlist = variant === 'watchlist';
   const isDiscoveries = variant === 'discoveries';
-  const prLabel = isDiscoveries ? 'Issues' : 'PRs';
-  const prSortKey: SortOption = isDiscoveries ? 'totalIssues' : 'totalPRs';
+  const singleActivityMode: ActivityMode = isDiscoveries ? 'issues' : 'prs';
+  const singleActivityLabel = isDiscoveries ? 'Issues' : 'PRs';
+  const singleActivitySortKey: SortOption = isDiscoveries
+    ? 'totalIssues'
+    : 'totalPRs';
+
+  const activityColumns: DataTableColumn<MinerStats, SortOption>[] = isWatchlist
+    ? [
+        {
+          key: 'prs',
+          header: 'PRs',
+          width: '13%',
+          align: 'right',
+          sortKey: 'totalPRs',
+          renderCell: (miner) => (
+            <MinerActivitySegments miner={miner} mode="prs" />
+          ),
+        },
+        {
+          key: 'issues',
+          header: 'Issues',
+          width: '13%',
+          align: 'right',
+          sortKey: 'totalIssues',
+          renderCell: (miner) => (
+            <MinerActivitySegments miner={miner} mode="issues" />
+          ),
+        },
+      ]
+    : [
+        {
+          key: 'activity',
+          header: singleActivityLabel,
+          width: '18%',
+          align: 'right',
+          sortKey: singleActivitySortKey,
+          renderCell: (miner) => (
+            <MinerActivitySegments miner={miner} mode={singleActivityMode} />
+          ),
+        },
+      ];
 
   const columns: DataTableColumn<MinerStats, SortOption>[] = [
     {
@@ -77,16 +119,7 @@ export const MinersList: React.FC<MinersListProps> = ({
         </Typography>
       ),
     },
-    {
-      key: 'activity',
-      header: prLabel,
-      width: '18%',
-      align: 'right',
-      sortKey: prSortKey,
-      renderCell: (miner) => (
-        <MinerActivitySegments miner={miner} variant={variant} />
-      ),
-    },
+    ...activityColumns,
     {
       key: 'credibility',
       header: 'Credibility',
@@ -222,15 +255,15 @@ const MinerIdentityCell: React.FC<MinerIdentityCellProps> = ({ miner }) => {
 
 interface MinerActivitySegmentsProps {
   miner: MinerStats;
-  variant: LeaderboardVariant;
+  mode: ActivityMode;
 }
 
 const MinerActivitySegments: React.FC<MinerActivitySegmentsProps> = ({
   miner,
-  variant,
+  mode,
 }) => {
   const segments =
-    variant === 'discoveries'
+    mode === 'issues'
       ? [
           { label: 'Solved', value: miner.totalSolvedIssues ?? 0 },
           { label: 'Open', value: miner.totalOpenIssues ?? 0 },

--- a/src/utils/minerMapper.ts
+++ b/src/utils/minerMapper.ts
@@ -11,32 +11,39 @@ export const mapAllMinersToStats = (
       .map((stat, index) => [String(stat.id), index + 1]),
   );
 
-  return allMinersStats.map((stat) => ({
-    id: String(stat.id),
-    githubId: stat.githubId || '',
-    author: stat.githubUsername || undefined,
-    totalScore: parseNumber(stat.totalScore),
-    baseTotalScore: parseNumber(stat.baseTotalScore),
-    totalPRs: parseNumber(stat.totalPrs),
-    linesChanged: parseNumber(stat.totalNodesScored),
-    linesAdded: parseNumber(stat.totalAdditions),
-    linesDeleted: parseNumber(stat.totalDeletions),
-    hotkey: stat.hotkey || 'N/A',
-    rank: rankById.get(String(stat.id)),
-    uniqueReposCount: parseNumber(stat.uniqueReposCount),
-    credibility: parseNumber(stat.credibility),
-    isEligible: stat.isEligible ?? false,
-    ossIsEligible: stat.isEligible ?? false,
-    discoveriesIsEligible: stat.isIssueEligible ?? false,
-    usdPerDay: parseNumber(stat.usdPerDay),
-    totalMergedPrs: parseNumber(stat.totalMergedPrs),
-    totalOpenPrs: parseNumber(stat.totalOpenPrs),
-    totalClosedPrs: parseNumber(stat.totalClosedPrs),
-    totalSolvedIssues: parseNumber(stat.totalSolvedIssues),
-    totalOpenIssues: parseNumber(stat.totalOpenIssues),
-    totalClosedIssues: parseNumber(stat.totalClosedIssues),
-    issueDiscoveryScore: parseNumber(stat.issueDiscoveryScore),
-    issueCredibility: parseNumber(stat.issueCredibility),
-    isIssueEligible: stat.isIssueEligible ?? false,
-  }));
+  return allMinersStats.map((stat) => {
+    const totalSolvedIssues = parseNumber(stat.totalSolvedIssues);
+    const totalOpenIssues = parseNumber(stat.totalOpenIssues);
+    const totalClosedIssues = parseNumber(stat.totalClosedIssues);
+
+    return {
+      id: String(stat.id),
+      githubId: stat.githubId || '',
+      author: stat.githubUsername || undefined,
+      totalScore: parseNumber(stat.totalScore),
+      baseTotalScore: parseNumber(stat.baseTotalScore),
+      totalPRs: parseNumber(stat.totalPrs),
+      totalIssues: totalSolvedIssues + totalOpenIssues + totalClosedIssues,
+      linesChanged: parseNumber(stat.totalNodesScored),
+      linesAdded: parseNumber(stat.totalAdditions),
+      linesDeleted: parseNumber(stat.totalDeletions),
+      hotkey: stat.hotkey || 'N/A',
+      rank: rankById.get(String(stat.id)),
+      uniqueReposCount: parseNumber(stat.uniqueReposCount),
+      credibility: parseNumber(stat.credibility),
+      isEligible: stat.isEligible ?? false,
+      ossIsEligible: stat.isEligible ?? false,
+      discoveriesIsEligible: stat.isIssueEligible ?? false,
+      usdPerDay: parseNumber(stat.usdPerDay),
+      totalMergedPrs: parseNumber(stat.totalMergedPrs),
+      totalOpenPrs: parseNumber(stat.totalOpenPrs),
+      totalClosedPrs: parseNumber(stat.totalClosedPrs),
+      totalSolvedIssues,
+      totalOpenIssues,
+      totalClosedIssues,
+      issueDiscoveryScore: parseNumber(stat.issueDiscoveryScore),
+      issueCredibility: parseNumber(stat.issueCredibility),
+      isIssueEligible: stat.isIssueEligible ?? false,
+    };
+  });
 };


### PR DESCRIPTION
## Summary

On Watchlist → Miners in list-view mode, the activity column was OSS-only — it showed merged / open / closed PR counts but omitted issue discovery counts (solved / open / closed issues), even though watchlist miners are tracked in both programs and the card view already surfaces both.

This PR splits the watchlist list-view activity column into two side-by-side columns — PRs and Issues — each rendering the same 3-segment dot UI (merged-or-solved · open · closed). The standard OSS and Discoveries leaderboards keep their existing single-column behavior.


## Related Issues

#778

## Type of Change

- [x] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots
**Before:**
<img width="1925" height="945" alt="Screenshot_1" src="https://github.com/user-attachments/assets/4c1f85d4-02cb-42d4-9f5a-f55c15e83c68" />

**Now:**
<img width="1919" height="944" alt="Screenshot_2" src="https://github.com/user-attachments/assets/7cf6924f-d79e-4c36-bf9a-ad280100eb6a" />


## Checklist

- [ ] New components are modularized/separated where sensible
- [X] Uses predefined theme (e.g. no hardcoded colors)
- [ ] Responsive/mobile checked
- [ ] Tested against the test API
- [ ] `npm run format` and `npm run lint:fix` have been run
- [X] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
