### PR TITLE
feat(watchlist): show why each PR is in the Pull Requests tab

### DIFF
--- a/src/hooks/useWatchedPRs.ts
+++ b/src/hooks/useWatchedPRs.ts
@@ -2,18 +2,39 @@ import { useMemo } from 'react';
 import { useAllPrs, type CommitLog } from '../api';
 import { useWatchlist, serializePRKey } from './useWatchlist';
 
+export type WatchedPRSource = 'starred' | 'miner' | 'repo';
+
+export const getWatchedSources = (
+  pr: CommitLog,
+  starredKeys: Set<string>,
+  watchedReposLowercase: Set<string>,
+  watchedMinerIds: Set<string>,
+): WatchedPRSource[] => {
+  const sources: WatchedPRSource[] = [];
+  if (starredKeys.has(serializePRKey(pr.repository, pr.pullRequestNumber))) {
+    sources.push('starred');
+  }
+  if (pr.githubId !== undefined && watchedMinerIds.has(pr.githubId)) {
+    sources.push('miner');
+  }
+  if (watchedReposLowercase.has(pr.repository.toLowerCase())) {
+    sources.push('repo');
+  }
+  return sources;
+};
+
 export const matchesWatchedSet = (
   pr: CommitLog,
   starredKeys: Set<string>,
   watchedReposLowercase: Set<string>,
   watchedMinerIds: Set<string>,
 ): boolean =>
-  starredKeys.has(serializePRKey(pr.repository, pr.pullRequestNumber)) ||
-  watchedReposLowercase.has(pr.repository.toLowerCase()) ||
-  (pr.githubId !== undefined && watchedMinerIds.has(pr.githubId));
+  getWatchedSources(pr, starredKeys, watchedReposLowercase, watchedMinerIds)
+    .length > 0;
 
 export interface UseWatchedPRsResult {
   items: CommitLog[];
+  sourcesByKey: Map<string, WatchedPRSource[]>;
   isLoading: boolean;
 }
 
