### PR TITLE
Feat/bounty card view implementation

### DIFF
--- a/src/components/issues/BountyCard.tsx
+++ b/src/components/issues/BountyCard.tsx
@@ -1,0 +1,287 @@
+import React from 'react';
+import {
+  Avatar,
+  Box,
+  Card,
+  Chip,
+  Divider,
+  Link,
+  Tooltip,
+  Typography,
+  alpha,
+} from '@mui/material';
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
+import { IssueBounty } from '../../api/models/Issues';
+import { linkResetSx, useLinkBehavior } from '../common/linkBehavior';
+import { WatchlistButton } from '../common';
+import BountyProgress from './BountyProgress';
+import { getIssueStatusMeta } from '../../utils/issueStatus';
+import {
+  formatTokenAmount,
+  formatDate,
+  formatAlphaToUsd,
+} from '../../utils/format';
+import { STATUS_COLORS, TEXT_OPACITY } from '../../theme';
+
+interface BountyCardProps {
+  issue: IssueBounty;
+  href?: string;
+  linkState?: Record<string, unknown>;
+  taoPrice?: number;
+  alphaPrice?: number;
+}
+
+export const BountyCard: React.FC<BountyCardProps> = ({
+  issue,
+  href,
+  linkState,
+  taoPrice,
+  alphaPrice,
+}) => {
+  const owner = issue.repositoryFullName.split('/')[0] || '';
+  const statusMeta = getIssueStatusMeta(issue.status);
+  const usdDisplay = formatAlphaToUsd(
+    issue.targetBounty,
+    taoPrice ?? 0,
+    alphaPrice ?? 0,
+  );
+  const isPending = issue.status === 'registered';
+  const isHistory =
+    issue.status === 'completed' || issue.status === 'cancelled';
+  const bountyLabel = isPending
+    ? 'Target Bounty'
+    : isHistory
+      ? 'Payout'
+      : 'Bounty';
+  const bountyColor = isPending ? STATUS_COLORS.award : STATUS_COLORS.merged;
+
+  const linkProps = useLinkBehavior<HTMLAnchorElement>(href ?? '', {
+    state: linkState,
+  });
+
+  return (
+    <Card
+      component={href ? 'a' : 'div'}
+      {...(href ? linkProps : {})}
+      aria-label={issue.title || `Issue #${issue.id}`}
+      sx={(theme) => ({
+        ...(href ? linkResetSx : {}),
+        p: 2,
+        height: '100%',
+        borderRadius: 2,
+        border: '1px solid',
+        borderColor: theme.palette.border.light,
+        backgroundColor: theme.palette.surface.transparent,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 1.5,
+        cursor: href ? 'pointer' : 'default',
+        transition: 'all 0.2s',
+        ...(href && {
+          '&:hover': {
+            backgroundColor: theme.palette.surface.light,
+            borderColor: theme.palette.border.medium,
+          },
+          '&:focus-visible': {
+            outline: '2px solid',
+            outlineColor: theme.palette.primary.main,
+            outlineOffset: '2px',
+          },
+        }),
+      })}
+      elevation={0}
+    >
+      {/* Repository header */}
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 0 }}>
+        <Avatar
+          src={`https://avatars.githubusercontent.com/${owner}`}
+          alt={owner}
+          sx={(theme) => ({
+            width: 28,
+            height: 28,
+            borderRadius: 1,
+            flexShrink: 0,
+            border: '1px solid',
+            borderColor: theme.palette.border.medium,
+          })}
+        />
+        <Tooltip title={issue.repositoryFullName} placement="top" arrow>
+          <Typography
+            sx={{
+              fontSize: '0.88rem',
+              fontWeight: 500,
+              color: STATUS_COLORS.info,
+              flex: 1,
+              minWidth: 0,
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {issue.repositoryFullName}
+          </Typography>
+        </Tooltip>
+        <Chip
+          label={statusMeta.text}
+          size="small"
+          sx={{
+            flexShrink: 0,
+            fontSize: '0.7rem',
+            fontWeight: 600,
+            backgroundColor: statusMeta.bgColor,
+            color: statusMeta.color,
+            border: `1px solid ${statusMeta.color}40`,
+            height: 22,
+            '& .MuiChip-label': { px: 1 },
+          }}
+        />
+        <WatchlistButton
+          category="bounties"
+          itemKey={String(issue.id)}
+          size="small"
+        />
+      </Box>
+
+      {/* Issue title + GitHub link */}
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5, flex: 1 }}>
+        {issue.title && (
+          <Typography
+            sx={{
+              fontSize: '0.85rem',
+              fontWeight: 500,
+              color: 'text.primary',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              display: '-webkit-box',
+              WebkitLineClamp: 2,
+              WebkitBoxOrient: 'vertical',
+              lineHeight: 1.4,
+            }}
+          >
+            {issue.title}
+          </Typography>
+        )}
+        <Link
+          href={issue.githubUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={(e) => e.stopPropagation()}
+          sx={(theme) => ({
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 0.5,
+            width: 'fit-content',
+            fontSize: '0.72rem',
+            color: alpha(theme.palette.common.white, TEXT_OPACITY.tertiary),
+            textDecoration: 'none',
+            '&:hover': {
+              color: STATUS_COLORS.info,
+              textDecoration: 'underline',
+            },
+          })}
+        >
+          #{issue.issueNumber}
+          <OpenInNewIcon sx={{ fontSize: 11, opacity: 0.5 }} />
+        </Link>
+      </Box>
+
+      <Divider sx={{ borderColor: 'border.light', opacity: 0.6 }} />
+
+      {/* Bounty amount */}
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'baseline',
+          justifyContent: 'space-between',
+          gap: 1,
+        }}
+      >
+        <Typography
+          sx={{
+            fontSize: '0.62rem',
+            color: 'text.tertiary',
+            textTransform: 'uppercase',
+            letterSpacing: '0.04em',
+          }}
+        >
+          {bountyLabel}
+        </Typography>
+        <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 0.75 }}>
+          <Typography
+            sx={{
+              fontSize: '0.9rem',
+              fontWeight: 700,
+              color: bountyColor,
+            }}
+          >
+            {formatTokenAmount(issue.targetBounty)} ل
+          </Typography>
+          {usdDisplay && (
+            <Typography
+              sx={(theme) => ({
+                fontSize: '0.7rem',
+                color: alpha(theme.palette.common.white, 0.35),
+              })}
+            >
+              {usdDisplay}
+            </Typography>
+          )}
+        </Box>
+      </Box>
+
+      {/* Pending: funding progress */}
+      {isPending && (
+        <BountyProgress
+          bountyAmount={issue.bountyAmount}
+          targetBounty={issue.targetBounty}
+        />
+      )}
+
+      {/* History: solver + date */}
+      {isHistory && (
+        <Box
+          sx={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            gap: 1,
+          }}
+        >
+          {issue.solverHotkey ? (
+            <Tooltip title={issue.solverHotkey} arrow>
+              <Typography
+                sx={{
+                  fontSize: '0.75rem',
+                  color: STATUS_COLORS.info,
+                  cursor: 'default',
+                }}
+              >
+                {`${issue.solverHotkey.slice(0, 6)}…${issue.solverHotkey.slice(-4)}`}
+              </Typography>
+            </Tooltip>
+          ) : (
+            <Typography
+              sx={(theme) => ({
+                fontSize: '0.75rem',
+                color: alpha(theme.palette.common.white, TEXT_OPACITY.faint),
+              })}
+            >
+              -
+            </Typography>
+          )}
+          <Typography
+            sx={(theme) => ({
+              fontSize: '0.72rem',
+              color: alpha(theme.palette.common.white, TEXT_OPACITY.muted),
+              whiteSpace: 'nowrap',
+            })}
+          >
+            {formatDate(issue.completedAt || issue.updatedAt)}
+          </Typography>
+        </Box>
+      )}
+    </Card>
+  );
+};
+
+export default BountyCard;

