### PR TITLE
fix(pr): make PR details page mobile responsive

### DIFF
--- a/src/components/prs/PRComments.tsx
+++ b/src/components/prs/PRComments.tsx
@@ -120,15 +120,15 @@ const PRComments: React.FC<PRCommentsProps> = ({
           key={item.id}
           sx={{
             display: 'flex',
-            gap: 2,
+            gap: { xs: 1.25, sm: 2 },
             position: 'relative',
             zIndex: 1,
             '&::before': {
               content: index !== allItems.length - 1 ? '""' : 'none',
               position: 'absolute',
-              top: '40px',
-              bottom: '-24px',
-              left: '20px',
+              top: { xs: '32px', sm: '40px' },
+              bottom: { xs: '-16px', sm: '-24px' },
+              left: { xs: '15px', sm: '20px' },
               width: '2px',
               backgroundColor: colors.timeline.line,
               zIndex: 0,
@@ -136,7 +136,7 @@ const PRComments: React.FC<PRCommentsProps> = ({
           }}
         >
           {/* Avatar Area */}
-          <Box sx={{ position: 'relative', zIndex: 1 }}>
+          <Box sx={{ position: 'relative', zIndex: 1, flexShrink: 0 }}>
             <Link
               href={item.user.htmlUrl}
               target="_blank"
@@ -146,8 +146,8 @@ const PRComments: React.FC<PRCommentsProps> = ({
                 src={item.user.avatarUrl}
                 alt={item.user.login}
                 sx={{
-                  width: 40,
-                  height: 40,
+                  width: { xs: 32, sm: 40 },
+                  height: { xs: 32, sm: 40 },
                   border: `1px solid ${alpha(UI_COLORS.white, 0.1)}`,
                   backgroundColor: UI_COLORS.black,
                 }}
@@ -166,7 +166,7 @@ const PRComments: React.FC<PRCommentsProps> = ({
               borderRadius: '6px',
               position: 'relative',
               '&::after': {
-                content: '""',
+                content: { xs: 'none', sm: '""' },
                 position: 'absolute',
                 top: '11px',
                 right: '100%',
@@ -183,8 +183,8 @@ const PRComments: React.FC<PRCommentsProps> = ({
             {/* Header */}
             <Box
               sx={{
-                px: 2,
-                py: 1.5, // Slightly more vertical padding
+                px: { xs: 1.5, sm: 2 },
+                py: { xs: 1, sm: 1.5 }, // Slightly more vertical padding on larger screens
                 backgroundColor: colors.canvas.subtle,
                 borderBottom: `1px solid ${colors.border.default}`,
                 borderTopLeftRadius: '6px',
@@ -192,8 +192,10 @@ const PRComments: React.FC<PRCommentsProps> = ({
                 display: 'flex',
                 alignItems: 'center',
                 justifyContent: 'space-between',
+                gap: 1,
+                flexWrap: 'wrap',
                 color: colors.fg.muted,
-                fontSize: '14px',
+                fontSize: { xs: '13px', sm: '14px' },
                 position: 'relative',
                 zIndex: 1, // Ensure above the arrow pseudo-element's main body
               }}
@@ -204,6 +206,7 @@ const PRComments: React.FC<PRCommentsProps> = ({
                   alignItems: 'center',
                   gap: 1,
                   flexWrap: 'wrap',
+                  minWidth: 0,
                 }}
               >
                 <Link
@@ -269,9 +272,9 @@ const PRComments: React.FC<PRCommentsProps> = ({
             {/* Markdown Content */}
             <Box
               sx={{
-                p: { xs: 2, md: 3 }, // More padding on larger screens
+                p: { xs: 1.5, sm: 2, md: 3 }, // More padding on larger screens
                 color: colors.fg.default,
-                fontSize: '14px',
+                fontSize: { xs: '13px', sm: '14px' },
                 lineHeight: 1.6,
                 fontFamily:
                   '-apple-system,BlinkMacSystemFont,"Segoe UI","Noto Sans",Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji"', // GitHub's exact font stack

--- a/src/components/prs/PRDetailsCard.tsx
+++ b/src/components/prs/PRDetailsCard.tsx
@@ -152,11 +152,14 @@ const PRDetailsCard: React.FC<PRDetailsCardProps> = ({
         },
         tooltip: {
           trigger: 'item',
+          confine: true,
           formatter: '{b}: {c} ({d}%)',
           backgroundColor: alpha(theme.palette.common.black, 0.9),
           borderColor: alpha(theme.palette.common.white, 0.15),
           borderWidth: 1,
           textStyle: { color: theme.palette.text.primary },
+          extraCssText:
+            'max-width: 90vw; white-space: normal; word-break: break-word;',
         },
         series: [
           {
@@ -195,7 +198,7 @@ const PRDetailsCard: React.FC<PRDetailsCardProps> = ({
         borderRadius: 3,
         border: `1px solid ${theme.palette.border.light}`,
         backgroundColor: 'transparent',
-        p: 3,
+        p: { xs: 2, sm: 3 },
       }}
       elevation={0}
     >

--- a/src/components/prs/PRFilesChanged.tsx
+++ b/src/components/prs/PRFilesChanged.tsx
@@ -1175,12 +1175,18 @@ const PRFileDiffViewer: React.FC<{
               alignItems: 'center',
               gap: 1,
               overflow: 'hidden',
+              minWidth: 0,
+              flex: 1,
             }}
           >
             <Typography
               sx={{
-                fontSize: '0.9rem',
+                fontSize: { xs: '0.8rem', sm: '0.9rem' },
                 fontWeight: 600,
+                whiteSpace: 'nowrap',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                minWidth: 0,
               }}
             >
               {file.filename}
@@ -1213,7 +1219,8 @@ const PRFileDiffViewer: React.FC<{
             sx={{
               display: 'flex',
               alignItems: 'center',
-              gap: 2,
+              gap: { xs: 1, sm: 2 },
+              ml: 1,
               mr: 1,
               flexShrink: 0,
             }}
@@ -1221,7 +1228,7 @@ const PRFileDiffViewer: React.FC<{
             <Typography
               sx={{
                 color: 'diff.additions',
-                fontSize: '0.85rem',
+                fontSize: { xs: '0.8rem', sm: '0.85rem' },
                 fontWeight: 600,
               }}
             >
@@ -1230,7 +1237,7 @@ const PRFileDiffViewer: React.FC<{
             <Typography
               sx={{
                 color: 'diff.deletions',
-                fontSize: '0.85rem',
+                fontSize: { xs: '0.8rem', sm: '0.85rem' },
                 fontWeight: 600,
               }}
             >
@@ -1255,7 +1262,7 @@ const PRFileDiffViewer: React.FC<{
               flex: 1,
               overflowX: 'auto',
               overflowY: 'auto',
-              mr: '16px',
+              mr: { xs: 0, sm: '16px' },
               ...scrollbarSx,
             }}
           >
@@ -1266,11 +1273,13 @@ const PRFileDiffViewer: React.FC<{
             )}
           </Box>
 
-          {/* Minimap */}
-          <DiffMinimap
-            files={parsedDiff}
-            scrollContainerRef={scrollContainerRef}
-          />
+          {/* Minimap (hidden on mobile) */}
+          <Box sx={{ display: { xs: 'none', sm: 'flex' } }}>
+            <DiffMinimap
+              files={parsedDiff}
+              scrollContainerRef={scrollContainerRef}
+            />
+          </Box>
         </AccordionDetails>
       </Accordion>
     </Paper>
@@ -1384,14 +1393,14 @@ const PRFilesChanged: React.FC<PRFilesChangedProps> = ({
   }
 
   return (
-    <Grid container spacing={3}>
+    <Grid container spacing={{ xs: 2, md: 3 }}>
       {/* Sidebar - File Tree */}
       <Grid item xs={12} md={3}>
         <Box
           sx={{
-            position: 'sticky',
-            top: 24,
-            maxHeight: 'calc(100vh - 100px)',
+            position: { xs: 'static', md: 'sticky' },
+            top: { md: 24 },
+            maxHeight: { xs: 280, md: 'calc(100vh - 100px)' },
             overflowY: 'auto',
             backgroundColor: 'background.paper',
             borderRadius: '8px',
@@ -1509,7 +1518,14 @@ const PRFilesChanged: React.FC<PRFilesChangedProps> = ({
 
       {/* Content - File Diffs */}
       <Grid item xs={12} md={9}>
-        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3, pb: 20 }}>
+        <Box
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: { xs: 2, md: 3 },
+            pb: { xs: 4, md: 20 },
+          }}
+        >
           {files.map((file) => (
             <PRFileDiffViewer
               key={file.sha}

--- a/src/components/prs/PRHeader.tsx
+++ b/src/components/prs/PRHeader.tsx
@@ -93,9 +93,10 @@ const PRHeader: React.FC<PRHeaderProps> = ({
           sx={{
             display: 'flex',
             alignItems: 'center',
-            flexWrap: 'wrap',
+            flexWrap: 'nowrap',
             gap: { xs: 1, sm: 1.5 },
             mb: 0.5,
+            minWidth: 0,
           }}
         >
           <Typography
@@ -104,6 +105,7 @@ const PRHeader: React.FC<PRHeaderProps> = ({
               color: 'text.primary',
               fontSize: { xs: '1.1rem', sm: '1.3rem' },
               fontWeight: 500,
+              flexShrink: 0,
             }}
           >
             #{pullRequestNumber}
@@ -117,6 +119,7 @@ const PRHeader: React.FC<PRHeaderProps> = ({
               backgroundColor: alpha(statusColor, 0.2),
               border: '1px solid',
               borderColor: alpha(statusColor, 0.4),
+              flexShrink: 0,
             }}
           >
             <Typography
@@ -147,10 +150,14 @@ const PRHeader: React.FC<PRHeaderProps> = ({
               fontFamily: '"JetBrains Mono", monospace',
               fontSize: { xs: '0.75rem', sm: '0.8rem' },
               fontWeight: 600,
-              px: { xs: 1, sm: 1.5 },
+              px: { xs: 0.75, sm: 1.5 },
               minWidth: 0,
+              flexShrink: 0,
               whiteSpace: 'nowrap',
-              '& .MuiButton-startIcon': { mr: { xs: 0.5, sm: 1 } },
+              '& .MuiButton-startIcon': {
+                mr: { xs: 0, sm: 1 },
+                ml: { xs: 0, sm: 0 },
+              },
               '&:hover': {
                 borderColor: STATUS_COLORS.info,
                 color: STATUS_COLORS.info,
@@ -163,12 +170,6 @@ const PRHeader: React.FC<PRHeaderProps> = ({
               sx={{ display: { xs: 'none', sm: 'inline' } }}
             >
               Open on GitHub
-            </Box>
-            <Box
-              component="span"
-              sx={{ display: { xs: 'inline', sm: 'none' } }}
-            >
-              GitHub
             </Box>
           </Button>
         </Box>

--- a/src/components/prs/PRHeader.tsx
+++ b/src/components/prs/PRHeader.tsx
@@ -54,193 +54,6 @@ const PRHeader: React.FC<PRHeaderProps> = ({
         ? STATUS_COLORS.merged
         : STATUS_COLORS.open;
 
-  const scoreContent = isOpenPR ? (
-    /* Open PR: Show Potential Score | Collateral */
-    <Box
-      sx={{
-        display: 'flex',
-        alignItems: 'flex-start',
-        gap: { xs: 1.5, sm: 2.5 },
-      }}
-    >
-      {/* Potential Score */}
-      <Box sx={{ textAlign: 'right' }}>
-        <Tooltip
-          title="Potential score is an estimated earned score if this PR is merged. Some factors like the repository uniqueness multiplier depend on other miners' results at merge time and cannot be predicted exactly."
-          arrow
-          placement="top"
-          slotProps={{
-            tooltip: {
-              sx: {
-                backgroundColor: 'surface.tooltip',
-                color: 'text.primary',
-                fontSize: '0.75rem',
-                padding: '8px 12px',
-                borderRadius: '6px',
-                border: '1px solid',
-                borderColor: 'border.light',
-                maxWidth: 280,
-              },
-            },
-            arrow: { sx: { color: 'surface.tooltip' } },
-          }}
-        >
-          <Typography
-            sx={{
-              color: 'text.tertiary',
-              fontSize: '0.75rem',
-              textTransform: 'uppercase',
-              letterSpacing: '0.5px',
-              mb: 0.5,
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'flex-end',
-              gap: 0.5,
-              cursor: 'pointer',
-            }}
-          >
-            Potential
-            <InfoOutlinedIcon sx={{ fontSize: '0.9rem' }} />
-          </Typography>
-        </Tooltip>
-        <Typography
-          sx={{
-            fontSize: { xs: '1.5rem', sm: '2.25rem' },
-            fontWeight: 700,
-            lineHeight: 1,
-            color: 'text.secondary',
-          }}
-        >
-          {(collateralScore * 5).toFixed(2)}
-        </Typography>
-      </Box>
-
-      {/* Divider */}
-      <Box
-        sx={{
-          width: '1px',
-          height: { xs: '40px', sm: '55px' },
-          backgroundColor: 'border.light',
-          mt: 0.5,
-        }}
-      />
-
-      {/* Collateral */}
-      <Box sx={{ textAlign: 'right' }}>
-        <Tooltip
-          title="Open collateral is deducted from your total score while PRs are open, preventing low-quality PR spam."
-          arrow
-          placement="top"
-          slotProps={{
-            tooltip: {
-              sx: {
-                backgroundColor: 'surface.tooltip',
-                color: 'text.primary',
-                fontSize: '0.75rem',
-                padding: '8px 12px',
-                borderRadius: '6px',
-                border: '1px solid',
-                borderColor: 'border.light',
-                maxWidth: 240,
-              },
-            },
-            arrow: { sx: { color: 'surface.tooltip' } },
-          }}
-        >
-          <Typography
-            sx={{
-              color: 'text.tertiary',
-              fontSize: '0.75rem',
-              textTransform: 'uppercase',
-              letterSpacing: '0.5px',
-              mb: 0.5,
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'flex-end',
-              gap: 0.5,
-              cursor: 'pointer',
-            }}
-          >
-            Collateral
-            <InfoOutlinedIcon sx={{ fontSize: '0.9rem' }} />
-          </Typography>
-        </Tooltip>
-        <Typography
-          sx={{
-            fontSize: { xs: '1.5rem', sm: '2.25rem' },
-            fontWeight: 700,
-            lineHeight: 1,
-            color: collateralScore > 0 ? 'risk.exceeded' : 'text.secondary',
-          }}
-        >
-          {collateralScore > 0
-            ? `-${collateralScore.toFixed(2)}`
-            : collateralScore.toFixed(2)}
-        </Typography>
-      </Box>
-    </Box>
-  ) : (
-    /* Merged/Closed PR: Show Score */
-    <Box sx={{ textAlign: 'right' }}>
-      <Typography
-        sx={{
-          color: 'text.tertiary',
-          fontSize: '0.75rem',
-          textTransform: 'uppercase',
-          letterSpacing: '0.5px',
-          mb: 0.5,
-        }}
-      >
-        Score
-      </Typography>
-      <Typography
-        sx={{
-          fontSize: { xs: '1.75rem', sm: '2.25rem' },
-          fontWeight: 700,
-          lineHeight: 1,
-          color: isClosed ? 'text.secondary' : 'text.primary',
-        }}
-      >
-        {earnedScore.toFixed(2)}
-      </Typography>
-      {!isClosed && predictedUsdPerDay != null && predictedUsdPerDay > 0 && (
-        <Tooltip
-          title="This is an estimation. Actual payouts depend on validator consensus, network incentive distribution, and other miners' scores."
-          arrow
-          placement="bottom"
-          slotProps={{
-            tooltip: {
-              sx: {
-                backgroundColor: 'surface.tooltip',
-                color: 'text.primary',
-                fontSize: '0.75rem',
-                padding: '8px 12px',
-                borderRadius: '6px',
-                border: '1px solid',
-                borderColor: 'border.light',
-                maxWidth: 280,
-              },
-            },
-            arrow: { sx: { color: 'surface.tooltip' } },
-          }}
-        >
-          <Typography
-            sx={{
-              fontSize: '0.95rem',
-              color: 'status.success',
-              opacity: 0.8,
-              mt: 0.5,
-              cursor: 'pointer',
-            }}
-          >
-            ~{formatUsdEstimate(predictedUsdPerDay, { showZero: true })}
-            /day
-          </Typography>
-        </Tooltip>
-      )}
-    </Box>
-  );
-
   return (
     <Box
       sx={{
@@ -580,7 +393,201 @@ const PRHeader: React.FC<PRHeaderProps> = ({
           gap: 0.75,
         }}
       >
-        {scoreContent}
+        {isOpenPR ? (
+          /* Open PR: Show Potential Score | Collateral */
+          <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 2.5 }}>
+            {/* Potential Score */}
+            <Box sx={{ textAlign: 'right' }}>
+              <Tooltip
+                title="Potential score is an estimated earned score if this PR is merged. Some factors like the repository uniqueness multiplier depend on other miners' results at merge time and cannot be predicted exactly."
+                arrow
+                placement="top"
+                slotProps={{
+                  tooltip: {
+                    sx: {
+                      backgroundColor: 'surface.tooltip',
+                      color: 'text.primary',
+                      fontSize: '0.75rem',
+                      padding: '8px 12px',
+                      borderRadius: '6px',
+                      border: '1px solid',
+                      borderColor: 'border.light',
+                      maxWidth: 280,
+                    },
+                  },
+                  arrow: {
+                    sx: {
+                      color: 'surface.tooltip',
+                    },
+                  },
+                }}
+              >
+                <Typography
+                  sx={{
+                    color: 'text.tertiary',
+                    fontSize: '0.75rem',
+                    textTransform: 'uppercase',
+                    letterSpacing: '0.5px',
+                    mb: 0.5,
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'flex-end',
+                    gap: 0.5,
+                    cursor: 'pointer',
+                  }}
+                >
+                  Potential
+                  <InfoOutlinedIcon sx={{ fontSize: '0.9rem' }} />
+                </Typography>
+              </Tooltip>
+              <Typography
+                sx={{
+                  fontSize: '2.25rem',
+                  fontWeight: 700,
+                  lineHeight: 1,
+                  color: 'text.secondary',
+                }}
+              >
+                {(collateralScore * 5).toFixed(2)}
+              </Typography>
+            </Box>
+
+            {/* Divider */}
+            <Box
+              sx={{
+                width: '1px',
+                height: '55px',
+                backgroundColor: 'border.light',
+                mt: 0.5,
+              }}
+            />
+
+            {/* Collateral */}
+            <Box sx={{ textAlign: 'right' }}>
+              <Tooltip
+                title="Open collateral is deducted from your total score while PRs are open, preventing low-quality PR spam."
+                arrow
+                placement="top"
+                slotProps={{
+                  tooltip: {
+                    sx: {
+                      backgroundColor: 'surface.tooltip',
+                      color: 'text.primary',
+                      fontSize: '0.75rem',
+                      padding: '8px 12px',
+                      borderRadius: '6px',
+                      border: '1px solid',
+                      borderColor: 'border.light',
+                      maxWidth: 240,
+                    },
+                  },
+                  arrow: {
+                    sx: {
+                      color: 'surface.tooltip',
+                    },
+                  },
+                }}
+              >
+                <Typography
+                  sx={{
+                    color: 'text.tertiary',
+                    fontSize: '0.75rem',
+                    textTransform: 'uppercase',
+                    letterSpacing: '0.5px',
+                    mb: 0.5,
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'flex-end',
+                    gap: 0.5,
+                    cursor: 'pointer',
+                  }}
+                >
+                  Collateral
+                  <InfoOutlinedIcon sx={{ fontSize: '0.9rem' }} />
+                </Typography>
+              </Tooltip>
+              <Typography
+                sx={{
+                  fontSize: '2.25rem',
+                  fontWeight: 700,
+                  lineHeight: 1,
+                  color:
+                    collateralScore > 0 ? 'risk.exceeded' : 'text.secondary',
+                }}
+              >
+                {collateralScore > 0
+                  ? `-${collateralScore.toFixed(2)}`
+                  : collateralScore.toFixed(2)}
+              </Typography>
+            </Box>
+          </Box>
+        ) : (
+          /* Merged/Closed PR: Show Score */
+          <Box sx={{ textAlign: 'right' }}>
+            <Typography
+              sx={{
+                color: 'text.tertiary',
+                fontSize: '0.75rem',
+                textTransform: 'uppercase',
+                letterSpacing: '0.5px',
+                mb: 0.5,
+              }}
+            >
+              Score
+            </Typography>
+            <Typography
+              sx={{
+                fontSize: '2.25rem',
+                fontWeight: 700,
+                lineHeight: 1,
+                color: isClosed ? 'text.secondary' : 'text.primary',
+              }}
+            >
+              {earnedScore.toFixed(2)}
+            </Typography>
+            {!isClosed &&
+              predictedUsdPerDay != null &&
+              predictedUsdPerDay > 0 && (
+                <Tooltip
+                  title="This is an estimation. Actual payouts depend on validator consensus, network incentive distribution, and other miners' scores."
+                  arrow
+                  placement="bottom"
+                  slotProps={{
+                    tooltip: {
+                      sx: {
+                        backgroundColor: 'surface.tooltip',
+                        color: 'text.primary',
+                        fontSize: '0.75rem',
+                        padding: '8px 12px',
+                        borderRadius: '6px',
+                        border: '1px solid',
+                        borderColor: 'border.light',
+                        maxWidth: 280,
+                      },
+                    },
+                    arrow: {
+                      sx: {
+                        color: 'surface.tooltip',
+                      },
+                    },
+                  }}
+                >
+                  <Typography
+                    sx={{
+                      fontSize: '0.95rem',
+                      color: 'status.success',
+                      opacity: 0.8,
+                      mt: 0.5,
+                      cursor: 'pointer',
+                    }}
+                  >
+                    ~{formatUsdEstimate(predictedUsdPerDay, { showZero: true })}
+                    /day
+                  </Typography>
+                </Tooltip>
+              )}
+          </Box>
+        )}
       </Box>
     </Box>
   );

--- a/src/components/prs/PRHeader.tsx
+++ b/src/components/prs/PRHeader.tsx
@@ -54,8 +54,203 @@ const PRHeader: React.FC<PRHeaderProps> = ({
         ? STATUS_COLORS.merged
         : STATUS_COLORS.open;
 
+  const scoreContent = isOpenPR ? (
+    /* Open PR: Show Potential Score | Collateral */
+    <Box
+      sx={{
+        display: 'flex',
+        alignItems: 'flex-start',
+        gap: { xs: 1.5, sm: 2.5 },
+      }}
+    >
+      {/* Potential Score */}
+      <Box sx={{ textAlign: 'right' }}>
+        <Tooltip
+          title="Potential score is an estimated earned score if this PR is merged. Some factors like the repository uniqueness multiplier depend on other miners' results at merge time and cannot be predicted exactly."
+          arrow
+          placement="top"
+          slotProps={{
+            tooltip: {
+              sx: {
+                backgroundColor: 'surface.tooltip',
+                color: 'text.primary',
+                fontSize: '0.75rem',
+                padding: '8px 12px',
+                borderRadius: '6px',
+                border: '1px solid',
+                borderColor: 'border.light',
+                maxWidth: 280,
+              },
+            },
+            arrow: { sx: { color: 'surface.tooltip' } },
+          }}
+        >
+          <Typography
+            sx={{
+              color: 'text.tertiary',
+              fontSize: '0.75rem',
+              textTransform: 'uppercase',
+              letterSpacing: '0.5px',
+              mb: 0.5,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'flex-end',
+              gap: 0.5,
+              cursor: 'pointer',
+            }}
+          >
+            Potential
+            <InfoOutlinedIcon sx={{ fontSize: '0.9rem' }} />
+          </Typography>
+        </Tooltip>
+        <Typography
+          sx={{
+            fontSize: { xs: '1.5rem', sm: '2.25rem' },
+            fontWeight: 700,
+            lineHeight: 1,
+            color: 'text.secondary',
+          }}
+        >
+          {(collateralScore * 5).toFixed(2)}
+        </Typography>
+      </Box>
+
+      {/* Divider */}
+      <Box
+        sx={{
+          width: '1px',
+          height: { xs: '40px', sm: '55px' },
+          backgroundColor: 'border.light',
+          mt: 0.5,
+        }}
+      />
+
+      {/* Collateral */}
+      <Box sx={{ textAlign: 'right' }}>
+        <Tooltip
+          title="Open collateral is deducted from your total score while PRs are open, preventing low-quality PR spam."
+          arrow
+          placement="top"
+          slotProps={{
+            tooltip: {
+              sx: {
+                backgroundColor: 'surface.tooltip',
+                color: 'text.primary',
+                fontSize: '0.75rem',
+                padding: '8px 12px',
+                borderRadius: '6px',
+                border: '1px solid',
+                borderColor: 'border.light',
+                maxWidth: 240,
+              },
+            },
+            arrow: { sx: { color: 'surface.tooltip' } },
+          }}
+        >
+          <Typography
+            sx={{
+              color: 'text.tertiary',
+              fontSize: '0.75rem',
+              textTransform: 'uppercase',
+              letterSpacing: '0.5px',
+              mb: 0.5,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'flex-end',
+              gap: 0.5,
+              cursor: 'pointer',
+            }}
+          >
+            Collateral
+            <InfoOutlinedIcon sx={{ fontSize: '0.9rem' }} />
+          </Typography>
+        </Tooltip>
+        <Typography
+          sx={{
+            fontSize: { xs: '1.5rem', sm: '2.25rem' },
+            fontWeight: 700,
+            lineHeight: 1,
+            color: collateralScore > 0 ? 'risk.exceeded' : 'text.secondary',
+          }}
+        >
+          {collateralScore > 0
+            ? `-${collateralScore.toFixed(2)}`
+            : collateralScore.toFixed(2)}
+        </Typography>
+      </Box>
+    </Box>
+  ) : (
+    /* Merged/Closed PR: Show Score */
+    <Box sx={{ textAlign: 'right' }}>
+      <Typography
+        sx={{
+          color: 'text.tertiary',
+          fontSize: '0.75rem',
+          textTransform: 'uppercase',
+          letterSpacing: '0.5px',
+          mb: 0.5,
+        }}
+      >
+        Score
+      </Typography>
+      <Typography
+        sx={{
+          fontSize: { xs: '1.75rem', sm: '2.25rem' },
+          fontWeight: 700,
+          lineHeight: 1,
+          color: isClosed ? 'text.secondary' : 'text.primary',
+        }}
+      >
+        {earnedScore.toFixed(2)}
+      </Typography>
+      {!isClosed && predictedUsdPerDay != null && predictedUsdPerDay > 0 && (
+        <Tooltip
+          title="This is an estimation. Actual payouts depend on validator consensus, network incentive distribution, and other miners' scores."
+          arrow
+          placement="bottom"
+          slotProps={{
+            tooltip: {
+              sx: {
+                backgroundColor: 'surface.tooltip',
+                color: 'text.primary',
+                fontSize: '0.75rem',
+                padding: '8px 12px',
+                borderRadius: '6px',
+                border: '1px solid',
+                borderColor: 'border.light',
+                maxWidth: 280,
+              },
+            },
+            arrow: { sx: { color: 'surface.tooltip' } },
+          }}
+        >
+          <Typography
+            sx={{
+              fontSize: '0.95rem',
+              color: 'status.success',
+              opacity: 0.8,
+              mt: 0.5,
+              cursor: 'pointer',
+            }}
+          >
+            ~{formatUsdEstimate(predictedUsdPerDay, { showZero: true })}
+            /day
+          </Typography>
+        </Tooltip>
+      )}
+    </Box>
+  );
+
   return (
-    <Box sx={{ mb: 3, display: 'flex', alignItems: 'flex-start', gap: 2 }}>
+    <Box
+      sx={{
+        mb: 3,
+        display: 'flex',
+        alignItems: 'flex-start',
+        gap: { xs: 1.5, sm: 2 },
+        flexWrap: { xs: 'wrap', md: 'nowrap' },
+      }}
+    >
       <Box
         component="a"
         {...repoLinkProps}
@@ -72,21 +267,29 @@ const PRHeader: React.FC<PRHeaderProps> = ({
           src={`https://avatars.githubusercontent.com/${owner}`}
           alt={owner}
           sx={{
-            width: 64,
-            height: 64,
+            width: { xs: 48, sm: 64 },
+            height: { xs: 48, sm: 64 },
             border: '2px solid',
             borderColor: 'border.medium',
             backgroundColor: ownerAvatarBackground,
           }}
         />
       </Box>
-      <Box sx={{ flex: 1 }}>
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, mb: 0.5 }}>
+      <Box sx={{ flex: 1, minWidth: 0 }}>
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            flexWrap: 'wrap',
+            gap: { xs: 1, sm: 1.5 },
+            mb: 0.5,
+          }}
+        >
           <Typography
             variant="h5"
             sx={{
               color: 'text.primary',
-              fontSize: '1.3rem',
+              fontSize: { xs: '1.1rem', sm: '1.3rem' },
               fontWeight: 500,
             }}
           >
@@ -129,8 +332,12 @@ const PRHeader: React.FC<PRHeaderProps> = ({
               backgroundColor: alpha(STATUS_COLORS.info, 0.1),
               textTransform: 'none',
               fontFamily: '"JetBrains Mono", monospace',
-              fontSize: '0.8rem',
+              fontSize: { xs: '0.75rem', sm: '0.8rem' },
               fontWeight: 600,
+              px: { xs: 1, sm: 1.5 },
+              minWidth: 0,
+              whiteSpace: 'nowrap',
+              '& .MuiButton-startIcon': { mr: { xs: 0.5, sm: 1 } },
               '&:hover': {
                 borderColor: STATUS_COLORS.info,
                 color: STATUS_COLORS.info,
@@ -138,15 +345,27 @@ const PRHeader: React.FC<PRHeaderProps> = ({
               },
             }}
           >
-            Open on GitHub
+            <Box
+              component="span"
+              sx={{ display: { xs: 'none', sm: 'inline' } }}
+            >
+              Open on GitHub
+            </Box>
+            <Box
+              component="span"
+              sx={{ display: { xs: 'inline', sm: 'none' } }}
+            >
+              GitHub
+            </Box>
           </Button>
         </Box>
         <Typography
           sx={{
             color: 'text.primary',
-            fontSize: '1rem',
+            fontSize: { xs: '0.95rem', sm: '1rem' },
             fontWeight: 400,
             mb: 0.5,
+            wordBreak: 'break-word',
           }}
         >
           {prDetails.title}
@@ -170,6 +389,116 @@ const PRHeader: React.FC<PRHeaderProps> = ({
             {repository}
           </Typography>
         </Box>
+        {/* Mobile-only score chip row: appears above user/merged chips */}
+        <Box
+          sx={{
+            display: { xs: 'flex', md: 'none' },
+            alignItems: 'center',
+            flexWrap: 'wrap',
+            gap: 1,
+            mt: 1,
+          }}
+        >
+          {isOpenPR ? (
+            <>
+              <Box
+                sx={{
+                  ...chipSx,
+                  borderColor: 'border.light',
+                  backgroundColor: 'surface.subtle',
+                }}
+              >
+                <Typography
+                  sx={{
+                    color: 'text.tertiary',
+                    fontSize: '0.7rem',
+                    fontWeight: 600,
+                    textTransform: 'uppercase',
+                    letterSpacing: '0.5px',
+                  }}
+                >
+                  Potential
+                </Typography>
+                <Typography
+                  sx={{
+                    color: 'text.secondary',
+                    fontSize: '0.9rem',
+                    fontWeight: 700,
+                  }}
+                >
+                  {(collateralScore * 5).toFixed(2)}
+                </Typography>
+              </Box>
+              <Box
+                sx={{
+                  ...chipSx,
+                  borderColor:
+                    collateralScore > 0
+                      ? alpha(STATUS_COLORS.error, 0.3)
+                      : 'border.light',
+                  backgroundColor:
+                    collateralScore > 0
+                      ? alpha(STATUS_COLORS.error, 0.08)
+                      : 'surface.subtle',
+                }}
+              >
+                <Typography
+                  sx={{
+                    color: 'text.tertiary',
+                    fontSize: '0.7rem',
+                    fontWeight: 600,
+                    textTransform: 'uppercase',
+                    letterSpacing: '0.5px',
+                  }}
+                >
+                  Collateral
+                </Typography>
+                <Typography
+                  sx={{
+                    color:
+                      collateralScore > 0 ? 'risk.exceeded' : 'text.secondary',
+                    fontSize: '0.9rem',
+                    fontWeight: 700,
+                  }}
+                >
+                  {collateralScore > 0
+                    ? `-${collateralScore.toFixed(2)}`
+                    : collateralScore.toFixed(2)}
+                </Typography>
+              </Box>
+            </>
+          ) : (
+            <Box
+              sx={{
+                ...chipSx,
+                borderColor: 'border.light',
+                backgroundColor: 'surface.subtle',
+              }}
+            >
+              <Typography
+                sx={{
+                  color: 'text.tertiary',
+                  fontSize: '0.7rem',
+                  fontWeight: 600,
+                  textTransform: 'uppercase',
+                  letterSpacing: '0.5px',
+                }}
+              >
+                Score
+              </Typography>
+              <Typography
+                sx={{
+                  color: isClosed ? 'text.secondary' : 'text.primary',
+                  fontSize: '0.9rem',
+                  fontWeight: 700,
+                }}
+              >
+                {earnedScore.toFixed(2)}
+              </Typography>
+            </Box>
+          )}
+        </Box>
+
         <Box
           sx={{
             display: 'flex',
@@ -242,210 +571,16 @@ const PRHeader: React.FC<PRHeaderProps> = ({
         </Box>
       </Box>
 
-      {/* Score Section */}
+      {/* Desktop score: right column */}
       <Box
         sx={{
-          display: 'flex',
+          display: { xs: 'none', md: 'flex' },
           flexDirection: 'column',
           alignItems: 'flex-end',
           gap: 0.75,
         }}
       >
-        {isOpenPR ? (
-          /* Open PR: Show Potential Score | Collateral */
-          <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 2.5 }}>
-            {/* Potential Score */}
-            <Box sx={{ textAlign: 'right' }}>
-              <Tooltip
-                title="Potential score is an estimated earned score if this PR is merged. Some factors like the repository uniqueness multiplier depend on other miners' results at merge time and cannot be predicted exactly."
-                arrow
-                placement="top"
-                slotProps={{
-                  tooltip: {
-                    sx: {
-                      backgroundColor: 'surface.tooltip',
-                      color: 'text.primary',
-                      fontSize: '0.75rem',
-                      padding: '8px 12px',
-                      borderRadius: '6px',
-                      border: '1px solid',
-                      borderColor: 'border.light',
-                      maxWidth: 280,
-                    },
-                  },
-                  arrow: {
-                    sx: {
-                      color: 'surface.tooltip',
-                    },
-                  },
-                }}
-              >
-                <Typography
-                  sx={{
-                    color: 'text.tertiary',
-                    fontSize: '0.75rem',
-                    textTransform: 'uppercase',
-                    letterSpacing: '0.5px',
-                    mb: 0.5,
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'flex-end',
-                    gap: 0.5,
-                    cursor: 'pointer',
-                  }}
-                >
-                  Potential
-                  <InfoOutlinedIcon sx={{ fontSize: '0.9rem' }} />
-                </Typography>
-              </Tooltip>
-              <Typography
-                sx={{
-                  fontSize: '2.25rem',
-                  fontWeight: 700,
-                  lineHeight: 1,
-                  color: 'text.secondary',
-                }}
-              >
-                {(collateralScore * 5).toFixed(2)}
-              </Typography>
-            </Box>
-
-            {/* Divider */}
-            <Box
-              sx={{
-                width: '1px',
-                height: '55px',
-                backgroundColor: 'border.light',
-                mt: 0.5,
-              }}
-            />
-
-            {/* Collateral */}
-            <Box sx={{ textAlign: 'right' }}>
-              <Tooltip
-                title="Open collateral is deducted from your total score while PRs are open, preventing low-quality PR spam."
-                arrow
-                placement="top"
-                slotProps={{
-                  tooltip: {
-                    sx: {
-                      backgroundColor: 'surface.tooltip',
-                      color: 'text.primary',
-                      fontSize: '0.75rem',
-                      padding: '8px 12px',
-                      borderRadius: '6px',
-                      border: '1px solid',
-                      borderColor: 'border.light',
-                      maxWidth: 240,
-                    },
-                  },
-                  arrow: {
-                    sx: {
-                      color: 'surface.tooltip',
-                    },
-                  },
-                }}
-              >
-                <Typography
-                  sx={{
-                    color: 'text.tertiary',
-                    fontSize: '0.75rem',
-                    textTransform: 'uppercase',
-                    letterSpacing: '0.5px',
-                    mb: 0.5,
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'flex-end',
-                    gap: 0.5,
-                    cursor: 'pointer',
-                  }}
-                >
-                  Collateral
-                  <InfoOutlinedIcon sx={{ fontSize: '0.9rem' }} />
-                </Typography>
-              </Tooltip>
-              <Typography
-                sx={{
-                  fontSize: '2.25rem',
-                  fontWeight: 700,
-                  lineHeight: 1,
-                  color:
-                    collateralScore > 0 ? 'risk.exceeded' : 'text.secondary',
-                }}
-              >
-                {collateralScore > 0
-                  ? `-${collateralScore.toFixed(2)}`
-                  : collateralScore.toFixed(2)}
-              </Typography>
-            </Box>
-          </Box>
-        ) : (
-          /* Merged/Closed PR: Show Score */
-          <Box sx={{ textAlign: 'right' }}>
-            <Typography
-              sx={{
-                color: 'text.tertiary',
-                fontSize: '0.75rem',
-                textTransform: 'uppercase',
-                letterSpacing: '0.5px',
-                mb: 0.5,
-              }}
-            >
-              Score
-            </Typography>
-            <Typography
-              sx={{
-                fontSize: '2.25rem',
-                fontWeight: 700,
-                lineHeight: 1,
-                color: isClosed ? 'text.secondary' : 'text.primary',
-              }}
-            >
-              {earnedScore.toFixed(2)}
-            </Typography>
-            {!isClosed &&
-              predictedUsdPerDay != null &&
-              predictedUsdPerDay > 0 && (
-                <Tooltip
-                  title="This is an estimation. Actual payouts depend on validator consensus, network incentive distribution, and other miners' scores."
-                  arrow
-                  placement="bottom"
-                  slotProps={{
-                    tooltip: {
-                      sx: {
-                        backgroundColor: 'surface.tooltip',
-                        color: 'text.primary',
-                        fontSize: '0.75rem',
-                        padding: '8px 12px',
-                        borderRadius: '6px',
-                        border: '1px solid',
-                        borderColor: 'border.light',
-                        maxWidth: 280,
-                      },
-                    },
-                    arrow: {
-                      sx: {
-                        color: 'surface.tooltip',
-                      },
-                    },
-                  }}
-                >
-                  <Typography
-                    sx={{
-                      fontSize: '0.95rem',
-                      color: 'status.success',
-                      opacity: 0.8,
-                      mt: 0.5,
-                      cursor: 'pointer',
-                    }}
-                  >
-                    ~{formatUsdEstimate(predictedUsdPerDay, { showZero: true })}
-                    /day
-                  </Typography>
-                </Tooltip>
-              )}
-          </Box>
-        )}
+        {scoreContent}
       </Box>
     </Box>
   );

--- a/src/pages/PRDetailsPage.tsx
+++ b/src/pages/PRDetailsPage.tsx
@@ -131,6 +131,9 @@ const PRDetailsPage: React.FC = () => {
                 value={tabValue}
                 onChange={handleTabChange}
                 aria-label="pr details tabs"
+                variant="scrollable"
+                scrollButtons={false}
+                allowScrollButtonsMobile={false}
                 sx={(theme) => ({
                   '& .MuiTab-root': {
                     color: STATUS_COLORS.open,
@@ -139,7 +142,9 @@ const PRDetailsPage: React.FC = () => {
                     textTransform: 'none',
                     fontWeight: 500,
                     minHeight: '48px',
-                    fontSize: '14px',
+                    fontSize: { xs: '13px', sm: '14px' },
+                    minWidth: { xs: 'auto', sm: 90 },
+                    px: { xs: 1.25, sm: 2 },
                     '&.Mui-selected': {
                       color: theme.palette.text.primary,
                       fontWeight: 600,


### PR DESCRIPTION
## Summary

Make the PR details page (/miners/pr) mobile responsive while preserving the desktop layout.

PRHeader: stack avatar/title with smaller sizing on xs; collapse the "Open on GitHub" button label to "GitHub"; render score as a chip-style row that sits above the @user / Merged-date chips on mobile, while keeping the original right-column score block on desktop.

PRDetailsPage: switch the Overview / Files Changed / Conversation tabs to scrollable with reduced padding so all three fit on narrow viewports.

PRDetailsCard: reduce card padding on xs; add confine: true and a max-width: 90vw cap to the Token Composition donut tooltip so it no longer overflows the screen on mobile.

PRFilesChanged: make the file-tree sidebar non-sticky and capped at 280px on xs; hide the diff minimap on mobile; truncate long filenames with ellipsis; scale down additions/deletions counters and the trailing pad.

PRComments: shrink avatar, gaps, paddings, and font sizes on xs; hide the bubble's arrow tail; allow the header row to wrap.

## Related Issues

Closes: #823 

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots
Before:

https://github.com/user-attachments/assets/f62e32d1-03cc-44e3-88d6-c74c110698ac

After:

https://github.com/user-attachments/assets/26c608cb-a61c-43c6-a214-4b525fc75039



## Checklist

- [ ] New components are modularized/separated where sensible
- [X] Uses predefined theme (e.g. no hardcoded colors)
- [X] Responsive/mobile checked
- [ ] Tested against the test API
- [X] `npm run format` and `npm run lint:fix` have been run
- [X] `npm run build` passes
- [X] Screenshots included for any UI/visual changes
