### PR TITLE
feat(watchlist): discovery score on cards & list, dual eligibility popover

### DIFF
--- a/src/components/leaderboard/MinerCard.tsx
+++ b/src/components/leaderboard/MinerCard.tsx
@@ -420,10 +420,7 @@ const MinerCardFooter: React.FC<MinerCardFooterProps> = ({
     : [inactiveColor, inactiveColor, inactiveColor];
 
   const issueSegments = getIssueSegments(miner);
-  const issueTotal =
-    (miner.totalSolvedIssues ?? 0) +
-    (miner.totalOpenIssues ?? 0) +
-    (miner.totalClosedIssues ?? 0);
+  const issueDiscoveryScore = Number(miner.issueDiscoveryScore ?? 0);
 
   return (
     <Box
@@ -467,7 +464,9 @@ const MinerCardFooter: React.FC<MinerCardFooterProps> = ({
             pl: 1.5,
           })}
         >
-          <StatLabel isEligible={isEligible}>Score</StatLabel>
+          <StatLabel isEligible={isEligible}>
+            {variant === 'watchlist' ? 'OSS' : 'Score'}
+          </StatLabel>
           <Typography
             sx={{
               fontFamily: FONTS.mono,
@@ -484,23 +483,10 @@ const MinerCardFooter: React.FC<MinerCardFooterProps> = ({
       {variant === 'watchlist' && (
         <Box
           sx={(theme) => ({
-            pt: 0.35,
+            pt: 0.75,
             borderTop: `1px solid ${theme.palette.border.light}`,
           })}
         >
-          <Typography
-            sx={{
-              fontFamily: FONTS.mono,
-              fontSize: '0.7rem',
-              fontWeight: 700,
-              color: muiTheme.palette.status.open,
-              textTransform: 'uppercase',
-              mb: 0.35,
-              letterSpacing: '0.04em',
-            }}
-          >
-            Issues
-          </Typography>
           <Box
             sx={{
               display: 'grid',
@@ -529,7 +515,7 @@ const MinerCardFooter: React.FC<MinerCardFooterProps> = ({
                 pl: 1.5,
               })}
             >
-              <StatLabel isEligible={isEligible}>Total</StatLabel>
+              <StatLabel isEligible={isEligible}>Discovery</StatLabel>
               <Typography
                 sx={{
                   fontFamily: FONTS.mono,
@@ -540,7 +526,7 @@ const MinerCardFooter: React.FC<MinerCardFooterProps> = ({
                   fontWeight: 700,
                 }}
               >
-                {issueTotal}
+                {issueDiscoveryScore.toFixed(2)}
               </Typography>
             </Box>
           </Box>

--- a/src/components/leaderboard/MinersList.tsx
+++ b/src/components/leaderboard/MinersList.tsx
@@ -56,7 +56,7 @@ export const MinersList: React.FC<MinersListProps> = ({
         {
           key: 'prs',
           header: 'PRs',
-          width: '13%',
+          width: '11%',
           align: 'right',
           sortKey: 'totalPRs',
           renderCell: (miner) => (
@@ -66,7 +66,7 @@ export const MinersList: React.FC<MinersListProps> = ({
         {
           key: 'issues',
           header: 'Issues',
-          width: '13%',
+          width: '11%',
           align: 'right',
           sortKey: 'totalIssues',
           renderCell: (miner) => (
@@ -134,7 +134,7 @@ export const MinersList: React.FC<MinersListProps> = ({
     },
     {
       key: 'totalScore',
-      header: 'Score',
+      header: isWatchlist ? 'OSS' : 'Score',
       width: '11%',
       align: 'right',
       sortKey: 'totalScore',
@@ -144,6 +144,22 @@ export const MinersList: React.FC<MinersListProps> = ({
         </Typography>
       ),
     },
+    ...(isWatchlist
+      ? ([
+          {
+            key: 'discovery',
+            header: 'Discovery',
+            width: '11%',
+            align: 'right' as const,
+            sortKey: 'issueDiscoveryScore',
+            renderCell: (miner: MinerStats) => (
+              <Typography sx={{ ...cellTypographySx, color: 'text.primary' }}>
+                {Number(miner.issueDiscoveryScore ?? 0).toFixed(2)}
+              </Typography>
+            ),
+          },
+        ] satisfies DataTableColumn<MinerStats, SortOption>[])
+      : []),
     {
       key: 'watch',
       header: '\u2605',
@@ -190,7 +206,7 @@ export const MinersList: React.FC<MinersListProps> = ({
           opacity: (miner.isEligible ?? false) ? 1 : 0.5,
           transition: 'opacity 0.2s, background-color 0.2s',
         })}
-        minWidth="900px"
+        minWidth="1020px"
         stickyHeader
         sort={{
           field: sortOption,

--- a/src/components/leaderboard/TopMinersTable.tsx
+++ b/src/components/leaderboard/TopMinersTable.tsx
@@ -534,7 +534,9 @@ interface SortButtonsProps {
 
 type SortButtonOption = { label: string; value: SortOption };
 
-const getSortButtonOptions = (variant: LeaderboardVariant): SortButtonOption[] => {
+const getSortButtonOptions = (
+  variant: LeaderboardVariant,
+): SortButtonOption[] => {
   const scoreLabel = variant === 'watchlist' ? 'OSS' : 'Score';
   const earnings = { label: 'Earnings', value: 'usdPerDay' as const };
   const prs = { label: 'PRs', value: 'totalPRs' as const };
@@ -547,14 +549,7 @@ const getSortButtonOptions = (variant: LeaderboardVariant): SortButtonOption[] =
   const score = { label: scoreLabel, value: 'totalScore' as const };
 
   if (variant === 'watchlist') {
-    return [
-      score,
-      discovery,
-      earnings,
-      prs,
-      issues,
-      credibility,
-    ];
+    return [score, discovery, earnings, prs, issues, credibility];
   }
   if (variant === 'discoveries') {
     return [score, earnings, issues, credibility];
@@ -724,7 +719,10 @@ const WatchlistEligibilityBar: React.FC<WatchlistEligibilityBarProps> = ({
 
   return (
     <>
-      <Tooltip title="Eligibility filters — OSS and Discovery (both apply)" arrow>
+      <Tooltip
+        title="Eligibility filters — OSS and Discovery (both apply)"
+        arrow
+      >
         <Box
           component="button"
           type="button"

--- a/src/components/leaderboard/TopMinersTable.tsx
+++ b/src/components/leaderboard/TopMinersTable.tsx
@@ -1,12 +1,15 @@
-import React, { useCallback, useEffect, useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   Box,
   Typography,
   CircularProgress,
   Grid,
   Tooltip,
+  Popover,
 } from '@mui/material';
 import { alpha, type Theme } from '@mui/material/styles';
+import TuneOutlinedIcon from '@mui/icons-material/TuneOutlined';
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import ViewModuleIcon from '@mui/icons-material/ViewModule';
 import ViewListIcon from '@mui/icons-material/ViewList';
 import { SectionCard } from './SectionCard';
@@ -30,6 +33,9 @@ export type { MinerStats } from './types';
 
 const MINERS_PAGE_SIZE = 60;
 const ELIGIBLE_QUERY_PARAM = 'eligible';
+/** Watchlist: separate URL params so OSS and discovery eligibility filters are independent. */
+const OSS_ELIGIBLE_QUERY_PARAM = 'ossElig';
+const DISC_ELIGIBLE_QUERY_PARAM = 'discElig';
 const VIEW_QUERY_PARAM = 'view';
 const SEARCH_QUERY_PARAM = 'search';
 const VISIBLE_QUERY_PARAM = 'visible';
@@ -73,12 +79,61 @@ const getAllowedSortOptions = (variant: LeaderboardVariant): SortOption[] => {
       'usdPerDay',
       'totalPRs',
       'totalIssues',
+      'issueDiscoveryScore',
       'credibility',
     ];
   return ['totalScore', 'usdPerDay', 'totalPRs', 'credibility'];
 };
 
 type EligibilityFilter = 'all' | 'eligible' | 'ineligible';
+
+type TopMinersUrlFilters = {
+  view: ViewMode;
+  search: string;
+  /** OSS Contributions / Discoveries: single toggle. Inactive on watchlist (always `all`). */
+  eligible: EligibilityFilter;
+  /** Watchlist OSS column. Inactive on other variants (always `all`). */
+  eligibleOss: EligibilityFilter;
+  /** Watchlist Discovery column. Inactive on other variants (always `all`). */
+  eligibleDiscovery: EligibilityFilter;
+};
+
+const eligibleUrlField = (paramKey: string) => ({
+  paramKey,
+  parse: (raw: string | null): EligibilityFilter =>
+    raw === 'true' ? 'eligible' : raw === 'false' ? 'ineligible' : 'all',
+  serialize: (value: EligibilityFilter): string | null =>
+    value === 'all' ? null : value === 'eligible' ? 'true' : 'false',
+});
+
+/** URL-inert slot: keeps a stable filter key for the data-table hook when a variant does not use it. */
+const inactiveEligibilitySlot = (paramKey: string) => ({
+  paramKey,
+  parse: (_raw: string | null): EligibilityFilter => 'all',
+  serialize: (_value: EligibilityFilter): string | null => null,
+});
+
+const passesOssEligibility = (
+  miner: MinerStats,
+  filter: EligibilityFilter,
+): boolean =>
+  filter === 'all' ||
+  (filter === 'eligible' ? Boolean(miner.ossIsEligible) : !miner.ossIsEligible);
+
+const passesDiscoveryEligibility = (
+  miner: MinerStats,
+  filter: EligibilityFilter,
+): boolean => {
+  const ok = Boolean(miner.discoveriesIsEligible ?? miner.isIssueEligible);
+  return filter === 'all' || (filter === 'eligible' ? ok : !ok);
+};
+
+const passesSingleProgramEligibility = (
+  miner: MinerStats,
+  filter: EligibilityFilter,
+): boolean =>
+  filter === 'all' ||
+  (filter === 'eligible' ? Boolean(miner.isEligible) : !miner.isEligible);
 
 const compareMiners = (
   a: MinerStats,
@@ -94,6 +149,10 @@ const compareMiners = (
       return a.totalPRs - b.totalPRs;
     case 'totalIssues':
       return (a.totalIssues ?? 0) - (b.totalIssues ?? 0);
+    case 'issueDiscoveryScore':
+      return (
+        Number(a.issueDiscoveryScore ?? 0) - Number(b.issueDiscoveryScore ?? 0)
+      );
     case 'credibility':
       return (a.credibility ?? 0) - (b.credibility ?? 0);
     default:
@@ -134,20 +193,25 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
         serialize: (value: ViewMode): string => value,
         resetPageOnChange: false,
       },
-      eligible: {
-        paramKey: ELIGIBLE_QUERY_PARAM,
-        parse: (raw: string | null): EligibilityFilter =>
-          raw === 'true' ? 'eligible' : raw === 'false' ? 'ineligible' : 'all',
-        serialize: (value: EligibilityFilter): string | null =>
-          value === 'all' ? null : value === 'eligible' ? 'true' : 'false',
-      },
       search: {
         paramKey: SEARCH_QUERY_PARAM,
         parse: (raw: string | null): string => raw ?? '',
         serialize: (value: string): string | null => value.trim() || null,
       },
+      eligible:
+        variant === 'watchlist'
+          ? inactiveEligibilitySlot('minersEligibleUnusedLegacy')
+          : eligibleUrlField(ELIGIBLE_QUERY_PARAM),
+      eligibleOss:
+        variant === 'watchlist'
+          ? eligibleUrlField(OSS_ELIGIBLE_QUERY_PARAM)
+          : inactiveEligibilitySlot('minersEligibleOssUnused'),
+      eligibleDiscovery:
+        variant === 'watchlist'
+          ? eligibleUrlField(DISC_ELIGIBLE_QUERY_PARAM)
+          : inactiveEligibilitySlot('minersEligibleDiscUnused'),
     }),
-    [],
+    [variant],
   );
 
   const {
@@ -156,16 +220,9 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
     setSort: handleSortChange,
     page: storedVisibleCount,
     setPage: setVisibleCount,
-    filters: {
-      view: viewMode,
-      eligible: eligibilityFilter,
-      search: searchQuery,
-    },
+    filters,
     setFilter,
-  } = useDataTableParams<
-    SortOption,
-    { view: ViewMode; eligible: EligibilityFilter; search: string }
-  >({
+  } = useDataTableParams<SortOption, TopMinersUrlFilters>({
     sortKeys: allowedSortKeys,
     defaultSortKey: 'totalScore',
     // Reuse the hook's `page` slot for our "show more" count — setSort and
@@ -173,6 +230,13 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
     paramKeys: { page: VISIBLE_QUERY_PARAM },
     filters: filtersConfig,
   });
+
+  const viewMode = filters.view;
+  const searchQuery = filters.search;
+  const eligibleOssFilter: EligibilityFilter =
+    variant === 'watchlist' ? filters.eligibleOss : filters.eligible;
+  const eligibleDiscoveryFilter: EligibilityFilter =
+    variant === 'watchlist' ? filters.eligibleDiscovery : 'all';
 
   // `page` is 0 when no visible param is set — clamp to the initial batch.
   const visibleCount =
@@ -192,8 +256,19 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
     [setFilter],
   );
 
-  const handleEligibilityChange = useCallback(
-    (nextFilter: EligibilityFilter) => setFilter('eligible', nextFilter),
+  const handleEligibleOssChange = useCallback(
+    (next: EligibilityFilter) => {
+      if (variant === 'watchlist') {
+        setFilter('eligibleOss', next);
+      } else {
+        setFilter('eligible', next);
+      }
+    },
+    [setFilter, variant],
+  );
+
+  const handleEligibleDiscoveryChange = useCallback(
+    (next: EligibilityFilter) => setFilter('eligibleDiscovery', next),
     [setFilter],
   );
 
@@ -225,14 +300,24 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
       );
     }
 
-    if (eligibilityFilter === 'eligible') {
-      result = result.filter((m) => m.isEligible);
-    } else if (eligibilityFilter === 'ineligible') {
-      result = result.filter((m) => !m.isEligible);
-    }
+    result = result.filter((m) => {
+      if (variant === 'watchlist') {
+        return (
+          passesOssEligibility(m, eligibleOssFilter) &&
+          passesDiscoveryEligibility(m, eligibleDiscoveryFilter)
+        );
+      }
+      return passesSingleProgramEligibility(m, eligibleOssFilter);
+    });
 
     return result;
-  }, [rankedMiners, searchQuery, eligibilityFilter]);
+  }, [
+    rankedMiners,
+    searchQuery,
+    variant,
+    eligibleOssFilter,
+    eligibleDiscoveryFilter,
+  ]);
 
   useEffect(() => {
     if (visibleCount <= filteredMiners.length) return;
@@ -318,11 +403,28 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
               onSortChange={handleSortChange}
               variant={variant}
             />
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-              <EligibilityToggle
-                value={eligibilityFilter}
-                onChange={handleEligibilityChange}
-              />
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 1,
+                flexWrap: 'wrap',
+                justifyContent: 'flex-end',
+              }}
+            >
+              {variant === 'watchlist' ? (
+                <WatchlistEligibilityBar
+                  ossValue={eligibleOssFilter}
+                  discoveryValue={eligibleDiscoveryFilter}
+                  onOssChange={handleEligibleOssChange}
+                  onDiscoveryChange={handleEligibleDiscoveryChange}
+                />
+              ) : (
+                <EligibilityToggle
+                  value={eligibleOssFilter}
+                  onChange={handleEligibleOssChange}
+                />
+              )}
               <ViewModeToggle
                 viewMode={viewMode}
                 onChange={handleViewModeChange}
@@ -430,6 +532,36 @@ interface SortButtonsProps {
   variant: LeaderboardVariant;
 }
 
+type SortButtonOption = { label: string; value: SortOption };
+
+const getSortButtonOptions = (variant: LeaderboardVariant): SortButtonOption[] => {
+  const scoreLabel = variant === 'watchlist' ? 'OSS' : 'Score';
+  const earnings = { label: 'Earnings', value: 'usdPerDay' as const };
+  const prs = { label: 'PRs', value: 'totalPRs' as const };
+  const issues = { label: 'Issues', value: 'totalIssues' as const };
+  const discovery = {
+    label: 'Discovery',
+    value: 'issueDiscoveryScore' as const,
+  };
+  const credibility = { label: 'Credibility', value: 'credibility' as const };
+  const score = { label: scoreLabel, value: 'totalScore' as const };
+
+  if (variant === 'watchlist') {
+    return [
+      score,
+      discovery,
+      earnings,
+      prs,
+      issues,
+      credibility,
+    ];
+  }
+  if (variant === 'discoveries') {
+    return [score, earnings, issues, credibility];
+  }
+  return [score, earnings, prs, credibility];
+};
+
 const SortButtons: React.FC<SortButtonsProps> = ({
   sortOption,
   sortDirection,
@@ -444,22 +576,12 @@ const SortButtons: React.FC<SortButtonsProps> = ({
       justifyContent: 'center',
     }}
   >
-    {[
-      { label: 'Score', value: 'totalScore' },
-      { label: 'Earnings', value: 'usdPerDay' },
-      ...(variant !== 'discoveries'
-        ? [{ label: 'PRs', value: 'totalPRs' as const }]
-        : []),
-      ...(variant === 'discoveries' || variant === 'watchlist'
-        ? [{ label: 'Issues', value: 'totalIssues' as const }]
-        : []),
-      { label: 'Credibility', value: 'credibility' },
-    ].map((option) => {
+    {getSortButtonOptions(variant).map((option) => {
       const isActive = sortOption === option.value;
       return (
         <Box
           key={option.value}
-          onClick={() => onSortChange(option.value as SortOption)}
+          onClick={() => onSortChange(option.value)}
           sx={(theme) => ({
             px: 1.5,
             height: 32,
@@ -581,9 +703,213 @@ const ViewModeToggle: React.FC<ViewModeToggleProps> = ({
   );
 };
 
+interface WatchlistEligibilityBarProps {
+  ossValue: EligibilityFilter;
+  discoveryValue: EligibilityFilter;
+  onOssChange: (next: EligibilityFilter) => void;
+  onDiscoveryChange: (next: EligibilityFilter) => void;
+}
+
+const WatchlistEligibilityBar: React.FC<WatchlistEligibilityBarProps> = ({
+  ossValue,
+  discoveryValue,
+  onOssChange,
+  onDiscoveryChange,
+}) => {
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+  const open = Boolean(anchorEl);
+  const popoverId = open ? 'watchlist-eligibility-popover' : undefined;
+  const hasActiveFilter = ossValue !== 'all' || discoveryValue !== 'all';
+  const ariaFilterSummary = `OSS ${ossValue}, Discovery ${discoveryValue}`;
+
+  return (
+    <>
+      <Tooltip title="Eligibility filters — OSS and Discovery (both apply)" arrow>
+        <Box
+          component="button"
+          type="button"
+          id="watchlist-eligibility-trigger"
+          aria-label={`Eligibility${hasActiveFilter ? ', filters applied' : ''}. ${ariaFilterSummary}.`}
+          aria-describedby={popoverId}
+          aria-controls={open ? popoverId : undefined}
+          aria-expanded={open}
+          aria-haspopup="true"
+          onClick={(e) => {
+            setAnchorEl((prev) => (prev ? null : e.currentTarget));
+          }}
+          sx={(theme) => ({
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 1,
+            pl: 1,
+            pr: 0.75,
+            py: 0.5,
+            minHeight: 32,
+            borderRadius: 2,
+            border: `1px solid ${theme.palette.border.light}`,
+            backgroundColor: alpha(theme.palette.background.default, 0.45),
+            cursor: 'pointer',
+            textAlign: 'left',
+            transition: 'background-color 0.15s, border-color 0.15s',
+            '&:hover': {
+              backgroundColor: alpha(theme.palette.text.primary, 0.04),
+              borderColor: theme.palette.border.medium,
+            },
+            '&:focus-visible': {
+              outline: `2px solid ${theme.palette.status.info}`,
+              outlineOffset: 2,
+            },
+          })}
+        >
+          <TuneOutlinedIcon
+            sx={{
+              fontSize: '1.1rem',
+              color: 'text.secondary',
+              flexShrink: 0,
+            }}
+          />
+          <Typography
+            component="span"
+            sx={{
+              fontFamily: FONTS.mono,
+              fontSize: '0.72rem',
+              fontWeight: 600,
+              color: 'text.primary',
+              lineHeight: 1.2,
+              whiteSpace: 'nowrap',
+            }}
+          >
+            Eligibility
+            {hasActiveFilter ? (
+              <Box
+                component="span"
+                sx={{
+                  ml: 0.75,
+                  display: 'inline-block',
+                  width: 6,
+                  height: 6,
+                  borderRadius: '50%',
+                  backgroundColor: 'status.info',
+                  verticalAlign: 'middle',
+                }}
+                aria-hidden
+              />
+            ) : null}
+          </Typography>
+          <KeyboardArrowDownIcon
+            sx={{
+              fontSize: '1.15rem',
+              color: 'text.secondary',
+              flexShrink: 0,
+              transform: open ? 'rotate(-180deg)' : 'none',
+              transition: 'transform 0.2s ease',
+            }}
+          />
+        </Box>
+      </Tooltip>
+      <Popover
+        id={popoverId}
+        open={open}
+        anchorEl={anchorEl}
+        onClose={() => setAnchorEl(null)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+        transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+        slotProps={{
+          paper: {
+            elevation: 8,
+            sx: (theme) => ({
+              mt: 0.75,
+              boxSizing: 'border-box',
+              width: 'fit-content',
+              maxWidth: 'min(300px, calc(100vw - 24px))',
+              minWidth: 0,
+              overflowY: 'visible',
+              overflowX: 'hidden',
+              borderRadius: 2,
+              border: `1px solid ${theme.palette.border.light}`,
+              backgroundImage: 'none',
+              backgroundColor: theme.palette.background.paper,
+              boxShadow: theme.shadows[12],
+            }),
+          },
+        }}
+      >
+        <Box
+          sx={{
+            p: 2,
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'flex-start',
+            gap: 2,
+            boxSizing: 'border-box',
+            maxWidth: '100%',
+          }}
+        >
+          <Box sx={{ maxWidth: '100%' }}>
+            <Typography
+              variant="subtitle2"
+              sx={{ fontWeight: 700, fontFamily: FONTS.mono, mb: 0.5 }}
+            >
+              Eligibility
+            </Typography>
+            <Typography
+              variant="caption"
+              color="text.secondary"
+              sx={{
+                display: 'block',
+                lineHeight: 1.5,
+                maxWidth: '15rem',
+              }}
+            >
+              Filter pinned miners by OSS track and Issue discovery eligibility.
+            </Typography>
+          </Box>
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.25 }}>
+            <Typography
+              component="div"
+              sx={{
+                fontFamily: FONTS.mono,
+                fontSize: '0.65rem',
+                fontWeight: 700,
+                letterSpacing: '0.08em',
+                color: 'text.secondary',
+                textTransform: 'uppercase',
+              }}
+            >
+              OSS contributions
+            </Typography>
+            <EligibilityToggle value={ossValue} onChange={onOssChange} />
+          </Box>
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.25 }}>
+            <Typography
+              component="div"
+              sx={{
+                fontFamily: FONTS.mono,
+                fontSize: '0.65rem',
+                fontWeight: 700,
+                letterSpacing: '0.08em',
+                color: 'text.secondary',
+                textTransform: 'uppercase',
+              }}
+            >
+              Issue discovery
+            </Typography>
+            <EligibilityToggle
+              value={discoveryValue}
+              onChange={onDiscoveryChange}
+            />
+          </Box>
+        </Box>
+      </Popover>
+    </>
+  );
+};
+
 interface EligibilityToggleProps {
   value: EligibilityFilter;
   onChange: (next: EligibilityFilter) => void;
+  /** Tighter pills for the dual watchlist bar. */
+  compact?: boolean;
 }
 
 const ELIGIBILITY_OPTIONS: Array<{ value: EligibilityFilter; label: string }> =
@@ -596,14 +922,16 @@ const ELIGIBILITY_OPTIONS: Array<{ value: EligibilityFilter; label: string }> =
 const EligibilityToggle: React.FC<EligibilityToggleProps> = ({
   value,
   onChange,
+  compact = false,
 }) => (
   <Box
     sx={(theme) => ({
       display: 'inline-flex',
-      gap: 0.5,
-      p: 0.5,
-      borderRadius: 2,
+      gap: compact ? 0.35 : 0.5,
+      p: compact ? 0.35 : 0.5,
+      borderRadius: 1.75,
       backgroundColor: theme.palette.surface.light,
+      flexShrink: 0,
     })}
   >
     {ELIGIBILITY_OPTIONS.map((option) => {
@@ -616,12 +944,12 @@ const EligibilityToggle: React.FC<EligibilityToggleProps> = ({
           aria-pressed={isActive}
           onClick={() => onChange(option.value)}
           sx={(theme) => ({
-            px: 1.5,
-            height: 24,
+            px: compact ? 1 : 1.5,
+            height: compact ? 22 : 24,
             display: 'flex',
             alignItems: 'center',
             border: 0,
-            borderRadius: 1.5,
+            borderRadius: 1.25,
             backgroundColor: isActive
               ? alpha(theme.palette.text.primary, 0.15)
               : 'transparent',
@@ -630,7 +958,7 @@ const EligibilityToggle: React.FC<EligibilityToggleProps> = ({
               : theme.palette.text.tertiary,
             cursor: 'pointer',
             fontFamily: FONTS.mono,
-            fontSize: '0.72rem',
+            fontSize: compact ? '0.65rem' : '0.72rem',
             fontWeight: isActive ? 600 : 500,
             lineHeight: 1,
             transition: 'all 0.2s ease',

--- a/src/components/leaderboard/types.ts
+++ b/src/components/leaderboard/types.ts
@@ -67,6 +67,7 @@ export type SortOption =
   | 'usdPerDay'
   | 'totalPRs'
   | 'totalIssues'
+  | 'issueDiscoveryScore'
   | 'credibility';
 
 export const FONTS = {


### PR DESCRIPTION
## Summary

Watchlist **Miners** surfaces **issue discovery** next to **OSS** and filters both programs independently.

- **`MinerCard`** (watchlist): Footer shows **OSS** (OSS score) and **Discovery** (**issue discovery score**); watchlist card copy/layout adjusted so dual-program stats stay clear.
- **`MinersList`** (watchlist): **Discovery** column after **OSS** with the same score; list behavior aligned with existing watchlist / Issues UX where applicable; sort support for **`issueDiscoveryScore`** when wired from the toolbar.
- **`TopMinersTable`**: Watchlist uses **`ossElig`** and **`discElig`** URL params (tri-state, same semantics as `eligible` elsewhere), with **AND** filtering on OSS vs discovery eligibility. Other variants keep the single **`eligible`** control. **`WatchlistEligibilityBar`**: compact trigger opens a **Popover** with two tri-state groups; panel width/padding tightened (`fit-content`, caption `maxWidth`, overflow tweaks). Sort options updated for watchlist (e.g. **Discovery** after **OSS**).
- **`types`**: **`SortOption`** includes **`issueDiscoveryScore`** as needed.

**Branch:** based on **`upstream/test`** (per [CONTRIBUTING.md](https://github.com/entrius/gittensor-ui/blob/test/CONTRIBUTING.md)).

## Related Issues

- Closes #820

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

-Before fix on watchlist 
<img width="1213" height="308" alt="image" src="https://github.com/user-attachments/assets/d6c34d1c-cfb7-4e67-b4d2-ef8c2b46af9e" />
<img width="1260" height="405" alt="image" src="https://github.com/user-attachments/assets/387baef6-63bb-40f6-859d-bcc0065f47b7" />

-After fix on watchlist 
<img width="1215" height="274" alt="image" src="https://github.com/user-attachments/assets/9ede8248-20d1-4176-a986-de093d8d4aba" />
<img width="1214" height="275" alt="image" src="https://github.com/user-attachments/assets/ec56534d-b992-4c15-b622-a19000d58cfc" />

-Popup filtering per eligibility

<img width="452" height="338" alt="image" src="https://github.com/user-attachments/assets/b01b667b-3db3-4c15-b44c-1688b3e12788" />


## Checklist

- [ ] New components are modularized/separated where sensible
- [ ] Uses predefined theme (e.g. no hardcoded colors)
- [ ] Responsive/mobile checked
- [ ] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [ ] Screenshots included for any UI/visual changes