### PR TITLE
feat(watchlist): auto-show PRs from watched miners and repos on PR tab

### DIFF
--- a/src/hooks/useWatchedPRs.ts
+++ b/src/hooks/useWatchedPRs.ts
@@ -1,0 +1,52 @@
+import { useMemo } from 'react';
+import { useAllPrs, type CommitLog } from '../api';
+import { useWatchlist, serializePRKey } from './useWatchlist';
+
+export const matchesWatchedSet = (
+  pr: CommitLog,
+  starredKeys: Set<string>,
+  watchedReposLowercase: Set<string>,
+  watchedMinerIds: Set<string>,
+): boolean =>
+  starredKeys.has(serializePRKey(pr.repository, pr.pullRequestNumber)) ||
+  watchedReposLowercase.has(pr.repository.toLowerCase()) ||
+  (pr.githubId !== undefined && watchedMinerIds.has(pr.githubId));
+
+export interface UseWatchedPRsResult {
+  items: CommitLog[];
+  isLoading: boolean;
+}
+
+export const useWatchedPRs = (
+  starredKeyList: string[],
+): UseWatchedPRsResult => {
+  const { data: allPrs, isLoading } = useAllPrs();
+  const { ids: watchedMinerIds } = useWatchlist('miners');
+  const { ids: watchedRepoIds } = useWatchlist('repos');
+
+  const watchedMinerIdSet = useMemo(
+    () => new Set(watchedMinerIds),
+    [watchedMinerIds],
+  );
+
+  const watchedReposLowercase = useMemo(
+    () => new Set(watchedRepoIds.map((r) => r.toLowerCase())),
+    [watchedRepoIds],
+  );
+
+  const starredKeys = useMemo(() => new Set(starredKeyList), [starredKeyList]);
+
+  const items = useMemo(() => {
+    if (!allPrs) return [];
+    return allPrs.filter((p) =>
+      matchesWatchedSet(
+        p,
+        starredKeys,
+        watchedReposLowercase,
+        watchedMinerIdSet,
+      ),
+    );
+  }, [allPrs, starredKeys, watchedReposLowercase, watchedMinerIdSet]);
+
+  return { items, isLoading };
+};

