### PR TITLE
fix: repositories table header interactions and label truncation

### DIFF
--- a/src/components/leaderboard/TopRepositoriesTable.tsx
+++ b/src/components/leaderboard/TopRepositoriesTable.tsx
@@ -702,7 +702,7 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
         startAdornment: searchAdornment,
       }}
       sx={{
-        width: '200px',
+        width: '300px',
         ...(isMobileSearchVisible
           ? {
               flexBasis: { xs: '100%', sm: 'auto' },
@@ -714,46 +714,16 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
     />
   );
 
-  // Custom sort header to preserve the original unicode arrow look and
-  // cell-wide click + hover (MUI's TableSortLabel differs visually). The
-  // Box takes on the cell's padding so clicks anywhere inside the cell hit.
-  const renderSortHeader = (
-    column: SortColumn,
-    label: string,
-    align: 'left' | 'right' = 'left',
-  ) => (
-    <Box
-      onClick={() => handleSort(column)}
-      sx={{
-        display: 'flex',
-        alignItems: 'center',
-        gap: 0.5,
-        cursor: 'pointer',
-        userSelect: 'none',
-        width: '100%',
-        height: '100%',
-        px: 2,
-        py: 1,
-        justifyContent: align === 'right' ? 'flex-end' : 'flex-start',
-      }}
-    >
-      {label}
-      {sortColumn === column && (
-        <Typography component="span" sx={{ fontSize: '0.7rem', opacity: 0.7 }}>
-          {sortDirection === 'asc' ? '▲' : '▼'}
-        </Typography>
-      )}
-    </Box>
-  );
-
-  const sortableHeaderSx = {
-    padding: 0,
-    cursor: 'pointer',
-    userSelect: 'none' as const,
-    '&:hover': {
-      backgroundColor: 'surface.light',
+  const compactSortableHeaderSx = {
+    whiteSpace: 'nowrap',
+    '& .MuiTableSortLabel-root': {
+      whiteSpace: 'nowrap',
+      maxWidth: '100%',
     },
-  };
+    '& .MuiTableSortLabel-icon': {
+      ml: 0.25,
+    },
+  } as const;
 
   const listColumns: DataTableColumn<RepoStats, SortColumn>[] = [
     {
@@ -765,9 +735,10 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
     },
     {
       key: 'repository',
-      header: renderSortHeader('repository', 'Repository'),
+      header: 'Repository',
       width: '30%',
-      headerSx: sortableHeaderSx,
+      sortKey: 'repository',
+      headerSx: compactSortableHeaderSx,
       cellSx: { pl: 1.5 },
       renderCell: (repo) => (
         <Box
@@ -819,10 +790,11 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
     },
     {
       key: 'weight',
-      header: renderSortHeader('weight', 'Weight', 'right'),
+      header: 'Weight',
       width: '10%',
       align: 'right',
-      headerSx: sortableHeaderSx,
+      sortKey: 'weight',
+      headerSx: compactSortableHeaderSx,
       renderCell: (repo) => (
         <Typography
           sx={{
@@ -837,10 +809,11 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
     },
     {
       key: 'totalScore',
-      header: renderSortHeader('totalScore', 'OSS score', 'right'),
+      header: 'OSS score',
       width: '11%',
       align: 'right',
-      headerSx: sortableHeaderSx,
+      sortKey: 'totalScore',
+      headerSx: compactSortableHeaderSx,
       renderCell: (repo) => {
         const active = repoHasOssActivity(repo);
         const v = repo.totalScore ?? 0;
@@ -859,10 +832,11 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
     },
     {
       key: 'totalPRs',
-      header: renderSortHeader('totalPRs', 'PRs', 'right'),
+      header: 'PRs',
       width: '7%',
       align: 'right',
-      headerSx: sortableHeaderSx,
+      sortKey: 'totalPRs',
+      headerSx: compactSortableHeaderSx,
       renderCell: (repo) => {
         const active = repoHasOssActivity(repo);
         const n = repo.totalPRs ?? 0;
@@ -880,10 +854,11 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
     },
     {
       key: 'discoveryScore',
-      header: renderSortHeader('discoveryScore', 'Issue score', 'right'),
+      header: 'Issue score',
       width: '10%',
       align: 'right',
-      headerSx: sortableHeaderSx,
+      sortKey: 'discoveryScore',
+      headerSx: compactSortableHeaderSx,
       renderCell: (repo) => {
         const active = repoHasDiscoveryActivity(repo);
         const v = repo.discoveryScore ?? 0;
@@ -902,10 +877,11 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
     },
     {
       key: 'discoveryIssues',
-      header: renderSortHeader('discoveryIssues', 'Issues', 'right'),
+      header: 'Issues',
       width: '7%',
       align: 'right',
-      headerSx: sortableHeaderSx,
+      sortKey: 'discoveryIssues',
+      headerSx: compactSortableHeaderSx,
       renderCell: (repo) => {
         const active = repoHasDiscoveryActivity(repo);
         const n = repo.discoveryIssues ?? 0;
@@ -923,10 +899,11 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
     },
     {
       key: 'contributors',
-      header: renderSortHeader('contributors', 'Contributors', 'right'),
+      header: 'Contributors',
       width: '9%',
       align: 'right',
-      headerSx: sortableHeaderSx,
+      sortKey: 'contributors',
+      headerSx: compactSortableHeaderSx,
       renderCell: (repo) => {
         const active = repoHasOssActivity(repo);
         const n = repo.uniqueMiners?.size ?? 0;
@@ -944,14 +921,11 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
     },
     {
       key: 'discoveryContributors',
-      header: renderSortHeader(
-        'discoveryContributors',
-        'Issue contrib.',
-        'right',
-      ),
-      width: '9%',
+      header: 'Issue contrib',
+      width: '10%',
       align: 'right',
-      headerSx: sortableHeaderSx,
+      sortKey: 'discoveryContributors',
+      headerSx: compactSortableHeaderSx,
       renderCell: (repo) => {
         const active = repoHasDiscoveryActivity(repo);
         const n = repo.discoveryContributors?.size ?? 0;
@@ -1398,6 +1372,11 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
             })}
             minWidth="1280px"
             stickyHeader
+            sort={{
+              field: sortColumn,
+              order: sortDirection,
+              onChange: handleSort,
+            }}
             emptyState={
               !filteredRepositories.length &&
               trimmedSearch &&

--- a/src/pages/RepositoriesPage.tsx
+++ b/src/pages/RepositoriesPage.tsx
@@ -340,7 +340,7 @@ const RepositoriesPage: React.FC = () => {
       <Box
         sx={{
           width: '100%',
-          maxWidth: 1200,
+          maxWidth: 1440,
           mx: 'auto',
           py: { xs: 2, sm: 3 },
           px: { xs: 2, sm: 3 },


### PR DESCRIPTION
## Summary

Aligns **Repositories** list-table header behavior with the shared leaderboard table pattern used by **OSS Contributions** and **Discoveries**. This fixes inconsistencies in hover states, sort chevron style, and header interaction area, and addresses truncation issues by widening layout/input space and stabilizing header labels.

## Related issue docs

Closes #816 

## Type of change

- [x] Bug fix (UI consistency)
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Screenshots

### Before
https://github.com/user-attachments/assets/131d6e23-ef69-4a0d-ab05-e55577ba669c

### After
https://github.com/user-attachments/assets/045085e5-8aeb-4689-9c01-01917781b14c




## Check list

- [ ] Compare Repositories list vs OSS/Discoveries list headers side-by-side
- [x] Verify hover color and full clickable region are visually consistent
- [x] Verify sort indicator matches shape/style used in peer list tables
- [x] Verify `Issue score` and `Contributors` do not wrap into broken two-line headers on target breakpoints
- [x] Verify `Issue contrib` text has no trailing dot
- [x] Verify search placeholder is less likely to truncate
- [x] Run lint/build after implementation

