### PR TITLE
feat: onboard tab content width inconsistency

### DIFF
--- a/src/components/onboard/AboutContent.tsx
+++ b/src/components/onboard/AboutContent.tsx
@@ -29,9 +29,8 @@ export const AboutContent: React.FC = () => {
     >
       <Box
         sx={{
-          maxWidth: 1000,
           width: '100%',
-          px: { xs: 2, sm: 3, md: 4 },
+          maxWidth: '100%',
         }}
       >
         {/* 1. Context: What is Gittensor? */}

--- a/src/components/onboard/FAQContent.tsx
+++ b/src/components/onboard/FAQContent.tsx
@@ -11,7 +11,7 @@ export const FAQContent: React.FC = () => (
       width: '100%',
     }}
   >
-    <Stack gap={{ xs: 2, sm: 3 }} sx={{ maxWidth: 900, width: '100%' }}>
+    <Stack gap={{ xs: 2, sm: 3 }} sx={{ width: '100%', maxWidth: '100%' }}>
       <FAQ
         question="What is an incentive mechanism?"
         answer="A set of rules, guidelines, and restrictions on how to judge, score, and rank a group of contestants. The goal usually to elicit or influence a specific behavior or outcome. In the Bittensor ecosystem, this is the foundation of a subnet."

--- a/src/components/onboard/GettingStarted.tsx
+++ b/src/components/onboard/GettingStarted.tsx
@@ -428,7 +428,7 @@ export const GettingStarted: React.FC = () => {
   const [activeStep, setActiveStep] = useState(0);
 
   return (
-    <Box sx={{ maxWidth: 1000, mx: 'auto', px: { xs: 2, md: 4 }, py: 4 }}>
+    <Box sx={{ width: '100%', maxWidth: '100%', py: 4 }}>
       <Typography
         variant="h4"
         fontWeight="bold"

--- a/src/components/onboard/Scoring.tsx
+++ b/src/components/onboard/Scoring.tsx
@@ -72,7 +72,7 @@ export const Scoring: React.FC = () => {
   const visibleCards = SCORING_CARDS.filter((c) => c.category === category);
 
   return (
-    <Box sx={{ maxWidth: 1000, mx: 'auto', px: { xs: 2, md: 4 }, py: 4 }}>
+    <Box sx={{ width: '100%', maxWidth: '100%', py: 4 }}>
       <Typography
         variant="h4"
         fontWeight="bold"

--- a/src/pages/OnboardPage.tsx
+++ b/src/pages/OnboardPage.tsx
@@ -65,6 +65,7 @@ const OnboardPage: React.FC = () => {
             zIndex: 2,
             maxWidth: 1200,
             width: '100%',
+            mx: 'auto',
             mb: 4,
             backgroundColor: theme.palette.background.default,
             borderBottom: '1px solid',
@@ -98,35 +99,33 @@ const OnboardPage: React.FC = () => {
           </Tabs>
         </Box>
 
-        <Box sx={{ width: '100%' }}>
+        <Box
+          sx={{
+            width: '100%',
+            maxWidth: 1200,
+            mx: 'auto',
+            px: 2,
+            boxSizing: 'border-box',
+          }}
+        >
           {activeTab === 0 && <AboutContent />}
           {activeTab === 1 && <GettingStarted />}
           {activeTab === 2 && <Scoring />}
           {activeTab === 3 && (
-            <Box
-              sx={{
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
+            <Card
+              sx={(theme) => ({
+                borderRadius: 3,
+                border: '1px solid',
+                borderColor: theme.palette.border.light,
+                backgroundColor: theme.palette.surface.transparent,
                 width: '100%',
-              }}
+              })}
+              elevation={0}
             >
-              <Card
-                sx={(theme) => ({
-                  borderRadius: 3,
-                  border: '1px solid',
-                  borderColor: theme.palette.border.light,
-                  backgroundColor: theme.palette.surface.transparent,
-                  maxWidth: 1200,
-                  width: '100%',
-                })}
-                elevation={0}
-              >
-                <CardContent>
-                  <LanguageWeightsTable />
-                </CardContent>
-              </Card>
-            </Box>
+              <CardContent>
+                <LanguageWeightsTable />
+              </CardContent>
+            </Card>
           )}
           {activeTab === 4 && <FAQContent />}
         </Box>


### PR DESCRIPTION
## Summary

Aligns **Onboard** page tab body content with the **sticky tab header** column so every tab (About, Getting Started, Scoring, Languages, FAQ) uses the same **max width (1200px)** and **horizontal padding** as the Languages tab and tab strip. Previously, Languages matched the header rail while other tabs used narrower inner layouts (1000px / 900px), which looked inconsistent on wide viewports.

## Related issue

Closes #794

## Type of change

- [x] Bug fix (UI layout)
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Screenshots

### Before
https://github.com/user-attachments/assets/aa342e90-b912-4844-8e76-29bcef9a20c6

### After
https://github.com/user-attachments/assets/b2af1c14-771a-4581-aac8-b78e5bdcf99b

## Checklist

- [x] Layout matches tab header width on desktop
- [x] `npm run lint` on touched files passes
- [ ] Full `npm run build` (if required by team before merge)
- [ ] Manual QA: all five tabs at `sm` / `md` / wide breakpoints
- [ ] Screenshots attached if required by team process