--- a/src/components/issues/IssuesList.tsx
+++ b/src/components/issues/IssuesList.tsx
@@ -7,6 +7,7 @@ import {
   Chip,
   Collapse,
   FormControl,
+  Grid,
   IconButton,
   InputAdornment,
   Link,
@@ -25,6 +26,8 @@ import BarChartIcon from '@mui/icons-material/BarChart';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import SearchIcon from '@mui/icons-material/Search';
 import TableChartIcon from '@mui/icons-material/TableChart';
+import ViewListIcon from '@mui/icons-material/ViewList';
+import ViewModuleIcon from '@mui/icons-material/ViewModule';
 import ReactECharts from 'echarts-for-react';
 import { format } from 'date-fns';
 import { IssueBounty } from '../../api/models/Issues';
@@ -39,6 +42,19 @@ import { STATUS_COLORS, TEXT_OPACITY } from '../../theme';
 import { DataTable, type DataTableColumn } from '../common/DataTable';
 import BountyProgress from './BountyProgress';
 import FilterButton from '../FilterButton';
+import { BountyCard } from './BountyCard';
+import {
+  type IssuesViewMode,
+  ISSUES_VIEW_QUERY_PARAM,
+  ISSUES_LIST_ROWS,
+  ISSUES_CARD_ROWS,
+  ISSUES_DEFAULT_CARD_ROWS,
+  ISSUES_DEFAULT_LIST_ROWS,
+  clampRowsForIssuesView,
+  getIssuesViewModeFromQuery,
+  readStoredIssuesViewMode,
+  writeStoredIssuesViewMode,
+} from './issuesViewMode';
 
 type FilterType = 'all' | 'available' | 'pending' | 'history';
 type SortDirection = 'asc' | 'desc';
@@ -51,8 +67,6 @@ type SortKey =
   | 'funding'
   | 'solver'
   | 'date';
-
-const VALID_ROWS = [10, 25, 50];
 
 interface IssuesListProps {
   issues: IssueBounty[];
@@ -67,6 +81,70 @@ const truncateAddress = (address: string | null): string => {
   return `${address.slice(0, 6)}...${address.slice(-4)}`;
 };
 
+interface ViewModeToggleProps {
+  viewMode: IssuesViewMode;
+  onChange: (mode: IssuesViewMode) => void;
+}
+
+const ViewModeToggle: React.FC<ViewModeToggleProps> = ({
+  viewMode,
+  onChange,
+}) => {
+  const options: {
+    value: IssuesViewMode;
+    label: string;
+    Icon: typeof ViewListIcon;
+  }[] = [
+    { value: 'list', label: 'List view', Icon: ViewListIcon },
+    { value: 'cards', label: 'Card view', Icon: ViewModuleIcon },
+  ];
+
+  return (
+    <Box
+      sx={(theme) => ({
+        display: 'inline-flex',
+        alignItems: 'center',
+        borderRadius: 2,
+        border: '1px solid',
+        borderColor: theme.palette.border.light,
+        overflow: 'hidden',
+      })}
+      role="group"
+      aria-label="Toggle view mode"
+    >
+      {options.map(({ value, label, Icon }) => {
+        const isActive = viewMode === value;
+        return (
+          <Tooltip key={value} title={label} placement="top" arrow>
+            <IconButton
+              onClick={() => onChange(value)}
+              size="small"
+              aria-label={label}
+              aria-pressed={isActive}
+              sx={(theme) => ({
+                borderRadius: 0,
+                padding: '6px 10px',
+                color: isActive
+                  ? theme.palette.text.primary
+                  : theme.palette.text.tertiary,
+                backgroundColor: isActive
+                  ? theme.palette.surface.light
+                  : 'transparent',
+                '&:hover': {
+                  backgroundColor: theme.palette.surface.light,
+                  color: theme.palette.text.primary,
+                },
+              })}
+            >
+              <Icon fontSize="small" />
+            </IconButton>
+          </Tooltip>
+        );
+      })}
+    </Box>
+  );
+};
+
 const IssuesList: React.FC<IssuesListProps> = ({
   issues,
   isLoading = false,
@@ -76,32 +154,64 @@ const IssuesList: React.FC<IssuesListProps> = ({
   const theme = useTheme();
   const [searchParams, setSearchParams] = useSearchParams();
 
-  // Derive filterType directly from URL — single source of truth so that
-  // redirects from /bounties/:tab and browser back/forward both work correctly.
   const filterType = useMemo<FilterType>(() => {
     const f = searchParams.get('filter');
     if (f === 'available' || f === 'pending' || f === 'history') return f;
     return 'all';
   }, [searchParams]);
 
+  const [storedViewMode, setStoredViewMode] = useState<IssuesViewMode>(
+    readStoredIssuesViewMode,
+  );
+  const viewMode = useMemo(
+    () =>
+      getIssuesViewModeFromQuery(
+        searchParams.get(ISSUES_VIEW_QUERY_PARAM),
+        storedViewMode,
+      ),
+    [searchParams, storedViewMode],
+  );
+
   const [sortKey, setSortKey] = useState<SortKey>('id');
   const [sortDirection, setSortDirection] = useState<SortDirection>('desc');
-  const [rowsPerPage, setRowsPerPage] = useState(10);
+  const [rowsPerPage, setRowsPerPage] = useState(
+    viewMode === 'cards' ? ISSUES_DEFAULT_CARD_ROWS : ISSUES_DEFAULT_LIST_ROWS,
+  );
   const [page, setPage] = useState(0);
   const [searchQuery, setSearchQuery] = useState('');
   const [showChart, setShowChart] = useState(false);
 
   const { taoPrice, alphaPrice } = usePrices();
 
-  const handleFilterChange = useCallback(
-    (f: FilterType) => {
-      if (f === 'all') {
-        setSearchParams({}, { replace: true });
-      } else {
-        setSearchParams({ filter: f }, { replace: true });
-      }
+  const syncParams = useCallback(
+    (overrides: { filter?: FilterType; view?: IssuesViewMode }) => {
+      const f = overrides.filter ?? filterType;
+      const v = overrides.view ?? viewMode;
+      const params: Record<string, string> = {};
+      if (f !== 'all') params.filter = f;
+      if (v === 'cards') params.view = 'cards';
+      setSearchParams(params, { replace: true });
     },
-    [setSearchParams],
+    [filterType, viewMode, setSearchParams],
+  );
+
+  const handleFilterChange = useCallback(
+    (f: FilterType) => syncParams({ filter: f }),
+    [syncParams],
+  );
+
+  const handleViewModeChange = useCallback(
+    (nextMode: IssuesViewMode) => {
+      writeStoredIssuesViewMode(nextMode);
+      setStoredViewMode(nextMode);
+      const nextRows = clampRowsForIssuesView(rowsPerPage, nextMode);
+      if (nextRows !== rowsPerPage) {
+        setRowsPerPage(nextRows);
+        setPage(0);
+      }
+      syncParams({ view: nextMode });
+    },
+    [rowsPerPage, syncParams],
   );
 
   const counts = useMemo(
@@ -612,7 +722,6 @@ const IssuesList: React.FC<IssuesListProps> = ({
         dateColumn,
       ];
     }
-    // 'all' and 'available' share the same column set
     return [
       idColumn,
       repositoryColumn,
@@ -622,31 +731,65 @@ const IssuesList: React.FC<IssuesListProps> = ({
     ];
   }, [filterType, theme, taoPrice, alphaPrice]);
 
+  const validRows = viewMode === 'cards' ? ISSUES_CARD_ROWS : ISSUES_LIST_ROWS;
+
+  const pagination = (
+    <TablePagination
+      rowsPerPageOptions={[]}
+      component="div"
+      count={sortedIssues.length}
+      rowsPerPage={rowsPerPage}
+      page={page}
+      onPageChange={(_event, newPage) => setPage(newPage)}
+      onRowsPerPageChange={() => {}}
+      showFirstButton
+      showLastButton
+    />
+  );
+
+  const cardSx = {
+    backgroundColor: 'background.default',
+    border: `1px solid ${theme.palette.border.light}`,
+    borderRadius: 3,
+    overflow: 'hidden',
+  };
+
   if (isLoading) {
     return (
-      <Card
-        sx={{
-          backgroundColor: 'background.default',
-          border: `1px solid ${theme.palette.border.light}`,
-          borderRadius: 3,
-        }}
-        elevation={0}
-      >
+      <Card sx={cardSx} elevation={0}>
         <Box sx={{ p: 2 }}>
-          {[1, 2, 3, 4, 5].map((i) => (
-            <Skeleton
-              key={i}
-              variant="rectangular"
-              height={48}
-              sx={{ mb: 1, borderRadius: 1 }}
-            />
-          ))}
+          {viewMode === 'cards' ? (
+            <Grid container spacing={2}>
+              {Array.from({ length: ISSUES_DEFAULT_CARD_ROWS }).map((_, i) => (
+                <Grid item xs={12} sm={6} md={4} key={i}>
+                  <Skeleton
+                    variant="rounded"
+                    height={220}
+                    sx={{
+                      bgcolor: (t) => alpha(t.palette.text.primary, 0.06),
+                    }}
+                  />
+                </Grid>
+              ))}
+            </Grid>
+          ) : (
+            <>
+              {[1, 2, 3, 4, 5].map((i) => (
+                <Skeleton
+                  key={i}
+                  variant="rectangular"
+                  height={48}
+                  sx={{ mb: 1, borderRadius: 1 }}
+                />
+              ))}
+            </>
+          )}
         </Box>
       </Card>
     );
   }
 
-  const headerToolbar = (
+  const toolbar = (
     <>
       <Box
         sx={{
@@ -654,13 +797,19 @@ const IssuesList: React.FC<IssuesListProps> = ({
           py: 1.5,
           borderBottom: `1px solid ${theme.palette.border.light}`,
           display: 'flex',
-          justifyContent: 'space-between',
           alignItems: 'center',
           flexWrap: 'wrap',
           gap: 2,
         }}
       >
-        <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+        {/* Left: filter buttons + chart toggle */}
+        <Stack
+          direction="row"
+          spacing={1}
+          alignItems="center"
+          flexWrap="wrap"
+          useFlexGap
+        >
           <FilterButton
             label="All"
             isActive={filterType === 'all'}
@@ -689,9 +838,7 @@ const IssuesList: React.FC<IssuesListProps> = ({
             count={counts.history}
             color={theme.palette.status.neutral}
           />
-        </Stack>
 
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
           <Tooltip title={showChart ? 'Hide Chart' : 'Show Chart'}>
             <IconButton
               onClick={() => setShowChart(!showChart)}
@@ -716,87 +863,92 @@ const IssuesList: React.FC<IssuesListProps> = ({
               )}
             </IconButton>
           </Tooltip>
+        </Stack>
 
-          <FormControl size="small">
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-              <Typography
-                variant="body2"
-                sx={{
-                  color: alpha(
-                    theme.palette.common.white,
-                    TEXT_OPACITY.secondary,
-                  ),
-                  fontSize: '0.8rem',
-                }}
-              >
-                Rows:
-              </Typography>
-              <Select
-                value={rowsPerPage}
-                onChange={(e) => {
-                  setRowsPerPage(e.target.value as number);
-                  setPage(0);
-                }}
-                sx={{
-                  color: theme.palette.text.primary,
-                  backgroundColor: alpha(theme.palette.common.black, 0.4),
-                  fontSize: '0.8rem',
-                  height: '36px',
-                  borderRadius: 2,
-                  minWidth: '80px',
-                  '& fieldset': { borderColor: theme.palette.border.light },
-                  '&:hover fieldset': {
-                    borderColor: theme.palette.border.medium,
-                  },
-                  '&.Mui-focused fieldset': { borderColor: 'primary.main' },
-                  '& .MuiSelect-select': { py: 0.75 },
-                }}
-              >
-                {VALID_ROWS.map((n) => (
-                  <MenuItem key={n} value={n}>
-                    {n}
-                  </MenuItem>
-                ))}
-              </Select>
-            </Box>
-          </FormControl>
-
-          <TextField
-            placeholder="Search..."
-            size="small"
-            value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
-            InputProps={{
-              startAdornment: (
-                <InputAdornment position="start">
-                  <SearchIcon
-                    sx={{
-                      color: alpha(
-                        theme.palette.common.white,
-                        TEXT_OPACITY.muted,
-                      ),
-                      fontSize: '1rem',
-                    }}
-                  />
-                </InputAdornment>
-              ),
-            }}
-            sx={{
-              width: '200px',
-              '& .MuiOutlinedInput-root': {
+        {/* Rows selector */}
+        <FormControl size="small">
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <Typography
+              variant="body2"
+              sx={{
+                color: alpha(
+                  theme.palette.common.white,
+                  TEXT_OPACITY.secondary,
+                ),
+                fontSize: '0.8rem',
+              }}
+            >
+              Rows:
+            </Typography>
+            <Select
+              value={rowsPerPage}
+              onChange={(e) => {
+                setRowsPerPage(e.target.value as number);
+                setPage(0);
+              }}
+              sx={{
                 color: theme.palette.text.primary,
                 backgroundColor: alpha(theme.palette.common.black, 0.4),
                 fontSize: '0.8rem',
                 height: '36px',
                 borderRadius: 2,
+                minWidth: '80px',
                 '& fieldset': { borderColor: theme.palette.border.light },
                 '&:hover fieldset': {
                   borderColor: theme.palette.border.medium,
                 },
                 '&.Mui-focused fieldset': { borderColor: 'primary.main' },
-              },
-            }}
-          />
+                '& .MuiSelect-select': { py: 0.75 },
+              }}
+            >
+              {validRows.map((n) => (
+                <MenuItem key={n} value={n}>
+                  {n}
+                </MenuItem>
+              ))}
+            </Select>
+          </Box>
+        </FormControl>
+
+        {/* Search */}
+        <TextField
+          placeholder="Search..."
+          size="small"
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          InputProps={{
+            startAdornment: (
+              <InputAdornment position="start">
+                <SearchIcon
+                  sx={{
+                    color: alpha(
+                      theme.palette.common.white,
+                      TEXT_OPACITY.muted,
+                    ),
+                    fontSize: '1rem',
+                  }}
+                />
+              </InputAdornment>
+            ),
+          }}
+          sx={{
+            width: '200px',
+            '& .MuiOutlinedInput-root': {
+              color: theme.palette.text.primary,
+              backgroundColor: alpha(theme.palette.common.black, 0.4),
+              fontSize: '0.8rem',
+              height: '36px',
+              borderRadius: 2,
+              '& fieldset': { borderColor: theme.palette.border.light },
+              '&:hover fieldset': { borderColor: theme.palette.border.medium },
+              '&.Mui-focused fieldset': { borderColor: 'primary.main' },
+            },
+          }}
+        />
+
+        {/* View toggle — pushed to far right */}
+        <Box sx={{ ml: 'auto' }}>
+          <ViewModeToggle viewMode={viewMode} onChange={handleViewModeChange} />
         </Box>
       </Box>
 
@@ -820,62 +972,70 @@ const IssuesList: React.FC<IssuesListProps> = ({
     </>
   );
 
-  return (
-    <Card
-      sx={{
-        backgroundColor: 'background.default',
-        border: `1px solid ${theme.palette.border.light}`,
-        borderRadius: 3,
-        overflow: 'hidden',
-      }}
-      elevation={0}
-    >
-      <DataTable<IssueBounty, SortKey>
-        columns={columns}
-        rows={paginatedIssues}
-        getRowKey={(issue) => issue.id}
-        getRowHref={
-          getIssueHref ? (issue) => getIssueHref(issue.id) : undefined
-        }
-        linkState={linkState}
-        minWidth={
-          filterType === 'history'
-            ? '1000px'
-            : filterType === 'pending'
-              ? '900px'
-              : '750px'
-        }
-        header={headerToolbar}
-        emptyState={
-          <Box sx={{ p: 4, textAlign: 'center' }}>
-            <Typography
-              sx={{
-                color: alpha(theme.palette.common.white, TEXT_OPACITY.tertiary),
-              }}
-            >
-              {searchQuery ? 'No issues match your search' : 'No issues found'}
-            </Typography>
-          </Box>
-        }
-        pagination={
-          <TablePagination
-            rowsPerPageOptions={[]}
-            component="div"
-            count={sortedIssues.length}
-            rowsPerPage={rowsPerPage}
-            page={page}
-            onPageChange={(_event, newPage) => setPage(newPage)}
-            onRowsPerPageChange={() => {}}
-            showFirstButton
-            showLastButton
-          />
-        }
-        sort={{
-          field: sortKey,
-          order: sortDirection,
-          onChange: handleSort,
+  const emptyState = (
+    <Box sx={{ p: 4, textAlign: 'center' }}>
+      <Typography
+        sx={{
+          color: alpha(theme.palette.common.white, TEXT_OPACITY.tertiary),
         }}
-      />
+      >
+        {searchQuery ? 'No issues match your search' : 'No issues found'}
+      </Typography>
+    </Box>
+  );
+
+  return (
+    <Card sx={cardSx} elevation={0}>
+      {toolbar}
+
+      {viewMode === 'cards' ? (
+        <>
+          {paginatedIssues.length > 0 ? (
+            <Box sx={{ p: 2 }}>
+              <Grid container spacing={2}>
+                {paginatedIssues.map((issue) => (
+                  <Grid item xs={12} sm={6} md={4} key={issue.id}>
+                    <BountyCard
+                      issue={issue}
+                      href={getIssueHref ? getIssueHref(issue.id) : undefined}
+                      linkState={linkState}
+                      taoPrice={taoPrice}
+                      alphaPrice={alphaPrice}
+                    />
+                  </Grid>
+                ))}
+              </Grid>
+            </Box>
+          ) : (
+            emptyState
+          )}
+          {pagination}
+        </>
+      ) : (
+        <DataTable<IssueBounty, SortKey>
+          columns={columns}
+          rows={paginatedIssues}
+          getRowKey={(issue) => issue.id}
+          getRowHref={
+            getIssueHref ? (issue) => getIssueHref(issue.id) : undefined
+          }
+          linkState={linkState}
+          minWidth={
+            filterType === 'history'
+              ? '1000px'
+              : filterType === 'pending'
+                ? '900px'
+                : '750px'
+          }
+          emptyState={emptyState}
+          pagination={pagination}
+          sort={{
+            field: sortKey,
+            order: sortDirection,
+            onChange: handleSort,
+          }}
+        />
+      )}
     </Card>
   );
 };

--- a/src/components/issues/issuesViewMode.ts
+++ b/src/components/issues/issuesViewMode.ts
@@ -1,0 +1,51 @@
+export type IssuesViewMode = 'cards' | 'list';
+
+export const ISSUES_VIEW_QUERY_PARAM = 'view';
+export const ISSUES_VIEW_STORAGE_KEY = 'issues:viewMode';
+
+export const readStoredIssuesViewMode = (): IssuesViewMode => {
+  try {
+    return window.localStorage.getItem(ISSUES_VIEW_STORAGE_KEY) === 'cards'
+      ? 'cards'
+      : 'list';
+  } catch {
+    return 'list';
+  }
+};
+
+export const writeStoredIssuesViewMode = (mode: IssuesViewMode): void => {
+  try {
+    window.localStorage.setItem(ISSUES_VIEW_STORAGE_KEY, mode);
+  } catch {
+    // localStorage unavailable (private mode, quota) — preference won't persist
+  }
+};
+
+export const getIssuesViewModeFromQuery = (
+  value: string | null,
+  fallback: IssuesViewMode,
+): IssuesViewMode => {
+  if (value === 'cards') return 'cards';
+  if (value === 'list') return 'list';
+  return fallback;
+};
+
+// Card grid: 3 cols (lg/md), 2 (sm), 1 (xs). Sizes divisible by 1, 2, 3 so
+// the last row of cards is never partial.
+export const ISSUES_LIST_ROWS = [10, 25, 50] as const;
+export const ISSUES_CARD_ROWS = [12, 24, 48] as const;
+export const ISSUES_VALID_ROWS: readonly number[] = [
+  ...ISSUES_LIST_ROWS,
+  ...ISSUES_CARD_ROWS,
+];
+export const ISSUES_DEFAULT_LIST_ROWS = 10;
+export const ISSUES_DEFAULT_CARD_ROWS = 12;
+
+export const clampRowsForIssuesView = (
+  rows: number,
+  mode: IssuesViewMode,
+): number => {
+  const options = mode === 'cards' ? ISSUES_CARD_ROWS : ISSUES_LIST_ROWS;
+  if ((options as readonly number[]).includes(rows)) return rows;
+  return mode === 'cards' ? ISSUES_DEFAULT_CARD_ROWS : ISSUES_DEFAULT_LIST_ROWS;
+};


### PR DESCRIPTION
## Closes: #802

## Summary

- **`issuesViewMode.ts`** — new utility mirroring `repositoriesViewMode.ts`; list rows `[10, 25, 50]`, card rows `[12, 24, 48]`, `clampRowsForIssuesView` helper; preference persisted in `localStorage` (`issues:viewMode`) and synced to `?view=` URL param
- **`BountyCard.tsx`** — new card component displaying:
  - Repository avatar (28×28) + name + status chip + watchlist ★ (`category="bounties"`)
  - Issue title (2-line clamp) + GitHub issue link
  - Bounty / Target Bounty / Payout amount with USD estimate
  - Funding progress bar (pending issues)
  - Solver address + completion date (history issues)
  - Inherits font from MUI theme (no custom `fontFamily`)
- **`IssuesList.tsx`** — card view wiring:
  - List/card toggle added to toolbar, matching the repository table style (filter buttons + chart on the left; Rows, Search, toggle on the right with `ml: auto`)
  - Rows selector switches between `[10, 25, 50]` (list) and `[12, 24, 48]` (cards)
  - Filter tab changes preserve `?view=` URL param
  - Loading skeleton adapts to current view mode
  - Card grid: `xs=12 sm=6 md=4` (3 cols desktop, 2 tablet, 1 mobile)

## Test plan

- [ ] Toggling list ↔ card view persists across page refresh (localStorage) and browser back/forward (URL param)
- [ ] Card view renders 3 columns on desktop, 2 on tablet, 1 on mobile
- [ ] Rows selector shows `[12, 24, 48]` in card view and `[10, 25, 50]` in list view
- [ ] Watchlist star toggles correctly and survives navigation
- [ ] Pending cards show funding progress bar; History cards show solver address + date
- [ ] Available/All cards show bounty amount only (no extra footer section)
- [ ] Filter tab changes preserve the `?view=` param
- [ ] List view is unchanged — all existing columns, sort, and pagination behaviour intact

## Screenshots

Before:

<img width="1893" height="954" alt="image" src="https://github.com/user-attachments/assets/5514c314-0055-4ac3-bca7-b4e2f1baeb26" />

After:

https://github.com/user-attachments/assets/51b0c83e-948e-41d8-a2af-bbc072b2879f

<img width="1637" height="704" alt="image" src="https://github.com/user-attachments/assets/50b12862-20d0-4ccb-bb81-f4f14b3d5ec1" />

<img width="1635" height="873" alt="image" src="https://github.com/user-attachments/assets/e0ab61db-a049-42db-b36b-7611dd71897f" />

<img width="1622" height="878" alt="image" src="https://github.com/user-attachments/assets/06f87f5f-71f7-4c7e-a8dd-d329c5d116e0" />
