### PR TITLE
ix(table): visible focus ring + right-aligned sort header parity

### DIFF
--- a/src/components/common/DataTable.tsx
+++ b/src/components/common/DataTable.tsx
@@ -100,6 +100,39 @@ const containerSx: SxProps<Theme> = {
   ...scrollbarSx,
 };
 
+/**
+ * sx for a sortable column's `TableSortLabel`. Two concerns rolled up:
+ *
+ *   1. **Right-aligned columns** — MUI puts the sort arrow to the right
+ *      of the label, which pushes the text away from the right edge so
+ *      the header no longer lines up with right-aligned numeric values
+ *      in the body. Flipping to `row-reverse` keeps the text flush right
+ *      and parks the icon on the inside.
+ *   2. **Keyboard focus visibility** — MUI's default focus outline is
+ *      the user-agent ring, which disappears against the dark
+ *      `surface.tooltip` header background. Scope an explicit
+ *      `:focus-visible` ring to the interactive label only (not the
+ *      whole `TableCell`).
+ */
+export function getSortLabelSx(
+  align: TableCellProps['align'],
+): SystemStyleObject<Theme> {
+  const focusRing = {
+    '&:focus-visible': {
+      outline: '2px solid',
+      outlineColor: 'primary.main',
+      outlineOffset: 2,
+      borderRadius: 1,
+    },
+  } as const;
+  if (align !== 'right') return focusRing;
+  return {
+    ...focusRing,
+    flexDirection: 'row-reverse',
+    '& .MuiTableSortLabel-icon': { ml: 0, mr: 0.5 },
+  };
+}
+
 const tableSx = {
   tableLayout: 'fixed',
   width: '100%',
@@ -198,6 +231,7 @@ export const DataTable = <T, SortKey extends string = never>({
                             active={isActive}
                             direction={isActive ? sort.order : 'desc'}
                             onClick={() => sort.onChange(sortKey)}
+                            sx={getSortLabelSx(column.align)}
                           >
                             {column.header}
                           </TableSortLabel>

--- a/src/tests/DataTable.test.ts
+++ b/src/tests/DataTable.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { getSortLabelSx } from '../components/common/DataTable';
+
+describe('getSortLabelSx', () => {
+  it('always exposes a visible :focus-visible ring on the sort label', () => {
+    for (const align of [
+      'left',
+      'right',
+      'center',
+      'inherit',
+      'justify',
+      undefined,
+    ] as const) {
+      const sx = getSortLabelSx(align);
+      const focus = (sx as Record<string, unknown>)['&:focus-visible'] as
+        | Record<string, unknown>
+        | undefined;
+      expect(focus).toBeDefined();
+      expect(focus?.outline).toBe('2px solid');
+      expect(focus?.outlineColor).toBe('primary.main');
+    }
+  });
+
+  it('does NOT reverse layout for left / center / default-align columns', () => {
+    for (const align of [
+      'left',
+      'center',
+      'inherit',
+      'justify',
+      undefined,
+    ] as const) {
+      const sx = getSortLabelSx(align) as Record<string, unknown>;
+      expect(sx.flexDirection).toBeUndefined();
+      expect(sx['& .MuiTableSortLabel-icon']).toBeUndefined();
+    }
+  });
+
+  it('reverses flex direction for right-aligned columns so text stays flush right', () => {
+    const sx = getSortLabelSx('right') as Record<string, unknown>;
+    expect(sx.flexDirection).toBe('row-reverse');
+    const iconSx = sx['& .MuiTableSortLabel-icon'] as Record<string, unknown>;
+    expect(iconSx).toBeDefined();
+    expect(iconSx.ml).toBe(0);
+    expect(iconSx.mr).toBe(0.5);
+  });
+});


### PR DESCRIPTION
```
## Summary

Closes #372.

Two related a11y / visual issues on the shared `DataTable`'s
sortable column headers:

1. **Focus ring invisibility.** MUI's `TableSortLabel` falls back to
   the user-agent focus outline, which is effectively invisible against
   the theme's dark `surface.tooltip` header background. Keyboard users
   tabbing through column headers couldn't tell which one was focused.

2. **Right-aligned column misalignment.** With the sort arrow rendered
   to the right of the label text, right-aligned headers (Weight, Total
   Score, PRs, Contributors, etc.) sit one icon-width away from the
   right edge — visibly out of line with the right-aligned numeric
   values in the body.

The third bullet of the original issue (missing `aria-sort` semantics)
was already addressed inline in `DataTable.tsx` — the existing
`isSortable` ternary emits `aria-sort="ascending" | "descending" |
"none"` per WAI-ARIA 1.2. No further change needed there.

## How it works

Adds `getSortLabelSx(align)` next to the existing `containerSx` and
`tableSx` constants. It returns:

- a scoped `:focus-visible` outline (2px `primary.main`, offset 2px,
  `borderRadius: 1`) on every sort label, so the focus indicator never
  disappears against the header background; and
- `flexDirection: row-reverse` plus icon-margin overrides for
  `align: 'right'` columns only, so the label text stays flush right
  and the arrow tucks inside the cell.

The single sortable-cell render path in `DataTable.tsx` then passes
`getSortLabelSx(column.align)` as `sx` on `TableSortLabel`. All
existing tables (`TopRepositoriesTable`, `TopMinersTable`,
`LanguageWeightsTable`, etc.) inherit the fix automatically because
they all consume the shared `DataTable`.

## How it was tested

- New unit tests in `src/tests/DataTable.test.ts` cover all six
  `align` values (`left`, `right`, `center`, `inherit`, `justify`,
  `undefined`) and assert that:
  - the `:focus-visible` ring is always emitted (3 properties checked)
  - `flexDirection: row-reverse` is exclusive to `align: 'right'`
  - the right-aligned variant emits the icon-margin override
- `npm run test` — 62 / 62 pass (3 new in `DataTable.test.ts`).
- `npm run build` — clean tsc + Vite production build.
- `npm run lint` — clean under `--max-warnings 0`.

## Notes

- No new dependencies.
- No public API change — `getSortLabelSx` is exported alongside
  `DataTable` for unit-testability; the production wiring is a single
  `sx={getSortLabelSx(column.align)}` prop on the existing
  `TableSortLabel`.
- All other tables on the site (`TopMiners`, `LanguageWeights`,
  `TopRepositories`, search results, etc.) automatically benefit.

Closes #372
```