### PR TITLE
feat(miner-details): add Issues tab on Issue Discovery view

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 # use test api
 VITE_REACT_APP_BASE_URL=https://test-api.gittensor.io
+VITE_REACT_APP_MIRROR_BASE_URL=https://mirror.gittensor.io/api/v1

--- a/src/api/ApiUtils.ts
+++ b/src/api/ApiUtils.ts
@@ -22,3 +22,35 @@ export const useApiQuery = <TResponse = void, TSelect = TResponse>(
     refetchInterval,
   });
 };
+
+// Mirror API (https://mirror.gittensor.io/api/v1) — returns raw snake_case
+// payloads, so callers receive the response as-is and may transform it via
+// `useQuery`'s `select`. Kept separate from `useApiQuery` so the camelCase
+// production API isn't accidentally pointed at the mirror.
+export const useMirrorApiQuery = <TResponse = unknown, TSelect = TResponse>(
+  queryName: string,
+  url: string,
+  options?: {
+    refetchInterval?: number;
+    queryParams?: Record<string, string | number | undefined>;
+    enabled?: boolean;
+    select?: (data: TResponse) => TSelect;
+  },
+) => {
+  const baseUrl = import.meta.env.VITE_REACT_APP_MIRROR_BASE_URL;
+
+  return useQuery<TResponse, AxiosError, TSelect>({
+    queryKey: ['mirror', queryName, url, options?.queryParams],
+    queryFn: async () => {
+      const requestUrl = baseUrl ? `${baseUrl}${url}` : url;
+      const { data } = await axios.get(requestUrl, {
+        params: options?.queryParams,
+      });
+      return data;
+    },
+    select: options?.select,
+    retry: false,
+    enabled: options?.enabled ?? true,
+    refetchInterval: options?.refetchInterval,
+  });
+};

--- a/src/api/MinerApi.ts
+++ b/src/api/MinerApi.ts
@@ -1,9 +1,11 @@
 // Miner API hooks - uses /miners endpoints
-import { useApiQuery } from './ApiUtils';
+import { useApiQuery, useMirrorApiQuery } from './ApiUtils';
 import {
   type GithubMinerData,
   type MinerEvaluation,
   type CommitLog,
+  type MinerIssue,
+  type MinerIssuesResponse,
 } from './models/Dashboard';
 
 /**
@@ -69,4 +71,21 @@ export const useMinerGithubData = (githubId: string, enabled?: boolean) =>
     undefined,
     undefined,
     enabled,
+  );
+
+/**
+ * Get all issues authored or solved by a specific miner.
+ * Hits the mirror API (https://mirror.gittensor.io/api/v1) which returns the
+ * raw snake_case payload — `select` unwraps `{ issues: [...] }` for callers.
+ * @param githubId - Numeric GitHub ID (e.g., "583231"), NOT username
+ * @param enabled - Optional flag to enable/disable the query
+ */
+export const useMinerIssues = (githubId: string, enabled?: boolean) =>
+  useMirrorApiQuery<MinerIssuesResponse, MinerIssue[]>(
+    'useMinerIssues',
+    `/miners/${githubId}/issues`,
+    {
+      enabled,
+      select: (data) => data?.issues ?? [],
+    },
   );

--- a/src/api/models/Dashboard.ts
+++ b/src/api/models/Dashboard.ts
@@ -67,6 +67,71 @@ export type Stats = {
   };
 };
 
