### PR TITLE
feat(issues): redesign open issues overview as table-style with filters, sorting, and search

### DIFF
--- a/src/components/miners/MinerOpenDiscoveryIssuesByRepo.tsx
+++ b/src/components/miners/MinerOpenDiscoveryIssuesByRepo.tsx
@@ -441,15 +441,17 @@ const MinerOpenDiscoveryIssuesByRepo: React.FC<
           headerSx: { verticalAlign: 'middle' },
           cellSx: { fontSize: { xs: '0.75rem', sm: '0.85rem' } },
           renderCell: (issue) => (
-            <Box
-              sx={{
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
-                whiteSpace: 'nowrap',
-              }}
-            >
-              {issue.title}
-            </Box>
+            <Tooltip title={issue.title} placement="bottom" arrow>
+              <Box
+                sx={{
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                {issue.title}
+              </Box>
+            </Tooltip>
           ),
         },
         {
@@ -480,12 +482,18 @@ const MinerOpenDiscoveryIssuesByRepo: React.FC<
                     borderColor: 'border.medium',
                   }}
                 />
-                <Box
-                  component="span"
-                  sx={{ wordBreak: 'break-word', lineHeight: 1.3 }}
+                <Tooltip
+                  title={issue.repositoryFullName}
+                  placement="bottom"
+                  arrow
                 >
-                  {issue.repositoryFullName}
-                </Box>
+                  <Box
+                    component="span"
+                    sx={{ wordBreak: 'break-word', lineHeight: 1.3 }}
+                  >
+                    {issue.repositoryFullName}
+                  </Box>
+                </Tooltip>
               </Box>
             );
           },
