### PR TITLE
make author name stay on one row, add tooltips missed, repository issues/PRs table layout, filters, and deduplication and sort by credibility

### DIFF
--- a/src/components/repositories/RepositoryIssuesTable.tsx
+++ b/src/components/repositories/RepositoryIssuesTable.tsx
@@ -5,6 +5,7 @@ import {
   Chip,
   CircularProgress,
   Stack,
+  Tooltip,
   Typography,
   alpha,
   useTheme,
@@ -27,7 +28,12 @@ import {
   getIssueStatusMeta,
   getBountyAmountColor,
 } from '../../utils/issueStatus';
-import { STATUS_COLORS, TEXT_OPACITY, scrollbarSx } from '../../theme';
+import {
+  STATUS_COLORS,
+  TEXT_OPACITY,
+  scrollbarSx,
+  tooltipSlotProps,
+} from '../../theme';
 import FilterButton from '../FilterButton';
 
 interface RepositoryIssuesTableProps {
@@ -125,16 +131,22 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
       key: 'title',
       header: 'Title',
       renderCell: (issue) => (
-        <Box
-          sx={{
-            maxWidth: '400px',
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
-            whiteSpace: 'nowrap',
-          }}
+        <Tooltip
+          title={issue.title}
+          arrow
+          placement="bottom"
+          slotProps={tooltipSlotProps}
         >
-          {issue.title}
-        </Box>
+          <Box
+            sx={{
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {issue.title}
+          </Box>
+        </Tooltip>
       ),
     },
     {

--- a/src/components/repositories/RepositoryIssuesTable.tsx
+++ b/src/components/repositories/RepositoryIssuesTable.tsx
@@ -48,21 +48,33 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
   const { data: bounties } = useRepoIssues(repositoryFullName);
   const [filter, setFilter] = useState<'all' | 'open' | 'closed'>('all');
 
-  const counts = useMemo(() => {
-    if (!issues) return { total: 0, open: 0, closed: 0 };
-    return {
-      total: issues.length,
-      open: issues.filter((issue) => !issue.closedAt).length,
-      closed: issues.filter((issue) => issue.closedAt).length,
-    };
+  const isIssueClosed = useCallback(
+    (issue: RepositoryIssue) =>
+      Boolean(issue.closedAt) || issue.state?.toLowerCase() === 'closed',
+    [],
+  );
+
+  const uniqueIssues = useMemo(() => {
+    if (!issues) return [];
+    const seen = new Set<string>();
+    return issues.filter((issue) => {
+      const key = `${issue.repositoryFullName}-${issue.number}`;
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
   }, [issues]);
 
+  const counts = useMemo(() => {
+    const closed = uniqueIssues.filter(isIssueClosed).length;
+    return { total: uniqueIssues.length, open: uniqueIssues.length - closed, closed };
+  }, [uniqueIssues, isIssueClosed]);
+
   const filteredIssues = useMemo(() => {
-    if (!issues) return [];
-    if (filter === 'open') return issues.filter((issue) => !issue.closedAt);
-    if (filter === 'closed') return issues.filter((issue) => issue.closedAt);
-    return issues;
-  }, [issues, filter]);
+    if (filter === 'open') return uniqueIssues.filter((issue) => !isIssueClosed(issue));
+    if (filter === 'closed') return uniqueIssues.filter(isIssueClosed);
+    return uniqueIssues;
+  }, [uniqueIssues, filter, isIssueClosed]);
 
   const sortedIssues = useMemo(
     () =>
@@ -156,18 +168,22 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
       header: 'Status',
       width: '14%',
       renderCell: (issue) => {
-        const isOpen = !issue.closedAt;
+        const closed = isIssueClosed(issue);
+        const label = closed ? 'CLOSED' : 'OPEN';
+        const color = closed ? STATUS_COLORS.merged : STATUS_COLORS.open;
         return (
-          <Chip
-            variant="status"
-            icon={isOpen ? <RadioButtonUncheckedIcon /> : <CheckCircleIcon />}
-            label={isOpen ? 'OPEN' : 'CLOSED'}
-            sx={{
-              color: isOpen ? STATUS_COLORS.open : STATUS_COLORS.merged,
-              borderColor: isOpen ? STATUS_COLORS.open : STATUS_COLORS.merged,
-              '& .MuiChip-icon': { color: 'inherit' },
-            }}
-          />
+          <Tooltip title={label} arrow placement="bottom" slotProps={tooltipSlotProps}>
+            <Chip
+              variant="status"
+              icon={closed ? <CheckCircleIcon /> : <RadioButtonUncheckedIcon />}
+              label={label}
+              sx={{
+                color,
+                borderColor: color,
+                '& .MuiChip-icon': { color: 'inherit' },
+              }}
+            />
+          </Tooltip>
         );
       },
     },

--- a/src/components/repositories/RepositoryIssuesTable.tsx
+++ b/src/components/repositories/RepositoryIssuesTable.tsx
@@ -19,10 +19,7 @@ import {
   type RepositoryIssue,
 } from '../../api';
 import { LinkBox } from '../common/linkBehavior';
-import {
-  DataTable,
-  type DataTableColumn,
-} from '../common/DataTable';
+import { DataTable, type DataTableColumn } from '../common/DataTable';
 import { formatTokenAmount } from '../../utils/format';
 import {
   getIssueStatusMeta,
@@ -67,11 +64,16 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
 
   const counts = useMemo(() => {
     const closed = uniqueIssues.filter(isIssueClosed).length;
-    return { total: uniqueIssues.length, open: uniqueIssues.length - closed, closed };
+    return {
+      total: uniqueIssues.length,
+      open: uniqueIssues.length - closed,
+      closed,
+    };
   }, [uniqueIssues, isIssueClosed]);
 
   const filteredIssues = useMemo(() => {
-    if (filter === 'open') return uniqueIssues.filter((issue) => !isIssueClosed(issue));
+    if (filter === 'open')
+      return uniqueIssues.filter((issue) => !isIssueClosed(issue));
     if (filter === 'closed') return uniqueIssues.filter(isIssueClosed);
     return uniqueIssues;
   }, [uniqueIssues, filter, isIssueClosed]);
@@ -172,7 +174,12 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
         const label = closed ? 'CLOSED' : 'OPEN';
         const color = closed ? STATUS_COLORS.merged : STATUS_COLORS.open;
         return (
-          <Tooltip title={label} arrow placement="bottom" slotProps={tooltipSlotProps}>
+          <Tooltip
+            title={label}
+            arrow
+            placement="bottom"
+            slotProps={tooltipSlotProps}
+          >
             <Chip
               variant="status"
               icon={closed ? <CheckCircleIcon /> : <RadioButtonUncheckedIcon />}

--- a/src/components/repositories/RepositoryIssuesTable.tsx
+++ b/src/components/repositories/RepositoryIssuesTable.tsx
@@ -22,7 +22,7 @@ import { LinkBox } from '../common/linkBehavior';
 import {
   DataTable,
   type DataTableColumn,
-} from '../../components/common/DataTable';
+} from '../common/DataTable';
 import { formatTokenAmount } from '../../utils/format';
 import {
   getIssueStatusMeta,

--- a/src/components/repositories/RepositoryIssuesTable.tsx
+++ b/src/components/repositories/RepositoryIssuesTable.tsx
@@ -111,6 +111,7 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
     {
       key: 'number',
       header: 'Issue #',
+      width: '8%',
       renderCell: (issue) => (
         <a
           href={`https://github.com/${issue.repositoryFullName}/issues/${issue.number}`}
@@ -130,6 +131,7 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
     {
       key: 'title',
       header: 'Title',
+      width: '26%',
       renderCell: (issue) => (
         <Tooltip
           title={issue.title}
@@ -152,6 +154,7 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
     {
       key: 'status',
       header: 'Status',
+      width: '14%',
       renderCell: (issue) => {
         const isOpen = !issue.closedAt;
         return (
@@ -171,6 +174,7 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
     {
       key: 'linkedPr',
       header: 'Linked PR',
+      width: '14%',
       renderCell: (issue) =>
         issue.prNumber ? (
           <a
@@ -199,14 +203,16 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
     {
       key: 'created',
       header: 'Created',
-      align: 'right',
+      width: '19%',
+      align: 'center',
       renderCell: (issue) =>
         issue.createdAt ? new Date(issue.createdAt).toLocaleDateString() : '-',
     },
     {
       key: 'closed',
       header: 'Closed',
-      align: 'right',
+      width: '19%',
+      align: 'center',
       renderCell: (issue) =>
         issue.closedAt ? new Date(issue.closedAt).toLocaleDateString() : '-',
     },
@@ -426,6 +432,7 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
           getRowKey={(issue) => `${issue.number}-${issue.repositoryFullName}`}
           stickyHeader
           size="medium"
+          minWidth="560px"
           header={headerToolbar}
           emptyState={
             <Box sx={{ p: 4, textAlign: 'center' }}>

--- a/src/components/repositories/RepositoryPRsTable.tsx
+++ b/src/components/repositories/RepositoryPRsTable.tsx
@@ -319,7 +319,12 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
         else if (state === 'OPEN') color = theme.palette.status.open;
         else if (state === 'CLOSED') color = theme.palette.status.closed;
         return (
-          <Tooltip title={state} arrow placement="bottom" slotProps={tooltipSlotProps}>
+          <Tooltip
+            title={state}
+            arrow
+            placement="bottom"
+            slotProps={tooltipSlotProps}
+          >
             <Chip
               variant="status"
               label={state}

--- a/src/components/repositories/RepositoryPRsTable.tsx
+++ b/src/components/repositories/RepositoryPRsTable.tsx
@@ -190,6 +190,7 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
     {
       key: 'pullRequestNumber',
       header: 'PR #',
+      width: '6%',
       sortKey: 'pullRequestNumber',
       renderCell: (pr) => (
         // Native <a> to GitHub — `onRowClick` (no row-as-anchor) keeps this valid HTML.
@@ -211,6 +212,7 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
     {
       key: 'pullRequestTitle',
       header: 'Title',
+      width: '25%',
       sortKey: 'pullRequestTitle',
       renderCell: (pr) => (
         <Tooltip
@@ -234,6 +236,7 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
     {
       key: 'author',
       header: 'Author',
+      width: '18%',
       sortKey: 'author',
       renderCell: (pr) => (
         <Tooltip
@@ -266,14 +269,16 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
     {
       key: 'commitCount',
       header: 'Commits',
-      align: 'right',
+      width: '8%',
+      align: 'center',
       sortKey: 'commitCount',
       renderCell: (pr) => pr.commitCount,
     },
     {
       key: 'lines',
       header: '+/-',
-      align: 'right',
+      width: '14%',
+      align: 'center',
       sortKey: 'lines',
       renderCell: (pr) => (
         <>
@@ -292,7 +297,8 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
     {
       key: 'score',
       header: 'Score',
-      align: 'right',
+      width: '10%',
+      align: 'center',
       sortKey: 'score',
       renderCell: (pr) => (
         <Typography sx={{ fontSize: '0.75rem', fontWeight: 600 }}>
@@ -303,6 +309,7 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
     {
       key: 'status',
       header: 'Status',
+      width: '13%',
       sortKey: 'status',
       renderCell: (pr) => {
         const state =
@@ -323,7 +330,8 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
     {
       key: 'mergedAt',
       header: 'Merged',
-      align: 'right',
+      width: '10%',
+      align: 'center',
       sortKey: 'mergedAt',
       renderCell: (pr) =>
         pr.mergedAt ? new Date(pr.mergedAt).toLocaleDateString() : '-',
@@ -377,6 +385,7 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
         getRowKey={(pr) => `${pr.repository}-${pr.pullRequestNumber}`}
         stickyHeader
         size="medium"
+        minWidth="700px"
         header={headerToolbar}
         emptyState={
           <Box sx={{ p: 4, textAlign: 'center' }}>

--- a/src/components/repositories/RepositoryPRsTable.tsx
+++ b/src/components/repositories/RepositoryPRsTable.tsx
@@ -15,7 +15,7 @@ import { useAllPrs, type CommitLog } from '../../api';
 import {
   DataTable,
   type DataTableColumn,
-} from '../../components/common/DataTable';
+} from '../common/DataTable';
 import theme, {
   TEXT_OPACITY,
   scrollbarSx,

--- a/src/components/repositories/RepositoryPRsTable.tsx
+++ b/src/components/repositories/RepositoryPRsTable.tsx
@@ -12,10 +12,7 @@ import {
 } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
 import { useAllPrs, type CommitLog } from '../../api';
-import {
-  DataTable,
-  type DataTableColumn,
-} from '../common/DataTable';
+import { DataTable, type DataTableColumn } from '../common/DataTable';
 import theme, {
   TEXT_OPACITY,
   scrollbarSx,

--- a/src/components/repositories/RepositoryPRsTable.tsx
+++ b/src/components/repositories/RepositoryPRsTable.tsx
@@ -6,6 +6,7 @@ import {
   Chip,
   CircularProgress,
   Stack,
+  Tooltip,
   Typography,
   alpha,
 } from '@mui/material';
@@ -15,7 +16,11 @@ import {
   DataTable,
   type DataTableColumn,
 } from '../../components/common/DataTable';
-import theme, { TEXT_OPACITY, scrollbarSx } from '../../theme';
+import theme, {
+  TEXT_OPACITY,
+  scrollbarSx,
+  tooltipSlotProps,
+} from '../../theme';
 import { filterPrs, getPrStatusCounts, type PrStatusFilter } from '../../utils';
 import FilterButton from '../FilterButton';
 
@@ -208,16 +213,22 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
       header: 'Title',
       sortKey: 'pullRequestTitle',
       renderCell: (pr) => (
-        <Box
-          sx={{
-            maxWidth: '300px',
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
-            whiteSpace: 'nowrap',
-          }}
+        <Tooltip
+          title={pr.pullRequestTitle}
+          arrow
+          placement="bottom"
+          slotProps={tooltipSlotProps}
         >
-          {pr.pullRequestTitle}
-        </Box>
+          <Box
+            sx={{
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {pr.pullRequestTitle}
+          </Box>
+        </Tooltip>
       ),
     },
     {
@@ -225,14 +236,31 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
       header: 'Author',
       sortKey: 'author',
       renderCell: (pr) => (
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-          <Avatar
-            src={`https://avatars.githubusercontent.com/${pr.author}`}
-            alt={pr.author}
-            sx={{ width: 20, height: 20 }}
-          />
-          {pr.author}
-        </Box>
+        <Tooltip
+          title={pr.author}
+          arrow
+          placement="bottom"
+          slotProps={tooltipSlotProps}
+        >
+          <Box
+            sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 0 }}
+          >
+            <Avatar
+              src={`https://avatars.githubusercontent.com/${pr.author}`}
+              alt={pr.author}
+              sx={{ width: 20, height: 20, flexShrink: 0 }}
+            />
+            <Box
+              sx={{
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+              }}
+            >
+              {pr.author}
+            </Box>
+          </Box>
+        </Tooltip>
       ),
     },
     {

--- a/src/components/repositories/RepositoryPRsTable.tsx
+++ b/src/components/repositories/RepositoryPRsTable.tsx
@@ -212,7 +212,7 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
     {
       key: 'pullRequestTitle',
       header: 'Title',
-      width: '25%',
+      width: '19%',
       sortKey: 'pullRequestTitle',
       renderCell: (pr) => (
         <Tooltip
@@ -277,7 +277,7 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
     {
       key: 'lines',
       header: '+/-',
-      width: '14%',
+      width: '11%',
       align: 'center',
       sortKey: 'lines',
       renderCell: (pr) => (
@@ -297,7 +297,7 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
     {
       key: 'score',
       header: 'Score',
-      width: '10%',
+      width: '13%',
       align: 'center',
       sortKey: 'score',
       renderCell: (pr) => (
@@ -309,7 +309,7 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
     {
       key: 'status',
       header: 'Status',
-      width: '13%',
+      width: '16%',
       sortKey: 'status',
       renderCell: (pr) => {
         const state =
@@ -319,18 +319,20 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
         else if (state === 'OPEN') color = theme.palette.status.open;
         else if (state === 'CLOSED') color = theme.palette.status.closed;
         return (
-          <Chip
-            variant="status"
-            label={state}
-            sx={{ color, borderColor: color }}
-          />
+          <Tooltip title={state} arrow placement="bottom" slotProps={tooltipSlotProps}>
+            <Chip
+              variant="status"
+              label={state}
+              sx={{ color, borderColor: color }}
+            />
+          </Tooltip>
         );
       },
     },
     {
       key: 'mergedAt',
       header: 'Merged',
-      width: '10%',
+      width: '13%',
       align: 'center',
       sortKey: 'mergedAt',
       renderCell: (pr) =>

--- a/src/components/repositories/RepositoryPRsTable.tsx
+++ b/src/components/repositories/RepositoryPRsTable.tsx
@@ -211,6 +211,7 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
       header: 'Title',
       width: '19%',
       sortKey: 'pullRequestTitle',
+      headerSx: { width: { xs: '35%', sm: '19%' } },
       renderCell: (pr) => (
         <Tooltip
           title={pr.pullRequestTitle}
@@ -235,6 +236,8 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
       header: 'Author',
       width: '18%',
       sortKey: 'author',
+      headerSx: { display: { xs: 'none', sm: 'table-cell' } },
+      cellSx: { display: { xs: 'none', sm: 'table-cell' } },
       renderCell: (pr) => (
         <Tooltip
           title={pr.author}
@@ -269,6 +272,8 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
       width: '8%',
       align: 'center',
       sortKey: 'commitCount',
+      headerSx: { display: { xs: 'none', sm: 'table-cell' } },
+      cellSx: { display: { xs: 'none', sm: 'table-cell' } },
       renderCell: (pr) => pr.commitCount,
     },
     {
@@ -277,6 +282,8 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
       width: '11%',
       align: 'center',
       sortKey: 'lines',
+      headerSx: { display: { xs: 'none', sm: 'table-cell' } },
+      cellSx: { display: { xs: 'none', sm: 'table-cell' } },
       renderCell: (pr) => (
         <>
           <Box
@@ -389,7 +396,7 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
         getRowKey={(pr) => `${pr.repository}-${pr.pullRequestNumber}`}
         stickyHeader
         size="medium"
-        minWidth="700px"
+        minWidth="480px"
         header={headerToolbar}
         emptyState={
           <Box sx={{ p: 4, textAlign: 'center' }}>

--- a/src/pages/DiscoveriesPage.tsx
+++ b/src/pages/DiscoveriesPage.tsx
@@ -39,6 +39,7 @@ const DiscoveriesPage: React.FC = () => {
       linesDeleted: parseNumber(stat.totalDeletions),
       hotkey: stat.hotkey || 'N/A',
       uniqueReposCount: parseNumber(stat.uniqueReposCount),
+      credibility: parseNumber(stat.issueCredibility),
       issueCredibility: parseNumber(stat.issueCredibility),
       isEligible: stat.isIssueEligible ?? false,
       ossIsEligible: stat.isEligible ?? false,


### PR DESCRIPTION
## Closes: #787

## Summary

- **Fix author name wrapping** in `RepositoryPRsTable`: added `minWidth: 0` + `overflow: hidden / text-overflow: ellipsis` so the avatar + username stay on one line with a tooltip on hover.
- **Add missing tooltips** on PR title and author columns in `RepositoryPRsTable`.
- **Fix broken mobile layout** for both `RepositoryIssuesTable` and `RepositoryPRsTable`: replaced column-hiding with `minWidth` + explicit percentage widths so the tables scroll horizontally instead of collapsing.
- **Add status tooltips** (`placement="bottom"`) on the Status chip in both tables.
- **Fix Open/Closed filter** in `RepositoryIssuesTable`: normalized `state` field comparison with `.toLowerCase()` to handle any casing (`'Closed'`, `'CLOSED'`, `'closed'`) returned by the API.
- **Deduplicate issues** in `RepositoryIssuesTable`: the API can return the same issue number multiple times; deduplicate by `repositoryFullName + number` before filtering so counts and filter results are accurate.
- **Fix sort by credibility** on Discoveries page: `credibility` field was missing from the miner stats mapping in `DiscoveriesPage.tsx`.
- **Column width adjustments**: increased space for Status, Score, and Merged columns in `RepositoryPRsTable`; increased space for Status and Linked PR columns in `RepositoryIssuesTable`.

## Files changed

- `src/components/repositories/RepositoryPRsTable.tsx`
- `src/components/repositories/RepositoryIssuesTable.tsx`
- `src/pages/DiscoveriesPage.tsx`

## Test plan

- [ ] On a repository detail page, verify the Issues table Open/Closed filters show correct counts and only matching rows
- [ ] Verify no duplicate issue rows appear in the Issues table
- [ ] On mobile (≤ 600 px), verify both tables scroll horizontally with all columns intact
- [ ] Verify author name + avatar in PR table stays on one line (no wrapping); tooltip shows on hover
- [ ] Verify Status chip tooltip appears below the chip in both tables
- [ ] On Discoveries page, verify sorting by Credibility column works correctly

## Screenshots

Before :
 
https://github.com/user-attachments/assets/db3a8a19-96de-43a2-aa04-565907af0b82

After :

https://github.com/user-attachments/assets/d0c2a621-683c-4b2f-80e9-53d463ca652f

Before:

https://github.com/user-attachments/assets/8519fa49-dd32-48d8-ad2d-da85985240f9

After:

https://github.com/user-attachments/assets/6458aa37-1493-41a8-996d-b0647c4b014f

Before:

https://github.com/user-attachments/assets/75ceb400-e1c4-4736-8e0c-d17994246e46

After:

https://github.com/user-attachments/assets/b2db5dbf-cef2-4ae3-b664-a7f997c7a00e

