### PR TITLE
Repositories leaderboard: align OSS vs issue-track metrics (cards, list, rollups)

### DIFF
--- a/src/components/leaderboard/RepositoryCard.tsx
+++ b/src/components/leaderboard/RepositoryCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Avatar, Box, Card, Tooltip, Typography } from '@mui/material';
+import { Avatar, Box, Card, Divider, Tooltip, Typography } from '@mui/material';
 import { alpha } from '@mui/material/styles';
 import { linkResetSx, useLinkBehavior } from '../common/linkBehavior';
 import { WatchlistButton } from '../common';
@@ -225,25 +225,47 @@ export const RepositoryCard: React.FC<RepositoryCardProps> = ({
         </Box>
       </Box>
 
-      <Box
-        sx={{
-          display: 'grid',
-          // Total Score needs more room for "TOTAL SCORE" label + values up to
-          // ~999.99; PRS holds a short int so it can afford a narrower column.
-          gridTemplateColumns: '1.4fr 0.6fr 1fr',
-          gap: 1.5,
-          pt: 0.5,
-        }}
-      >
-        <MetricCell
-          label="Total Score"
-          value={formatMetric(repo.totalScore, 2)}
-        />
-        <MetricCell label="PRs" value={formatMetric(repo.totalPRs)} />
-        <MetricCell
-          label="Contributors"
-          value={formatMetric(repo.uniqueMiners?.size ?? 0)}
-        />
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.25, pt: 0.5 }}>
+        <Box
+          sx={{
+            display: 'grid',
+            gridTemplateColumns: '1.4fr 0.6fr 1fr',
+            gap: 1.5,
+          }}
+        >
+          <MetricCell
+            label="OSS Score"
+            value={formatMetric(repo.totalScore, 2)}
+          />
+          <MetricCell label="PRs" value={formatMetric(repo.totalPRs)} />
+          <MetricCell
+            label="Contributors"
+            value={formatMetric(repo.uniqueMiners?.size ?? 0)}
+          />
+        </Box>
+
+        <Divider sx={{ borderColor: 'border.light', opacity: 0.85 }} />
+
+        <Box
+          sx={{
+            display: 'grid',
+            gridTemplateColumns: '1.4fr 0.6fr 1fr',
+            gap: 1.5,
+          }}
+        >
+          <MetricCell
+            label="Issue score"
+            value={formatMetric(repo.discoveryScore, 2)}
+          />
+          <MetricCell
+            label="Issues"
+            value={formatMetric(repo.discoveryIssues)}
+          />
+          <MetricCell
+            label="Contributors"
+            value={formatMetric(repo.discoveryContributors?.size ?? 0)}
+          />
+        </Box>
       </Box>
     </Card>
   );

