### PR TITLE
fix(miner-discovery): collapse duplicate empty-state on Your Open Issues card

### DIFF
--- a/src/components/miners/MinerOpenDiscoveryIssuesByRepo.tsx
+++ b/src/components/miners/MinerOpenDiscoveryIssuesByRepo.tsx
@@ -635,10 +635,11 @@ const MinerOpenDiscoveryIssuesByRepo: React.FC<
                 author fields, or you have no open reports in these
                 repositories. Use the GitHub button above for a definitive list.
               </Typography>
-            ) : null}
-            {renderRepoAccordionMap(
-              mineByRepo,
-              'No matching open issues in the scanned repositories.',
+            ) : (
+              renderRepoAccordionMap(
+                mineByRepo,
+                'No matching open issues in the scanned repositories.',
+              )
             )}
           </Card>
 


### PR DESCRIPTION
```
## Summary

When a miner has no authored open issues in the scanned repositories
(`mineTotal === 0`), the "Your open discovery issues" card on
`MinerOpenDiscoveryIssuesByRepo` renders TWO stacked empty-state
messages that say substantially the same thing:

1. The detailed explanatory Typography at line 631-638:
   *"No open issues in this index matched your GitHub login as
   author. That usually means the API response does not yet include
   author fields, or you have no open reports in these
   repositories. Use the GitHub button above for a definitive list."*

2. Immediately below, the generic accordion empty-state from
   `renderRepoAccordionMap`:
   *"No matching open issues in the scanned repositories."*

Both are visible at the same time because the conditional is
`mineTotal === 0 ? <typography> : null` followed by an
**unconditional** `renderRepoAccordionMap(...)` call.

## Fix

Switch from a `? null` plus unconditional render to a single ternary:
show the detailed Typography on empty, show the populated accordion
otherwise. Five-line diff in
`src/components/miners/MinerOpenDiscoveryIssuesByRepo.tsx`.

```tsx
{mineTotal === 0 ? (
  <Typography color="text.secondary" sx={{ mb: 1.5 }}>
    No open issues in this index matched your GitHub login as
    author. ...
  </Typography>
) : (
  renderRepoAccordionMap(
    mineByRepo,
    'No matching open issues in the scanned repositories.',
  )
)}
```