### PR TITLE
fix(miner-discovery): show Other issues in all engagement repos + drop empty-repo cache pollution

### DIFF
--- a/src/components/miners/MinerOpenDiscoveryIssuesByRepo.tsx
+++ b/src/components/miners/MinerOpenDiscoveryIssuesByRepo.tsx
@@ -318,10 +318,16 @@ const MinerOpenDiscoveryIssuesByRepo: React.FC<
       addToMap(mine, repo, indexedIssueByKey.get(key) ?? issue);
     });
 
+    // Remove authored issues from "other" buckets across every repository in
+    // `reposForGrouping` (PR-active OR authored-issue). Previously the result
+    // was further restricted to only repos where the miner had authored open
+    // issues, which contradicted the card heading ("Other people's open
+    // issues in the same repositories" = same as the miner's engagement set,
+    // not just the strict authored-issues set) and silenced the entire section
+    // for miners who haven't filed any GitHub issues yet — even when they had
+    // dozens of PR-active repos with discovery opportunities.
     const filteredOther = new Map<string, RepositoryIssue[]>();
-    const mineRepos = new Set(mine.keys());
     other.forEach((issues, repo) => {
-      if (!mineRepos.has(repo)) return;
       const filtered = issues.filter(
         (issue) => !mineKeys.has(`${repo}#${issue.number}`),
       );

--- a/src/hooks/useMinerRepositoriesOpenIssues.ts
+++ b/src/hooks/useMinerRepositoriesOpenIssues.ts
@@ -22,15 +22,22 @@ const fetchRepositoryIssues = async (
 /**
  * Repositories where the miner has scored PR activity, ordered by most recent
  * PR timestamp (merged or created), capped for parallel fetch limits.
+ *
+ * PRs with a missing or blank ``repository`` field are dropped — leaving them
+ * in produces an empty-string entry that the consumer dispatches as
+ * ``GET /repos//issues``, which 404s on every fetch and pollutes the
+ * react-query cache with a useless key.
  */
 export const selectMinerIssueScanRepos = (prs: CommitLog[] | undefined) => {
   if (!prs?.length) return [];
   const latest = new Map<string, number>();
   prs.forEach((pr) => {
+    const repo = pr.repository?.trim();
+    if (!repo) return;
     const raw = pr.mergedAt || pr.prCreatedAt;
     const t = raw ? new Date(raw).getTime() : 0;
-    const prev = latest.get(pr.repository) ?? 0;
-    if (t >= prev) latest.set(pr.repository, t);
+    const prev = latest.get(repo) ?? 0;
+    if (t >= prev) latest.set(repo, t);
   });
   return [...latest.entries()]
     .sort((a, b) => b[1] - a[1])

--- a/src/tests/useMinerRepositoriesOpenIssues.test.ts
+++ b/src/tests/useMinerRepositoriesOpenIssues.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import { selectMinerIssueScanRepos } from '../hooks/useMinerRepositoriesOpenIssues';
+import type { CommitLog } from '../api';
+
+const pr = (overrides: Partial<CommitLog> = {}): CommitLog =>
+  ({
+    pullRequestNumber: 1,
+    hotkey: 'hk',
+    pullRequestTitle: 't',
+    additions: 0,
+    deletions: 0,
+    commitCount: 1,
+    repository: 'owner/repo',
+    mergedAt: null,
+    closedAt: null,
+    prCreatedAt: '2024-01-01',
+    prState: 'open',
+    author: 'alice',
+    githubId: 'gh',
+    score: '0',
+    ...overrides,
+  }) as CommitLog;
+
+describe('selectMinerIssueScanRepos', () => {
+  it('returns empty for missing or empty PR list', () => {
+    expect(selectMinerIssueScanRepos(undefined)).toEqual([]);
+    expect(selectMinerIssueScanRepos([])).toEqual([]);
+  });
+
+  it('orders by most recent PR timestamp descending', () => {
+    const prs = [
+      pr({ repository: 'a/old', mergedAt: '2024-01-01' }),
+      pr({ repository: 'a/recent', mergedAt: '2024-06-01' }),
+      pr({ repository: 'a/middle', mergedAt: '2024-03-01' }),
+    ];
+    expect(selectMinerIssueScanRepos(prs)).toEqual([
+      'a/recent',
+      'a/middle',
+      'a/old',
+    ]);
+  });
+
+  it('uses prCreatedAt when mergedAt is null', () => {
+    const prs = [
+      pr({
+        repository: 'a/created',
+        mergedAt: null,
+        prCreatedAt: '2024-05-01',
+      }),
+      pr({
+        repository: 'a/merged',
+        mergedAt: '2024-03-01',
+        prCreatedAt: '2024-01-01',
+      }),
+    ];
+    expect(selectMinerIssueScanRepos(prs)).toEqual(['a/created', 'a/merged']);
+  });
+
+  it('drops PRs whose repository field is missing, blank, or whitespace', () => {
+    // Without the guard, blank repos produce an empty-string entry that the
+    // caller dispatches as `GET /repos//issues` — 404 every fetch and pollutes
+    // the react-query cache with a useless key.
+    const prs = [
+      pr({ repository: '', mergedAt: '2024-06-01' }),
+      pr({ repository: '   ', mergedAt: '2024-05-01' }),
+      pr({
+        repository: undefined as unknown as string,
+        mergedAt: '2024-04-01',
+      }),
+      pr({ repository: 'a/valid', mergedAt: '2024-01-01' }),
+    ];
+    expect(selectMinerIssueScanRepos(prs)).toEqual(['a/valid']);
+  });
+
+  it('trims surrounding whitespace from the repository name', () => {
+    // Repos arriving with leading/trailing whitespace must not bypass the dedup
+    // map by being treated as distinct keys from their trimmed form.
+    const prs = [
+      pr({ repository: '  a/repo  ', mergedAt: '2024-06-01' }),
+      pr({ repository: 'a/repo', mergedAt: '2024-05-01' }),
+    ];
+    expect(selectMinerIssueScanRepos(prs)).toEqual(['a/repo']);
+  });
+
+  it('caps result length at the parallel-fetch limit', () => {
+    const prs = Array.from({ length: 80 }, (_, i) =>
+      pr({
+        repository: `org/repo-${String(i).padStart(3, '0')}`,
+        mergedAt: `2024-01-${String((i % 28) + 1).padStart(2, '0')}`,
+      }),
+    );
+    const result = selectMinerIssueScanRepos(prs);
+    expect(result.length).toBe(50);
+  });
+});


### PR DESCRIPTION
```
## Summary

Two related correctness bugs in the miner-discovery flow that conspired
to leave the "Other open discovery issues" section misleadingly empty
for a common miner profile shape.

### Bug 1 — `mineRepos` filter is too narrow

`src/components/miners/MinerOpenDiscoveryIssuesByRepo.tsx:261-265`

After removing the miner's own authored issues from the "other"
bucket, the result was further restricted to only repositories where
the miner ALSO had authored open issues:

```ts
const mineRepos = new Set(mine.keys());
const filteredOther = new Map<string, RepositoryIssue[]>();
filteredOtherRaw.forEach((issues, repo) => {
  if (mineRepos.has(repo)) filteredOther.set(repo, issues);
});
```

The card heading reads *"Other people's open issues in the same
repositories (still part of the discovery index). Useful for triage
and collaboration"*. The natural reading of "same repositories" is
the miner's full engagement set (PR-active OR authored-issue), not
specifically "repositories where I have authored issues."

For a miner with PR activity but no GitHub-authored open issues — a
common shape, especially for contribution-focused miners — the filter
zeroed the entire "Other" section despite dozens of legitimate triage
opportunities in the miner's PR-active repos.

The upstream `reposForGrouping = scanRepos ∪ authoredRepos` already
scopes the engagement set correctly. Drop the post-hoc `mineRepos`
narrowing.

### Bug 2 — `selectMinerIssueScanRepos` admits blank repository names

`src/hooks/useMinerRepositoriesOpenIssues.ts:26`

PRs whose `repository` field is missing, undefined, or whitespace
produce an empty-string entry in the returned list:

```ts
const prev = latest.get(pr.repository) ?? 0;
if (t >= prev) latest.set(pr.repository, t);
```