### PR TITLE
feat(dashboard): dynamic Featured Work — recency decay + category-distinct cards

### DIFF
--- a/src/pages/dashboard/dashboardData.ts
+++ b/src/pages/dashboard/dashboardData.ts
@@ -754,9 +754,21 @@ export const buildFeaturedWork = (
   issues: IssueBounty[],
 ): DashboardFeaturedWork[] => {
   const currentWindow = getWindowBounds(CURRENT_LOOKBACK_WINDOW);
-  const now = currentWindow.endMs;
-  const recentWindow: WindowBounds = { startMs: now - 7 * DAY_MS, endMs: now };
-  const mediumWindow: WindowBounds = { startMs: now - 14 * DAY_MS, endMs: now };
+  // Age decay: value halves every HALF_LIFE_DAYS so older items yield to
+  // fresher work without hard cutoffs that degrade quality.
+  const HALF_LIFE_DAYS = 7;
+  const prRecencyFactor = (pr: CommitLog): number => {
+    const ts = toTimestamp(pr.mergedAt ?? pr.prCreatedAt);
+    if (ts === null) return 0.5;
+    const ageDays = (currentWindow.endMs - ts) / DAY_MS;
+    return 1 / (1 + ageDays / HALF_LIFE_DAYS);
+  };
+  const issueRecencyFactor = (issue: IssueBounty): number => {
+    const ts = toTimestamp(issue.completedAt ?? issue.createdAt);
+    if (ts === null) return 0.5;
+    const ageDays = (currentWindow.endMs - ts) / DAY_MS;
+    return 1 / (1 + ageDays / HALF_LIFE_DAYS);
+  };
   const selectedRepos = new Set<string>();
   const selectedOrgs = new Set<string>();
   const selectedAuthors = new Set<string>();
@@ -886,30 +898,11 @@ export const buildFeaturedWork = (
     featuredLabel: string,
     sortFn: (a: CommitLog, b: CommitLog) => number,
   ) => {
-    const mergedRecent = mergedPrs
-      .filter((pr) =>
-        isWithinWindow(
-          toTimestamp(pr.mergedAt ?? pr.prCreatedAt),
-          recentWindow,
-        ),
-      )
-      .sort(sortFn);
-    const mergedMedium = mergedPrs
-      .filter((pr) =>
-        isWithinWindow(
-          toTimestamp(pr.mergedAt ?? pr.prCreatedAt),
-          mediumWindow,
-        ),
-      )
-      .sort(sortFn);
     const mergedSorted = [...mergedPrs].sort(sortFn);
-    const allRecent = allWindowPrs
-      .filter((pr) => isWithinWindow(toTimestamp(pr.prCreatedAt), recentWindow))
-      .sort(sortFn);
     const allSorted = [...allWindowPrs].sort(sortFn);
     const candidate =
       pickFirstDiverse(
-        [mergedRecent, mergedMedium, mergedSorted, allRecent, allSorted],
+        [mergedSorted, allSorted],
         (pr) => pr.repository,
         (pr) => pr.author || 'unknown',
       ) ??
@@ -920,14 +913,10 @@ export const buildFeaturedWork = (
     return toPrCard(candidate, featuredLabel);
   };
 
-  const issueSortFn = (a: IssueBounty, b: IssueBounty) => {
-    const bountyDiff = getIssueDisplayAmount(b) - getIssueDisplayAmount(a);
-    if (bountyDiff !== 0) return bountyDiff;
-    return (
-      (toTimestamp(b.completedAt ?? b.createdAt) ?? 0) -
-      (toTimestamp(a.completedAt ?? a.createdAt) ?? 0)
-    );
-  };
+  const issueSortFn = (a: IssueBounty, b: IssueBounty) =>
+    getIssueDisplayAmount(b) * issueRecencyFactor(b) -
+    getIssueDisplayAmount(a) * issueRecencyFactor(a);
+
   const rankedHighestBountyIssues = [...issues]
     .filter((issue) =>
       isWithinWindow(
@@ -936,27 +925,7 @@ export const buildFeaturedWork = (
       ),
     )
     .sort(issueSortFn);
-  const rankedHighestBountyIssuesRecent = rankedHighestBountyIssues.filter(
-    (issue) =>
-      isWithinWindow(
-        toTimestamp(issue.completedAt ?? issue.createdAt),
-        recentWindow,
-      ),
-  );
-  const rankedHighestBountyIssuesMedium = rankedHighestBountyIssues.filter(
-    (issue) =>
-      isWithinWindow(
-        toTimestamp(issue.completedAt ?? issue.createdAt),
-        mediumWindow,
-      ),
-  );
   const rankedCompletedIssues = rankedHighestBountyIssues.filter(
-    (issue) => issue.status === 'completed',
-  );
-  const rankedCompletedIssuesRecent = rankedHighestBountyIssuesRecent.filter(
-    (issue) => issue.status === 'completed',
-  );
-  const rankedCompletedIssuesMedium = rankedHighestBountyIssuesMedium.filter(
     (issue) => issue.status === 'completed',
   );
 
@@ -994,15 +963,10 @@ export const buildFeaturedWork = (
     };
   };
 
-  const pickIssue = (
-    featuredLabel: string,
-    pool: IssueBounty[],
-    recentPool: IssueBounty[],
-    mediumPool: IssueBounty[],
-  ) => {
+  const pickIssue = (featuredLabel: string, pool: IssueBounty[]) => {
     const candidate =
       pickFirstDiverse(
-        [recentPool, mediumPool, pool, fallbackIssuePool],
+        [pool, fallbackIssuePool],
         (issue) => issue.repositoryFullName,
         (issue) => issue.authorLogin || 'open bounty',
       ) ??
@@ -1018,21 +982,25 @@ export const buildFeaturedWork = (
 
   const picks: Array<DashboardFeaturedWork | undefined> = [
     pickPr('Top PR by Score', (a, b) => {
-      const scoreDiff = parseNumber(b.score) - parseNumber(a.score);
-      if (scoreDiff !== 0) return scoreDiff;
-      return (toTimestamp(b.mergedAt) ?? 0) - (toTimestamp(a.mergedAt) ?? 0);
+      return (
+        parseNumber(b.score) * prRecencyFactor(b) -
+        parseNumber(a.score) * prRecencyFactor(a)
+      );
     }),
     pickPr('Largest PR', (a, b) => {
-      const aChanges = parseNumber(a.additions) + parseNumber(a.deletions);
-      const bChanges = parseNumber(b.additions) + parseNumber(b.deletions);
-      if (bChanges !== aChanges) return bChanges - aChanges;
-      return parseNumber(b.score) - parseNumber(a.score);
+      const aChanges =
+        (parseNumber(a.additions) + parseNumber(a.deletions)) *
+        prRecencyFactor(a);
+      const bChanges =
+        (parseNumber(b.additions) + parseNumber(b.deletions)) *
+        prRecencyFactor(b);
+      return bChanges - aChanges;
     }),
     pickPr('Most Commits PR', (a, b) => {
-      const commitDiff =
-        parseNumber(b.commitCount) - parseNumber(a.commitCount);
-      if (commitDiff !== 0) return commitDiff;
-      return parseNumber(b.score) - parseNumber(a.score);
+      return (
+        parseNumber(b.commitCount) * prRecencyFactor(b) -
+        parseNumber(a.commitCount) * prRecencyFactor(a)
+      );
     }),
     pickPr('Newest Merged PR', (a, b) => {
       const dateDiff =
@@ -1040,18 +1008,8 @@ export const buildFeaturedWork = (
       if (dateDiff !== 0) return dateDiff;
       return parseNumber(b.score) - parseNumber(a.score);
     }),
-    pickIssue(
-      'Top Completed Issue',
-      rankedCompletedIssues,
-      rankedCompletedIssuesRecent,
-      rankedCompletedIssuesMedium,
-    ),
-    pickIssue(
-      'Highest Bounty Issue',
-      rankedHighestBountyIssues,
-      rankedHighestBountyIssuesRecent,
-      rankedHighestBountyIssuesMedium,
-    ),
+    pickIssue('Top Completed Issue', rankedCompletedIssues),
+    pickIssue('Highest Bounty Issue', rankedHighestBountyIssues),
   ];
 
   return picks.filter((entry): entry is DashboardFeaturedWork =>

--- a/src/pages/dashboard/dashboardData.ts
+++ b/src/pages/dashboard/dashboardData.ts
@@ -754,6 +754,9 @@ export const buildFeaturedWork = (
   issues: IssueBounty[],
 ): DashboardFeaturedWork[] => {
   const currentWindow = getWindowBounds(CURRENT_LOOKBACK_WINDOW);
+  const now = currentWindow.endMs;
+  const recentWindow: WindowBounds = { startMs: now - 7 * DAY_MS, endMs: now };
+  const mediumWindow: WindowBounds = { startMs: now - 14 * DAY_MS, endMs: now };
   const selectedRepos = new Set<string>();
   const selectedOrgs = new Set<string>();
   const selectedAuthors = new Set<string>();
@@ -883,11 +886,32 @@ export const buildFeaturedWork = (
     featuredLabel: string,
     sortFn: (a: CommitLog, b: CommitLog) => number,
   ) => {
+    const mergedRecent = mergedPrs
+      .filter((pr) =>
+        isWithinWindow(
+          toTimestamp(pr.mergedAt ?? pr.prCreatedAt),
+          recentWindow,
+        ),
+      )
+      .sort(sortFn);
+    const mergedMedium = mergedPrs
+      .filter((pr) =>
+        isWithinWindow(
+          toTimestamp(pr.mergedAt ?? pr.prCreatedAt),
+          mediumWindow,
+        ),
+      )
+      .sort(sortFn);
     const mergedSorted = [...mergedPrs].sort(sortFn);
+    const allRecent = allWindowPrs
+      .filter((pr) =>
+        isWithinWindow(toTimestamp(pr.prCreatedAt), recentWindow),
+      )
+      .sort(sortFn);
     const allSorted = [...allWindowPrs].sort(sortFn);
     const candidate =
       pickFirstDiverse(
-        [mergedSorted, allSorted],
+        [mergedRecent, mergedMedium, mergedSorted, allRecent, allSorted],
         (pr) => pr.repository,
         (pr) => pr.author || 'unknown',
       ) ??
@@ -898,6 +922,14 @@ export const buildFeaturedWork = (
     return toPrCard(candidate, featuredLabel);
   };
 
+  const issueSortFn = (a: IssueBounty, b: IssueBounty) => {
+    const bountyDiff = getIssueDisplayAmount(b) - getIssueDisplayAmount(a);
+    if (bountyDiff !== 0) return bountyDiff;
+    return (
+      (toTimestamp(b.completedAt ?? b.createdAt) ?? 0) -
+      (toTimestamp(a.completedAt ?? a.createdAt) ?? 0)
+    );
+  };
   const rankedHighestBountyIssues = [...issues]
     .filter((issue) =>
       isWithinWindow(
@@ -905,15 +937,28 @@ export const buildFeaturedWork = (
         currentWindow,
       ),
     )
-    .sort((a, b) => {
-      const bountyDiff = getIssueDisplayAmount(b) - getIssueDisplayAmount(a);
-      if (bountyDiff !== 0) return bountyDiff;
-      return (
-        (toTimestamp(b.completedAt ?? b.createdAt) ?? 0) -
-        (toTimestamp(a.completedAt ?? a.createdAt) ?? 0)
-      );
-    });
+    .sort(issueSortFn);
+  const rankedHighestBountyIssuesRecent = rankedHighestBountyIssues.filter(
+    (issue) =>
+      isWithinWindow(
+        toTimestamp(issue.completedAt ?? issue.createdAt),
+        recentWindow,
+      ),
+  );
+  const rankedHighestBountyIssuesMedium = rankedHighestBountyIssues.filter(
+    (issue) =>
+      isWithinWindow(
+        toTimestamp(issue.completedAt ?? issue.createdAt),
+        mediumWindow,
+      ),
+  );
   const rankedCompletedIssues = rankedHighestBountyIssues.filter(
+    (issue) => issue.status === 'completed',
+  );
+  const rankedCompletedIssuesRecent = rankedHighestBountyIssuesRecent.filter(
+    (issue) => issue.status === 'completed',
+  );
+  const rankedCompletedIssuesMedium = rankedHighestBountyIssuesMedium.filter(
     (issue) => issue.status === 'completed',
   );
 
@@ -951,10 +996,15 @@ export const buildFeaturedWork = (
     };
   };
 
-  const pickIssue = (featuredLabel: string, pool: IssueBounty[]) => {
+  const pickIssue = (
+    featuredLabel: string,
+    pool: IssueBounty[],
+    recentPool: IssueBounty[],
+    mediumPool: IssueBounty[],
+  ) => {
     const candidate =
       pickFirstDiverse(
-        [pool, fallbackIssuePool],
+        [recentPool, mediumPool, pool, fallbackIssuePool],
         (issue) => issue.repositoryFullName,
         (issue) => issue.authorLogin || 'open bounty',
       ) ??
@@ -992,8 +1042,8 @@ export const buildFeaturedWork = (
       if (dateDiff !== 0) return dateDiff;
       return parseNumber(b.score) - parseNumber(a.score);
     }),
-    pickIssue('Top Completed Issue', rankedCompletedIssues),
-    pickIssue('Highest Bounty Issue', rankedHighestBountyIssues),
+    pickIssue('Top Completed Issue', rankedCompletedIssues, rankedCompletedIssuesRecent, rankedCompletedIssuesMedium),
+    pickIssue('Highest Bounty Issue', rankedHighestBountyIssues, rankedHighestBountyIssuesRecent, rankedHighestBountyIssuesMedium),
   ];
 
   return picks.filter((entry): entry is DashboardFeaturedWork =>

--- a/src/pages/dashboard/dashboardData.ts
+++ b/src/pages/dashboard/dashboardData.ts
@@ -904,9 +904,7 @@ export const buildFeaturedWork = (
       .sort(sortFn);
     const mergedSorted = [...mergedPrs].sort(sortFn);
     const allRecent = allWindowPrs
-      .filter((pr) =>
-        isWithinWindow(toTimestamp(pr.prCreatedAt), recentWindow),
-      )
+      .filter((pr) => isWithinWindow(toTimestamp(pr.prCreatedAt), recentWindow))
       .sort(sortFn);
     const allSorted = [...allWindowPrs].sort(sortFn);
     const candidate =
@@ -1042,8 +1040,18 @@ export const buildFeaturedWork = (
       if (dateDiff !== 0) return dateDiff;
       return parseNumber(b.score) - parseNumber(a.score);
     }),
-    pickIssue('Top Completed Issue', rankedCompletedIssues, rankedCompletedIssuesRecent, rankedCompletedIssuesMedium),
-    pickIssue('Highest Bounty Issue', rankedHighestBountyIssues, rankedHighestBountyIssuesRecent, rankedHighestBountyIssuesMedium),
+    pickIssue(
+      'Top Completed Issue',
+      rankedCompletedIssues,
+      rankedCompletedIssuesRecent,
+      rankedCompletedIssuesMedium,
+    ),
+    pickIssue(
+      'Highest Bounty Issue',
+      rankedHighestBountyIssues,
+      rankedHighestBountyIssuesRecent,
+      rankedHighestBountyIssuesMedium,
+    ),
   ];
 
   return picks.filter((entry): entry is DashboardFeaturedWork =>

--- a/src/pages/dashboard/views/DashboardFeaturedWork.tsx
+++ b/src/pages/dashboard/views/DashboardFeaturedWork.tsx
@@ -1,5 +1,12 @@
 import React from 'react';
+import AccountTreeIcon from '@mui/icons-material/AccountTree';
+import CallMergeIcon from '@mui/icons-material/CallMerge';
+import EmojiEventsIcon from '@mui/icons-material/EmojiEvents';
 import GitHubIcon from '@mui/icons-material/GitHub';
+import MonetizationOnIcon from '@mui/icons-material/MonetizationOn';
+import OpenInFullIcon from '@mui/icons-material/OpenInFull';
+import TaskAltIcon from '@mui/icons-material/TaskAlt';
+import { type SvgIconComponent } from '@mui/icons-material';
 import {
   Avatar,
   Box,
@@ -88,6 +95,18 @@ const renderChangesMetric = (theme: Theme, value: string) => {
   );
 };
 
+const CATEGORY_STYLE: Record<
+  string,
+  { color: string; Icon: SvgIconComponent }
+> = {
+  'Top PR by Score': { color: '#F59E0B', Icon: EmojiEventsIcon },
+  'Largest PR': { color: '#3B82F6', Icon: OpenInFullIcon },
+  'Most Commits PR': { color: '#8B5CF6', Icon: AccountTreeIcon },
+  'Newest Merged PR': { color: '#22C55E', Icon: CallMergeIcon },
+  'Top Completed Issue': { color: '#14B8A6', Icon: TaskAltIcon },
+  'Highest Bounty Issue': { color: '#F97316', Icon: MonetizationOnIcon },
+};
+
 const DashboardFeaturedWorkSection: React.FC<DashboardFeaturedWorkProps> = ({
   items,
   isLoading = false,
@@ -115,10 +134,9 @@ const DashboardFeaturedWorkSection: React.FC<DashboardFeaturedWorkProps> = ({
     const owner = item.repository.split('/')[0] || '';
     const metrics = item.metrics.slice(0, 3);
     const n = metrics.length || 1;
-    const labelTint =
-      item.kind === 'issue'
-        ? alpha(theme.palette.status.award, 0.9)
-        : alpha(theme.palette.status.merged, 0.9);
+    const cat = CATEGORY_STYLE[item.featuredLabel];
+    const catColor = cat?.color ?? alpha(theme.palette.status.merged, 0.9);
+    const CatIcon = cat?.Icon;
 
     return (
       <Stack
@@ -137,9 +155,10 @@ const DashboardFeaturedWorkSection: React.FC<DashboardFeaturedWorkProps> = ({
           minHeight: 262,
           p: 0.9,
           fontFamily: mono,
-          backgroundColor: alpha(theme.palette.common.white, 0.015),
+          backgroundColor: alpha(catColor, 0.04),
           borderRadius: 2,
           border: `1px solid ${border}`,
+          borderTop: `2.5px solid ${alpha(catColor, 0.55)}`,
           display: 'grid',
           gridTemplateRows: 'auto auto 2.56em auto auto',
           rowGap: 0.55,
@@ -148,12 +167,13 @@ const DashboardFeaturedWorkSection: React.FC<DashboardFeaturedWorkProps> = ({
             'transform 0.18s ease, border-color 0.18s ease, box-shadow 0.18s ease',
           '&:hover': {
             transform: 'translateY(-1px)',
-            borderColor: alpha(theme.palette.status.merged, 0.3),
-            backgroundColor: theme.palette.surface.subtle,
+            borderColor: alpha(catColor, 0.45),
+            borderTopColor: catColor,
+            backgroundColor: alpha(catColor, 0.07),
             boxShadow: `0 8px 24px ${alpha(theme.palette.common.black, 0.22)}`,
           },
           '&:focus-visible': {
-            outline: `2px solid ${alpha(toneColor, 0.45)}`,
+            outline: `2px solid ${alpha(catColor, 0.5)}`,
             outlineOffset: '2px',
           },
         }}
@@ -198,21 +218,32 @@ const DashboardFeaturedWorkSection: React.FC<DashboardFeaturedWorkProps> = ({
             >
               {item.repository}
             </Typography>
-            <Typography
-              sx={{
-                mt: 0.28,
-                color: labelTint,
-                fontFamily: mono,
-                fontSize: '0.72rem',
-                fontWeight: 700,
-                letterSpacing: '0.02em',
-                whiteSpace: 'nowrap',
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
-              }}
+            <Stack
+              direction="row"
+              spacing={0.4}
+              alignItems="center"
+              sx={{ mt: 0.28, minWidth: 0 }}
             >
-              {item.featuredLabel}
-            </Typography>
+              {CatIcon && (
+                <CatIcon
+                  sx={{ fontSize: 13, color: catColor, flexShrink: 0 }}
+                />
+              )}
+              <Typography
+                sx={{
+                  color: catColor,
+                  fontFamily: mono,
+                  fontSize: '0.72rem',
+                  fontWeight: 700,
+                  letterSpacing: '0.02em',
+                  whiteSpace: 'nowrap',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                }}
+              >
+                {item.featuredLabel}
+              </Typography>
+            </Stack>
           </Box>
         </Box>
 

--- a/src/pages/dashboard/views/DashboardFeaturedWork.tsx
+++ b/src/pages/dashboard/views/DashboardFeaturedWork.tsx
@@ -182,7 +182,7 @@ const DashboardFeaturedWorkSection: React.FC<DashboardFeaturedWorkProps> = ({
         <Box
           sx={{
             display: 'grid',
-            gridTemplateColumns: '56px minmax(0, 1fr)',
+            gridTemplateColumns: '64px minmax(0, 1fr)',
             columnGap: 1.15,
             alignItems: 'center',
             minWidth: 0,
@@ -193,8 +193,8 @@ const DashboardFeaturedWorkSection: React.FC<DashboardFeaturedWorkProps> = ({
             src={getGithubAvatarSrc(owner)}
             alt={owner}
             sx={{
-              width: 56,
-              height: 56,
+              width: 64,
+              height: 64,
               bgcolor: theme.palette.surface.light,
               border: `1px solid ${border}`,
               '& .MuiSvgIcon-root': { fontSize: 29 },

--- a/src/pages/dashboard/views/DashboardFeaturedWork.tsx
+++ b/src/pages/dashboard/views/DashboardFeaturedWork.tsx
@@ -12,6 +12,7 @@ import {
   Box,
   CircularProgress,
   Stack,
+  Tooltip,
   Typography,
 } from '@mui/material';
 import { alpha, useTheme, type Theme } from '@mui/material/styles';
@@ -247,26 +248,28 @@ const DashboardFeaturedWorkSection: React.FC<DashboardFeaturedWorkProps> = ({
           </Box>
         </Box>
 
-        <Typography
-          sx={{
-            color: alpha(theme.palette.text.primary, 0.78),
-            fontFamily: 'inherit',
-            fontSize: '0.8rem',
-            fontWeight: 500,
-            lineHeight: 1.28,
-            height: '2.52em',
-            display: '-webkit-box',
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
-            WebkitLineClamp: 2,
-            WebkitBoxOrient: 'vertical',
-            wordBreak: 'break-word',
-            mt: 1.05,
-            mb: -0.35,
-          }}
-        >
-          {item.title}
-        </Typography>
+        <Tooltip title={item.title} arrow placement="bottom">
+          <Typography
+            sx={{
+              color: alpha(theme.palette.text.primary, 0.78),
+              fontFamily: 'inherit',
+              fontSize: '0.8rem',
+              fontWeight: 500,
+              lineHeight: 1.28,
+              height: '2.52em',
+              display: '-webkit-box',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              WebkitLineClamp: 2,
+              WebkitBoxOrient: 'vertical',
+              wordBreak: 'break-word',
+              mt: 1.05,
+              mb: -0.35,
+            }}
+          >
+            {item.title}
+          </Typography>
+        </Tooltip>
 
         <Stack
           direction="row"


### PR DESCRIPTION
## Closes: #818 

## Summary

- **Recency decay on selection** (`dashboardData.ts`): each Featured Work slot previously ranked candidates purely by its metric (score, additions, commits, bounty), letting a single dominant PR or issue hold a slot for the entire 35-day lookback window. 
- Candidates are now ranked by `metric × recencyFactor`, where `recencyFactor = 1 / (1 + ageDays / 7)` —  halving an item's effective weight every 7 days. A score-0 PR from yesterday will never displace a score-40 PR from last week, but a score-15 PR from yesterday will displace a score-40 PR from 30 days ago. 
- "Newest Merged PR" keeps its pure date sort; issues apply the same decay against `completedAt ?? createdAt`.

- **Category-distinct card visuals** (`DashboardFeaturedWork.tsx`): all 6 cards  were visually identical except for a small label. 

- Each slot now has a unique  accent color and icon tied to its category:

  | Slot | Color | Icon |
  |---|---|---|
  | Top PR by Score | Amber `#F59E0B` | Trophy |
  | Largest PR | Blue `#3B82F6` | Expand |
  | Most Commits PR | Purple `#8B5CF6` | Branch tree |
  | Newest Merged PR | Green `#22C55E` | Merge |
  | Top Completed Issue | Teal `#14B8A6` | Check circle |
  | Highest Bounty Issue | Orange `#F97316` | Coin |

  Applied as a 2.5px colored top border, subtle background tint, category-  colored label + icon, and matching hover/focus states. Grid layout and all  card content are unchanged.

- **Title tooltip** (`DashboardFeaturedWork.tsx`): card titles are clamped to  2 lines. A MUI `Tooltip` with an arrow now shows the full title on hover,  positioned below the title text.

## Test plan

- [ ] Verify Featured Work rotates over days as new PRs/issues are submitted
- [ ] Confirm score-0 PRs do not appear as "Top PR by Score" when higher-scored
  PRs exist anywhere in the 35-day window
- [ ] Check all 6 category colors and icons render correctly in the UI
- [ ] Confirm hover and focus states use the per-category color
- [ ] Hover over a truncated card title — tooltip should appear below with full text and arrow
- [ ] Spot-check mobile (xs) and tablet (sm) layouts for regressions



## Screenshots

<img width="1035" height="565" alt="image" src="https://github.com/user-attachments/assets/f7b4fc59-81ff-480b-9193-d916d8bca0af" />

https://github.com/user-attachments/assets/9be3f822-75f3-4bdb-a56e-c77becb90373


Mobile compatibility:

<img width="411" height="786" alt="image" src="https://github.com/user-attachments/assets/b8ea20f2-8be3-41be-b2c2-ed04be760be8" />

<img width="411" height="782" alt="image" src="https://github.com/user-attachments/assets/6c8876a5-28a8-4904-8d23-e9c01136be94" />