@@ -553,7 +561,8 @@ const MinerOpenDiscoveryIssuesByRepo: React.FC<
             issue.createdAt ? (
               <Tooltip
                 title={new Date(issue.createdAt).toLocaleDateString()}
-                placement="top"
+                placement="bottom"
+                arrow
               >
                 <span style={{ cursor: 'default' }}>
                   {formatDistanceToNow(new Date(issue.createdAt), {
@@ -600,15 +609,17 @@ const MinerOpenDiscoveryIssuesByRepo: React.FC<
           headerSx: { verticalAlign: 'middle' },
           cellSx: { fontSize: { xs: '0.75rem', sm: '0.85rem' } },
           renderCell: (issue) => (
-            <Box
-              sx={{
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
-                whiteSpace: 'nowrap',
-              }}
-            >
-              {issue.title}
-            </Box>
+            <Tooltip title={issue.title} placement="bottom" arrow>
+              <Box
+                sx={{
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                {issue.title}
+              </Box>
+            </Tooltip>
           ),
         },
         {
@@ -639,12 +650,18 @@ const MinerOpenDiscoveryIssuesByRepo: React.FC<
                     borderColor: 'border.medium',
                   }}
                 />
-                <Box
-                  component="span"
-                  sx={{ wordBreak: 'break-word', lineHeight: 1.3 }}
+                <Tooltip
+                  title={issue.repositoryFullName}
+                  placement="bottom"
+                  arrow
                 >
-                  {issue.repositoryFullName}
-                </Box>
+                  <Box
+                    component="span"
+                    sx={{ wordBreak: 'break-word', lineHeight: 1.3 }}
+                  >
+                    {issue.repositoryFullName}
+                  </Box>
+                </Tooltip>
               </Box>
             );
           },
@@ -712,7 +729,8 @@ const MinerOpenDiscoveryIssuesByRepo: React.FC<
             issue.createdAt ? (
               <Tooltip
                 title={new Date(issue.createdAt).toLocaleDateString()}
-                placement="top"
+                placement="bottom"
+                arrow
               >
                 <span style={{ cursor: 'default' }}>
                   {formatDistanceToNow(new Date(issue.createdAt), {

--- a/src/components/miners/MinerOpenDiscoveryIssuesByRepo.tsx
+++ b/src/components/miners/MinerOpenDiscoveryIssuesByRepo.tsx
@@ -415,6 +415,7 @@ const MinerOpenDiscoveryIssuesByRepo: React.FC<
           header: 'Issue #',
           width: '9%',
           sortKey: 'number',
+          headerSx: { verticalAlign: 'middle' },
           cellSx: { fontSize: { xs: '0.75rem', sm: '0.85rem' } },
           renderCell: (issue) => (
             // stopPropagation keeps the row's onRowClick from also firing
@@ -436,7 +437,8 @@ const MinerOpenDiscoveryIssuesByRepo: React.FC<
         {
           key: 'title',
           header: 'Title',
-          width: '35%',
+          width: '38%',
+          headerSx: { verticalAlign: 'middle' },
           cellSx: { fontSize: { xs: '0.75rem', sm: '0.85rem' } },
           renderCell: (issue) => (
             <Box
@@ -453,8 +455,9 @@ const MinerOpenDiscoveryIssuesByRepo: React.FC<
         {
           key: 'repository',
           header: 'Repository',
-          width: '24%',
+          width: '20%',
           sortKey: 'repository',
+          headerSx: { verticalAlign: 'middle' },
           renderCell: (issue) => {
             const owner = issue.repositoryFullName.split('/')[0];
             return (
@@ -490,7 +493,8 @@ const MinerOpenDiscoveryIssuesByRepo: React.FC<
         {
           key: 'linked_pr',
           header: 'Linked PR',
-          width: '17%',
+          width: '14%',
+          headerSx: { verticalAlign: 'middle' },
           renderCell: (issue) =>
             issue.prNumber != null ? (
               <a
@@ -537,9 +541,10 @@ const MinerOpenDiscoveryIssuesByRepo: React.FC<
         {
           key: 'opened',
           header: 'Opened',
-          width: '15%',
+          width: '19%',
           align: 'right',
           sortKey: 'opened',
+          headerSx: { verticalAlign: 'middle' },
           cellSx: {
             fontSize: { xs: '0.75rem', sm: '0.85rem' },
             color: (t) => alpha(t.palette.text.primary, 0.7),
@@ -570,6 +575,7 @@ const MinerOpenDiscoveryIssuesByRepo: React.FC<
           header: 'Issue #',
           width: '9%',
           sortKey: 'number' as IssueSortField,
+          headerSx: { verticalAlign: 'middle' },
           cellSx: { fontSize: { xs: '0.75rem', sm: '0.85rem' } },
           renderCell: (issue) => (
             <a
@@ -590,7 +596,8 @@ const MinerOpenDiscoveryIssuesByRepo: React.FC<
         {
           key: 'title',
           header: 'Title',
-          width: '28%',
+          width: '38%',
+          headerSx: { verticalAlign: 'middle' },
           cellSx: { fontSize: { xs: '0.75rem', sm: '0.85rem' } },
           renderCell: (issue) => (
             <Box
@@ -609,6 +616,7 @@ const MinerOpenDiscoveryIssuesByRepo: React.FC<
           header: 'Repository',
           width: '20%',
           sortKey: 'repository' as IssueSortField,
+          headerSx: { verticalAlign: 'middle' },
           renderCell: (issue) => {
             const owner = issue.repositoryFullName.split('/')[0];
             return (
@@ -642,51 +650,10 @@ const MinerOpenDiscoveryIssuesByRepo: React.FC<
           },
         },
         {
-          key: 'author',
-          header: 'Author',
-          width: '14%',
-          renderCell: (issue) => {
-            const authorLogin = issue.authorLogin ?? issue.author ?? null;
-            if (!authorLogin) return null;
-            return (
-              <Box
-                sx={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: 1,
-                  overflow: 'hidden',
-                }}
-              >
-                <Avatar
-                  src={`https://avatars.githubusercontent.com/${authorLogin}`}
-                  alt={authorLogin}
-                  sx={{
-                    width: 18,
-                    height: 18,
-                    flexShrink: 0,
-                    border: '1px solid',
-                    borderColor: 'border.medium',
-                  }}
-                />
-                <Box
-                  component="span"
-                  sx={{
-                    overflow: 'hidden',
-                    textOverflow: 'ellipsis',
-                    whiteSpace: 'nowrap',
-                    fontSize: '0.8rem',
-                  }}
-                >
-                  @{authorLogin}
-                </Box>
-              </Box>
-            );
-          },
-        },
-        {
           key: 'linked_pr',
           header: 'Linked PR',
-          width: '15%',
+          width: '14%',
+          headerSx: { verticalAlign: 'middle' },
           renderCell: (issue) =>
             issue.prNumber != null ? (
               <a
@@ -733,9 +700,10 @@ const MinerOpenDiscoveryIssuesByRepo: React.FC<
         {
           key: 'opened',
           header: 'Opened',
-          width: '14%',
+          width: '19%',
           align: 'right',
           sortKey: 'opened' as IssueSortField,
+          headerSx: { verticalAlign: 'middle' },
           cellSx: {
             fontSize: { xs: '0.75rem', sm: '0.85rem' },
             color: (t) => alpha(t.palette.text.primary, 0.7),

--- a/src/components/miners/MinerOpenDiscoveryIssuesByRepo.tsx
+++ b/src/components/miners/MinerOpenDiscoveryIssuesByRepo.tsx
@@ -49,9 +49,11 @@ const DEFAULT_SORT_DIR: Record<IssueSortField, SortDir> = {
 // Issue is still open
 const isOpenIssue = (i: RepositoryIssue) => !i.closedAt;
 // Issue was closed and has a linked PR (solved by a contributor)
-const isSolvedIssue = (i: RepositoryIssue) => !!i.closedAt && i.prNumber != null;
+const isSolvedIssue = (i: RepositoryIssue) =>
+  !!i.closedAt && i.prNumber != null;
 // Issue was closed without a linked PR (rejected, duplicate, etc.)
-const isClosedIssue = (i: RepositoryIssue) => !!i.closedAt && i.prNumber == null;
+const isClosedIssue = (i: RepositoryIssue) =>
+  !!i.closedAt && i.prNumber == null;
 
 const githubIssueUrl = (issue: RepositoryIssue) =>
   issue.url ??
@@ -140,7 +142,9 @@ const fetchGithubIssuesByAuthor = async (
   const mapped = (data.items || [])
     .filter((item) => !item.pull_request)
     .map((item) => {
-      const repositoryFullName = parseRepoFromRepositoryUrl(item.repository_url);
+      const repositoryFullName = parseRepoFromRepositoryUrl(
+        item.repository_url,
+      );
       return {
         number: item.number,
         repositoryFullName: repositoryFullName ?? '',
@@ -228,7 +232,8 @@ const MinerOpenDiscoveryIssuesByRepo: React.FC<
   // Other section state
   const [otherFilter, setOtherFilter] = useState<IssueFilter>('all');
   const [otherSearch, setOtherSearch] = useState('');
-  const [otherSortField, setOtherSortField] = useState<IssueSortField>('opened');
+  const [otherSortField, setOtherSortField] =
+    useState<IssueSortField>('opened');
   const [otherSortDir, setOtherSortDir] = useState<SortDir>('desc');
   const [otherPage, setOtherPage] = useState(0);
   const [otherExpanded, setOtherExpanded] = useState(false);
@@ -251,9 +256,9 @@ const MinerOpenDiscoveryIssuesByRepo: React.FC<
 
   const authoredRepos = useMemo(
     () =>
-      [...new Set(githubAuthoredIssues.map((i) => i.repositoryFullName))].filter(
-        Boolean,
-      ),
+      [
+        ...new Set(githubAuthoredIssues.map((i) => i.repositoryFullName)),
+      ].filter(Boolean),
     [githubAuthoredIssues],
   );
 
@@ -365,11 +370,25 @@ const MinerOpenDiscoveryIssuesByRepo: React.FC<
   }, []);
 
   const filteredMine = useMemo(
-    () => applyIssueFilter(mineIssues, mineFilter, mineSearch, mineSortField, mineSortDir),
+    () =>
+      applyIssueFilter(
+        mineIssues,
+        mineFilter,
+        mineSearch,
+        mineSortField,
+        mineSortDir,
+      ),
     [mineIssues, mineFilter, mineSearch, mineSortField, mineSortDir],
   );
   const filteredOther = useMemo(
-    () => applyIssueFilter(otherIssues, otherFilter, otherSearch, otherSortField, otherSortDir),
+    () =>
+      applyIssueFilter(
+        otherIssues,
+        otherFilter,
+        otherSearch,
+        otherSortField,
+        otherSortDir,
+      ),
     [otherIssues, otherFilter, otherSearch, otherSortField, otherSortDir],
   );
 
@@ -388,304 +407,356 @@ const MinerOpenDiscoveryIssuesByRepo: React.FC<
   const mineCounts = useMemo(() => getIssueCounts(mineIssues), [mineIssues]);
   const otherCounts = useMemo(() => getIssueCounts(otherIssues), [otherIssues]);
 
-  const mineColumns: DataTableColumn<RepositoryIssue, IssueSortField>[] = useMemo(
-    () => [
-      {
-        key: 'number',
-        header: 'Issue #',
-        width: '9%',
-        sortKey: 'number',
-        cellSx: { fontSize: { xs: '0.75rem', sm: '0.85rem' } },
-        renderCell: (issue) => (
-          // stopPropagation keeps the row's onRowClick from also firing
-          <a
-            href={githubIssueUrl(issue)}
-            target="_blank"
-            rel="noopener noreferrer"
-            style={{ color: 'inherit', textDecoration: 'none', fontWeight: 500 }}
-            onClick={(e) => e.stopPropagation()}
-          >
-            #{issue.number}
-          </a>
-        ),
-      },
-      {
-        key: 'title',
-        header: 'Title',
-        width: '35%',
-        cellSx: { fontSize: { xs: '0.75rem', sm: '0.85rem' } },
-        renderCell: (issue) => (
-          <Box
-            sx={{
-              overflow: 'hidden',
-              textOverflow: 'ellipsis',
-              whiteSpace: 'nowrap',
-            }}
-          >
-            {issue.title}
-          </Box>
-        ),
-      },
-      {
-        key: 'repository',
-        header: 'Repository',
-        width: '24%',
-        sortKey: 'repository',
-        renderCell: (issue) => {
-          const owner = issue.repositoryFullName.split('/')[0];
-          return (
+  const mineColumns: DataTableColumn<RepositoryIssue, IssueSortField>[] =
+    useMemo(
+      () => [
+        {
+          key: 'number',
+          header: 'Issue #',
+          width: '9%',
+          sortKey: 'number',
+          cellSx: { fontSize: { xs: '0.75rem', sm: '0.85rem' } },
+          renderCell: (issue) => (
+            // stopPropagation keeps the row's onRowClick from also firing
+            <a
+              href={githubIssueUrl(issue)}
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{
+                color: 'inherit',
+                textDecoration: 'none',
+                fontWeight: 500,
+              }}
+              onClick={(e) => e.stopPropagation()}
+            >
+              #{issue.number}
+            </a>
+          ),
+        },
+        {
+          key: 'title',
+          header: 'Title',
+          width: '35%',
+          cellSx: { fontSize: { xs: '0.75rem', sm: '0.85rem' } },
+          renderCell: (issue) => (
             <Box
               sx={{
-                display: 'flex',
-                alignItems: 'center',
-                gap: 1.5,
                 overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
               }}
             >
-              <Avatar
-                src={`https://avatars.githubusercontent.com/${owner}`}
-                alt={owner}
-                sx={{
-                  width: 20,
-                  height: 20,
-                  flexShrink: 0,
-                  border: '1px solid',
-                  borderColor: 'border.medium',
-                }}
-              />
-              <Box
-                component="span"
-                sx={{ wordBreak: 'break-word', lineHeight: 1.3 }}
-              >
-                {issue.repositoryFullName}
-              </Box>
+              {issue.title}
             </Box>
-          );
-        },
-      },
-      {
-        key: 'linked_pr',
-        header: 'Linked PR',
-        width: '17%',
-        renderCell: (issue) =>
-          issue.prNumber != null ? (
-            <a
-              href={`https://github.com/${issue.repositoryFullName}/pull/${issue.prNumber}`}
-              target="_blank"
-              rel="noopener noreferrer"
-              style={{ textDecoration: 'none' }}
-              onClick={(e) => e.stopPropagation()}
-            >
-              <Chip
-                size="small"
-                label={`PR #${issue.prNumber}`}
-                sx={{
-                  height: 20,
-                  fontSize: '0.72rem',
-                  cursor: 'pointer',
-                  bgcolor: (t) => alpha(t.palette.success.main, 0.14),
-                  color: 'success.light',
-                  borderColor: (t) => alpha(t.palette.success.main, 0.35),
-                  '& .MuiChip-label': { px: 1 },
-                  '&:hover': {
-                    bgcolor: (t) => alpha(t.palette.success.main, 0.25),
-                  },
-                }}
-                variant="outlined"
-              />
-            </a>
-          ) : (
-            <Chip
-              size="small"
-              label="No PR yet"
-              sx={{
-                height: 20,
-                fontSize: '0.72rem',
-                bgcolor: (t) => alpha(t.palette.warning.main, 0.1),
-                color: (t) => alpha(t.palette.warning.light, 0.75),
-                borderColor: (t) => alpha(t.palette.warning.main, 0.25),
-                '& .MuiChip-label': { px: 1 },
-              }}
-              variant="outlined"
-            />
           ),
-      },
-      {
-        key: 'opened',
-        header: 'Opened',
-        width: '15%',
-        align: 'right',
-        sortKey: 'opened',
-        cellSx: {
-          fontSize: { xs: '0.75rem', sm: '0.85rem' },
-          color: (t) => alpha(t.palette.text.primary, 0.7),
         },
-        renderCell: (issue) =>
-          issue.createdAt ? (
-            <Tooltip
-              title={new Date(issue.createdAt).toLocaleDateString()}
-              placement="top"
-            >
-              <span style={{ cursor: 'default' }}>
-                {formatDistanceToNow(new Date(issue.createdAt), {
-                  addSuffix: true,
-                })}
-              </span>
-            </Tooltip>
-          ) : null,
-      },
-    ],
-    [],
-  );
-
-  const otherColumns: DataTableColumn<RepositoryIssue, IssueSortField>[] = useMemo(
-    () => [
-      {
-        key: 'number',
-        header: 'Issue #',
-        width: '9%',
-        sortKey: 'number' as IssueSortField,
-        cellSx: { fontSize: { xs: '0.75rem', sm: '0.85rem' } },
-        renderCell: (issue) => (
-          <a
-            href={githubIssueUrl(issue)}
-            target="_blank"
-            rel="noopener noreferrer"
-            style={{ color: 'inherit', textDecoration: 'none', fontWeight: 500 }}
-            onClick={(e) => e.stopPropagation()}
-          >
-            #{issue.number}
-          </a>
-        ),
-      },
-      {
-        key: 'title',
-        header: 'Title',
-        width: '28%',
-        cellSx: { fontSize: { xs: '0.75rem', sm: '0.85rem' } },
-        renderCell: (issue) => (
-          <Box sx={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-            {issue.title}
-          </Box>
-        ),
-      },
-      {
-        key: 'repository',
-        header: 'Repository',
-        width: '20%',
-        sortKey: 'repository' as IssueSortField,
-        renderCell: (issue) => {
-          const owner = issue.repositoryFullName.split('/')[0];
-          return (
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, overflow: 'hidden' }}>
-              <Avatar
-                src={`https://avatars.githubusercontent.com/${owner}`}
-                alt={owner}
-                sx={{ width: 20, height: 20, flexShrink: 0, border: '1px solid', borderColor: 'border.medium' }}
-              />
-              <Box component="span" sx={{ wordBreak: 'break-word', lineHeight: 1.3 }}>
-                {issue.repositoryFullName}
-              </Box>
-            </Box>
-          );
-        },
-      },
-      {
-        key: 'author',
-        header: 'Author',
-        width: '14%',
-        renderCell: (issue) => {
-          const authorLogin = issue.authorLogin ?? issue.author ?? null;
-          if (!authorLogin) return null;
-          return (
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, overflow: 'hidden' }}>
-              <Avatar
-                src={`https://avatars.githubusercontent.com/${authorLogin}`}
-                alt={authorLogin}
-                sx={{ width: 18, height: 18, flexShrink: 0, border: '1px solid', borderColor: 'border.medium' }}
-              />
+        {
+          key: 'repository',
+          header: 'Repository',
+          width: '24%',
+          sortKey: 'repository',
+          renderCell: (issue) => {
+            const owner = issue.repositoryFullName.split('/')[0];
+            return (
               <Box
-                component="span"
                 sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 1.5,
                   overflow: 'hidden',
-                  textOverflow: 'ellipsis',
-                  whiteSpace: 'nowrap',
-                  fontSize: '0.8rem',
                 }}
               >
-                @{authorLogin}
+                <Avatar
+                  src={`https://avatars.githubusercontent.com/${owner}`}
+                  alt={owner}
+                  sx={{
+                    width: 20,
+                    height: 20,
+                    flexShrink: 0,
+                    border: '1px solid',
+                    borderColor: 'border.medium',
+                  }}
+                />
+                <Box
+                  component="span"
+                  sx={{ wordBreak: 'break-word', lineHeight: 1.3 }}
+                >
+                  {issue.repositoryFullName}
+                </Box>
               </Box>
-            </Box>
-          );
+            );
+          },
         },
-      },
-      {
-        key: 'linked_pr',
-        header: 'Linked PR',
-        width: '15%',
-        renderCell: (issue) =>
-          issue.prNumber != null ? (
-            <a
-              href={`https://github.com/${issue.repositoryFullName}/pull/${issue.prNumber}`}
-              target="_blank"
-              rel="noopener noreferrer"
-              style={{ textDecoration: 'none' }}
-              onClick={(e) => e.stopPropagation()}
-            >
+        {
+          key: 'linked_pr',
+          header: 'Linked PR',
+          width: '17%',
+          renderCell: (issue) =>
+            issue.prNumber != null ? (
+              <a
+                href={`https://github.com/${issue.repositoryFullName}/pull/${issue.prNumber}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                style={{ textDecoration: 'none' }}
+                onClick={(e) => e.stopPropagation()}
+              >
+                <Chip
+                  size="small"
+                  label={`PR #${issue.prNumber}`}
+                  sx={{
+                    height: 20,
+                    fontSize: '0.72rem',
+                    cursor: 'pointer',
+                    bgcolor: (t) => alpha(t.palette.success.main, 0.14),
+                    color: 'success.light',
+                    borderColor: (t) => alpha(t.palette.success.main, 0.35),
+                    '& .MuiChip-label': { px: 1 },
+                    '&:hover': {
+                      bgcolor: (t) => alpha(t.palette.success.main, 0.25),
+                    },
+                  }}
+                  variant="outlined"
+                />
+              </a>
+            ) : (
               <Chip
                 size="small"
-                label={`PR #${issue.prNumber}`}
+                label="No PR yet"
                 sx={{
                   height: 20,
                   fontSize: '0.72rem',
-                  cursor: 'pointer',
-                  bgcolor: (t) => alpha(t.palette.success.main, 0.14),
-                  color: 'success.light',
-                  borderColor: (t) => alpha(t.palette.success.main, 0.35),
+                  bgcolor: (t) => alpha(t.palette.warning.main, 0.1),
+                  color: (t) => alpha(t.palette.warning.light, 0.75),
+                  borderColor: (t) => alpha(t.palette.warning.main, 0.25),
                   '& .MuiChip-label': { px: 1 },
-                  '&:hover': { bgcolor: (t) => alpha(t.palette.success.main, 0.25) },
                 }}
                 variant="outlined"
               />
-            </a>
-          ) : (
-            <Chip
-              size="small"
-              label="No PR yet"
-              sx={{
-                height: 20,
-                fontSize: '0.72rem',
-                bgcolor: (t) => alpha(t.palette.warning.main, 0.1),
-                color: (t) => alpha(t.palette.warning.light, 0.75),
-                borderColor: (t) => alpha(t.palette.warning.main, 0.25),
-                '& .MuiChip-label': { px: 1 },
-              }}
-              variant="outlined"
-            />
-          ),
-      },
-      {
-        key: 'opened',
-        header: 'Opened',
-        width: '14%',
-        align: 'right',
-        sortKey: 'opened' as IssueSortField,
-        cellSx: {
-          fontSize: { xs: '0.75rem', sm: '0.85rem' },
-          color: (t) => alpha(t.palette.text.primary, 0.7),
+            ),
         },
-        renderCell: (issue) =>
-          issue.createdAt ? (
-            <Tooltip title={new Date(issue.createdAt).toLocaleDateString()} placement="top">
-              <span style={{ cursor: 'default' }}>
-                {formatDistanceToNow(new Date(issue.createdAt), { addSuffix: true })}
-              </span>
-            </Tooltip>
-          ) : null,
-      },
-    ],
-    [],
-  );
+        {
+          key: 'opened',
+          header: 'Opened',
+          width: '15%',
+          align: 'right',
+          sortKey: 'opened',
+          cellSx: {
+            fontSize: { xs: '0.75rem', sm: '0.85rem' },
+            color: (t) => alpha(t.palette.text.primary, 0.7),
+          },
+          renderCell: (issue) =>
+            issue.createdAt ? (
+              <Tooltip
+                title={new Date(issue.createdAt).toLocaleDateString()}
+                placement="top"
+              >
+                <span style={{ cursor: 'default' }}>
+                  {formatDistanceToNow(new Date(issue.createdAt), {
+                    addSuffix: true,
+                  })}
+                </span>
+              </Tooltip>
+            ) : null,
+        },
+      ],
+      [],
+    );
+
+  const otherColumns: DataTableColumn<RepositoryIssue, IssueSortField>[] =
+    useMemo(
+      () => [
+        {
+          key: 'number',
+          header: 'Issue #',
+          width: '9%',
+          sortKey: 'number' as IssueSortField,
+          cellSx: { fontSize: { xs: '0.75rem', sm: '0.85rem' } },
+          renderCell: (issue) => (
+            <a
+              href={githubIssueUrl(issue)}
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{
+                color: 'inherit',
+                textDecoration: 'none',
+                fontWeight: 500,
+              }}
+              onClick={(e) => e.stopPropagation()}
+            >
+              #{issue.number}
+            </a>
+          ),
+        },
+        {
+          key: 'title',
+          header: 'Title',
+          width: '28%',
+          cellSx: { fontSize: { xs: '0.75rem', sm: '0.85rem' } },
+          renderCell: (issue) => (
+            <Box
+              sx={{
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+              }}
+            >
+              {issue.title}
+            </Box>
+          ),
+        },
+        {
+          key: 'repository',
+          header: 'Repository',
+          width: '20%',
+          sortKey: 'repository' as IssueSortField,
+          renderCell: (issue) => {
+            const owner = issue.repositoryFullName.split('/')[0];
+            return (
+              <Box
+                sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 1.5,
+                  overflow: 'hidden',
+                }}
+              >
+                <Avatar
+                  src={`https://avatars.githubusercontent.com/${owner}`}
+                  alt={owner}
+                  sx={{
+                    width: 20,
+                    height: 20,
+                    flexShrink: 0,
+                    border: '1px solid',
+                    borderColor: 'border.medium',
+                  }}
+                />
+                <Box
+                  component="span"
+                  sx={{ wordBreak: 'break-word', lineHeight: 1.3 }}
+                >
+                  {issue.repositoryFullName}
+                </Box>
+              </Box>
+            );
+          },
+        },
+        {
+          key: 'author',
+          header: 'Author',
+          width: '14%',
+          renderCell: (issue) => {
+            const authorLogin = issue.authorLogin ?? issue.author ?? null;
+            if (!authorLogin) return null;
+            return (
+              <Box
+                sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 1,
+                  overflow: 'hidden',
+                }}
+              >
+                <Avatar
+                  src={`https://avatars.githubusercontent.com/${authorLogin}`}
+                  alt={authorLogin}
+                  sx={{
+                    width: 18,
+                    height: 18,
+                    flexShrink: 0,
+                    border: '1px solid',
+                    borderColor: 'border.medium',
+                  }}
+                />
+                <Box
+                  component="span"
+                  sx={{
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                    fontSize: '0.8rem',
+                  }}
+                >
+                  @{authorLogin}
+                </Box>
+              </Box>
+            );
+          },
+        },
+        {
+          key: 'linked_pr',
+          header: 'Linked PR',
+          width: '15%',
+          renderCell: (issue) =>
+            issue.prNumber != null ? (
+              <a
+                href={`https://github.com/${issue.repositoryFullName}/pull/${issue.prNumber}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                style={{ textDecoration: 'none' }}
+                onClick={(e) => e.stopPropagation()}
+              >
+                <Chip
+                  size="small"
+                  label={`PR #${issue.prNumber}`}
+                  sx={{
+                    height: 20,
+                    fontSize: '0.72rem',
+                    cursor: 'pointer',
+                    bgcolor: (t) => alpha(t.palette.success.main, 0.14),
+                    color: 'success.light',
+                    borderColor: (t) => alpha(t.palette.success.main, 0.35),
+                    '& .MuiChip-label': { px: 1 },
+                    '&:hover': {
+                      bgcolor: (t) => alpha(t.palette.success.main, 0.25),
+                    },
+                  }}
+                  variant="outlined"
+                />
+              </a>
+            ) : (
+              <Chip
+                size="small"
+                label="No PR yet"
+                sx={{
+                  height: 20,
+                  fontSize: '0.72rem',
+                  bgcolor: (t) => alpha(t.palette.warning.main, 0.1),
+                  color: (t) => alpha(t.palette.warning.light, 0.75),
+                  borderColor: (t) => alpha(t.palette.warning.main, 0.25),
+                  '& .MuiChip-label': { px: 1 },
+                }}
+                variant="outlined"
+              />
+            ),
+        },
+        {
+          key: 'opened',
+          header: 'Opened',
+          width: '14%',
+          align: 'right',
+          sortKey: 'opened' as IssueSortField,
+          cellSx: {
+            fontSize: { xs: '0.75rem', sm: '0.85rem' },
+            color: (t) => alpha(t.palette.text.primary, 0.7),
+          },
+          renderCell: (issue) =>
+            issue.createdAt ? (
+              <Tooltip
+                title={new Date(issue.createdAt).toLocaleDateString()}
+                placement="top"
+              >
+                <span style={{ cursor: 'default' }}>
+                  {formatDistanceToNow(new Date(issue.createdAt), {
+                    addSuffix: true,
+                  })}
+                </span>
+              </Tooltip>
+            ) : null,
+        },
+      ],
+      [],
+    );
 
   const renderToolbar = (
     title: string | null,
@@ -706,88 +777,52 @@ const MinerOpenDiscoveryIssuesByRepo: React.FC<
         borderColor: 'border.light',
       }}
     >
-      <Box
-        sx={{
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'space-between',
-          flexWrap: 'wrap',
-          gap: 2,
-        }}
-      >
-        {title != null && (
-          <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 1.5 }}>
-            <Typography
-              variant="h6"
-              sx={{
-                color: 'text.primary',
-                fontSize: { xs: '0.95rem', sm: '1.1rem' },
-                fontWeight: 500,
-              }}
-            >
-              {title}
-            </Typography>
-            <Typography
-              sx={{
-                color: (t) => alpha(t.palette.text.primary, 0.5),
-                fontSize: '0.75rem',
-              }}
-            >
-              ({filteredCount}
-              {hasFilters ? ` of ${totalIssues.length}` : ''})
-            </Typography>
-          </Box>
-        )}
-
-        <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap', ml: 'auto' }}>
-          <ExplorerFilterButton
-            label="All"
-            count={counts.all}
-            color={theme.palette.status.neutral}
-            selected={filter === 'all'}
-            onClick={() => { onFilterChange('all'); }}
-          />
-          <ExplorerFilterButton
-            label="Open"
-            count={counts.open}
-            color={theme.palette.status.open}
-            selected={filter === 'open'}
-            onClick={() => { onFilterChange('open'); }}
-          />
-          <ExplorerFilterButton
-            label="Solved"
-            count={counts.solved}
-            color={theme.palette.status.merged}
-            selected={filter === 'solved'}
-            onClick={() => { onFilterChange('solved'); }}
-          />
-          <ExplorerFilterButton
-            label="Closed"
-            count={counts.closed}
-            color={theme.palette.status.closed}
-            selected={filter === 'closed'}
-            onClick={() => { onFilterChange('closed'); }}
-          />
-        </Box>
-      </Box>
-
-      {subtitle && (
-        <Typography
-          variant="body2"
-          color="text.secondary"
-          sx={{ mt: 1 }}
+      {/* Title row — only when a title is provided */}
+      {title != null && (
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'baseline',
+            gap: 1.5,
+            mb: subtitle ? 0.75 : 2,
+          }}
         >
+          <Typography
+            variant="h6"
+            sx={{
+              color: 'text.primary',
+              fontSize: { xs: '0.95rem', sm: '1.1rem' },
+              fontWeight: 500,
+            }}
+          >
+            {title}
+          </Typography>
+          <Typography
+            sx={{
+              color: (t) => alpha(t.palette.text.primary, 0.5),
+              fontSize: '0.75rem',
+            }}
+          >
+            ({filteredCount}
+            {hasFilters ? ` of ${totalIssues.length}` : ''})
+          </Typography>
+        </Box>
+      )}
+
+      {/* Subtitle description */}
+      {subtitle && (
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
           {subtitle}
         </Typography>
       )}
 
+      {/* Search + filters on one line */}
       <Box
         sx={{
-          mt: 2,
           display: 'flex',
+          alignItems: 'center',
           gap: 1,
           flexWrap: 'wrap',
-          alignItems: 'center',
         }}
       >
         <TextField
@@ -809,7 +844,7 @@ const MinerOpenDiscoveryIssuesByRepo: React.FC<
           }}
           sx={{
             maxWidth: 400,
-            minWidth: 300,
+            minWidth: 260,
             '& .MuiOutlinedInput-root': {
               fontSize: '0.8rem',
               color: 'text.primary',
@@ -821,6 +856,45 @@ const MinerOpenDiscoveryIssuesByRepo: React.FC<
             },
           }}
         />
+
+        <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap', ml: 'auto' }}>
+          <ExplorerFilterButton
+            label="All"
+            count={counts.all}
+            color={theme.palette.status.neutral}
+            selected={filter === 'all'}
+            onClick={() => {
+              onFilterChange('all');
+            }}
+          />
+          <ExplorerFilterButton
+            label="Open"
+            count={counts.open}
+            color={theme.palette.status.open}
+            selected={filter === 'open'}
+            onClick={() => {
+              onFilterChange('open');
+            }}
+          />
+          <ExplorerFilterButton
+            label="Solved"
+            count={counts.solved}
+            color={theme.palette.status.merged}
+            selected={filter === 'solved'}
+            onClick={() => {
+              onFilterChange('solved');
+            }}
+          />
+          <ExplorerFilterButton
+            label="Closed"
+            count={counts.closed}
+            color={theme.palette.status.closed}
+            selected={filter === 'closed'}
+            onClick={() => {
+              onFilterChange('closed');
+            }}
+          />
+        </Box>
       </Box>
     </Box>
   );
@@ -939,8 +1013,8 @@ const MinerOpenDiscoveryIssuesByRepo: React.FC<
 
       {prs.length > repoFetchLimit ? (
         <Typography variant="caption" color="text.secondary">
-          You have PRs in more than {repoFetchLimit} repositories; only the
-          most active {repoFetchLimit} are scanned here to limit load.
+          You have PRs in more than {repoFetchLimit} repositories; only the most
+          active {repoFetchLimit} are scanned here to limit load.
         </Typography>
       ) : null}
 
@@ -951,14 +1025,19 @@ const MinerOpenDiscoveryIssuesByRepo: React.FC<
       )}
       {isAuthorFallbackError && !isDataLoading && (
         <Alert severity="warning" sx={{ borderRadius: 2 }}>
-          Could not load all authored open issues from GitHub right now.
-          Showing indexed results only.
+          Could not load all authored open issues from GitHub right now. Showing
+          indexed results only.
         </Alert>
       )}
 
       {/* Your open discovery issues */}
       <Card
-        sx={{ p: 0, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}
+        sx={{
+          p: 0,
+          display: 'flex',
+          flexDirection: 'column',
+          overflow: 'hidden',
+        }}
         elevation={0}
       >
         <DataTable<RepositoryIssue, IssueSortField>
@@ -975,9 +1054,15 @@ const MinerOpenDiscoveryIssuesByRepo: React.FC<
             filteredMine.length,
             mineCounts,
             mineFilter,
-            (f) => { setMineFilter(f); setMinePage(0); },
+            (f) => {
+              setMineFilter(f);
+              setMinePage(0);
+            },
             mineSearch,
-            (s) => { setMineSearch(s); setMinePage(0); },
+            (s) => {
+              setMineSearch(s);
+              setMinePage(0);
+            },
             mineSectionHasFilters,
             'Open issues authored by you in the scanned repositories (discovery index plus GitHub fallback). Use this list to track your own active reports.',
           )}
@@ -1022,7 +1107,12 @@ const MinerOpenDiscoveryIssuesByRepo: React.FC<
 
       {/* Other open discovery issues — collapsed by default */}
       <Card
-        sx={{ p: 0, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}
+        sx={{
+          p: 0,
+          display: 'flex',
+          flexDirection: 'column',
+          overflow: 'hidden',
+        }}
         elevation={0}
       >
         <Box
@@ -1094,9 +1184,15 @@ const MinerOpenDiscoveryIssuesByRepo: React.FC<
               filteredOther.length,
               otherCounts,
               otherFilter,
-              (f) => { setOtherFilter(f); setOtherPage(0); },
+              (f) => {
+                setOtherFilter(f);
+                setOtherPage(0);
+              },
               otherSearch,
-              (s) => { setOtherSearch(s); setOtherPage(0); },
+              (s) => {
+                setOtherSearch(s);
+                setOtherPage(0);
+              },
               otherSectionHasFilters,
               "Other people's open issues in the same repositories (still part of the discovery index). Useful for triage and collaboration.",
             )}

--- a/src/components/miners/MinerOpenDiscoveryIssuesByRepo.tsx
+++ b/src/components/miners/MinerOpenDiscoveryIssuesByRepo.tsx
@@ -1,10 +1,8 @@
-import React, { useMemo } from 'react';
+import React, { useState, useMemo, useCallback } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import axios from 'axios';
+import { formatDistanceToNow } from 'date-fns';
 import {
-  Accordion,
-  AccordionDetails,
-  AccordionSummary,
   Alert,
   Avatar,
   Box,
@@ -12,30 +10,55 @@ import {
   Card,
   Chip,
   CircularProgress,
-  Link,
-  Stack,
+  Collapse,
+  InputAdornment,
+  TextField,
+  Tooltip,
   Typography,
   alpha,
+  useTheme,
 } from '@mui/material';
-import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
-import OpenInNewIcon from '@mui/icons-material/OpenInNew';
+import {
+  ExpandMore as ExpandMoreIcon,
+  Search as SearchIcon,
+  OpenInNew as OpenInNewIcon,
+} from '@mui/icons-material';
 import { useMinerGithubData, useMinerPRs } from '../../api';
-import { LinkBox } from '../common/linkBehavior';
-import { STATUS_COLORS, TEXT_OPACITY } from '../../theme';
+import { paginateItems } from '../../utils';
+import { DataTable, type DataTableColumn } from '../common/DataTable';
+import ExplorerFilterButton from './ExplorerFilterButton';
+import TablePagination from './TablePagination';
 import {
   selectMinerIssueScanRepos,
   useMinerRepositoriesOpenIssues,
 } from '../../hooks/useMinerRepositoriesOpenIssues';
 import { type RepositoryIssue } from '../../api/models/Miner';
 
-const isIssueOpen = (issue: RepositoryIssue) => !issue.closedAt;
+type IssueFilter = 'all' | 'open' | 'solved' | 'closed';
+type IssueSortField = 'number' | 'repository' | 'opened';
+type SortDir = 'asc' | 'desc';
+
+const PAGE_SIZE = 20;
+
+const DEFAULT_SORT_DIR: Record<IssueSortField, SortDir> = {
+  number: 'desc',
+  repository: 'asc',
+  opened: 'desc',
+};
+
+// Issue is still open
+const isOpenIssue = (i: RepositoryIssue) => !i.closedAt;
+// Issue was closed and has a linked PR (solved by a contributor)
+const isSolvedIssue = (i: RepositoryIssue) => !!i.closedAt && i.prNumber != null;
+// Issue was closed without a linked PR (rejected, duplicate, etc.)
+const isClosedIssue = (i: RepositoryIssue) => !!i.closedAt && i.prNumber == null;
 
 const githubIssueUrl = (issue: RepositoryIssue) =>
   issue.url ??
   `https://github.com/${issue.repositoryFullName}/issues/${issue.number}`;
 
-const githubSearchOpenByAuthor = (login: string) =>
-  `https://github.com/search?q=${encodeURIComponent(`is:issue is:open author:${login}`)}&type=issues`;
+const githubSearchIssuesByAuthor = (login: string) =>
+  `https://github.com/search?q=${encodeURIComponent(`is:issue author:${login}`)}&type=issues`;
 
 interface GithubSearchIssueItem {
   number: number;
@@ -92,7 +115,6 @@ const fetchLinkedPrNumberForIssue = async (
         },
       },
     );
-
     for (const event of data ?? []) {
       const prUrl = event.source?.issue?.pull_request?.html_url;
       if (!prUrl) continue;
@@ -105,25 +127,20 @@ const fetchLinkedPrNumberForIssue = async (
   return null;
 };
 
-const fetchGithubOpenIssuesByAuthor = async (
+const fetchGithubIssuesByAuthor = async (
   login: string,
 ): Promise<RepositoryIssue[]> => {
   const { data } = await axios.get<GithubSearchIssuesResponse>(
     'https://api.github.com/search/issues',
     {
-      params: {
-        q: `is:issue is:open author:${login}`,
-        per_page: 100,
-      },
+      params: { q: `is:issue author:${login}`, per_page: 100 },
     },
   );
 
   const mapped = (data.items || [])
     .filter((item) => !item.pull_request)
     .map((item) => {
-      const repositoryFullName = parseRepoFromRepositoryUrl(
-        item.repository_url,
-      );
+      const repositoryFullName = parseRepoFromRepositoryUrl(item.repository_url);
       return {
         number: item.number,
         repositoryFullName: repositoryFullName ?? '',
@@ -145,14 +162,47 @@ const fetchGithubOpenIssuesByAuthor = async (
         issue.repositoryFullName,
         issue.number,
       );
-      return {
-        ...issue,
-        prNumber,
-      } satisfies RepositoryIssue;
+      return { ...issue, prNumber } satisfies RepositoryIssue;
     }),
   );
-
   return enriched;
+};
+
+const getIssueCounts = (issues: RepositoryIssue[]) => ({
+  all: issues.length,
+  open: issues.filter(isOpenIssue).length,
+  solved: issues.filter(isSolvedIssue).length,
+  closed: issues.filter(isClosedIssue).length,
+});
+
+const applyIssueFilter = (
+  issues: RepositoryIssue[],
+  filter: IssueFilter,
+  search: string,
+  sortField: IssueSortField,
+  sortDir: SortDir,
+): RepositoryIssue[] => {
+  let result = issues;
+  if (filter === 'open') result = result.filter(isOpenIssue);
+  else if (filter === 'solved') result = result.filter(isSolvedIssue);
+  else if (filter === 'closed') result = result.filter(isClosedIssue);
+  const q = search.trim().toLowerCase();
+  if (q) {
+    result = result.filter(
+      (i) =>
+        i.title.toLowerCase().includes(q) ||
+        i.repositoryFullName.toLowerCase().includes(q) ||
+        String(i.number).includes(q),
+    );
+  }
+  return [...result].sort((a, b) => {
+    let cmp = 0;
+    if (sortField === 'number') cmp = a.number - b.number;
+    else if (sortField === 'repository')
+      cmp = a.repositoryFullName.localeCompare(b.repositoryFullName);
+    else cmp = (a.createdAt ?? '').localeCompare(b.createdAt ?? '');
+    return sortDir === 'asc' ? cmp : -cmp;
+  });
 };
 
 interface MinerOpenDiscoveryIssuesByRepoProps {
@@ -162,34 +212,54 @@ interface MinerOpenDiscoveryIssuesByRepoProps {
 const MinerOpenDiscoveryIssuesByRepo: React.FC<
   MinerOpenDiscoveryIssuesByRepoProps
 > = ({ githubId }) => {
+  const theme = useTheme();
+
   const { data: prs, isLoading: isLoadingPrs } = useMinerPRs(githubId);
   const { data: githubProfile, isLoading: isLoadingGithub } =
     useMinerGithubData(githubId);
 
+  // Mine section state
+  const [mineFilter, setMineFilter] = useState<IssueFilter>('all');
+  const [mineSearch, setMineSearch] = useState('');
+  const [mineSortField, setMineSortField] = useState<IssueSortField>('opened');
+  const [mineSortDir, setMineSortDir] = useState<SortDir>('desc');
+  const [minePage, setMinePage] = useState(0);
+
+  // Other section state
+  const [otherFilter, setOtherFilter] = useState<IssueFilter>('all');
+  const [otherSearch, setOtherSearch] = useState('');
+  const [otherSortField, setOtherSortField] = useState<IssueSortField>('opened');
+  const [otherSortDir, setOtherSortDir] = useState<SortDir>('desc');
+  const [otherPage, setOtherPage] = useState(0);
+  const [otherExpanded, setOtherExpanded] = useState(false);
+
   const scanRepos = useMemo(() => selectMinerIssueScanRepos(prs), [prs]);
   const login = githubProfile?.login ?? '';
+
   const {
     data: githubAuthoredIssues = [],
     isLoading: isLoadingAuthoredIssues,
     isFetching: isFetchingAuthoredIssues,
     isError: isAuthorFallbackError,
   } = useQuery({
-    queryKey: ['githubAuthorOpenIssues', login],
-    queryFn: () => fetchGithubOpenIssuesByAuthor(login),
+    queryKey: ['githubAuthorIssues', login],
+    queryFn: () => fetchGithubIssuesByAuthor(login),
     enabled: !!login,
     staleTime: 60_000,
     retry: 1,
   });
+
   const authoredRepos = useMemo(
     () =>
-      [
-        ...new Set(githubAuthoredIssues.map((i) => i.repositoryFullName)),
-      ].filter(Boolean),
+      [...new Set(githubAuthoredIssues.map((i) => i.repositoryFullName))].filter(
+        Boolean,
+      ),
     [githubAuthoredIssues],
   );
 
   const { issuesByRepo, isLoading, isError, repoFetchLimit } =
     useMinerRepositoriesOpenIssues(scanRepos, !isLoadingPrs);
+
   const {
     issuesByRepo: authoredReposIssuesByRepo,
     isLoading: isLoadingAuthoredRepoIssues,
@@ -204,11 +274,12 @@ const MinerOpenDiscoveryIssuesByRepo: React.FC<
     [authoredRepos, scanRepos],
   );
 
-  const { mineByRepo, otherByRepo, mineTotal, otherTotal } = useMemo(() => {
+  const { mineIssues, otherIssues } = useMemo(() => {
     const mine = new Map<string, RepositoryIssue[]>();
     const other = new Map<string, RepositoryIssue[]>();
     const mineKeys = new Set<string>();
     const indexedIssueByKey = new Map<string, RepositoryIssue>();
+
     const addToMap = (
       target: Map<string, RepositoryIssue[]>,
       repo: string,
@@ -226,55 +297,35 @@ const MinerOpenDiscoveryIssuesByRepo: React.FC<
       [...fromScan, ...fromAuthoredRepoFetch].forEach((issue) => {
         listByNumber.set(issue.number, issue);
       });
-      const list = [...listByNumber.values()];
-      list.forEach((issue) => {
-        if (!isIssueOpen(issue)) return;
+      listByNumber.forEach((issue) => {
         const key = `${repo}#${issue.number}`;
         indexedIssueByKey.set(key, issue);
         addToMap(other, repo, issue);
       });
     });
 
-    // Canonical "mine" source: GitHub open issues authored by this miner.
-    // We still overlay indexed records when available to preserve enriched fields
-    // such as linked PR numbers in the row metadata.
     githubAuthoredIssues.forEach((issue) => {
-      if (!isIssueOpen(issue)) return;
       const repo = issue.repositoryFullName;
       if (!repo) return;
       const key = `${repo}#${issue.number}`;
       if (mineKeys.has(key)) return;
       mineKeys.add(key);
-      const indexedIssue = indexedIssueByKey.get(key);
-      addToMap(mine, repo, indexedIssue ?? issue);
+      addToMap(mine, repo, indexedIssueByKey.get(key) ?? issue);
     });
 
-    // Remove authored issues from "other" buckets in the same repos.
-    const filteredOtherRaw = new Map<string, RepositoryIssue[]>();
+    const filteredOther = new Map<string, RepositoryIssue[]>();
+    const mineRepos = new Set(mine.keys());
     other.forEach((issues, repo) => {
+      if (!mineRepos.has(repo)) return;
       const filtered = issues.filter(
         (issue) => !mineKeys.has(`${repo}#${issue.number}`),
       );
-      if (filtered.length) filteredOtherRaw.set(repo, filtered);
+      if (filtered.length) filteredOther.set(repo, filtered);
     });
-
-    const mineRepos = new Set(mine.keys());
-    const filteredOther = new Map<string, RepositoryIssue[]>();
-    filteredOtherRaw.forEach((issues, repo) => {
-      if (mineRepos.has(repo)) filteredOther.set(repo, issues);
-    });
-
-    const m = [...mine.values()].reduce((sum, items) => sum + items.length, 0);
-    const o = [...filteredOther.values()].reduce(
-      (sum, items) => sum + items.length,
-      0,
-    );
 
     return {
-      mineByRepo: mine,
-      otherByRepo: filteredOther,
-      mineTotal: m,
-      otherTotal: o,
+      mineIssues: [...mine.values()].flat(),
+      otherIssues: [...filteredOther.values()].flat(),
     };
   }, [
     authoredReposIssuesByRepo,
@@ -282,6 +333,497 @@ const MinerOpenDiscoveryIssuesByRepo: React.FC<
     issuesByRepo,
     reposForGrouping,
   ]);
+
+  const handleMineSort = useCallback(
+    (field: IssueSortField) => {
+      if (mineSortField === field) {
+        setMineSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
+      } else {
+        setMineSortField(field);
+        setMineSortDir(DEFAULT_SORT_DIR[field]);
+      }
+      setMinePage(0);
+    },
+    [mineSortField],
+  );
+
+  const handleOtherSort = useCallback(
+    (field: IssueSortField) => {
+      if (otherSortField === field) {
+        setOtherSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
+      } else {
+        setOtherSortField(field);
+        setOtherSortDir(DEFAULT_SORT_DIR[field]);
+      }
+      setOtherPage(0);
+    },
+    [otherSortField],
+  );
+
+  const handleRowClick = useCallback((issue: RepositoryIssue) => {
+    window.open(githubIssueUrl(issue), '_blank', 'noopener,noreferrer');
+  }, []);
+
+  const filteredMine = useMemo(
+    () => applyIssueFilter(mineIssues, mineFilter, mineSearch, mineSortField, mineSortDir),
+    [mineIssues, mineFilter, mineSearch, mineSortField, mineSortDir],
+  );
+  const filteredOther = useMemo(
+    () => applyIssueFilter(otherIssues, otherFilter, otherSearch, otherSortField, otherSortDir),
+    [otherIssues, otherFilter, otherSearch, otherSortField, otherSortDir],
+  );
+
+  const pagedMine = useMemo(
+    () => paginateItems(filteredMine, minePage, PAGE_SIZE),
+    [filteredMine, minePage],
+  );
+  const pagedOther = useMemo(
+    () => paginateItems(filteredOther, otherPage, PAGE_SIZE),
+    [filteredOther, otherPage],
+  );
+
+  const mineTotalPages = Math.ceil(filteredMine.length / PAGE_SIZE);
+  const otherTotalPages = Math.ceil(filteredOther.length / PAGE_SIZE);
+
+  const mineCounts = useMemo(() => getIssueCounts(mineIssues), [mineIssues]);
+  const otherCounts = useMemo(() => getIssueCounts(otherIssues), [otherIssues]);
+
+  const mineColumns: DataTableColumn<RepositoryIssue, IssueSortField>[] = useMemo(
+    () => [
+      {
+        key: 'number',
+        header: 'Issue #',
+        width: '9%',
+        sortKey: 'number',
+        cellSx: { fontSize: { xs: '0.75rem', sm: '0.85rem' } },
+        renderCell: (issue) => (
+          // stopPropagation keeps the row's onRowClick from also firing
+          <a
+            href={githubIssueUrl(issue)}
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{ color: 'inherit', textDecoration: 'none', fontWeight: 500 }}
+            onClick={(e) => e.stopPropagation()}
+          >
+            #{issue.number}
+          </a>
+        ),
+      },
+      {
+        key: 'title',
+        header: 'Title',
+        width: '35%',
+        cellSx: { fontSize: { xs: '0.75rem', sm: '0.85rem' } },
+        renderCell: (issue) => (
+          <Box
+            sx={{
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {issue.title}
+          </Box>
+        ),
+      },
+      {
+        key: 'repository',
+        header: 'Repository',
+        width: '24%',
+        sortKey: 'repository',
+        renderCell: (issue) => {
+          const owner = issue.repositoryFullName.split('/')[0];
+          return (
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 1.5,
+                overflow: 'hidden',
+              }}
+            >
+              <Avatar
+                src={`https://avatars.githubusercontent.com/${owner}`}
+                alt={owner}
+                sx={{
+                  width: 20,
+                  height: 20,
+                  flexShrink: 0,
+                  border: '1px solid',
+                  borderColor: 'border.medium',
+                }}
+              />
+              <Box
+                component="span"
+                sx={{ wordBreak: 'break-word', lineHeight: 1.3 }}
+              >
+                {issue.repositoryFullName}
+              </Box>
+            </Box>
+          );
+        },
+      },
+      {
+        key: 'linked_pr',
+        header: 'Linked PR',
+        width: '17%',
+        renderCell: (issue) =>
+          issue.prNumber != null ? (
+            <a
+              href={`https://github.com/${issue.repositoryFullName}/pull/${issue.prNumber}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{ textDecoration: 'none' }}
+              onClick={(e) => e.stopPropagation()}
+            >
+              <Chip
+                size="small"
+                label={`PR #${issue.prNumber}`}
+                sx={{
+                  height: 20,
+                  fontSize: '0.72rem',
+                  cursor: 'pointer',
+                  bgcolor: (t) => alpha(t.palette.success.main, 0.14),
+                  color: 'success.light',
+                  borderColor: (t) => alpha(t.palette.success.main, 0.35),
+                  '& .MuiChip-label': { px: 1 },
+                  '&:hover': {
+                    bgcolor: (t) => alpha(t.palette.success.main, 0.25),
+                  },
+                }}
+                variant="outlined"
+              />
+            </a>
+          ) : (
+            <Chip
+              size="small"
+              label="No PR yet"
+              sx={{
+                height: 20,
+                fontSize: '0.72rem',
+                bgcolor: (t) => alpha(t.palette.warning.main, 0.1),
+                color: (t) => alpha(t.palette.warning.light, 0.75),
+                borderColor: (t) => alpha(t.palette.warning.main, 0.25),
+                '& .MuiChip-label': { px: 1 },
+              }}
+              variant="outlined"
+            />
+          ),
+      },
+      {
+        key: 'opened',
+        header: 'Opened',
+        width: '15%',
+        align: 'right',
+        sortKey: 'opened',
+        cellSx: {
+          fontSize: { xs: '0.75rem', sm: '0.85rem' },
+          color: (t) => alpha(t.palette.text.primary, 0.7),
+        },
+        renderCell: (issue) =>
+          issue.createdAt ? (
+            <Tooltip
+              title={new Date(issue.createdAt).toLocaleDateString()}
+              placement="top"
+            >
+              <span style={{ cursor: 'default' }}>
+                {formatDistanceToNow(new Date(issue.createdAt), {
+                  addSuffix: true,
+                })}
+              </span>
+            </Tooltip>
+          ) : null,
+      },
+    ],
+    [],
+  );
+
+  const otherColumns: DataTableColumn<RepositoryIssue, IssueSortField>[] = useMemo(
+    () => [
+      {
+        key: 'number',
+        header: 'Issue #',
+        width: '9%',
+        sortKey: 'number' as IssueSortField,
+        cellSx: { fontSize: { xs: '0.75rem', sm: '0.85rem' } },
+        renderCell: (issue) => (
+          <a
+            href={githubIssueUrl(issue)}
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{ color: 'inherit', textDecoration: 'none', fontWeight: 500 }}
+            onClick={(e) => e.stopPropagation()}
+          >
+            #{issue.number}
+          </a>
+        ),
+      },
+      {
+        key: 'title',
+        header: 'Title',
+        width: '28%',
+        cellSx: { fontSize: { xs: '0.75rem', sm: '0.85rem' } },
+        renderCell: (issue) => (
+          <Box sx={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+            {issue.title}
+          </Box>
+        ),
+      },
+      {
+        key: 'repository',
+        header: 'Repository',
+        width: '20%',
+        sortKey: 'repository' as IssueSortField,
+        renderCell: (issue) => {
+          const owner = issue.repositoryFullName.split('/')[0];
+          return (
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, overflow: 'hidden' }}>
+              <Avatar
+                src={`https://avatars.githubusercontent.com/${owner}`}
+                alt={owner}
+                sx={{ width: 20, height: 20, flexShrink: 0, border: '1px solid', borderColor: 'border.medium' }}
+              />
+              <Box component="span" sx={{ wordBreak: 'break-word', lineHeight: 1.3 }}>
+                {issue.repositoryFullName}
+              </Box>
+            </Box>
+          );
+        },
+      },
+      {
+        key: 'author',
+        header: 'Author',
+        width: '14%',
+        renderCell: (issue) => {
+          const authorLogin = issue.authorLogin ?? issue.author ?? null;
+          if (!authorLogin) return null;
+          return (
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, overflow: 'hidden' }}>
+              <Avatar
+                src={`https://avatars.githubusercontent.com/${authorLogin}`}
+                alt={authorLogin}
+                sx={{ width: 18, height: 18, flexShrink: 0, border: '1px solid', borderColor: 'border.medium' }}
+              />
+              <Box
+                component="span"
+                sx={{
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                  fontSize: '0.8rem',
+                }}
+              >
+                @{authorLogin}
+              </Box>
+            </Box>
+          );
+        },
+      },
+      {
+        key: 'linked_pr',
+        header: 'Linked PR',
+        width: '15%',
+        renderCell: (issue) =>
+          issue.prNumber != null ? (
+            <a
+              href={`https://github.com/${issue.repositoryFullName}/pull/${issue.prNumber}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{ textDecoration: 'none' }}
+              onClick={(e) => e.stopPropagation()}
+            >
+              <Chip
+                size="small"
+                label={`PR #${issue.prNumber}`}
+                sx={{
+                  height: 20,
+                  fontSize: '0.72rem',
+                  cursor: 'pointer',
+                  bgcolor: (t) => alpha(t.palette.success.main, 0.14),
+                  color: 'success.light',
+                  borderColor: (t) => alpha(t.palette.success.main, 0.35),
+                  '& .MuiChip-label': { px: 1 },
+                  '&:hover': { bgcolor: (t) => alpha(t.palette.success.main, 0.25) },
+                }}
+                variant="outlined"
+              />
+            </a>
+          ) : (
+            <Chip
+              size="small"
+              label="No PR yet"
+              sx={{
+                height: 20,
+                fontSize: '0.72rem',
+                bgcolor: (t) => alpha(t.palette.warning.main, 0.1),
+                color: (t) => alpha(t.palette.warning.light, 0.75),
+                borderColor: (t) => alpha(t.palette.warning.main, 0.25),
+                '& .MuiChip-label': { px: 1 },
+              }}
+              variant="outlined"
+            />
+          ),
+      },
+      {
+        key: 'opened',
+        header: 'Opened',
+        width: '14%',
+        align: 'right',
+        sortKey: 'opened' as IssueSortField,
+        cellSx: {
+          fontSize: { xs: '0.75rem', sm: '0.85rem' },
+          color: (t) => alpha(t.palette.text.primary, 0.7),
+        },
+        renderCell: (issue) =>
+          issue.createdAt ? (
+            <Tooltip title={new Date(issue.createdAt).toLocaleDateString()} placement="top">
+              <span style={{ cursor: 'default' }}>
+                {formatDistanceToNow(new Date(issue.createdAt), { addSuffix: true })}
+              </span>
+            </Tooltip>
+          ) : null,
+      },
+    ],
+    [],
+  );
+
+  const renderToolbar = (
+    title: string | null,
+    totalIssues: RepositoryIssue[],
+    filteredCount: number,
+    counts: ReturnType<typeof getIssueCounts>,
+    filter: IssueFilter,
+    onFilterChange: (f: IssueFilter) => void,
+    search: string,
+    onSearchChange: (s: string) => void,
+    hasFilters: boolean,
+    subtitle?: string,
+  ) => (
+    <Box
+      sx={{
+        p: { xs: 2, sm: 3 },
+        borderBottom: '1px solid',
+        borderColor: 'border.light',
+      }}
+    >
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          flexWrap: 'wrap',
+          gap: 2,
+        }}
+      >
+        {title != null && (
+          <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 1.5 }}>
+            <Typography
+              variant="h6"
+              sx={{
+                color: 'text.primary',
+                fontSize: { xs: '0.95rem', sm: '1.1rem' },
+                fontWeight: 500,
+              }}
+            >
+              {title}
+            </Typography>
+            <Typography
+              sx={{
+                color: (t) => alpha(t.palette.text.primary, 0.5),
+                fontSize: '0.75rem',
+              }}
+            >
+              ({filteredCount}
+              {hasFilters ? ` of ${totalIssues.length}` : ''})
+            </Typography>
+          </Box>
+        )}
+
+        <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap', ml: 'auto' }}>
+          <ExplorerFilterButton
+            label="All"
+            count={counts.all}
+            color={theme.palette.status.neutral}
+            selected={filter === 'all'}
+            onClick={() => { onFilterChange('all'); }}
+          />
+          <ExplorerFilterButton
+            label="Open"
+            count={counts.open}
+            color={theme.palette.status.open}
+            selected={filter === 'open'}
+            onClick={() => { onFilterChange('open'); }}
+          />
+          <ExplorerFilterButton
+            label="Solved"
+            count={counts.solved}
+            color={theme.palette.status.merged}
+            selected={filter === 'solved'}
+            onClick={() => { onFilterChange('solved'); }}
+          />
+          <ExplorerFilterButton
+            label="Closed"
+            count={counts.closed}
+            color={theme.palette.status.closed}
+            selected={filter === 'closed'}
+            onClick={() => { onFilterChange('closed'); }}
+          />
+        </Box>
+      </Box>
+
+      {subtitle && (
+        <Typography
+          variant="body2"
+          color="text.secondary"
+          sx={{ mt: 1 }}
+        >
+          {subtitle}
+        </Typography>
+      )}
+
+      <Box
+        sx={{
+          mt: 2,
+          display: 'flex',
+          gap: 1,
+          flexWrap: 'wrap',
+          alignItems: 'center',
+        }}
+      >
+        <TextField
+          size="small"
+          placeholder="Search by title, repo, or issue #..."
+          value={search}
+          onChange={(e) => onSearchChange(e.target.value)}
+          InputProps={{
+            startAdornment: (
+              <InputAdornment position="start">
+                <SearchIcon
+                  sx={{
+                    color: (t) => alpha(t.palette.text.primary, 0.3),
+                    fontSize: '1rem',
+                  }}
+                />
+              </InputAdornment>
+            ),
+          }}
+          sx={{
+            maxWidth: 400,
+            minWidth: 300,
+            '& .MuiOutlinedInput-root': {
+              fontSize: '0.8rem',
+              color: 'text.primary',
+              backgroundColor: 'surface.subtle',
+              borderRadius: 2,
+              '& fieldset': { borderColor: 'border.light' },
+              '&:hover fieldset': { borderColor: 'border.medium' },
+              '&.Mui-focused fieldset': { borderColor: 'primary.main' },
+            },
+          }}
+        />
+      </Box>
+    </Box>
+  );
 
   if (isLoadingPrs || isLoadingGithub) {
     return (
@@ -339,199 +881,19 @@ const MinerOpenDiscoveryIssuesByRepo: React.FC<
     );
   }
 
-  const renderRepoAccordionMap = (
-    map: Map<string, RepositoryIssue[]>,
-    emptyHint: string,
-  ) => {
-    const entries = [...map.entries()].filter(([, issues]) => issues.length);
-    if (!entries.length) {
-      return (
-        <Typography color="text.secondary" sx={{ py: 1 }}>
-          {emptyHint}
-        </Typography>
-      );
-    }
+  const isDataLoading =
+    isLoading ||
+    isLoadingAuthoredIssues ||
+    isFetchingAuthoredIssues ||
+    isLoadingAuthoredRepoIssues;
 
-    return (
-      <Stack spacing={1}>
-        {entries.map(([repo, issues]) => (
-          <Accordion
-            key={repo}
-            disableGutters
-            elevation={0}
-            sx={{
-              border: '1px solid',
-              borderColor: 'border.light',
-              borderRadius: 2,
-              bgcolor: (t) => alpha(t.palette.background.paper, 0.35),
-              '&:before': { display: 'none' },
-              overflow: 'hidden',
-            }}
-          >
-            <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-              <Box
-                sx={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'space-between',
-                  width: '100%',
-                  gap: 1,
-                  pr: 1,
-                }}
-              >
-                <Box
-                  sx={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: 1,
-                    minWidth: 0,
-                  }}
-                >
-                  <Avatar
-                    src={`https://avatars.githubusercontent.com/${repo.split('/')[0]}`}
-                    sx={{
-                      width: 22,
-                      height: 22,
-                      borderRadius: '50%',
-                      flexShrink: 0,
-                    }}
-                  />
-                  <LinkBox
-                    href={`/miners/repository?name=${encodeURIComponent(repo)}`}
-                    sx={{
-                      color: (t) => alpha(t.palette.common.white, 0.9),
-                      fontWeight: 600,
-                      fontSize: '0.9rem',
-                      minWidth: 0,
-                      overflow: 'hidden',
-                      textOverflow: 'ellipsis',
-                      whiteSpace: 'nowrap',
-                      '&:hover': {
-                        textDecoration: 'underline',
-                        color: 'text.primary',
-                      },
-                    }}
-                  >
-                    {repo}
-                  </LinkBox>
-                </Box>
-                <Chip
-                  size="small"
-                  label={`${issues.length} open`}
-                  sx={{
-                    borderColor: alpha(STATUS_COLORS.open, 0.4),
-                    color: STATUS_COLORS.open,
-                    bgcolor: alpha(STATUS_COLORS.open, 0.12),
-                    flexShrink: 0,
-                  }}
-                  variant="outlined"
-                />
-              </Box>
-            </AccordionSummary>
-            <AccordionDetails sx={{ pt: 0, px: 2, pb: 2 }}>
-              <Stack spacing={1.25}>
-                {issues.map((issue) => (
-                  <Box
-                    key={`${repo}-${issue.number}`}
-                    sx={{
-                      display: 'flex',
-                      flexDirection: 'column',
-                      gap: 0.5,
-                      py: 1,
-                      borderTop: '1px solid',
-                      borderColor: 'border.light',
-                      '&:first-of-type': {
-                        borderTop: 'none',
-                        pt: 0,
-                      },
-                    }}
-                  >
-                    <Box
-                      sx={{
-                        display: 'flex',
-                        alignItems: 'flex-start',
-                        justifyContent: 'space-between',
-                        gap: 1,
-                      }}
-                    >
-                      <Link
-                        href={githubIssueUrl(issue)}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        underline="hover"
-                        sx={{
-                          color: 'text.primary',
-                          fontWeight: 500,
-                          fontSize: '0.85rem',
-                          minWidth: 0,
-                        }}
-                      >
-                        <Typography component="span" sx={{ fontWeight: 600 }}>
-                          #{issue.number}
-                        </Typography>{' '}
-                        <Typography component="span" sx={{ fontWeight: 400 }}>
-                          {issue.title}
-                        </Typography>
-                      </Link>
-                      <Link
-                        href={githubIssueUrl(issue)}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        underline="none"
-                        sx={{ display: 'inline-flex', flexShrink: 0 }}
-                        aria-label={`Open issue #${issue.number} on GitHub`}
-                      >
-                        <OpenInNewIcon
-                          sx={{
-                            fontSize: '1rem',
-                            color: (t) =>
-                              alpha(t.palette.common.white, TEXT_OPACITY.faint),
-                          }}
-                        />
-                      </Link>
-                    </Box>
-                    <Box
-                      sx={{
-                        display: 'flex',
-                        flexWrap: 'wrap',
-                        gap: 1,
-                        alignItems: 'center',
-                      }}
-                    >
-                      {issue.prNumber != null ? (
-                        <Link
-                          href={`https://github.com/${issue.repositoryFullName}/pull/${issue.prNumber}`}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          variant="caption"
-                          sx={{ color: 'primary.main' }}
-                        >
-                          PR #{issue.prNumber}
-                        </Link>
-                      ) : (
-                        <Typography variant="caption" color="text.secondary">
-                          No linked PR yet
-                        </Typography>
-                      )}
-                      {issue.createdAt ? (
-                        <Typography variant="caption" color="text.secondary">
-                          Opened{' '}
-                          {new Date(issue.createdAt).toLocaleDateString()}
-                        </Typography>
-                      ) : null}
-                    </Box>
-                  </Box>
-                ))}
-              </Stack>
-            </AccordionDetails>
-          </Accordion>
-        ))}
-      </Stack>
-    );
-  };
+  const mineSectionHasFilters =
+    mineFilter !== 'all' || mineSearch.trim() !== '';
+  const otherSectionHasFilters =
+    otherFilter !== 'all' || otherSearch.trim() !== '';
 
   return (
-    <Stack spacing={2}>
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
       <Alert
         severity="info"
         sx={{
@@ -544,7 +906,7 @@ const MinerOpenDiscoveryIssuesByRepo: React.FC<
           },
         }}
       >
-        Open issues are loaded from Gittensor’s per-repository issue index for
+        Open issues are loaded from Gittensor's per-repository issue index for
         up to {repoFetchLimit} repositories where you have scored PRs (most
         recent first). When the API includes an issue author, issues you opened
         are grouped separately. Use GitHub search for the canonical list of
@@ -553,7 +915,7 @@ const MinerOpenDiscoveryIssuesByRepo: React.FC<
           <Box sx={{ mt: 1.5 }}>
             <Button
               component="a"
-              href={githubSearchOpenByAuthor(login)}
+              href={githubSearchIssuesByAuthor(login)}
               target="_blank"
               rel="noopener noreferrer"
               size="small"
@@ -577,114 +939,203 @@ const MinerOpenDiscoveryIssuesByRepo: React.FC<
 
       {prs.length > repoFetchLimit ? (
         <Typography variant="caption" color="text.secondary">
-          You have PRs in more than {repoFetchLimit} repositories; only the most
-          active {repoFetchLimit} are scanned here to limit load.
+          You have PRs in more than {repoFetchLimit} repositories; only the
+          most active {repoFetchLimit} are scanned here to limit load.
         </Typography>
       ) : null}
 
-      {isError || isAuthoredRepoIssuesError ? (
+      {(isError || isAuthoredRepoIssuesError) && (
         <Alert severity="error" sx={{ borderRadius: 2 }}>
           Some issue lists could not be loaded. Try again later.
         </Alert>
-      ) : null}
+      )}
+      {isAuthorFallbackError && !isDataLoading && (
+        <Alert severity="warning" sx={{ borderRadius: 2 }}>
+          Could not load all authored open issues from GitHub right now.
+          Showing indexed results only.
+        </Alert>
+      )}
 
-      {isLoading ||
-      isLoadingAuthoredIssues ||
-      isFetchingAuthoredIssues ||
-      isLoadingAuthoredRepoIssues ? (
-        <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
-          <CircularProgress size={36} />
-        </Box>
-      ) : (
-        <>
-          {isAuthorFallbackError ? (
-            <Alert severity="warning" sx={{ borderRadius: 2 }}>
-              Could not load all authored open issues from GitHub right now.
-              Showing indexed results only.
-            </Alert>
-          ) : null}
-          <Card
-            elevation={0}
-            sx={{
-              borderRadius: 3,
-              border: '1px solid',
-              borderColor: 'border.light',
-              p: 2.5,
-            }}
-          >
-            <Typography variant="h6" sx={{ fontSize: '1.05rem', mb: 1 }}>
-              Your open discovery issues
-              {mineTotal > 0 ? (
-                <Typography
-                  component="span"
-                  sx={{ ml: 1, color: 'text.secondary', fontSize: '0.85rem' }}
-                >
-                  ({mineTotal})
+      {/* Your open discovery issues */}
+      <Card
+        sx={{ p: 0, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}
+        elevation={0}
+      >
+        <DataTable<RepositoryIssue, IssueSortField>
+          columns={mineColumns}
+          rows={pagedMine}
+          getRowKey={(issue) => `${issue.repositoryFullName}-${issue.number}`}
+          isLoading={isDataLoading}
+          minWidth="700px"
+          stickyHeader
+          size="medium"
+          header={renderToolbar(
+            'Your open discovery issues',
+            mineIssues,
+            filteredMine.length,
+            mineCounts,
+            mineFilter,
+            (f) => { setMineFilter(f); setMinePage(0); },
+            mineSearch,
+            (s) => { setMineSearch(s); setMinePage(0); },
+            mineSectionHasFilters,
+            'Open issues authored by you in the scanned repositories (discovery index plus GitHub fallback). Use this list to track your own active reports.',
+          )}
+          emptyState={
+            <Box sx={{ px: 3, py: mineIssues.length === 0 ? 2.5 : 6 }}>
+              {mineIssues.length === 0 ? (
+                <Typography color="text.secondary">
+                  No open issues in this index matched your GitHub login as
+                  author. That usually means the API response does not yet
+                  include author fields, or you have no open reports in these
+                  repositories. Use the GitHub button above for a definitive
+                  list.
                 </Typography>
-              ) : null}
-            </Typography>
-            <Typography variant="body2" color="text.secondary" sx={{ mb: 1.5 }}>
-              Open issues authored by you in the scanned repositories (discovery
-              index plus GitHub fallback). Use this list to track your own
-              active reports.
-            </Typography>
-            {mineTotal === 0 ? (
-              <Typography color="text.secondary" sx={{ mb: 1.5 }}>
-                No open issues in this index matched your GitHub login as
-                author. That usually means the API response does not yet include
-                author fields, or you have no open reports in these
-                repositories. Use the GitHub button above for a definitive list.
-              </Typography>
-            ) : null}
-            {renderRepoAccordionMap(
-              mineByRepo,
-              'No matching open issues in the scanned repositories.',
-            )}
-          </Card>
+              ) : (
+                <Typography
+                  sx={{
+                    color: (t) => alpha(t.palette.text.primary, 0.5),
+                    fontSize: '0.9rem',
+                    textAlign: 'center',
+                  }}
+                >
+                  No matching open issues in the scanned repositories.
+                </Typography>
+              )}
+            </Box>
+          }
+          onRowClick={handleRowClick}
+          sort={{
+            field: mineSortField,
+            order: mineSortDir,
+            onChange: handleMineSort,
+          }}
+          pagination={
+            <TablePagination
+              page={minePage}
+              totalPages={mineTotalPages}
+              onPageChange={setMinePage}
+            />
+          }
+        />
+      </Card>
 
-          <Card
-            elevation={0}
-            sx={{
-              borderRadius: 3,
-              border: '1px solid',
-              borderColor: 'border.light',
-              p: 2.5,
-            }}
-          >
-            <Box
+      {/* Other open discovery issues — collapsed by default */}
+      <Card
+        sx={{ p: 0, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}
+        elevation={0}
+      >
+        <Box
+          role="button"
+          tabIndex={0}
+          onClick={() => setOtherExpanded((v) => !v)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault();
+              setOtherExpanded((v) => !v);
+            }
+          }}
+          sx={{
+            p: { xs: 2, sm: 3 },
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            cursor: 'pointer',
+            userSelect: 'none',
+            borderBottom: otherExpanded ? '1px solid' : 'none',
+            borderColor: 'border.light',
+            '&:hover': {
+              bgcolor: (t) => alpha(t.palette.common.white, 0.03),
+            },
+          }}
+        >
+          <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 1.5 }}>
+            <Typography
+              variant="h6"
               sx={{
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'space-between',
-                gap: 1,
-                flexWrap: 'wrap',
-                mb: 1,
+                color: 'text.primary',
+                fontSize: { xs: '0.95rem', sm: '1.1rem' },
+                fontWeight: 500,
               }}
             >
-              <Typography variant="h6" sx={{ fontSize: '1.05rem' }}>
-                Other open discovery issues
-                {otherTotal > 0 ? (
-                  <Typography
-                    component="span"
-                    sx={{ ml: 1, color: 'text.secondary', fontSize: '0.85rem' }}
-                  >
-                    ({otherTotal})
-                  </Typography>
-                ) : null}
-              </Typography>
-            </Box>
-            <Typography variant="body2" color="text.secondary" sx={{ mb: 1.5 }}>
-              Other people’s open issues in the same repositories (still part of
-              the discovery index). Useful for triage and collaboration.
+              Other open discovery issues
             </Typography>
-            {renderRepoAccordionMap(
-              otherByRepo,
-              'No other open issues in the scanned repositories.',
+            <Typography
+              sx={{
+                color: (t) => alpha(t.palette.text.primary, 0.5),
+                fontSize: '0.75rem',
+              }}
+            >
+              ({otherIssues.length})
+            </Typography>
+          </Box>
+          <ExpandMoreIcon
+            sx={{
+              color: 'text.secondary',
+              transition: 'transform 0.2s',
+              transform: otherExpanded ? 'rotate(180deg)' : 'rotate(0deg)',
+            }}
+          />
+        </Box>
+
+        <Collapse in={otherExpanded}>
+          <DataTable<RepositoryIssue, IssueSortField>
+            columns={otherColumns}
+            rows={pagedOther}
+            getRowKey={(issue) =>
+              `other-${issue.repositoryFullName}-${issue.number}`
+            }
+            isLoading={isDataLoading}
+            minWidth="700px"
+            size="medium"
+            header={renderToolbar(
+              null,
+              otherIssues,
+              filteredOther.length,
+              otherCounts,
+              otherFilter,
+              (f) => { setOtherFilter(f); setOtherPage(0); },
+              otherSearch,
+              (s) => { setOtherSearch(s); setOtherPage(0); },
+              otherSectionHasFilters,
+              "Other people's open issues in the same repositories (still part of the discovery index). Useful for triage and collaboration.",
             )}
-          </Card>
-        </>
-      )}
-    </Stack>
+            emptyState={
+              <Box sx={{ px: 3, py: otherIssues.length === 0 ? 2.5 : 6 }}>
+                {otherIssues.length === 0 ? (
+                  <Typography color="text.secondary">
+                    No other open issues in the scanned repositories.
+                  </Typography>
+                ) : (
+                  <Typography
+                    sx={{
+                      color: (t) => alpha(t.palette.text.primary, 0.5),
+                      fontSize: '0.9rem',
+                      textAlign: 'center',
+                    }}
+                  >
+                    No issues match the selected filters.
+                  </Typography>
+                )}
+              </Box>
+            }
+            onRowClick={handleRowClick}
+            sort={{
+              field: otherSortField,
+              order: otherSortDir,
+              onChange: handleOtherSort,
+            }}
+            pagination={
+              <TablePagination
+                page={otherPage}
+                totalPages={otherTotalPages}
+                onPageChange={setOtherPage}
+              />
+            }
+          />
+        </Collapse>
+      </Card>
+    </Box>
   );
 };
 


### PR DESCRIPTION
## Closes: #804

## Summary

Rewrites `MinerOpenDiscoveryIssuesByRepo` from an accordion-per-repository layout into a table-style view consistent with the OSS Contributions pull requests overview.

### Changes

**Layout & structure**
- Replaced accordion groups with two `DataTable` cards — "Your open discovery issues" and "Other open discovery issues"
- "Other open discovery issues" is collapsed by default; clicking the header expands it
- Retained the original amber info `Alert` at the top with the "View all open issues on GitHub" button

**Filtering & search**
- Added `All / Open / Solved / Closed` status filter buttons (matching the PR table's `All / Open / Merged / Closed`)
  - **Open** — issue has no `closedAt`
  - **Solved** — issue is closed and has a linked PR (contributor fixed it)
  - **Closed** — issue is closed without a linked PR (rejected, duplicate, etc.)
- Added a search bar filtering by title, repository, or issue number
- Both sections have independent filter/search/sort/page state
- Removed the `is:open` constraint from the GitHub author search so closed issues are included

**Table columns**
- "Your issues" table: `Issue #` · `Title` · `Repository` · `Linked PR` · `Opened`
- "Other issues" table: same columns + `Author` (avatar + `@login`) inserted before `Linked PR`

**UX polish**
- `Linked PR` shown as a green chip (clickable → opens PR); "No PR yet" shown as an amber chip
- `Opened` column uses relative time ("3 days ago") with full date on hover
- Filter buttons always right-aligned regardless of whether a section title is present
- Subtitles and all original empty-state / warning messages preserved verbatim

**Pagination & sorting**
- 20 rows per page using the shared `TablePagination` component
- Sortable columns: `Issue #`, `Repository`, `Opened`

## Test plan

- [ ] "Your open discovery issues" table loads and shows correct issues for a miner with PR history
- [ ] "Other open discovery issues" expands on click and loads other authors' issues
- [ ] `All / Open / Solved / Closed` filter buttons update counts and rows correctly
- [ ] Search filters rows across title, repo name, and issue number
- [ ] Clicking a row opens the GitHub issue in a new tab
- [ ] Clicking a `PR #N` chip opens the linked PR in a new tab without also navigating to the issue
- [ ] `Author` column appears only in the "Other issues" table
- [ ] Relative dates show in the `Opened` column; hovering reveals the full date
- [ ] Pagination appears when there are more than 20 rows
- [ ] Original info alert and all empty-state messages display correctly when data is absent

## Screenshots

Before: 

https://github.com/user-attachments/assets/d3ba5c8d-442d-4696-b6c7-8ef531d9e601

After:

https://github.com/user-attachments/assets/9e65add6-5f61-4171-939f-072be8b99eb3