--- a/src/pages/WatchlistPage.tsx
+++ b/src/pages/WatchlistPage.tsx
@@ -4,6 +4,7 @@ import {
   Box,
   Card,
   Chip,
+  CircularProgress,
   FormControl,
   Grid,
   IconButton,
@@ -41,7 +42,7 @@ import {
   type DataTableColumn,
 } from '../components/common/DataTable';
 import { LinkBox } from '../components/common/linkBehavior';
-import { useAllMiners, useAllPrs, useReposAndWeights, useIssues } from '../api';
+import { useAllMiners, useReposAndWeights, useIssues } from '../api';
 import { mapAllMinersToStats } from '../utils/minerMapper';
 import {
   useWatchlist,
@@ -49,6 +50,7 @@ import {
   serializePRKey,
   type WatchlistCategory,
 } from '../hooks/useWatchlist';
+import { useWatchedPRs } from '../hooks/useWatchedPRs';
 import {
   isMergedPr,
   isClosedUnmergedPr,
@@ -105,7 +107,7 @@ const TAB_DISCOVERY: Record<
   prs: {
     label: 'repositories',
     path: '/repositories',
-    hint: 'Open a pull request and star it to monitor its scoring here.',
+    hint: 'Star a pull request, miner, or repository to populate this tab.',
   },
 };
 
@@ -124,7 +126,11 @@ const WatchlistPage: React.FC = () => {
   const { ids, count, clear } = useWatchlist(activeTab);
   const [confirmOpen, setConfirmOpen] = useState(false);
 
-  const isEmpty = count === 0;
+  const tabHasContent =
+    activeTab === 'prs'
+      ? counts.prs + counts.miners + counts.repos > 0
+      : count > 0;
+  const isEmpty = !tabHasContent;
   const noun = TAB_NOUN[activeTab];
   const discovery = TAB_DISCOVERY[activeTab];
 
@@ -215,6 +221,8 @@ const WatchlistPage: React.FC = () => {
             >
               Your watchlist — {count}{' '}
               {count === 1 ? `${noun.single} pinned` : `${noun.plural} pinned`}.
+              {activeTab === 'prs' &&
+                ' Also shows PRs from watched miners and repositories.'}{' '}
               Stored locally in this browser.
             </Typography>
             {count > 0 && (
@@ -986,7 +994,7 @@ const PRCard: React.FC<{ pr: CommitLog }> = ({ pr }) => {
 const PR_ROWS_OPTIONS = [10, 25, 50] as const;
 
 const PRsList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
-  const { data: allPrs } = useAllPrs();
+  const { items, isLoading } = useWatchedPRs(itemKeys);
   const [searchQuery, setSearchQuery] = useState('');
   const [statusFilter, setStatusFilter] = useState<PrStatusFilter>('all');
   const [viewMode, setViewMode] = useState<PRsViewMode>('list');
@@ -1008,14 +1016,6 @@ const PRsList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
     }
     setPage(0);
   };
-
-  const items = useMemo(() => {
-    if (!allPrs) return [];
-    const set = new Set(itemKeys);
-    return allPrs.filter((pr) =>
-      set.has(serializePRKey(pr.repository, pr.pullRequestNumber)),
-    );
-  }, [allPrs, itemKeys]);
 
   const counts = useMemo(() => getPrStatusCounts(items), [items]);
 
@@ -1194,6 +1194,7 @@ const PRsList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
           linkState={{ backLabel: 'Back to Watchlist' }}
           minWidth="750px"
           stickyHeader
+          isLoading={isLoading && items.length === 0}
           emptyLabel="No watched pull requests found."
           sort={{
             field: sortField,
@@ -1209,7 +1210,11 @@ const PRsList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
             ...scrollbarSx,
           }}
         >
-          {paged.length === 0 ? (
+          {isLoading && paged.length === 0 ? (
+            <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+              <CircularProgress size={24} />
+            </Box>
+          ) : paged.length === 0 ? (
             <Typography
               sx={{
                 color: 'text.secondary',

--- a/src/tests/useWatchedPRs.test.ts
+++ b/src/tests/useWatchedPRs.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect } from 'vitest';
+import { matchesWatchedSet } from '../hooks/useWatchedPRs';
+import type { CommitLog } from '../api';
+
+const pr = (overrides: Partial<CommitLog> = {}): CommitLog =>
+  ({
+    pullRequestNumber: 1,
+    hotkey: 'hk-default',
+    pullRequestTitle: 't',
+    additions: 0,
+    deletions: 0,
+    commitCount: 1,
+    repository: 'owner/repo',
+    mergedAt: null,
+    closedAt: null,
+    prCreatedAt: '',
+    prState: 'open',
+    author: 'alice',
+    githubId: 'gh-default',
+    score: '0',
+    ...overrides,
+  }) as CommitLog;
+
+describe('matchesWatchedSet', () => {
+  const empty = {
+    starred: new Set<string>(),
+    repos: new Set<string>(),
+    miners: new Set<string>(),
+  };
+
+  it('returns false when no source matches', () => {
+    expect(
+      matchesWatchedSet(
+        pr({ repository: 'owner/repo', pullRequestNumber: 5 }),
+        empty.starred,
+        empty.repos,
+        empty.miners,
+      ),
+    ).toBe(false);
+  });
+
+  it('matches an explicitly starred PR by composite key', () => {
+    expect(
+      matchesWatchedSet(
+        pr({ repository: 'owner/repo', pullRequestNumber: 5 }),
+        new Set(['owner/repo#5']),
+        empty.repos,
+        empty.miners,
+      ),
+    ).toBe(true);
+  });
+
+  it('matches a watched repo case-insensitively', () => {
+    expect(
+      matchesWatchedSet(
+        pr({ repository: 'Owner/Repo' }),
+        empty.starred,
+        new Set(['owner/repo']),
+        empty.miners,
+      ),
+    ).toBe(true);
+  });
+
+  it('matches a PR whose githubId belongs to a watched miner', () => {
+    expect(
+      matchesWatchedSet(
+        pr({ githubId: '12345' }),
+        empty.starred,
+        empty.repos,
+        new Set(['12345']),
+      ),
+    ).toBe(true);
+  });
+
+  it('does not match when pr.githubId is undefined even if the set is non-empty', () => {
+    expect(
+      matchesWatchedSet(
+        pr({ githubId: undefined }),
+        empty.starred,
+        empty.repos,
+        new Set(['12345']),
+      ),
+    ).toBe(false);
+  });
+
+  it('returns true when a PR matches multiple sources', () => {
+    const p = pr({
+      repository: 'owner/repo',
+      pullRequestNumber: 5,
+      githubId: '12345',
+    });
+    expect(
+      matchesWatchedSet(
+        p,
+        new Set(['owner/repo#5']),
+        new Set(['owner/repo']),
+        new Set(['12345']),
+      ),
+    ).toBe(true);
+  });
+
+  it('does not match a watched repo when casing differs and the watched set is not normalized', () => {
+    expect(
+      matchesWatchedSet(
+        pr({ repository: 'Owner/Repo' }),
+        empty.starred,
+        new Set(['Owner/Repo']),
+        empty.miners,
+      ),
+    ).toBe(false);
+  });
+
+  it('does not match a miner whose id is not in the watched set', () => {
+    expect(
+      matchesWatchedSet(
+        pr({ githubId: '99999' }),
+        empty.starred,
+        empty.repos,
+        new Set(['12345']),
+      ),
+    ).toBe(false);
+  });
+
+  it('does not false-positive when a watched repo is a substring of pr.repository', () => {
+    expect(
+      matchesWatchedSet(
+        pr({ repository: 'owner/repo' }),
+        empty.starred,
+        new Set(['own']),
+        empty.miners,
+      ),
+    ).toBe(false);
+  });
+
+  it('does not false-positive when a watched miner id is a substring of pr.githubId', () => {
+    expect(
+      matchesWatchedSet(
+        pr({ githubId: '12345' }),
+        empty.starred,
+        empty.repos,
+        new Set(['12']),
+      ),
+    ).toBe(false);
+  });
+
+  it('classifies a realistic mixed dataset by the correct source', () => {
+    const starred = new Set(['acme/web#1']);
+    const repos = new Set(['acme/db']);
+    const miners = new Set(['gh-alice', 'gh-bob']);
+
+    expect(
+      matchesWatchedSet(
+        pr({
+          repository: 'acme/web',
+          pullRequestNumber: 1,
+          githubId: 'gh-x',
+        }),
+        starred,
+        repos,
+        miners,
+      ),
+    ).toBe(true);
+
+    expect(
+      matchesWatchedSet(
+        pr({
+          repository: 'acme/db',
+          pullRequestNumber: 99,
+          githubId: 'gh-x',
+        }),
+        starred,
+        repos,
+        miners,
+      ),
+    ).toBe(true);
+
+    expect(
+      matchesWatchedSet(
+        pr({
+          repository: 'other/code',
+          pullRequestNumber: 5,
+          githubId: 'gh-alice',
+        }),
+        starred,
+        repos,
+        miners,
+      ),
+    ).toBe(true);
+
+    expect(
+      matchesWatchedSet(
+        pr({
+          repository: 'other/code',
+          pullRequestNumber: 6,
+          githubId: 'gh-x',
+        }),
+        starred,
+        repos,
+        miners,
+      ),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Auto-shows PRs from any miner or repository on the watchlist, not just explicitly starred PRs. Closes #784.

A new hook, `src/hooks/useWatchedPRs.ts`, unions three sources in a single pass over the cached `/prs` response:

1. **Starred PRs** — composite `owner/repo#N` key (existing behavior, preserved).
2. **Watched repositories** — `pr.repository` matched case-insensitively. Defends against casing drift between the five `WatchlistButton` callsites that write to the watchlist (`MinersList`, `MinerCard`, `MinerDetailsPage`, `TopRepositoriesTable`, `RepositoryDetailsPage`), each of which passes a different field (`repo.repository`, `repo.fullName`, route params, etc.) in whatever casing the source provides.
3. **Watched miners** — `pr.githubId` matched directly against the watchlist's stored miner ids. Joining on `githubId` (numeric, immutable, surfaced by `/prs` itself) — rather than `hotkey` or `author` login — avoids a `/miners` round-trip and survives username changes or miner deregistration.

Two regressions the minimum-viable fix would otherwise introduce, addressed here:

- `tabHasContent` now considers `prs + miners + repos > 0` so a user with watched miners but no starred PRs sees their populated list instead of the empty discovery screen.
- `isLoading` from `useAllPrs` is piped into both the list (`DataTable`) and card views so the first fetch shows a loading state rather than a brief "No watched pull requests found." flash.

The discovery hint and the in-tab subtitle are updated to reflect the broader behavior:

- Hint: `"Star a pull request, miner, or repository to populate this tab."`
- Subtitle: `"Also shows PRs from watched miners and repositories."`

`matchesWatchedSet` is exposed as a pure predicate so every branch is unit-testable without React Testing Library overhead. **11 unit tests** cover each source in isolation, multi-source matches, case-insensitive repo matching, the `githubId === undefined` guard, the non-normalized-input regression, the miner-not-in-set negative case, and substring-trap defenses for both repo and miner ids (which guard against naive `String.includes()`-based filtering).

### Files

- `src/hooks/useWatchedPRs.ts` *(new, 52 LOC)* — `matchesWatchedSet` predicate + `useWatchedPRs(starredKeyList)` hook returning `{ items, isLoading }`.
- `src/pages/WatchlistPage.tsx` *(+18 / −13)* — replaces the local starred-only filter in `PRsList` with `useWatchedPRs`; widens the empty-state guard for the PRs tab; updates discovery hint and subtitle copy; pipes `isLoading` into the list `DataTable` and into a symmetric `<CircularProgress />` branch in the card view.
- `src/tests/useWatchedPRs.test.ts` *(new, 203 LOC)* — 11 unit tests.

**SOURCE diff: 83 lines.** No new dependencies. No API contract changes. No layout changes.

## Related Issues

Closes #784.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

[Watchlist PR Auto-Show Demo](https://github.com/user-attachments/assets/246b1262-3caf-4afa-8b24-77d8d42f91fa)

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