+// Mirror API (snake_case) — kept as-is to avoid a transform layer.
+export type MinerIssue = {
+  repo_full_name: string;
+  issue_number: number;
+  title: string;
+  state: 'OPEN' | 'CLOSED' | string;
+  state_reason?: string | null;
+  author_github_id?: string | null;
+  author_login?: string | null;
+  author_association?: string | null;
+  created_at?: string | null;
+  closed_at?: string | null;
+  updated_at?: string | null;
+  last_edited_at?: string | null;
+  is_transferred?: boolean;
+  solved_by_pr?: number | null;
+  solving_pr?: {
+    pr_number: number;
+    author_github_id?: string | null;
+    state?: string;
+    merged_at?: string | null;
+    hours_since_merge?: number;
+    edited_after_merge?: boolean;
+    head_sha?: string;
+    base_sha?: string;
+    merge_base_sha?: string;
+    labels?: Array<{ name: string }>;
+    review_summary?: {
+      maintainer_changes_requested_count?: number;
+    };
+    repo_full_name?: string;
+  } | null;
+  labels?: Array<{
+    name: string;
+    actor_github_id?: string | null;
+    actor_association?: string | null;
+  }>;
+};
+
+export type MinerIssuesResponse = {
+  github_id: string;
+  since: string;
+  generated_at: string;
+  issues: MinerIssue[];
+};
+
+export type LinkedIssue = {
+  number: number;
+  title: string;
+  state: 'OPEN' | 'CLOSED' | string;
+  stateReason?: string | null;
+  authorGithubId?: string | null;
+  authorAssociation?: string | null;
+  createdAt?: string | null;
+  closedAt?: string | null;
+  updatedAt?: string | null;
+  isTransferred?: boolean;
+  solvedByPr?: number | null;
+  labels?: Array<{
+    name: string;
+    actorGithubId?: string | null;
+    actorAssociation?: string | null;
+  }>;
+};
+
 export type CommitLog = {
   pullRequestNumber: number;
   hotkey: string;
@@ -115,6 +180,9 @@ export type CommitLog = {
   predictedAlphaPerDay?: number | null;
   predictedTaoPerDay?: number | null;
   predictedUsdPerDay?: number | null;
+
+  // Linked issues (from /miners/{id}/pulls — issues this PR closes/references)
+  linkedIssues?: LinkedIssue[];
 };
 
 export type MinerEvaluation = {

--- a/src/components/miners/MinerIssuesTable.tsx
+++ b/src/components/miners/MinerIssuesTable.tsx
@@ -17,7 +17,7 @@ import { Link as RouterLink, useSearchParams } from 'react-router-dom';
 import { useMinerIssues } from '../../api';
 import { type MinerIssue } from '../../api/models/Dashboard';
 import { paginateItems } from '../../utils';
-import { getIssueStatusMeta } from '../../utils/issueStatus';
+import { LABEL_COLORS } from '../../theme';
 import {
   DataTable,
   type DataTableColumn,
@@ -323,49 +323,52 @@ const MinerIssuesTable: React.FC<MinerIssuesTableProps> = ({ githubId }) => {
       },
     },
     {
-      key: 'status',
-      header: 'Status',
-      width: '12%',
-      align: 'center',
+      key: 'labels',
+      header: 'Labels',
+      width: '15%',
       renderCell: (issue) => {
-        const reason = (issue.state_reason ?? '').toLowerCase();
-        // Match the bounties-page chip for completed issues: same alpha-tinted
-        // "Completed" badge sourced from getIssueStatusMeta.
-        if (reason === 'completed') {
-          const meta = getIssueStatusMeta('completed');
+        const labels = issue.labels ?? [];
+        if (labels.length === 0) {
           return (
-            <Chip
-              label="Resolved"
-              size="small"
+            <Typography
               sx={{
-                fontSize: '0.7rem',
-                height: 20,
-                color: meta.color,
-                backgroundColor: meta.bgColor,
-                border: '1px solid',
-                borderColor: meta.borderColor,
+                fontSize: '0.75rem',
+                color: (t) => alpha(t.palette.text.primary, 0.4),
               }}
-            />
+            >
+              —
+            </Typography>
           );
         }
-        // Prefer state_reason; fall back to OPEN/CLOSED state.
-        const s = issueState(issue);
-        const label = reason ? reason.replace(/_/g, ' ') : statusLabel(s);
-        const color = statusColor(theme, s);
         return (
-          <Chip
-            label={label}
-            size="small"
-            sx={{
-              fontSize: '0.7rem',
-              height: 20,
-              textTransform: 'capitalize',
-              color,
-              backgroundColor: alpha(color, 0.12),
-              border: '1px solid',
-              borderColor: alpha(color, 0.3),
-            }}
-          />
+          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
+            {labels.map((l) => {
+              // Map known label names to project theme colors. Unknown labels
+              // fall back to the neutral text-primary tint.
+              const name = l.name.toLowerCase();
+              let color: string | null = null;
+              if (name in LABEL_COLORS) {
+                color = LABEL_COLORS[name as keyof typeof LABEL_COLORS];
+              }
+              const bg = color ?? theme.palette.text.primary;
+              return (
+                <Chip
+                  key={l.name}
+                  label={l.name}
+                  size="small"
+                  sx={{
+                    fontSize: '0.65rem',
+                    height: 18,
+                    textTransform: 'lowercase',
+                    color,
+                    backgroundColor: alpha(bg, 0.12),
+                    border: '1px solid',
+                    borderColor: alpha(bg, 0.3),
+                  }}
+                />
+              );
+            })}
+          </Box>
         );
       },
     },

--- a/src/components/miners/MinerIssuesTable.tsx
+++ b/src/components/miners/MinerIssuesTable.tsx
@@ -1,0 +1,539 @@
+import React, { useState, useMemo, useCallback, useEffect } from 'react';
+import {
+  Avatar,
+  Box,
+  Card,
+  Chip,
+  CircularProgress,
+  InputAdornment,
+  TextField,
+  Typography,
+  alpha,
+  useTheme,
+  type Theme,
+} from '@mui/material';
+import { Search as SearchIcon } from '@mui/icons-material';
+import { Link as RouterLink, useSearchParams } from 'react-router-dom';
+import { useMinerIssues } from '../../api';
+import { type MinerIssue } from '../../api/models/Dashboard';
+import { paginateItems } from '../../utils';
+import { getIssueStatusMeta } from '../../utils/issueStatus';
+import {
+  DataTable,
+  type DataTableColumn,
+} from '../../components/common/DataTable';
+import ExplorerFilterButton from './ExplorerFilterButton';
+import TablePagination from './TablePagination';
+
+type IssueSortField = 'number' | 'repository' | 'date';
+type SortDir = 'asc' | 'desc';
+
+type IssueStatusFilter = 'all' | 'open' | 'resolved' | 'closed';
+
+const STATUS_FILTERS: readonly IssueStatusFilter[] = [
+  'all',
+  'open',
+  'resolved',
+  'closed',
+];
+
+const PAGE_SIZE = 20;
+
+const DEFAULT_SORT_DIR: Record<IssueSortField, SortDir> = {
+  number: 'desc',
+  repository: 'asc',
+  date: 'desc',
+};
+
+const isStatusFilter = (value: string | null): value is IssueStatusFilter =>
+  value !== null && (STATUS_FILTERS as readonly string[]).includes(value);
+
+type IssueRow = MinerIssue;
+
+const getDate = (issue: IssueRow): string =>
+  issue.closed_at || issue.updated_at || issue.created_at || '';
+
+const statusColor = (theme: Theme, status: IssueStatusFilter) => {
+  switch (status) {
+    case 'all':
+      return theme.palette.status.neutral;
+    case 'open':
+      return theme.palette.status.open;
+    case 'resolved':
+      return theme.palette.status.merged;
+    case 'closed':
+      return theme.palette.status.closed;
+  }
+};
+
+const statusLabel = (status: IssueStatusFilter): string =>
+  status[0].toUpperCase() + status.slice(1);
+
+const issueState = (issue: IssueRow): Exclude<IssueStatusFilter, 'all'> => {
+  if ((issue.state_reason ?? '').toLowerCase() === 'completed')
+    return 'resolved';
+  return issue.state === 'CLOSED' ? 'closed' : 'open';
+};
+
+interface MinerIssuesTableProps {
+  githubId: string;
+}
+
+const MinerIssuesTable: React.FC<MinerIssuesTableProps> = ({ githubId }) => {
+  const theme = useTheme();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const { data: issuesData, isLoading } = useMinerIssues(githubId, !!githubId);
+  const issues = useMemo<IssueRow[]>(() => issuesData ?? [], [issuesData]);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [sortField, setSortField] = useState<IssueSortField>('date');
+  const [sortDir, setSortDir] = useState<SortDir>('desc');
+  const issueStatusParam = searchParams.get('issueStatus');
+  const statusFilter: IssueStatusFilter = isStatusFilter(issueStatusParam)
+    ? issueStatusParam
+    : 'all';
+
+  useEffect(() => {
+    setSearchQuery('');
+    setSortField('date');
+    setSortDir('desc');
+  }, [githubId]);
+
+  const page = parseInt(searchParams.get('issuePage') || '0', 10);
+  const setPage = useCallback(
+    (updater: number | ((prev: number) => number)) => {
+      const next = typeof updater === 'function' ? updater(page) : updater;
+      setSearchParams(
+        (prev) => {
+          const p = new URLSearchParams(prev);
+          if (next === 0) p.delete('issuePage');
+          else p.set('issuePage', String(next));
+          return p;
+        },
+        { replace: true },
+      );
+    },
+    [page, setSearchParams],
+  );
+
+  const setStatusFilter = useCallback(
+    (next: IssueStatusFilter) => {
+      setSearchParams(
+        (prev) => {
+          const p = new URLSearchParams(prev);
+          if (next === 'all') p.delete('issueStatus');
+          else p.set('issueStatus', next);
+          p.delete('issuePage');
+          return p;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
+  );
+
+  const handleSort = useCallback(
+    (field: IssueSortField) => {
+      if (sortField === field) {
+        setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
+      } else {
+        setSortField(field);
+        setSortDir(DEFAULT_SORT_DIR[field]);
+      }
+      setPage(0);
+    },
+    [sortField, setPage],
+  );
+
+  const filteredIssues = useMemo(() => {
+    const q = searchQuery.trim().toLowerCase();
+    return issues.filter((issue) => {
+      if (statusFilter !== 'all' && issueState(issue) !== statusFilter)
+        return false;
+      if (!q) return true;
+      const num = String(issue.issue_number);
+      return (
+        (issue.title || '').toLowerCase().includes(q) ||
+        issue.repo_full_name.toLowerCase().includes(q) ||
+        num.includes(q)
+      );
+    });
+  }, [issues, statusFilter, searchQuery]);
+
+  const sortedIssues = useMemo(() => {
+    const sorted = [...filteredIssues];
+    sorted.sort((a, b) => {
+      let cmp = 0;
+      switch (sortField) {
+        case 'number':
+          cmp = a.issue_number - b.issue_number;
+          break;
+        case 'repository':
+          cmp = a.repo_full_name.localeCompare(b.repo_full_name);
+          if (cmp === 0) cmp = a.issue_number - b.issue_number;
+          break;
+        case 'date':
+          cmp = getDate(a).localeCompare(getDate(b));
+          break;
+      }
+      return sortDir === 'asc' ? cmp : -cmp;
+    });
+    return sorted;
+  }, [filteredIssues, sortField, sortDir]);
+
+  const pagedIssues = useMemo(
+    () => paginateItems(sortedIssues, page, PAGE_SIZE),
+    [sortedIssues, page],
+  );
+
+  const totalPages = Math.ceil(sortedIssues.length / PAGE_SIZE);
+
+  const statusCounts = useMemo(() => {
+    const counts: Record<IssueStatusFilter, number> = {
+      all: issues.length,
+      open: 0,
+      resolved: 0,
+      closed: 0,
+    };
+    issues.forEach((issue) => {
+      counts[issueState(issue)] += 1;
+    });
+    return counts;
+  }, [issues]);
+
+  const hasFilters = statusFilter !== 'all' || searchQuery.trim() !== '';
+
+  const columns: DataTableColumn<IssueRow, IssueSortField>[] = [
+    {
+      key: 'number',
+      header: 'Issue #',
+      width: '10%',
+      sortKey: 'number',
+      headerSx: { whiteSpace: 'nowrap' },
+      cellSx: { fontSize: { xs: '0.75rem', sm: '0.85rem' } },
+      renderCell: (issue) => (
+        <a
+          href={`https://github.com/${issue.repo_full_name}/issues/${issue.issue_number}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          style={{
+            color: 'inherit',
+            textDecoration: 'none',
+            fontWeight: 500,
+          }}
+          onClick={(e) => e.stopPropagation()}
+        >
+          #{issue.issue_number}
+        </a>
+      ),
+    },
+    {
+      key: 'title',
+      header: 'Title',
+      width: '37%',
+      cellSx: { fontSize: { xs: '0.75rem', sm: '0.85rem' } },
+      renderCell: (issue) => (
+        <Box
+          sx={{
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {issue.title || '—'}
+        </Box>
+      ),
+    },
+    {
+      key: 'repository',
+      header: 'Repository',
+      width: '28%',
+      sortKey: 'repository',
+      renderCell: (issue) => {
+        const owner = issue.repo_full_name.split('/')[0];
+        return (
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 1.5,
+              overflow: 'hidden',
+            }}
+          >
+            <Avatar
+              src={`https://avatars.githubusercontent.com/${owner}`}
+              alt={owner}
+              sx={{
+                width: 20,
+                height: 20,
+                flexShrink: 0,
+                border: '1px solid',
+                borderColor: 'border.medium',
+                backgroundColor:
+                  owner === 'opentensor'
+                    ? 'text.primary'
+                    : owner === 'bitcoin'
+                      ? 'status.warning'
+                      : 'transparent',
+              }}
+            />
+            <Box
+              component="span"
+              sx={{ wordBreak: 'break-word', lineHeight: 1.3 }}
+            >
+              {issue.repo_full_name}
+            </Box>
+          </Box>
+        );
+      },
+    },
+    {
+      key: 'pr',
+      header: 'PR',
+      width: '10%',
+      align: 'center',
+      renderCell: (issue) => {
+        const prNumber = issue.solving_pr?.pr_number ?? issue.solved_by_pr;
+        if (!prNumber) {
+          return (
+            <Typography
+              sx={{
+                fontSize: '0.75rem',
+                color: (t) => alpha(t.palette.text.primary, 0.4),
+              }}
+            >
+              —
+            </Typography>
+          );
+        }
+        const repo = issue.solving_pr?.repo_full_name ?? issue.repo_full_name;
+        return (
+          <RouterLink
+            to={`/miners/pr?repo=${encodeURIComponent(repo)}&number=${prNumber}`}
+            style={{
+              color: 'inherit',
+              textDecoration: 'none',
+              fontWeight: 500,
+              fontSize: '0.85rem',
+            }}
+            onClick={(e) => e.stopPropagation()}
+          >
+            #{prNumber}
+          </RouterLink>
+        );
+      },
+    },
+    {
+      key: 'status',
+      header: 'Status',
+      width: '12%',
+      align: 'center',
+      renderCell: (issue) => {
+        const reason = (issue.state_reason ?? '').toLowerCase();
+        // Match the bounties-page chip for completed issues: same alpha-tinted
+        // "Completed" badge sourced from getIssueStatusMeta.
+        if (reason === 'completed') {
+          const meta = getIssueStatusMeta('completed');
+          return (
+            <Chip
+              label="Resolved"
+              size="small"
+              sx={{
+                fontSize: '0.7rem',
+                height: 20,
+                color: meta.color,
+                backgroundColor: meta.bgColor,
+                border: '1px solid',
+                borderColor: meta.borderColor,
+              }}
+            />
+          );
+        }
+        // Prefer state_reason; fall back to OPEN/CLOSED state.
+        const s = issueState(issue);
+        const label = reason ? reason.replace(/_/g, ' ') : statusLabel(s);
+        const color = statusColor(theme, s);
+        return (
+          <Chip
+            label={label}
+            size="small"
+            sx={{
+              fontSize: '0.7rem',
+              height: 20,
+              textTransform: 'capitalize',
+              color,
+              backgroundColor: alpha(color, 0.12),
+              border: '1px solid',
+              borderColor: alpha(color, 0.3),
+            }}
+          />
+        );
+      },
+    },
+    {
+      key: 'date',
+      header: 'Date',
+      width: '15%',
+      align: 'right',
+      sortKey: 'date',
+      cellSx: {
+        fontSize: { xs: '0.75rem', sm: '0.85rem' },
+        color: (t) => alpha(t.palette.text.primary, 0.7),
+      },
+      renderCell: (issue) => {
+        const d = getDate(issue);
+        return d ? new Date(d).toLocaleDateString() : '-';
+      },
+    },
+  ];
+
+  if (isLoading) {
+    return (
+      <Card sx={{ p: 4, textAlign: 'center' }} elevation={0}>
+        <CircularProgress size={40} sx={{ color: 'primary.main' }} />
+      </Card>
+    );
+  }
+
+  const headerToolbar = (
+    <Box
+      sx={{
+        p: { xs: 2, sm: 3 },
+        borderBottom: '1px solid',
+        borderColor: 'border.light',
+      }}
+    >
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          flexWrap: 'wrap',
+          gap: 2,
+        }}
+      >
+        <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 1.5 }}>
+          <Typography
+            variant="h6"
+            sx={{
+              color: 'text.primary',
+              fontSize: { xs: '0.95rem', sm: '1.1rem' },
+              fontWeight: 500,
+            }}
+          >
+            Issues
+          </Typography>
+          <Typography
+            sx={{
+              color: (t) => alpha(t.palette.text.primary, 0.5),
+              fontSize: '0.75rem',
+            }}
+          >
+            ({filteredIssues.length}
+            {hasFilters ? ` of ${issues.length}` : ''})
+          </Typography>
+        </Box>
+        <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap' }}>
+          {STATUS_FILTERS.map((s) => (
+            <ExplorerFilterButton
+              key={s}
+              label={statusLabel(s)}
+              count={statusCounts[s]}
+              color={statusColor(theme, s)}
+              selected={statusFilter === s}
+              onClick={() => setStatusFilter(s)}
+            />
+          ))}
+        </Box>
+      </Box>
+
+      <TextField
+        size="small"
+        placeholder="Search by title, repo, or issue number..."
+        value={searchQuery}
+        onChange={(e) => {
+          setSearchQuery(e.target.value);
+          setPage(0);
+        }}
+        InputProps={{
+          startAdornment: (
+            <InputAdornment position="start">
+              <SearchIcon
+                sx={{
+                  color: (t) => alpha(t.palette.text.primary, 0.3),
+                  fontSize: '1rem',
+                }}
+              />
+            </InputAdornment>
+          ),
+        }}
+        sx={{
+          mt: 2,
+          maxWidth: 400,
+          minWidth: 350,
+          '& .MuiOutlinedInput-root': {
+            fontSize: '0.8rem',
+            color: 'text.primary',
+            backgroundColor: 'surface.subtle',
+            borderRadius: 2,
+            '& fieldset': { borderColor: 'border.light' },
+            '&:hover fieldset': { borderColor: 'border.medium' },
+            '&.Mui-focused fieldset': { borderColor: 'primary.main' },
+          },
+        }}
+      />
+    </Box>
+  );
+
+  const noDataAtAll = issues.length === 0;
+  const emptyMessage = noDataAtAll
+    ? 'No issues found'
+    : 'No issues found for the selected filters';
+
+  return (
+    <Card
+      sx={{
+        p: 0,
+        display: 'flex',
+        flexDirection: 'column',
+        overflow: 'hidden',
+      }}
+      elevation={0}
+    >
+      <DataTable<IssueRow, IssueSortField>
+        columns={columns}
+        rows={pagedIssues}
+        getRowKey={(issue) => `${issue.repo_full_name}#${issue.issue_number}`}
+        minWidth="700px"
+        stickyHeader
+        size="medium"
+        header={headerToolbar}
+        emptyState={
+          <Box sx={{ textAlign: 'center', py: 8 }}>
+            <Typography
+              sx={{
+                color: (t) => alpha(t.palette.text.primary, 0.5),
+                fontSize: '0.9rem',
+              }}
+            >
+              {emptyMessage}
+            </Typography>
+          </Box>
+        }
+        sort={{
+          field: sortField,
+          order: sortDir,
+          onChange: handleSort,
+        }}
+        pagination={
+          <TablePagination
+            page={page}
+            totalPages={totalPages}
+            onPageChange={setPage}
+          />
+        }
+      />
+    </Card>
+  );
+};
+
+export default MinerIssuesTable;

--- a/src/components/miners/index.ts
+++ b/src/components/miners/index.ts
@@ -1,6 +1,7 @@
 export { default as MinerActivity } from './MinerActivity';
 export { default as MinerInsightsCard } from './MinerInsightsCard';
 export { default as MinerPRsTable } from './MinerPRsTable';
+export { default as MinerIssuesTable } from './MinerIssuesTable';
 export { default as MinerRepositoriesTable } from './MinerRepositoriesTable';
 export { default as MinerScoreBreakdown } from './MinerScoreBreakdown';
 export { default as MinerScoreCard } from './MinerScoreCard';

--- a/src/pages/MinerDetailsPage.tsx
+++ b/src/pages/MinerDetailsPage.tsx
@@ -29,6 +29,7 @@ const ISSUE_TABS = [
   'overview',
   'activity',
   'open-issues',
+  'issues',
   'repositories',
 ] as const;
 type MinerDetailsTab = (typeof PR_TABS)[number] | (typeof ISSUE_TABS)[number];

--- a/src/pages/MinerDetailsPage.tsx
+++ b/src/pages/MinerDetailsPage.tsx
@@ -7,6 +7,7 @@ import {
   BackButton,
   MinerActivity,
   MinerInsightsCard,
+  MinerIssuesTable,
   MinerPRsTable,
   MinerRepositoriesTable,
   MinerScoreBreakdown,
@@ -23,7 +24,7 @@ const PR_TABS = [
   'pull-requests',
   'repositories',
 ] as const;
-const ISSUE_TABS = ['overview', 'activity', 'repositories'] as const;
+const ISSUE_TABS = ['overview', 'activity', 'issues', 'repositories'] as const;
 type MinerDetailsTab = (typeof PR_TABS)[number] | (typeof ISSUE_TABS)[number];
 
 /**
@@ -204,6 +205,7 @@ const MinerDetailsPage: React.FC = () => {
               {viewMode === 'prs' && (
                 <Tab value="pull-requests" label="Pull Requests" />
               )}
+              {viewMode === 'issues' && <Tab value="issues" label="Issues" />}
               <Tab value="repositories" label="Repositories" />
             </Tabs>
           </Box>
@@ -222,6 +224,7 @@ const MinerDetailsPage: React.FC = () => {
             {activeTab === 'pull-requests' && (
               <MinerPRsTable githubId={githubId} />
             )}
+            {activeTab === 'issues' && <MinerIssuesTable githubId={githubId} />}
             {activeTab === 'repositories' && (
               <MinerRepositoriesTable githubId={githubId} />
             )}

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -54,6 +54,16 @@ export const DIFF_COLORS = {
   deletions: '#ef4444', // Red - line deletions (same as closed/error)
 } as const;
 
+// GitHub-style colors for issue/PR labels. Theme-only so chips don't hardcode
+// hex values at call sites.
+export const LABEL_COLORS = {
+  bug: '#ff7b72', // Red - matches STATUS_COLORS.closed
+  enhancement: 'rgb(163, 238, 239)', // Light cyan - GitHub default
+  feature: '#3fb950', // Green - matches STATUS_COLORS.merged
+  documentation: '#58a6ff', // Blue - matches STATUS_COLORS.info
+  question: '#f59e0b', // Amber - matches STATUS_COLORS.warning
+} as const;
+
 // Chart colors - different from status colors for better visual distinction in pie/donut charts
 export const CHART_COLORS = {
   merged: '#3fb950', // Green - successful merges


### PR DESCRIPTION
## Summary

Adds an **Issues** tab to the Miner Details page when in `?mode=issues` (Issue Discovery), mirroring the existing Pull Requests tab in the OSS Contributions view. Sourced from the new mirror API.

## Changes

**New mirror-API hook**
- `VITE_REACT_APP_MIRROR_BASE_URL` env var (defaults to `https://mirror.gittensor.io/api/v1`).
- `useMirrorApiQuery` in `src/api/ApiUtils.ts` — separate from the production `useApiQuery` so the camelCase prod API isn't accidentally pointed at the mirror's snake_case payloads. Supports `select` for unwrapping.
- `useMinerIssues(githubId)` calls `/miners/{githubId}/issues`, `select` returns `data.issues`.
- `MinerIssue` / `MinerIssuesResponse` types added in raw snake_case (mirror's shape, no transform layer).

**Issues tab**
- New `MinerIssuesTable` component mirroring `MinerPRsTable`'s shell: status filter chips, search box, sortable columns, pagination, URL-synced `?issueStatus=` and `?issuePage=`.
- Columns: **Issue #** (links to GitHub issue) · **Title** · **Repository** (with owner avatar) · **PR** (in-app link to the PR that solved it via `solving_pr.pr_number`, falls back to `solved_by_pr`) · **Status** · **Date**.
- Status chip: alpha-tinted **Resolved** badge (green, sourced from `getIssueStatusMeta('completed')` to match the bounties table) when `state_reason === 'completed'`. Other `state_reason` values render their text; null falls back to OPEN/CLOSED from `state`.
- Status filters: **All / Open / Resolved / Closed**.

**Wiring**
- `ISSUE_TABS` now includes `'issues'`; `<Tab value="issues" label="Issues" />` rendered when `viewMode === 'issues'`; renders `<MinerIssuesTable />` when `activeTab === 'issues'`.

## Test plan

- [ ] `/miners/details?githubId=89318445&mode=issues` → Issues tab appears next to Repositories.
- [ ] Click Issues tab → table renders with mirror-API data (`https://mirror.gittensor.io/api/v1/miners/89318445/issues`).
- [ ] Filter chips (All / Open / Resolved / Closed) update counts and filter rows; reflected in `?issueStatus=`.
- [ ] Search by title, repo, or issue number.
- [ ] Sort by Issue # / Repository / Date headers.
- [ ] Click an issue # → opens GitHub issue in new tab.
- [ ] Click a PR # → navigates in-app to `/miners/pr?repo=…&number=…`.
- [ ] Resolved rows show the green "Resolved" chip styled like the bounties table's Completed badge.
- [ ] Switching `mode=prs` hides the Issues tab and shows Pull Requests instead.
- [ ] `.env.example` updated; existing `.env` needs the new `VITE_REACT_APP_MIRROR_BASE_URL` and a dev-server restart.

<img width="1444" height="747" alt="image" src="https://github.com/user-attachments/assets/bb4922ac-8a91-4a2d-b31a-9045681c213c" />

Fixes #796 