--- a/src/components/leaderboard/RepositoryCard.tsx
+++ b/src/components/leaderboard/RepositoryCard.tsx
@@ -225,7 +225,9 @@ export const RepositoryCard: React.FC<RepositoryCardProps> = ({
         </Box>
       </Box>
 
-      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.25, pt: 0.5 }}>
+      <Box
+        sx={{ display: 'flex', flexDirection: 'column', gap: 1.25, pt: 0.5 }}
+      >
         <Box
           sx={{
             display: 'grid',

--- a/src/components/leaderboard/TopRepositoriesTable.tsx
+++ b/src/components/leaderboard/TopRepositoriesTable.tsx
@@ -73,15 +73,20 @@ type SortColumn =
   | 'weight'
   | 'totalScore'
   | 'totalPRs'
-  | 'contributors';
+  | 'contributors'
+  | 'discoveryScore'
+  | 'discoveryIssues'
+  | 'discoveryContributors';
 type SortDirection = 'asc' | 'desc';
 type ViewMode = RepositoriesViewMode;
 
+/** Card sort: classic metrics + Issues; issue score/contrib. sort via list headers / URL. */
 const CARD_SORT_OPTIONS: Array<{ value: SortColumn; label: string }> = [
   { value: 'weight', label: 'Weight' },
-  { value: 'totalScore', label: 'Total Score' },
+  { value: 'totalScore', label: 'OSS score' },
   { value: 'totalPRs', label: 'PRs' },
   { value: 'contributors', label: 'Contributors' },
+  { value: 'discoveryIssues', label: 'Issues' },
   { value: 'repository', label: 'Repository' },
 ];
 
@@ -99,7 +104,20 @@ const VALID_SORT_COLUMNS: SortColumn[] = [
   'totalScore',
   'totalPRs',
   'contributors',
+  'discoveryScore',
+  'discoveryIssues',
+  'discoveryContributors',
 ];
+
+/** List view: show numeric zeros when the row has OSS activity (avoids PRs > 0 with OSS score "-"). */
+const repoHasOssActivity = (repo: RepoStats) =>
+  (repo.totalPRs ?? 0) > 0 || (repo.totalScore ?? 0) > 0;
+
+/** List view: show discovery numbers when any discovery dimension is non-zero. */
+const repoHasDiscoveryActivity = (repo: RepoStats) =>
+  (repo.discoveryIssues ?? 0) !== 0 ||
+  (repo.discoveryScore ?? 0) !== 0 ||
+  (repo.discoveryContributors?.size ?? 0) > 0;
 
 const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
   repositories,
@@ -169,6 +187,26 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
   const isMobileSearchVisible =
     isMobile && (isMobileSearchOpen || !!trimmedSearch);
   const isDirectRepoInput = /^[^/\s]+\/[^/\s]+$/.test(trimmedSearch);
+
+  const cardSortSelectOptions = useMemo(() => {
+    const opts = [...CARD_SORT_OPTIONS];
+    const inCardList = opts.some((o) => o.value === sortColumn);
+    if (
+      !inCardList &&
+      (sortColumn === 'discoveryScore' ||
+        sortColumn === 'discoveryContributors')
+    ) {
+      opts.push(
+        sortColumn === 'discoveryScore'
+          ? { value: 'discoveryScore' as const, label: 'Issue score' }
+          : {
+              value: 'discoveryContributors' as const,
+              label: 'Issue contributors',
+            },
+      );
+    }
+    return opts;
+  }, [sortColumn]);
 
   // Sync filter state to URL params (replace, don't push)
   const syncToUrl = useCallback(
@@ -245,6 +283,16 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
         case 'contributors':
           comparison = a.uniqueMiners.size - b.uniqueMiners.size;
           break;
+        case 'discoveryScore':
+          comparison = a.discoveryScore - b.discoveryScore;
+          break;
+        case 'discoveryIssues':
+          comparison = a.discoveryIssues - b.discoveryIssues;
+          break;
+        case 'discoveryContributors':
+          comparison =
+            a.discoveryContributors.size - b.discoveryContributors.size;
+          break;
         default:
           // Default to totalScore descending (original behavior)
           comparison = b.totalScore - a.totalScore;
@@ -317,8 +365,8 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
         value: (r) => r.weight || 0,
       },
       totalScore: {
-        title: 'Total Score',
-        yAxis: 'Total Score',
+        title: 'OSS score by repository',
+        yAxis: 'OSS score',
         value: (r) => r.totalScore || 0,
       },
       totalPRs: {
@@ -327,18 +375,33 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
         value: (r) => r.totalPRs || 0,
       },
       contributors: {
-        title: 'Contributors by Repository',
+        title: 'OSS contributors by repository',
         yAxis: 'Contributors',
         value: (r) => r.uniqueMiners?.size || 0,
       },
+      discoveryScore: {
+        title: 'Issue score by repository',
+        yAxis: 'Issue score',
+        value: (r) => r.discoveryScore || 0,
+      },
+      discoveryIssues: {
+        title: 'Issues by repository',
+        yAxis: 'Issues',
+        value: (r) => r.discoveryIssues || 0,
+      },
+      discoveryContributors: {
+        title: 'Issue contributors by repository',
+        yAxis: 'Contributors',
+        value: (r) => r.discoveryContributors?.size || 0,
+      },
       rank: {
-        title: 'Total Score',
-        yAxis: 'Total Score',
+        title: 'OSS score by repository',
+        yAxis: 'OSS score',
         value: (r) => r.totalScore || 0,
       },
       repository: {
-        title: 'Total Score',
-        yAxis: 'Total Score',
+        title: 'OSS score by repository',
+        yAxis: 'OSS score',
         value: (r) => r.totalScore || 0,
       },
     };
@@ -347,7 +410,9 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
       useLogScale &&
       sortColumn !== 'weight' &&
       sortColumn !== 'totalPRs' &&
-      sortColumn !== 'contributors';
+      sortColumn !== 'contributors' &&
+      sortColumn !== 'discoveryIssues' &&
+      sortColumn !== 'discoveryContributors';
 
     const barGradient = {
       type: 'linear',
@@ -374,6 +439,10 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
       weight: item?.weight || 0,
       prs: item?.totalPRs || 0,
       contributors: item?.uniqueMiners?.size || 0,
+      ossScore: item?.totalScore || 0,
+      discoveryScore: item?.discoveryScore || 0,
+      discoveryIssues: item?.discoveryIssues || 0,
+      discoveryContributors: item?.discoveryContributors?.size || 0,
       itemStyle: {
         color: barGradient,
         borderRadius: [6, 6, 0, 0],
@@ -430,10 +499,13 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
                 #${item.rank} ${item.repository}
               </div>
               <div style="margin-top: 0; padding-top: 8px; border-top: 1px solid ${tooltipBorderColor}; display: grid; grid-template-columns: minmax(0, 1fr) auto; column-gap: 10px; row-gap: 6px; align-items: baseline; min-width: 0;">
-                ${statRow('Total Score:', item.value.toFixed(2))}
+                ${statRow('OSS score:', item.ossScore.toFixed(2))}
+                ${statRow('PRs:', String(item.prs))}
+                ${statRow('OSS contributors:', String(item.contributors))}
+                ${statRow('Issue score:', item.discoveryScore.toFixed(2))}
+                ${statRow('Issues:', String(item.discoveryIssues))}
+                ${statRow('Issue contributors:', String(item.discoveryContributors))}
                 ${statRow('Weight:', item.weight.toFixed(2))}
-                ${statRow('Pull Requests:', String(item.prs))}
-                ${statRow('Contributors:', String(item.contributors))}
               </div>
             </div>
           `;
@@ -493,6 +565,20 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
           formatter: (value: number) => {
             if (value >= 1000) return `${(value / 1000).toFixed(1)}k`;
             if (sortColumn === 'weight') return value.toFixed(2);
+            if (
+              sortColumn === 'totalPRs' ||
+              sortColumn === 'contributors' ||
+              sortColumn === 'discoveryIssues' ||
+              sortColumn === 'discoveryContributors'
+            )
+              return String(Math.round(value));
+            if (
+              sortColumn === 'totalScore' ||
+              sortColumn === 'discoveryScore' ||
+              sortColumn === 'rank' ||
+              sortColumn === 'repository'
+            )
+              return value.toFixed(2);
             return value.toFixed(0);
           },
         },
@@ -680,7 +766,7 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
     {
       key: 'repository',
       header: renderSortHeader('repository', 'Repository'),
-      width: '35%',
+      width: '30%',
       headerSx: sortableHeaderSx,
       cellSx: { pl: 1.5 },
       renderCell: (repo) => (
@@ -734,7 +820,7 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
     {
       key: 'weight',
       header: renderSortHeader('weight', 'Weight', 'right'),
-      width: '12%',
+      width: '10%',
       align: 'right',
       headerSx: sortableHeaderSx,
       renderCell: (repo) => (
@@ -751,61 +837,135 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
     },
     {
       key: 'totalScore',
-      header: renderSortHeader('totalScore', 'Total Score', 'right'),
-      width: '18%',
+      header: renderSortHeader('totalScore', 'OSS score', 'right'),
+      width: '11%',
       align: 'right',
       headerSx: sortableHeaderSx,
-      renderCell: (repo) => (
-        <Typography
-          sx={{
-            fontSize: '0.75rem',
-            fontWeight: 600,
-            color:
-              (repo.totalScore || 0) > 0 ? 'text.primary' : 'text.secondary',
-          }}
-        >
-          {(repo.totalScore || 0) > 0
-            ? Number(repo.totalScore || 0).toFixed(2)
-            : '-'}
-        </Typography>
-      ),
+      renderCell: (repo) => {
+        const active = repoHasOssActivity(repo);
+        const v = repo.totalScore ?? 0;
+        return (
+          <Typography
+            sx={{
+              fontSize: '0.75rem',
+              fontWeight: 600,
+              color: active && v > 0 ? 'text.primary' : 'text.secondary',
+            }}
+          >
+            {active ? Number(v).toFixed(2) : '-'}
+          </Typography>
+        );
+      },
     },
     {
       key: 'totalPRs',
       header: renderSortHeader('totalPRs', 'PRs', 'right'),
-      width: '15%',
+      width: '7%',
       align: 'right',
       headerSx: sortableHeaderSx,
-      renderCell: (repo) => (
-        <Typography
-          sx={{
-            fontSize: '0.75rem',
-            color: (repo.totalPRs || 0) > 0 ? 'text.primary' : 'text.secondary',
-          }}
-        >
-          {(repo.totalPRs || 0) > 0 ? repo.totalPRs : '-'}
-        </Typography>
-      ),
+      renderCell: (repo) => {
+        const active = repoHasOssActivity(repo);
+        const n = repo.totalPRs ?? 0;
+        return (
+          <Typography
+            sx={{
+              fontSize: '0.75rem',
+              color: active && n > 0 ? 'text.primary' : 'text.secondary',
+            }}
+          >
+            {active ? String(n) : '-'}
+          </Typography>
+        );
+      },
+    },
+    {
+      key: 'discoveryScore',
+      header: renderSortHeader('discoveryScore', 'Issue score', 'right'),
+      width: '10%',
+      align: 'right',
+      headerSx: sortableHeaderSx,
+      renderCell: (repo) => {
+        const active = repoHasDiscoveryActivity(repo);
+        const v = repo.discoveryScore ?? 0;
+        return (
+          <Typography
+            sx={{
+              fontSize: '0.75rem',
+              fontWeight: 600,
+              color: active && v > 0 ? 'text.primary' : 'text.secondary',
+            }}
+          >
+            {active ? Number(v).toFixed(2) : '-'}
+          </Typography>
+        );
+      },
+    },
+    {
+      key: 'discoveryIssues',
+      header: renderSortHeader('discoveryIssues', 'Issues', 'right'),
+      width: '7%',
+      align: 'right',
+      headerSx: sortableHeaderSx,
+      renderCell: (repo) => {
+        const active = repoHasDiscoveryActivity(repo);
+        const n = repo.discoveryIssues ?? 0;
+        return (
+          <Typography
+            sx={{
+              fontSize: '0.75rem',
+              color: active && n > 0 ? 'text.primary' : 'text.secondary',
+            }}
+          >
+            {active ? String(n) : '-'}
+          </Typography>
+        );
+      },
     },
     {
       key: 'contributors',
       header: renderSortHeader('contributors', 'Contributors', 'right'),
-      width: '15%',
+      width: '9%',
       align: 'right',
       headerSx: sortableHeaderSx,
-      renderCell: (repo) => (
-        <Typography
-          sx={{
-            fontSize: '0.75rem',
-            color:
-              (repo.uniqueMiners?.size || 0) > 0
-                ? 'text.primary'
-                : 'text.secondary',
-          }}
-        >
-          {(repo.uniqueMiners?.size || 0) > 0 ? repo.uniqueMiners?.size : '-'}
-        </Typography>
+      renderCell: (repo) => {
+        const active = repoHasOssActivity(repo);
+        const n = repo.uniqueMiners?.size ?? 0;
+        return (
+          <Typography
+            sx={{
+              fontSize: '0.75rem',
+              color: active && n > 0 ? 'text.primary' : 'text.secondary',
+            }}
+          >
+            {active ? String(n) : '-'}
+          </Typography>
+        );
+      },
+    },
+    {
+      key: 'discoveryContributors',
+      header: renderSortHeader(
+        'discoveryContributors',
+        'Issue contrib.',
+        'right',
       ),
+      width: '9%',
+      align: 'right',
+      headerSx: sortableHeaderSx,
+      renderCell: (repo) => {
+        const active = repoHasDiscoveryActivity(repo);
+        const n = repo.discoveryContributors?.size ?? 0;
+        return (
+          <Typography
+            sx={{
+              fontSize: '0.75rem',
+              color: active && n > 0 ? 'text.primary' : 'text.secondary',
+            }}
+          >
+            {active ? String(n) : '-'}
+          </Typography>
+        );
+      },
     },
     {
       key: 'watch',
@@ -1081,7 +1241,7 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
                 '& .MuiSelect-select': { py: 0.75 },
               }}
             >
-              {CARD_SORT_OPTIONS.map((opt) => (
+              {cardSortSelectOptions.map((opt) => (
                 <MenuItem key={opt.value} value={opt.value}>
                   {opt.label}
                 </MenuItem>
@@ -1152,7 +1312,7 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
                 <Grid item xs={12} sm={6} md={4} lg={4} key={i}>
                   <Skeleton
                     variant="rounded"
-                    height={168}
+                    height={220}
                     sx={{
                       bgcolor: (t) => alpha(t.palette.text.primary, 0.06),
                     }}
@@ -1236,7 +1396,7 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
               borderBottom: '1px solid',
               borderColor: 'surface.light',
             })}
-            minWidth="1000px"
+            minWidth="1280px"
             stickyHeader
             emptyState={
               !filteredRepositories.length &&

--- a/src/components/leaderboard/types.ts
+++ b/src/components/leaderboard/types.ts
@@ -49,6 +49,15 @@ export interface RepoStats {
   weight: number;
   rank?: number;
   inactiveAt?: string | null;
+  /** Issue discovery track score (UI: "Issue score"; miner stats + merged multiplier PRs). */
+  discoveryScore: number;
+  /**
+   * Completed/solved discovery issues (pro-rated — excludes open-issue totals).
+   * Aligned with OSS row: merged PRs only.
+   */
+  discoveryIssues: number;
+  /** Identities with non-zero pro-rated discovery score/issues in this repo. */
+  discoveryContributors: Set<string>;
 }
 
 export type LeaderboardVariant = 'oss' | 'discoveries' | 'watchlist';

--- a/src/pages/RepositoriesPage.tsx
+++ b/src/pages/RepositoriesPage.tsx
@@ -6,8 +6,10 @@ import { alpha, type Theme } from '@mui/material/styles';
 import { LinkBox } from '../components/common/linkBehavior';
 import { Page } from '../components/layout';
 import { TopRepositoriesTable, SEO } from '../components';
-import { useAllPrs, useReposAndWeights } from '../api';
+import { useAllPrs, useAllMiners, useReposAndWeights } from '../api';
 import { type CommitLog } from '../api/models/Dashboard';
+import { buildRepoDiscoveryRollupFromMiners } from '../utils/ExplorerUtils';
+import { isMergedPr } from '../utils/prStatus';
 
 const FONTS = { mono: '"JetBrains Mono", monospace' } as const;
 
@@ -136,10 +138,11 @@ const RepositoriesPage: React.FC = () => {
   };
 
   const { data: allPRs, isLoading: isLoadingPRs } = useAllPrs();
+  const { data: allMiners, isLoading: isLoadingMiners } = useAllMiners();
   const { data: reposWithWeights, isLoading: isLoadingRepos } =
     useReposAndWeights();
 
-  const isLoading = isLoadingPRs || isLoadingRepos;
+  const isLoading = isLoadingPRs || isLoadingRepos || isLoadingMiners;
 
   // ── Main table stats ────────────────────────────────────────────────────
   const repoStats = useMemo(() => {
@@ -153,8 +156,7 @@ const RepositoriesPage: React.FC = () => {
     if (allPRs) {
       allPRs.forEach((pr: CommitLog) => {
         if (!pr?.repository) return;
-        // Only count merged PRs for the main table stats
-        if (!pr.mergedAt) return;
+        if (!isMergedPr(pr)) return;
 
         const repoKey = pr.repository.toLowerCase();
         const cur = prStatsMap.get(repoKey) || {
@@ -169,9 +171,16 @@ const RepositoriesPage: React.FC = () => {
       });
     }
 
+    const discoveryByRepo = buildRepoDiscoveryRollupFromMiners(
+      allPRs,
+      allMiners,
+    );
+
     return reposWithWeights
       .map((repo) => {
-        const s = prStatsMap.get(repo.fullName.toLowerCase());
+        const key = repo.fullName.toLowerCase();
+        const s = prStatsMap.get(key);
+        const d = discoveryByRepo.get(key);
         return {
           repository: repo.fullName,
           totalScore: s?.totalScore || 0,
@@ -179,10 +188,14 @@ const RepositoriesPage: React.FC = () => {
           uniqueMiners: s?.uniqueMiners || new Set<string>(),
           weight: repo.weight ? parseFloat(String(repo.weight)) : 0,
           inactiveAt: repo.inactiveAt,
+          discoveryScore: d?.discoveryScore ?? 0,
+          discoveryIssues: d?.discoveryIssues ?? 0,
+          discoveryContributors:
+            d?.discoveryContributors ?? new Set<string>(),
         };
       })
       .sort((a, b) => b.totalScore - a.totalScore);
-  }, [allPRs, reposWithWeights]);
+  }, [allPRs, allMiners, reposWithWeights]);
 
   // ── Trending: repos with biggest % score increase in the last 7 days ──
   // Excludes brand-new repos (no prior score) so only genuine growth shows

--- a/src/pages/RepositoriesPage.tsx
+++ b/src/pages/RepositoriesPage.tsx
@@ -190,8 +190,7 @@ const RepositoriesPage: React.FC = () => {
           inactiveAt: repo.inactiveAt,
           discoveryScore: d?.discoveryScore ?? 0,
           discoveryIssues: d?.discoveryIssues ?? 0,
-          discoveryContributors:
-            d?.discoveryContributors ?? new Set<string>(),
+          discoveryContributors: d?.discoveryContributors ?? new Set<string>(),
         };
       })
       .sort((a, b) => b.totalScore - a.totalScore);

--- a/src/tests/ExplorerUtils.test.ts
+++ b/src/tests/ExplorerUtils.test.ts
@@ -10,6 +10,12 @@ import {
   hasActiveFilters,
   getDisplayCount,
   filterBySearch,
+  isIssueDiscoveryContributionPr,
+  isIssueDiscoveryMultiplierPr,
+  aggregateIssueDiscoveryRepos,
+  buildMergedIssueDiscoveryByRepo,
+  buildRepoDiscoveryRollupFromMiners,
+  buildIssueBountyRollupByRepo,
   type RepoStats,
 } from '../utils/ExplorerUtils';
 
@@ -234,6 +240,14 @@ describe('buildRepoWeightsMap', () => {
     const map = buildRepoWeightsMap(repos);
     expect(map.size).toBe(0);
   });
+
+  it('lower-cases fullName keys for consistent PR lookup', () => {
+    const repos = [
+      { fullName: 'Org/RepoA', owner: '', name: '', weight: '0.7' },
+    ] as any[];
+    const map = buildRepoWeightsMap(repos);
+    expect(map.get('org/repoa')).toBe(0.7);
+  });
 });
 
 describe('aggregatePRsByRepository', () => {
@@ -278,6 +292,196 @@ describe('aggregatePRsByRepository', () => {
     ] as any[];
     const result = aggregatePRsByRepository(prs, weights);
     expect(result).toHaveLength(2);
+  });
+
+  it('matches weights when PR repository casing differs', () => {
+    const w = new Map([['org/repo1', 0.5]]);
+    const prs = [
+      {
+        repository: 'ORG/REPO1',
+        score: '10',
+        prState: 'MERGED',
+        mergedAt: '2024-01-01',
+        tokenScore: 50,
+      },
+    ] as any[];
+    const result = aggregatePRsByRepository(prs, w);
+    expect(result).toHaveLength(1);
+    expect(result[0].weight).toBe(0.5);
+    expect(result[0].repository).toBe('ORG/REPO1');
+  });
+});
+
+describe('isIssueDiscoveryContributionPr', () => {
+  it('is true when issueMultiplier parses positive', () => {
+    expect(
+      isIssueDiscoveryContributionPr({ issueMultiplier: '1.2' } as any),
+    ).toBe(true);
+  });
+
+  it('is true when label only (miner payloads)', () => {
+    expect(
+      isIssueDiscoveryContributionPr({
+        issueMultiplier: '0',
+        label: 'bounty',
+      } as any),
+    ).toBe(true);
+  });
+});
+
+describe('isIssueDiscoveryMultiplierPr', () => {
+  it('requires multiplier fields, not label alone', () => {
+    expect(
+      isIssueDiscoveryMultiplierPr({ issueMultiplier: '1.1' } as any),
+    ).toBe(true);
+    expect(
+      isIssueDiscoveryMultiplierPr({
+        issueMultiplier: '0',
+        label: 'bounty',
+      } as any),
+    ).toBe(false);
+  });
+});
+
+describe('aggregateIssueDiscoveryRepos', () => {
+  const w = new Map([['org/a', 0.2]]);
+
+  it('aggregates merged discovery PRs only', () => {
+    const prs = [
+      {
+        repository: 'org/a',
+        score: '2',
+        issueMultiplier: '1.2',
+        prState: 'MERGED',
+        mergedAt: '2024-01-01',
+        tokenScore: 10,
+      },
+    ] as any[];
+    const r = aggregateIssueDiscoveryRepos(prs, w);
+    expect(r).toHaveLength(1);
+    expect(r[0].prs).toBe(1);
+  });
+
+  it('excludes open issue-discovery PRs', () => {
+    const prs = [
+      {
+        repository: 'org/a',
+        score: '99',
+        issueMultiplier: '1',
+        prState: 'OPEN',
+        mergedAt: null,
+      },
+      {
+        repository: 'org/a',
+        score: '2',
+        issueMultiplier: '1',
+        prState: 'MERGED',
+        mergedAt: '2024-01-01',
+      },
+    ] as any[];
+    const r = aggregateIssueDiscoveryRepos(prs, w);
+    expect(r).toHaveLength(1);
+    expect(r[0].prs).toBe(1);
+    expect(r[0].score).toBe(2);
+  });
+});
+
+describe('buildMergedIssueDiscoveryByRepo', () => {
+  it('only counts merged PRs with discovery multipliers', () => {
+    const prs = [
+      {
+        repository: 'org/a',
+        mergedAt: null,
+        prState: 'OPEN',
+        issueMultiplier: '1',
+      },
+      {
+        repository: 'org/a',
+        mergedAt: '2024-01-01',
+        prState: 'MERGED',
+        issueMultiplier: '1',
+        score: '3',
+        tokenScore: 0,
+      },
+    ] as any[];
+    const m = buildMergedIssueDiscoveryByRepo(prs);
+    const row = m.get('org/a');
+    expect(row?.discoveryIssues).toBe(1);
+    expect(row?.discoveryScore).toBe(3);
+  });
+});
+
+describe('buildRepoDiscoveryRollupFromMiners', () => {
+  const discoveryPr = (overrides: Record<string, unknown>) =>
+    ({
+      repository: 'org/repo',
+      mergedAt: '2024-01-01',
+      prState: 'MERGED',
+      issueMultiplier: '1',
+      score: '1',
+      tokenScore: 0,
+      ...overrides,
+    }) as any;
+
+  it('pro-rates miner discovery score and completed issues', () => {
+    const miners = [
+      {
+        githubId: '99',
+        issueDiscoveryScore: 200,
+        totalValidSolvedIssues: 12,
+        totalSolvedIssues: 0,
+      },
+    ] as any[];
+
+    const prs = [
+      discoveryPr({ repository: 'org/a', githubId: '99', author: 'alice' }),
+      discoveryPr({ repository: 'org/b', githubId: '99', author: 'alice' }),
+      discoveryPr({ repository: 'org/b', githubId: '99', author: 'alice' }),
+    ];
+
+    const m = buildRepoDiscoveryRollupFromMiners(prs, miners);
+    const a = m.get('org/a');
+    const b = m.get('org/b');
+    expect(a!.discoveryScore).toBeCloseTo(200 / 3, 5);
+    expect(a!.discoveryIssues).toBe(Math.round(12 / 3));
+    expect(b!.discoveryScore).toBeCloseTo((200 * 2) / 3, 5);
+    expect(b!.discoveryIssues).toBe(Math.round((12 * 2) / 3));
+    expect(a!.discoveryContributors.has('alice')).toBe(true);
+  });
+
+  it('does not count contributors with zero miner discovery stats', () => {
+    const miners = [
+      {
+        githubId: '99',
+        issueDiscoveryScore: 0,
+        totalValidSolvedIssues: 0,
+        totalSolvedIssues: 0,
+      },
+    ] as any[];
+    const prs = [
+      discoveryPr({
+        repository: 'org/z',
+        githubId: '99',
+        author: 'ghost',
+      }),
+    ];
+    const m = buildRepoDiscoveryRollupFromMiners(prs, miners);
+    const z = m.get('org/z');
+    expect(z!.discoveryContributors.size).toBe(0);
+  });
+});
+
+describe('buildIssueBountyRollupByRepo', () => {
+  it('aggregates bounty issues by repository', () => {
+    const issues = [
+      { repositoryFullName: 'org/A', status: 'active' },
+      { repositoryFullName: 'org/A', status: 'completed' },
+    ] as any[];
+    const m = buildIssueBountyRollupByRepo(issues);
+    const a = m.get('org/a');
+    expect(a!.bountyIssuesTotal).toBe(2);
+    expect(a!.bountyIssuesActive).toBe(1);
+    expect(a!.bountyIssuesCompleted).toBe(1);
   });
 });
 

--- a/src/utils/ExplorerUtils.ts
+++ b/src/utils/ExplorerUtils.ts
@@ -4,6 +4,7 @@ import {
   type Repository,
   type RepositoryPrScoring,
 } from '../api';
+import { type IssueBounty } from '../api/models/Issues';
 import { isMergedPr } from './prStatus';
 
 export const getGithubAvatarSrc = (username?: string | null) => {
@@ -196,7 +197,7 @@ export const buildRepoWeightsMap = (
   if (!Array.isArray(repos)) return map;
   for (const repo of repos) {
     if (repo && repo.fullName) {
-      map.set(repo.fullName, parseFloat(repo.weight || '0'));
+      map.set(repo.fullName.toLowerCase(), parseFloat(repo.weight || '0'));
     }
   }
   return map;
@@ -215,12 +216,14 @@ export const aggregatePRsByRepository = (
   const statsMap = new Map<string, RepoStats>();
 
   for (const pr of prs) {
-    const existing = statsMap.get(pr.repository) || {
+    if (!pr.repository) continue;
+    const repoKey = pr.repository.toLowerCase();
+    const existing = statsMap.get(repoKey) || {
       repository: pr.repository,
       prs: 0,
       score: 0,
       tokenScore: 0,
-      weight: repoWeights.get(pr.repository) || 0,
+      weight: repoWeights.get(repoKey) || 0,
       latestPrDate: null as string | null,
     };
     existing.prs += 1;
@@ -234,10 +237,251 @@ export const aggregatePRsByRepository = (
     ) {
       existing.latestPrDate = pr.mergedAt;
     }
-    statsMap.set(pr.repository, existing);
+    statsMap.set(repoKey, existing);
   }
 
   return Array.from(statsMap.values());
+};
+
+// ---------------------------------------------------------------------------
+// Issue discovery – repo rollups from issue-linked / multiplier PRs
+// ---------------------------------------------------------------------------
+
+/**
+ * PR counts toward Issue Discovery repo rollups. The miner PR list often omits
+ * `issueMultiplier` even when the PR is issue-linked; use label / labelMultiplier too.
+ */
+export const isIssueDiscoveryContributionPr = (pr: CommitLog): boolean => {
+  const rawIm = pr.issueMultiplier;
+  if (rawIm != null && String(rawIm).trim() !== '') {
+    if (parseNumber(rawIm, 0) > 0) return true;
+  }
+  if (parseNumber(pr.labelMultiplier, 0) > 0) return true;
+  if (pr.label != null && String(pr.label).trim() !== '') return true;
+  return false;
+};
+
+/**
+ * PR counts toward **issue discovery** in global feeds (e.g. `/prs`).
+ * Stricter than {@link isIssueDiscoveryContributionPr}: requires a positive
+ * issue or label **multiplier**, not merely any GitHub label.
+ */
+export const isIssueDiscoveryMultiplierPr = (pr: CommitLog): boolean => {
+  const rawIm = pr.issueMultiplier;
+  if (rawIm != null && String(rawIm).trim() !== '') {
+    if (parseNumber(rawIm, 0) > 0) return true;
+  }
+  if (parseNumber(pr.labelMultiplier, 0) > 0) return true;
+  return false;
+};
+
+/**
+ * Per-repository stats for a miner's issue-discovery repos: **merged** PRs only
+ * (aligned with Repositories OSS row), passing {@link isIssueDiscoveryContributionPr}.
+ */
+export const aggregateIssueDiscoveryRepos = (
+  prs: CommitLog[] | undefined,
+  repoWeights: Map<string, number>,
+): RepoStats[] => {
+  const filtered = (prs || [])
+    .filter(isIssueDiscoveryContributionPr)
+    .filter(isMergedPr);
+  return aggregatePRsByRepository(filtered, repoWeights);
+};
+
+/** Per-repository rollup for merged PRs that count toward issue discovery. */
+export type MergedIssueDiscoveryRepoRollup = {
+  discoveryScore: number;
+  /** Merged issue-discovery PRs in this repo (proxy when not using miner pro-rating). */
+  discoveryIssues: number;
+  discoveryContributors: Set<string>;
+};
+
+/**
+ * Builds discovery stats per repo from the global PR feed: merged PRs with
+ * issue-discovery multipliers ({@link isIssueDiscoveryMultiplierPr}).
+ */
+export const buildMergedIssueDiscoveryByRepo = (
+  prs: CommitLog[] | undefined,
+): Map<string, MergedIssueDiscoveryRepoRollup> => {
+  const map = new Map<string, MergedIssueDiscoveryRepoRollup>();
+  if (!prs?.length) return map;
+
+  for (const pr of prs) {
+    if (!pr?.repository) continue;
+    if (!isMergedPr(pr)) continue;
+    if (!isIssueDiscoveryMultiplierPr(pr)) continue;
+
+    const key = pr.repository.toLowerCase();
+    const cur = map.get(key) ?? {
+      discoveryScore: 0,
+      discoveryIssues: 0,
+      discoveryContributors: new Set<string>(),
+    };
+    const token = parseNumber(pr.tokenScore);
+    cur.discoveryScore +=
+      token > 0 ? token : parseFloat(pr.score || '0');
+    cur.discoveryIssues += 1;
+    const minerKey = pr.githubId || pr.author;
+    if (minerKey) cur.discoveryContributors.add(String(minerKey));
+    map.set(key, cur);
+  }
+
+  return map;
+};
+
+const discoveryWeightKey = (pr: CommitLog): string | null => {
+  if (pr.githubId) return String(pr.githubId);
+  if (pr.author?.trim()) return pr.author.trim().toLowerCase();
+  return null;
+};
+
+const discoveryDisplayContributorKey = (pr: CommitLog): string | null => {
+  if (pr.author?.trim()) return pr.author.trim();
+  if (pr.githubId) return String(pr.githubId);
+  return null;
+};
+
+export const buildMinerLookupByIdentity = (
+  miners: MinerEvaluation[] | undefined,
+): Map<string, MinerEvaluation> => {
+  const map = new Map<string, MinerEvaluation>();
+  if (!miners?.length) return map;
+  for (const m of miners) {
+    if (m.githubId) map.set(String(m.githubId), m);
+    const u = m.githubUsername?.trim().toLowerCase();
+    if (u) map.set(u, m);
+  }
+  return map;
+};
+
+/** Prefer program-valid solved; fall back to total solved — not open or all-issue totals. */
+const completedDiscoveryIssuesForMiner = (m: MinerEvaluation): number => {
+  const valid = parseNumber(m.totalValidSolvedIssues);
+  if (valid > 0) return valid;
+  return parseNumber(m.totalSolvedIssues);
+};
+
+/**
+ * Repositories leaderboard discovery row: pro-rated {@link MinerEvaluation.issueDiscoveryScore}
+ * and **completed** discovery issues; merged discovery PRs only. Contributors only if they add
+ * non-zero pro-rated score or issues in this repo.
+ */
+export const buildRepoDiscoveryRollupFromMiners = (
+  prs: CommitLog[] | undefined,
+  miners: MinerEvaluation[] | undefined,
+): Map<string, MergedIssueDiscoveryRepoRollup> => {
+  const out = new Map<string, MergedIssueDiscoveryRepoRollup>();
+  if (!prs?.length) return out;
+
+  const minerByIdentity = buildMinerLookupByIdentity(miners);
+  const globalDiscoveryPr = new Map<string, number>();
+  const repoDiscoveryPr = new Map<string, Map<string, number>>();
+  const displayLabelByWk = new Map<string, string>();
+  const unmatched = new Map<string, { score: number; issues: number }>();
+
+  for (const pr of prs) {
+    if (!pr?.repository || !isMergedPr(pr)) continue;
+    if (!isIssueDiscoveryMultiplierPr(pr)) continue;
+
+    const wk = discoveryWeightKey(pr);
+    if (!wk) continue;
+
+    const dk = discoveryDisplayContributorKey(pr);
+    if (dk && !displayLabelByWk.has(wk)) displayLabelByWk.set(wk, dk);
+
+    const repoKey = pr.repository.toLowerCase();
+    globalDiscoveryPr.set(wk, (globalDiscoveryPr.get(wk) || 0) + 1);
+
+    if (!repoDiscoveryPr.has(repoKey)) {
+      repoDiscoveryPr.set(repoKey, new Map());
+    }
+    const rm = repoDiscoveryPr.get(repoKey)!;
+    rm.set(wk, (rm.get(wk) || 0) + 1);
+
+    const miner = minerByIdentity.get(wk);
+    if (!miner) {
+      const uk = `${repoKey}\0${wk}`;
+      const cur = unmatched.get(uk) || { score: 0, issues: 0 };
+      const token = parseNumber(pr.tokenScore);
+      cur.score += token > 0 ? token : parseFloat(pr.score || '0');
+      cur.issues += 1;
+      unmatched.set(uk, cur);
+    }
+  }
+
+  for (const [repoKey, weightMap] of repoDiscoveryPr) {
+    let discoveryScore = 0;
+    let discoveryIssues = 0;
+    const discoveryContributors = new Set<string>();
+
+    for (const wk of weightMap.keys()) {
+      const inRepo = weightMap.get(wk) || 0;
+      const globalN = Math.max(1, globalDiscoveryPr.get(wk) || 0);
+      const w = inRepo / globalN;
+      const miner = minerByIdentity.get(wk);
+
+      if (miner) {
+        const scorePart = parseNumber(miner.issueDiscoveryScore) * w;
+        const issuesPart = completedDiscoveryIssuesForMiner(miner) * w;
+        discoveryScore += scorePart;
+        discoveryIssues += issuesPart;
+        if (scorePart > 0 || issuesPart > 0) {
+          const label = displayLabelByWk.get(wk);
+          if (label) discoveryContributors.add(label);
+        }
+      } else {
+        const u = unmatched.get(`${repoKey}\0${wk}`);
+        if (u) {
+          discoveryScore += u.score;
+          discoveryIssues += u.issues;
+          if (u.score > 0 || u.issues > 0) {
+            const label = displayLabelByWk.get(wk);
+            if (label) discoveryContributors.add(label);
+          }
+        }
+      }
+    }
+
+    out.set(repoKey, {
+      discoveryScore,
+      discoveryIssues: Math.round(discoveryIssues),
+      discoveryContributors,
+    });
+  }
+
+  return out;
+};
+
+export type IssueBountyRepoRollup = {
+  bountyIssuesTotal: number;
+  bountyIssuesActive: number;
+  bountyIssuesCompleted: number;
+};
+
+export const buildIssueBountyRollupByRepo = (
+  issues: IssueBounty[] | undefined,
+): Map<string, IssueBountyRepoRollup> => {
+  const map = new Map<string, IssueBountyRepoRollup>();
+  if (!issues?.length) return map;
+
+  for (const issue of issues) {
+    const name = issue.repositoryFullName?.trim();
+    if (!name) continue;
+    const key = name.toLowerCase();
+    const cur = map.get(key) ?? {
+      bountyIssuesTotal: 0,
+      bountyIssuesActive: 0,
+      bountyIssuesCompleted: 0,
+    };
+    cur.bountyIssuesTotal += 1;
+    const st = (issue.status || '').toLowerCase();
+    if (st === 'active') cur.bountyIssuesActive += 1;
+    if (st === 'completed') cur.bountyIssuesCompleted += 1;
+    map.set(key, cur);
+  }
+
+  return map;
 };
 
 // ---------------------------------------------------------------------------

--- a/src/utils/ExplorerUtils.ts
+++ b/src/utils/ExplorerUtils.ts
@@ -319,8 +319,7 @@ export const buildMergedIssueDiscoveryByRepo = (
       discoveryContributors: new Set<string>(),
     };
     const token = parseNumber(pr.tokenScore);
-    cur.discoveryScore +=
-      token > 0 ? token : parseFloat(pr.score || '0');
+    cur.discoveryScore += token > 0 ? token : parseFloat(pr.score || '0');
     cur.discoveryIssues += 1;
     const minerKey = pr.githubId || pr.author;
     if (minerKey) cur.discoveryContributors.add(String(minerKey));


### PR DESCRIPTION
## Summary

- **Repositories page:** OSS stats use merged PRs (`isMergedPr`); issue-track row uses `buildRepoDiscoveryRollupFromMiners` with `useAllMiners` (pro-rated issue score and completed/solved issues; contributors only when they have non-zero pro-rated discovery share).
- **ExplorerUtils:** Case-insensitive repo weight keys; issue-discovery helpers (`isIssueDiscoveryContributionPr` / `isIssueDiscoveryMultiplierPr`), `aggregateIssueDiscoveryRepos` (merged-only), `buildRepoDiscoveryRollupFromMiners`, `buildIssueBountyRollupByRepo`, tests.
- **UI:** Repository cards show two bands (OSS score / PRs / contributors; issue score / issues / issue contributors). List view: column order (scores & issues first, contributor columns last), **Issue score** / **Contributors** / **Issue contrib.** labels, and numeric display when a row has OSS or issue-track activity (avoid `PRs > 0` with OSS score shown as `-`). Chart tooltips and sort options aligned.
- Branch based on **`test`** per contributor guide; avoids unrelated refactors.


Closes #792

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- `npm run build` passes locally.
- `ExplorerUtils` unit tests pass.
- Manual against **test API** (`.env` from `.env.example`, `npm run dev`): Repositories page card + list parity, sort by weight / OSS score / Issues, repos with zero OSS score but non-zero PRs, issue score / issues / contributor columns.

## Screenshots
-Before fix on repository page

<img width="1151" height="662" alt="image" src="https://github.com/user-attachments/assets/85838dbe-3ca3-4f90-9361-b7639cfc4ec8" />
<img width="1181" height="600" alt="image" src="https://github.com/user-attachments/assets/30ae7945-6539-496f-8d27-fd70a806cdf6" />

<img width="255" height="272" alt="image" src="https://github.com/user-attachments/assets/5a439b4b-f08a-4e5e-a730-c320a0cedae6" />


-After fix on repository page

<img width="1162" height="572" alt="image" src="https://github.com/user-attachments/assets/78440834-9c8f-4165-b6ee-ee2924112160" />

<img width="1216" height="384" alt="image" src="https://github.com/user-attachments/assets/a4903dcb-e339-4a63-82e0-562c2773dbef" />

<img width="270" height="331" alt="image" src="https://github.com/user-attachments/assets/eeeb9e5a-1534-49a5-8808-719c6bf5888f" />


## Checklist

- [ ] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [ ] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [ ] Screenshots included for any UI/visual changes