@@ -36,17 +57,23 @@ export const useWatchedPRs = (
 
   const starredKeys = useMemo(() => new Set(starredKeyList), [starredKeyList]);
 
-  const items = useMemo(() => {
-    if (!allPrs) return [];
-    return allPrs.filter((p) =>
-      matchesWatchedSet(
+  const { items, sourcesByKey } = useMemo(() => {
+    const filtered: CommitLog[] = [];
+    const map = new Map<string, WatchedPRSource[]>();
+    if (!allPrs) return { items: filtered, sourcesByKey: map };
+    for (const p of allPrs) {
+      const sources = getWatchedSources(
         p,
         starredKeys,
         watchedReposLowercase,
         watchedMinerIdSet,
-      ),
-    );
+      );
+      if (sources.length === 0) continue;
+      filtered.push(p);
+      map.set(serializePRKey(p.repository, p.pullRequestNumber), sources);
+    }
+    return { items: filtered, sourcesByKey: map };
   }, [allPrs, starredKeys, watchedReposLowercase, watchedMinerIdSet]);
 
-  return { items, isLoading };
+  return { items, sourcesByKey, isLoading };
 };

--- a/src/pages/WatchlistPage.tsx
+++ b/src/pages/WatchlistPage.tsx
@@ -29,6 +29,9 @@ import {
 import SearchIcon from '@mui/icons-material/Search';
 import ViewModuleIcon from '@mui/icons-material/ViewModule';
 import ViewListIcon from '@mui/icons-material/ViewList';
+import StarIcon from '@mui/icons-material/Star';
+import PersonIcon from '@mui/icons-material/Person';
+import FolderIcon from '@mui/icons-material/Folder';
 import { Link as RouterLink, useSearchParams } from 'react-router-dom';
 import { Page } from '../components/layout';
 import {
@@ -50,7 +53,7 @@ import {
   serializePRKey,
   type WatchlistCategory,
 } from '../hooks/useWatchlist';
-import { useWatchedPRs } from '../hooks/useWatchedPRs';
+import { useWatchedPRs, type WatchedPRSource } from '../hooks/useWatchedPRs';
 import {
   isMergedPr,
   isClosedUnmergedPr,
@@ -627,7 +630,77 @@ type PrSortKey = 'pr' | 'title' | 'repo' | 'author' | 'score';
 
 const prCellSx = { py: 1.5 } as const;
 
-const prColumns: DataTableColumn<CommitLog, PrSortKey>[] = [
+const SOURCE_META: Record<
+  WatchedPRSource,
+  { label: string; tooltip: string; Icon: typeof StarIcon; color: string }
+> = {
+  starred: {
+    label: 'Starred',
+    tooltip: 'You starred this pull request',
+    Icon: StarIcon,
+    color: '#facc15',
+  },
+  miner: {
+    label: 'Miner',
+    tooltip: 'From a watched miner',
+    Icon: PersonIcon,
+    color: '#60a5fa',
+  },
+  repo: {
+    label: 'Repo',
+    tooltip: 'From a watched repository',
+    Icon: FolderIcon,
+    color: '#a78bfa',
+  },
+};
+
+const SOURCE_RENDER_ORDER: WatchedPRSource[] = ['starred', 'miner', 'repo'];
+
+const WatchedSourceBadges: React.FC<{ sources: WatchedPRSource[] }> = ({
+  sources,
+}) => {
+  if (sources.length === 0) return null;
+  const present = new Set(sources);
+  return (
+    <Stack
+      direction="row"
+      spacing={0.5}
+      alignItems="center"
+      role="list"
+      aria-label="Reasons this PR is in your watchlist"
+    >
+      {SOURCE_RENDER_ORDER.filter((s) => present.has(s)).map((s) => {
+        const { label, tooltip, Icon, color } = SOURCE_META[s];
+        return (
+          <Tooltip key={s} title={tooltip} placement="top" arrow>
+            <Box
+              role="listitem"
+              aria-label={label}
+              sx={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                width: 22,
+                height: 22,
+                borderRadius: 1,
+                backgroundColor: alpha(color, 0.14),
+                border: '1px solid',
+                borderColor: alpha(color, 0.35),
+                color,
+              }}
+            >
+              <Icon sx={{ fontSize: '0.85rem' }} />
+            </Box>
+          </Tooltip>
+        );
+      })}
+    </Stack>
+  );
+};
+
+const buildPrColumns = (
+  sourcesByKey: Map<string, WatchedPRSource[]>,
+): DataTableColumn<CommitLog, PrSortKey>[] => [
   {
     key: 'pr',
     header: 'PR',
@@ -736,6 +809,22 @@ const prColumns: DataTableColumn<CommitLog, PrSortKey>[] = [
     ),
   },
   {
+    key: 'source',
+    header: 'Why',
+    width: '92px',
+    align: 'center',
+    cellSx: prCellSx,
+    renderCell: (pr) => (
+      <WatchedSourceBadges
+        sources={
+          sourcesByKey.get(
+            serializePRKey(pr.repository, pr.pullRequestNumber),
+          ) ?? []
+        }
+      />
+    ),
+  },
+  {
     key: 'watch',
     header: '★',
     width: '52px',
@@ -815,7 +904,10 @@ const PRsViewModeToggle: React.FC<{
 const getPrHref = (pr: CommitLog) =>
   `/miners/pr?repo=${encodeURIComponent(pr.repository)}&number=${pr.pullRequestNumber}`;
 
-const PRCard: React.FC<{ pr: CommitLog }> = ({ pr }) => {
+const PRCard: React.FC<{
+  pr: CommitLog;
+  sources?: WatchedPRSource[];
+}> = ({ pr, sources = [] }) => {
   const { label, color } = prStatusMeta(pr);
   const key = serializePRKey(pr.repository, pr.pullRequestNumber);
   return (
@@ -895,6 +987,7 @@ const PRCard: React.FC<{ pr: CommitLog }> = ({ pr }) => {
               backgroundColor: alpha(color, 0.08),
             }}
           />
+          <WatchedSourceBadges sources={sources} />
           <WatchlistButton category="prs" itemKey={key} size="small" />
         </Stack>
       </Box>
@@ -994,7 +1087,8 @@ const PRCard: React.FC<{ pr: CommitLog }> = ({ pr }) => {
 const PR_ROWS_OPTIONS = [10, 25, 50] as const;
 
 const PRsList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
-  const { items, isLoading } = useWatchedPRs(itemKeys);
+  const { items, sourcesByKey, isLoading } = useWatchedPRs(itemKeys);
+  const prColumns = useMemo(() => buildPrColumns(sourcesByKey), [sourcesByKey]);
   const [searchQuery, setSearchQuery] = useState('');
   const [statusFilter, setStatusFilter] = useState<PrStatusFilter>('all');
   const [viewMode, setViewMode] = useState<PRsViewMode>('list');
@@ -1237,7 +1331,12 @@ const PRsList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
                   sx={{ display: 'flex' }}
                 >
                   <Box sx={{ width: '100%' }}>
-                    <PRCard pr={pr} />
+                    <PRCard
+                      pr={pr}
+                      sources={sourcesByKey.get(
+                        serializePRKey(pr.repository, pr.pullRequestNumber),
+                      )}
+                    />
                   </Box>
                 </Grid>
               ))}

--- a/src/tests/useWatchedPRs.test.ts
+++ b/src/tests/useWatchedPRs.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { matchesWatchedSet } from '../hooks/useWatchedPRs';
+import {
+  getWatchedSources,
+  matchesWatchedSet,
+  type WatchedPRSource,
+} from '../hooks/useWatchedPRs';
 import type { CommitLog } from '../api';
 
 const pr = (overrides: Partial<CommitLog> = {}): CommitLog =>
@@ -199,5 +203,94 @@ describe('matchesWatchedSet', () => {
         miners,
       ),
     ).toBe(false);
+  });
+});
+
+describe('getWatchedSources', () => {
+  const empty = {
+    starred: new Set<string>(),
+    repos: new Set<string>(),
+    miners: new Set<string>(),
+  };
+
+  it('returns an empty array when no source matches', () => {
+    expect(
+      getWatchedSources(
+        pr({ repository: 'owner/repo', pullRequestNumber: 5 }),
+        empty.starred,
+        empty.repos,
+        empty.miners,
+      ),
+    ).toEqual([]);
+  });
+
+  it('returns ["starred"] when only the starred set matches', () => {
+    expect(
+      getWatchedSources(
+        pr({ repository: 'owner/repo', pullRequestNumber: 5 }),
+        new Set(['owner/repo#5']),
+        empty.repos,
+        empty.miners,
+      ),
+    ).toEqual<WatchedPRSource[]>(['starred']);
+  });
+
+  it('returns ["miner"] when only the miner set matches', () => {
+    expect(
+      getWatchedSources(
+        pr({ githubId: 'gh-alice' }),
+        empty.starred,
+        empty.repos,
+        new Set(['gh-alice']),
+      ),
+    ).toEqual<WatchedPRSource[]>(['miner']);
+  });
+
+  it('returns ["repo"] when only the repo set matches (case-insensitive)', () => {
+    expect(
+      getWatchedSources(
+        pr({ repository: 'Owner/Repo' }),
+        empty.starred,
+        new Set(['owner/repo']),
+        empty.miners,
+      ),
+    ).toEqual<WatchedPRSource[]>(['repo']);
+  });
+
+  it('returns sources in stable order [starred, miner, repo] when multiple match', () => {
+    expect(
+      getWatchedSources(
+        pr({
+          repository: 'owner/repo',
+          pullRequestNumber: 5,
+          githubId: 'gh-alice',
+        }),
+        new Set(['owner/repo#5']),
+        new Set(['owner/repo']),
+        new Set(['gh-alice']),
+      ),
+    ).toEqual<WatchedPRSource[]>(['starred', 'miner', 'repo']);
+  });
+
+  it('returns ["miner", "repo"] when starred is absent but miner and repo match', () => {
+    expect(
+      getWatchedSources(
+        pr({ repository: 'owner/repo', githubId: 'gh-alice' }),
+        empty.starred,
+        new Set(['owner/repo']),
+        new Set(['gh-alice']),
+      ),
+    ).toEqual<WatchedPRSource[]>(['miner', 'repo']);
+  });
+
+  it('returns no "miner" entry when pr.githubId is undefined even if the miner set is populated', () => {
+    expect(
+      getWatchedSources(
+        pr({ githubId: undefined }),
+        empty.starred,
+        empty.repos,
+        new Set(['gh-alice']),
+      ),
+    ).toEqual<WatchedPRSource[]>([]);
   });
 });


### PR DESCRIPTION
## Summary

Adds a per-row **Source** indicator on the Watchlist *Pull Requests* tab so users can see at a glance *why* each PR is shown. The auto-show behavior from #784 unions PRs from three sources (starred PRs, watched miners, watched repositories), but until now the resulting list was flat — the most common confusion in production has been *"I don't remember starring this, why is it here?"*

Each row now displays up to three icon badges in stable order, one per matching source:

- **Starred** (gold star) — the user explicitly starred this PR.
- **Miner** (blue person) — the PR's author is in the user's watched-miners list.
- **Repo** (purple folder) — the PR's repository is in the user's watched-repositories list.

A PR matched by multiple sources renders all matching badges side-by-side. The badges appear in both the list view (a new `Why` column between Score and the watch ★) and the card view (in the card header next to the status chip). Each badge has a tooltip naming the source, and the whole group is wrapped in a `role="list"` / `role="listitem"` ARIA structure so screen readers announce it as *"Reasons this PR is in your watchlist"*.

Badge styling — 22×22 px with `borderRadius: 1`, an `alpha(color, 0.14)` fill, and a `1px` `alpha(color, 0.35)` border — matches the square-ish chip pattern already used across the site (`PRHeader`, `IssueHeaderCard`), per the feedback to make the indicators *"slightly more square-ish, like the buttons throughout the site"* rather than circular avatars.

### Implementation

The matching infrastructure from #784 (`useWatchedPRs`) is extended in a backward-compatible way:

- A new pure helper `getWatchedSources(pr, starred, repos, miners) → WatchedPRSource[]` returns the sources a PR matches, in stable order (`starred → miner → repo`).
- `matchesWatchedSet` is now a thin wrapper over `getWatchedSources(...).length > 0`, establishing a single source of truth with no behavior change — all 11 pre-existing `matchesWatchedSet` tests pass unmodified.
- The hook's return type gains a `sourcesByKey: Map<string, WatchedPRSource[]>` field populated in the same single pass that already drives `items`, so the UI gets per-row source info without any extra computation or re-filtering.

### Files changed

- `src/hooks/useWatchedPRs.ts` — adds `WatchedPRSource` type and `getWatchedSources` helper, refactors `matchesWatchedSet` to delegate, extends the hook return with `sourcesByKey`.
- `src/pages/WatchlistPage.tsx` — adds three icon imports (`Star`, `Person`, `Folder`), adds `SOURCE_META`, `SOURCE_RENDER_ORDER`, and the `WatchedSourceBadges` component, converts `prColumns` from a const to a `buildPrColumns(sourcesByKey)` factory, inserts the new `Why` column, and pipes `sources` into `PRCard` for card-view parity.
- `src/tests/useWatchedPRs.test.ts` — adds 7 unit tests for `getWatchedSources` covering the empty-result negative case, each source in isolation (with case-insensitive repo matching), the two-source partial union, the stable-order invariant when all three sources match, and the `pr.githubId === undefined` guard.

### Behavior preserved

- The watchlist storage model is unchanged and no new API endpoints are called.
- Empty-state guard, loading state, search, status filter, sort, pagination, and the list/cards view-mode toggle on the PRs tab are all untouched.
- The watchlist button (★) on every PR row continues to control only explicit starring; auto-discovered PRs are *not* auto-starred. This preserves the semantic distinction between *"watching a repo/miner"* and *"starring a specific PR"* — starring remains a separate explicit action, and unstarring a PR that still matches via miner/repo keeps the PR in the list with only the non-starred badges visible.

## Related Issues

Closes #798.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

https://github.com/user-attachments/assets/291ee619-64df-4a82-938f-35310c9d8cb5

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors) — badge colors live in `SOURCE_META` and are applied through `alpha()`, matching the existing chip pattern.
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
