### PR TITLE
feat(dashboard): improve Featured Work selection logic and card design

### DIFF
--- a/src/pages/dashboard/DashboardPage.tsx
+++ b/src/pages/dashboard/DashboardPage.tsx
@@ -23,6 +23,7 @@ const DashboardFeaturePage: React.FC = () => {
     trendLabels,
     trendSeries,
     featuredWork,
+    isFeaturedWorkLoading,
     featuredContributors,
     featuredDiscoveryContributors,
     isLoading,
@@ -96,7 +97,7 @@ const DashboardFeaturePage: React.FC = () => {
 
             <DashboardFeaturedWorkSection
               items={featuredWork}
-              isLoading={isLoading}
+              isLoading={isFeaturedWorkLoading}
             />
           </Box>
 

--- a/src/pages/dashboard/dashboardData.ts
+++ b/src/pages/dashboard/dashboardData.ts
@@ -7,10 +7,13 @@
  * Most dashboard sections are driven by the caller-provided time range.
  * Featured contributors intentionally use a fixed 35-day lookback window.
  */
-import { type CommitLog, type MinerEvaluation } from '../../api';
+import {
+  type CommitLog,
+  type MinerEvaluation,
+  type Repository,
+} from '../../api';
 import { type IssueBounty } from '../../api/models/Issues';
 import { getPrStatusLabel, parseNumber } from '../../utils';
-import { formatTokenAmount } from '../../utils/format';
 
 export type PresetTimeRange = '1d' | '7d' | '35d';
 export type TrendTimeRange = PresetTimeRange | 'all';
@@ -59,32 +62,41 @@ export interface DashboardFeaturedContributor {
     unit: string;
   }>;
   repos: string[];
+  /** Earnings in USD per day (displayed prominently like miner cards). */
+  usdPerDay?: number;
+  /** Credibility as 0-1 fraction (rendered as donut ring). */
+  credibility?: number;
+  /** Segments for the credibility donut (e.g. Merged/Open/Closed). */
+  segments?: Array<{ label: string; value: number }>;
 }
 
-export type DashboardFeaturedWorkKind = 'pr' | 'issue';
+type FeaturedWorkStatusTone = 'merged' | 'open' | 'closed';
 
-export interface DashboardFeaturedWork {
-  id: string;
-  kind: DashboardFeaturedWorkKind;
-  prNumber?: number;
-  issueId?: number;
-  githubNumber: number;
-  featuredLabel: string;
-  repository: string;
+export interface FeaturedWorkPr {
+  prNumber: number;
   title: string;
   score: number;
-  statusLabel: string;
-  statusTone: 'merged' | 'open' | 'closed';
-  authorLabel: string;
-  githubUsername?: string;
-  openedAt: string | null;
+  author: string;
+  mergedAt: string | null;
   additions: number;
   deletions: number;
-  metrics: Array<{
-    label: string;
-    value: string;
-    tone?: 'positive' | 'negative' | 'neutral';
-  }>;
+  statusLabel: string;
+  statusTone: FeaturedWorkStatusTone;
+}
+
+export interface FeaturedWorkRepo {
+  repository: string;
+  prCount: number;
+  totalScore: number;
+  windowLabel: string;
+  prs: FeaturedWorkPr[];
+}
+
+interface FeaturedWorkConfig {
+  readonly repoCount: number;
+  readonly prsPerRepo: number;
+  readonly windowHours: number;
+  readonly windowLabel: string;
 }
 
 const HOUR_MS = 60 * 60 * 1000;
@@ -606,6 +618,8 @@ const getTopContributorRepos = (prs: CommitLog[], githubId: string) => {
 
 const getHighestScoringMergedAuthor = (
   prs: CommitLog[],
+  miners: MinerEvaluation[],
+  exclude: Set<string> = new Set(),
 ): DashboardFeaturedContributor | undefined => {
   const currentWindow = getWindowBounds(CURRENT_LOOKBACK_WINDOW);
 
@@ -613,6 +627,7 @@ const getHighestScoringMergedAuthor = (
     .filter(
       (pr) =>
         !!pr.githubId &&
+        !exclude.has(pr.githubId) &&
         isWithinWindow(toTimestamp(pr.mergedAt), currentWindow),
     )
     .sort((a, b) => {
@@ -628,6 +643,7 @@ const getHighestScoringMergedAuthor = (
 
   if (!topPr?.githubId) return undefined;
 
+  const miner = miners.find((m) => m.githubId === topPr.githubId);
   return {
     githubId: topPr.githubId,
     githubUsername: topPr.author || undefined,
@@ -638,14 +654,23 @@ const getHighestScoringMergedAuthor = (
         value: Math.round(parseNumber(topPr.score)).toLocaleString(),
         unit: 'Score',
       },
+      ...optionalCredibilityMetrics(miner?.credibility),
     ],
     repos: topPr.repository ? [topPr.repository] : [],
+    usdPerDay: parseNumber(miner?.usdPerDay),
+    credibility: parseNumber(miner?.credibility),
+    segments: [
+      { label: 'Merged', value: parseNumber(miner?.totalMergedPrs) },
+      { label: 'Open', value: parseNumber(miner?.totalOpenPrs) },
+      { label: 'Closed', value: parseNumber(miner?.totalClosedPrs) },
+    ],
   };
 };
 
 const pickTopOssContributor = (
   prs: CommitLog[],
   miners: MinerEvaluation[],
+  exclude: Set<string> = new Set(),
 ): DashboardFeaturedContributor | undefined => {
   const topOssMiner = [...miners]
     .sort((a, b) => {
@@ -657,7 +682,10 @@ const pickTopOssContributor = (
 
       return a.id - b.id;
     })
-    .find((miner) => parseNumber(miner.totalScore) > 0);
+    .find(
+      (miner) =>
+        parseNumber(miner.totalScore) > 0 && !exclude.has(miner.githubId),
+    );
 
   if (!topOssMiner) return undefined;
 
@@ -674,18 +702,28 @@ const pickTopOssContributor = (
       ...optionalCredibilityMetrics(topOssMiner.credibility),
     ],
     repos: getTopContributorRepos(prs, topOssMiner.githubId),
+    usdPerDay: parseNumber(topOssMiner.usdPerDay),
+    credibility: parseNumber(topOssMiner.credibility),
+    segments: [
+      { label: 'Merged', value: parseNumber(topOssMiner.totalMergedPrs) },
+      { label: 'Open', value: parseNumber(topOssMiner.totalOpenPrs) },
+      { label: 'Closed', value: parseNumber(topOssMiner.totalClosedPrs) },
+    ],
   };
 };
 
 const pickMostMergedPrMiner = (
   prs: CommitLog[],
   miners: MinerEvaluation[],
+  exclude: Set<string> = new Set(),
 ): DashboardFeaturedContributor | undefined => {
-  const mostMergedPrMiner = [...miners].sort((a, b) => {
-    const diff = (b.totalMergedPrs ?? 0) - (a.totalMergedPrs ?? 0);
-    if (diff !== 0) return diff;
-    return b.totalScore - a.totalScore;
-  })[0];
+  const mostMergedPrMiner = [...miners]
+    .filter((m) => !exclude.has(m.githubId))
+    .sort((a, b) => {
+      const diff = (b.totalMergedPrs ?? 0) - (a.totalMergedPrs ?? 0);
+      if (diff !== 0) return diff;
+      return b.totalScore - a.totalScore;
+    })[0];
 
   if (!mostMergedPrMiner) return undefined;
 
@@ -702,6 +740,13 @@ const pickMostMergedPrMiner = (
       ...optionalCredibilityMetrics(mostMergedPrMiner.credibility),
     ],
     repos: getTopContributorRepos(prs, mostMergedPrMiner.githubId),
+    usdPerDay: parseNumber(mostMergedPrMiner.usdPerDay),
+    credibility: parseNumber(mostMergedPrMiner.credibility),
+    segments: [
+      { label: 'Merged', value: parseNumber(mostMergedPrMiner.totalMergedPrs) },
+      { label: 'Open', value: parseNumber(mostMergedPrMiner.totalOpenPrs) },
+      { label: 'Closed', value: parseNumber(mostMergedPrMiner.totalClosedPrs) },
+    ],
   };
 };
 
@@ -709,304 +754,171 @@ export const buildFeaturedContributors = (
   prs: CommitLog[],
   miners: MinerEvaluation[],
 ): DashboardFeaturedContributor[] => {
-  const highestScoringMergedAuthor = getHighestScoringMergedAuthor(prs);
-  const topOssMiner = pickTopOssContributor(prs, miners);
-  const mostMergedPrMiner = pickMostMergedPrMiner(prs, miners);
+  const seen = new Set<string>();
   const contributors: DashboardFeaturedContributor[] = [];
-
-  if (topOssMiner) contributors.push(topOssMiner);
-  if (mostMergedPrMiner) contributors.push(mostMergedPrMiner);
-  if (highestScoringMergedAuthor) contributors.push(highestScoringMergedAuthor);
-
+  const pickers: Array<() => DashboardFeaturedContributor | undefined> = [
+    () => pickTopOssContributor(prs, miners, seen),
+    () => pickMostMergedPrMiner(prs, miners, seen),
+    () => getHighestScoringMergedAuthor(prs, miners, seen),
+  ];
+  for (const pick of pickers) {
+    const c = pick();
+    if (c) {
+      seen.add(c.githubId);
+      contributors.push(c);
+    }
+  }
   return contributors;
 };
 
 const mapPrStatusTone = (
   statusLabel: ReturnType<typeof getPrStatusLabel>,
-): 'merged' | 'open' | 'closed' => {
+): FeaturedWorkStatusTone => {
   if (statusLabel === 'Merged') return 'merged';
   if (statusLabel === 'Closed') return 'closed';
   return 'open';
 };
 
-const mapIssueStatusTone = (
-  status: IssueBounty['status'],
-): 'merged' | 'open' | 'closed' => {
-  if (status === 'completed') return 'merged';
-  if (status === 'cancelled') return 'closed';
-  return 'open';
+const FEATURED_WORK_CONFIG: FeaturedWorkConfig = {
+  repoCount: 3,
+  prsPerRepo: 4,
+  windowHours: 24,
+  windowLabel: '24h',
+} as const;
+
+interface RepoAccumulator {
+  prs: CommitLog[];
+  totalScore: number;
+}
+
+type InactiveRepoSet = Set<string>;
+
+const buildInactiveRepoSet = (repos: Repository[]): InactiveRepoSet =>
+  new Set(
+    repos
+      .filter((r: Repository): boolean => !!r.inactiveAt)
+      .map((r: Repository): string => r.fullName.toLowerCase()),
+  );
+
+const isMergedInWindow = (
+  pr: CommitLog,
+  cutoff: number,
+  inactiveRepos: InactiveRepoSet,
+): boolean => {
+  const merged: number | null = toTimestamp(pr.mergedAt);
+  return (
+    merged !== null &&
+    merged >= cutoff &&
+    getPrStatusLabel(pr) === 'Merged' &&
+    Boolean(pr.repository) &&
+    !inactiveRepos.has(pr.repository.toLowerCase())
+  );
 };
 
-const getIssueStatusLabel = (status: IssueBounty['status']) => {
-  if (status === 'completed') return 'Completed';
-  if (status === 'cancelled') return 'Closed';
-  return 'Open';
+const groupPrsByRepo = (
+  windowPrs: CommitLog[],
+): Map<string, RepoAccumulator> => {
+  const repoMap = new Map<string, RepoAccumulator>();
+  for (const pr of windowPrs) {
+    const key: string = pr.repository.toLowerCase();
+    const entry: RepoAccumulator = repoMap.get(key) ?? {
+      prs: [],
+      totalScore: 0,
+    };
+    entry.prs.push(pr);
+    entry.totalScore += parseNumber(pr.score);
+    repoMap.set(key, entry);
+  }
+  return repoMap;
 };
 
-const getIssueDisplayAmount = (issue: IssueBounty): number => {
-  const target = parseNumber(issue.targetBounty);
-  const current = parseNumber(issue.bountyAmount);
-  return target > 0 ? target : current;
+const sortReposByActivity = (
+  entries: Array<[string, RepoAccumulator]>,
+): Array<[string, RepoAccumulator]> =>
+  entries.sort(
+    ([, a]: [string, RepoAccumulator], [, b]: [string, RepoAccumulator]) =>
+      b.totalScore - a.totalScore || b.prs.length - a.prs.length,
+  );
+
+const mapCommitLogToFeaturedPr = (pr: CommitLog): FeaturedWorkPr => {
+  const statusLabel: ReturnType<typeof getPrStatusLabel> = getPrStatusLabel(pr);
+  const statusTone: FeaturedWorkStatusTone = mapPrStatusTone(statusLabel);
+  return {
+    prNumber: pr.pullRequestNumber,
+    title: pr.pullRequestTitle || `PR #${pr.pullRequestNumber}`,
+    score: parseNumber(pr.score),
+    author: pr.author || 'unknown',
+    mergedAt: pr.mergedAt ?? null,
+    additions: parseNumber(pr.additions),
+    deletions: parseNumber(pr.deletions),
+    statusLabel,
+    statusTone,
+  };
+};
+
+const buildRepoEntry = (
+  repoPrs: CommitLog[],
+  totalScore: number,
+  config: FeaturedWorkConfig,
+): FeaturedWorkRepo => {
+  const sorted: CommitLog[] = [...repoPrs].sort(
+    (a: CommitLog, b: CommitLog) => parseNumber(b.score) - parseNumber(a.score),
+  );
+  const canonical: string = sorted[0].repository;
+  const topPrs: FeaturedWorkPr[] = sorted
+    .slice(0, config.prsPerRepo)
+    .map(mapCommitLogToFeaturedPr);
+  return {
+    repository: canonical,
+    prCount: repoPrs.length,
+    totalScore,
+    windowLabel: config.windowLabel,
+    prs: topPrs,
+  };
 };
 
 export const buildFeaturedWork = (
   prs: CommitLog[],
-  issues: IssueBounty[],
-): DashboardFeaturedWork[] => {
-  const currentWindow = getWindowBounds(CURRENT_LOOKBACK_WINDOW);
-  const selectedRepos = new Set<string>();
-  const selectedOrgs = new Set<string>();
-  const selectedAuthors = new Set<string>();
+  repos: Repository[],
+): FeaturedWorkRepo[] => {
+  const config: FeaturedWorkConfig = FEATURED_WORK_CONFIG;
+  const now: number = Date.now();
+  const cutoff: number = now - config.windowHours * HOUR_MS;
 
-  const isCandidateAllowed = (
-    repository: string,
-    authorLabel: string,
-    allowOrgAuthorDuplicates = false,
-  ) => {
-    const normalizedRepo = repository.toLowerCase();
-    const org = (repository.split('/')[0] || '').toLowerCase();
-    const author = (authorLabel || 'unknown').toLowerCase();
-    if (!normalizedRepo || !org) return false;
-    if (selectedRepos.has(normalizedRepo)) return false;
-    if (allowOrgAuthorDuplicates) return true;
-    return !selectedOrgs.has(org) && !selectedAuthors.has(author);
-  };
+  const inactiveRepos: InactiveRepoSet = buildInactiveRepoSet(repos);
 
-  const markAsSelected = (repository: string, authorLabel: string) => {
-    selectedRepos.add(repository.toLowerCase());
-    selectedOrgs.add((repository.split('/')[0] || '').toLowerCase());
-    selectedAuthors.add((authorLabel || 'unknown').toLowerCase());
-  };
-
-  const pickFirstDiverse = <T>(
-    sortedLists: T[][],
-    getRepository: (item: T) => string,
-    getAuthor: (item: T) => string,
-  ): T | undefined => {
-    for (const list of sortedLists) {
-      const found =
-        list.find((item) =>
-          isCandidateAllowed(getRepository(item), getAuthor(item)),
-        ) ??
-        list.find((item) =>
-          isCandidateAllowed(getRepository(item), getAuthor(item), true),
-        );
-      if (found) return found;
-    }
-    return undefined;
-  };
-
-  const mergedPrs = [...prs].filter(
-    (pr) =>
-      getPrStatusLabel(pr) === 'Merged' &&
-      isWithinWindow(toTimestamp(pr.mergedAt ?? pr.prCreatedAt), currentWindow),
-  );
-  const allWindowPrs = [...prs].filter((pr) =>
-    isWithinWindow(toTimestamp(pr.prCreatedAt), currentWindow),
+  const windowPrs: CommitLog[] = prs.filter((pr: CommitLog): boolean =>
+    isMergedInWindow(pr, cutoff, inactiveRepos),
   );
 
-  const toPrCard = (
-    pr: CommitLog,
-    featuredLabel: string,
-  ): DashboardFeaturedWork => {
-    const score = parseNumber(pr.score);
-    const additions = parseNumber(pr.additions);
-    const deletions = parseNumber(pr.deletions);
-    const commits = parseNumber(pr.commitCount);
-    const baseMetrics: DashboardFeaturedWork['metrics'] = [
-      { label: 'Score', value: score.toFixed(2) },
-      {
-        label: 'Changes',
-        value: `+${additions.toLocaleString()} / -${deletions.toLocaleString()}`,
-        tone: 'positive',
-      },
-      { label: 'Commits', value: commits.toLocaleString() },
-    ];
-    if (featuredLabel === 'Largest PR') {
-      baseMetrics[0] = {
-        label: 'Additions',
-        value: `+${additions.toLocaleString()}`,
-        tone: 'positive',
-      };
-      baseMetrics[1] = {
-        label: 'Deletions',
-        value: `-${deletions.toLocaleString()}`,
-        tone: 'negative',
-      };
-      baseMetrics[2] = {
-        label: 'Net Changes',
-        value: `+${(additions - deletions).toLocaleString()}`,
-        tone: 'positive',
-      };
-    } else if (featuredLabel === 'Most Commits PR') {
-      baseMetrics[0] = { label: 'Commits', value: commits.toLocaleString() };
-      baseMetrics[2] = { label: 'Score', value: score.toFixed(2) };
-    } else if (featuredLabel === 'Newest Merged PR') {
-      const mergedAt = toTimestamp(pr.mergedAt);
-      const ageDays =
-        mergedAt === null
-          ? null
-          : Math.max(0, Math.floor((currentWindow.endMs - mergedAt) / DAY_MS));
-      baseMetrics[0] = {
-        label: 'Merged',
-        value:
-          ageDays === null
-            ? '-'
-            : `${ageDays} day${ageDays === 1 ? '' : 's'} ago`,
-      };
-      baseMetrics[2] = { label: 'Score', value: score.toFixed(2) };
-    }
+  const repoMap: Map<string, RepoAccumulator> = groupPrsByRepo(windowPrs);
 
-    const statusLabel = getPrStatusLabel(pr);
-
-    return {
-      id: `pr-${featuredLabel}-${pr.repository}-${pr.pullRequestNumber}`,
-      kind: 'pr',
-      prNumber: pr.pullRequestNumber,
-      githubNumber: pr.pullRequestNumber,
-      featuredLabel,
-      repository: pr.repository,
-      title: pr.pullRequestTitle || `PR #${pr.pullRequestNumber}`,
-      score,
-      statusLabel,
-      statusTone: mapPrStatusTone(statusLabel),
-      authorLabel: pr.author || 'unknown',
-      githubUsername: pr.author || undefined,
-      openedAt: pr.mergedAt ?? pr.prCreatedAt ?? null,
-      additions,
-      deletions,
-      metrics: baseMetrics,
-    };
-  };
-
-  const pickPr = (
-    featuredLabel: string,
-    sortFn: (a: CommitLog, b: CommitLog) => number,
-  ) => {
-    const mergedSorted = [...mergedPrs].sort(sortFn);
-    const allSorted = [...allWindowPrs].sort(sortFn);
-    const candidate =
-      pickFirstDiverse(
-        [mergedSorted, allSorted],
-        (pr) => pr.repository,
-        (pr) => pr.author || 'unknown',
-      ) ??
-      mergedSorted.find((pr) => Boolean(pr.repository)) ??
-      allSorted.find((pr) => Boolean(pr.repository));
-    if (!candidate) return undefined;
-    markAsSelected(candidate.repository, candidate.author || 'unknown');
-    return toPrCard(candidate, featuredLabel);
-  };
-
-  const rankedHighestBountyIssues = [...issues]
-    .filter((issue) =>
-      isWithinWindow(
-        toTimestamp(issue.completedAt ?? issue.createdAt),
-        currentWindow,
-      ),
-    )
-    .sort((a, b) => {
-      const bountyDiff = getIssueDisplayAmount(b) - getIssueDisplayAmount(a);
-      if (bountyDiff !== 0) return bountyDiff;
-      return (
-        (toTimestamp(b.completedAt ?? b.createdAt) ?? 0) -
-        (toTimestamp(a.completedAt ?? a.createdAt) ?? 0)
-      );
-    });
-  const rankedCompletedIssues = rankedHighestBountyIssues.filter(
-    (issue) => issue.status === 'completed',
+  const rankedEntries: Array<[string, RepoAccumulator]> = sortReposByActivity(
+    Array.from(repoMap.entries()),
   );
 
-  const fallbackIssuePool = [...issues].sort(
-    (a, b) => getIssueDisplayAmount(b) - getIssueDisplayAmount(a),
-  );
-
-  const toIssueCard = (
-    issue: IssueBounty,
-    featuredLabel: string,
-  ): DashboardFeaturedWork => {
-    const payoutAmount = getIssueDisplayAmount(issue);
-    const author = issue.authorLogin || 'open bounty';
-    const statusLabel = getIssueStatusLabel(issue.status);
-    return {
-      id: `issue-${featuredLabel}-${issue.id}`,
-      kind: 'issue',
-      issueId: issue.id,
-      githubNumber: issue.issueNumber,
-      featuredLabel,
-      repository: issue.repositoryFullName,
-      title: issue.title || `Issue #${issue.issueNumber}`,
-      score: payoutAmount,
-      statusLabel,
-      statusTone: mapIssueStatusTone(issue.status),
-      authorLabel: author,
-      githubUsername: issue.authorLogin || undefined,
-      openedAt: issue.completedAt ?? issue.closedAt ?? issue.createdAt ?? null,
-      additions: payoutAmount,
-      deletions: 0,
-      metrics: [
-        { label: 'Payout', value: `${formatTokenAmount(payoutAmount, 2)} ل` },
-        { label: 'Issue #', value: `#${issue.issueNumber}` },
-      ],
-    };
-  };
-
-  const pickIssue = (featuredLabel: string, pool: IssueBounty[]) => {
-    const candidate =
-      pickFirstDiverse(
-        [pool, fallbackIssuePool],
-        (issue) => issue.repositoryFullName,
-        (issue) => issue.authorLogin || 'open bounty',
-      ) ??
-      pool[0] ??
-      fallbackIssuePool[0];
-    if (!candidate) return undefined;
-    markAsSelected(
-      candidate.repositoryFullName,
-      candidate.authorLogin || 'open bounty',
+  return rankedEntries
+    .slice(0, config.repoCount)
+    .map(
+      ([, { prs: repoPrs, totalScore }]: [
+        string,
+        RepoAccumulator,
+      ]): FeaturedWorkRepo => buildRepoEntry(repoPrs, totalScore, config),
     );
-    return toIssueCard(candidate, featuredLabel);
-  };
-
-  const picks: Array<DashboardFeaturedWork | undefined> = [
-    pickPr('Top PR by Score', (a, b) => {
-      const scoreDiff = parseNumber(b.score) - parseNumber(a.score);
-      if (scoreDiff !== 0) return scoreDiff;
-      return (toTimestamp(b.mergedAt) ?? 0) - (toTimestamp(a.mergedAt) ?? 0);
-    }),
-    pickPr('Largest PR', (a, b) => {
-      const aChanges = parseNumber(a.additions) + parseNumber(a.deletions);
-      const bChanges = parseNumber(b.additions) + parseNumber(b.deletions);
-      if (bChanges !== aChanges) return bChanges - aChanges;
-      return parseNumber(b.score) - parseNumber(a.score);
-    }),
-    pickPr('Most Commits PR', (a, b) => {
-      const commitDiff =
-        parseNumber(b.commitCount) - parseNumber(a.commitCount);
-      if (commitDiff !== 0) return commitDiff;
-      return parseNumber(b.score) - parseNumber(a.score);
-    }),
-    pickPr('Newest Merged PR', (a, b) => {
-      const dateDiff =
-        (toTimestamp(b.mergedAt) ?? 0) - (toTimestamp(a.mergedAt) ?? 0);
-      if (dateDiff !== 0) return dateDiff;
-      return parseNumber(b.score) - parseNumber(a.score);
-    }),
-    pickIssue('Top Completed Issue', rankedCompletedIssues),
-    pickIssue('Highest Bounty Issue', rankedHighestBountyIssues),
-  ];
-
-  return picks.filter((entry): entry is DashboardFeaturedWork =>
-    Boolean(entry),
-  );
 };
 
 const pickTopDiscoveryMiner = (
   prs: CommitLog[],
   miners: MinerEvaluation[],
+  exclude: Set<string> = new Set(),
 ): DashboardFeaturedContributor | undefined => {
   const top = [...miners]
-    .filter((m) => m.isIssueEligible && parseNumber(m.issueDiscoveryScore) > 0)
+    .filter(
+      (m) =>
+        m.isIssueEligible &&
+        parseNumber(m.issueDiscoveryScore) > 0 &&
+        !exclude.has(m.githubId),
+    )
     .sort((a, b) => {
       const diff =
         parseNumber(b.issueDiscoveryScore) - parseNumber(a.issueDiscoveryScore);
@@ -1030,15 +942,28 @@ const pickTopDiscoveryMiner = (
       ...optionalCredibilityMetrics(top.issueCredibility),
     ],
     repos: getTopContributorRepos(prs, top.githubId),
+    usdPerDay: parseNumber(top.usdPerDay),
+    credibility: parseNumber(top.issueCredibility),
+    segments: [
+      { label: 'Solved', value: parseNumber(top.totalValidSolvedIssues) },
+      { label: 'Open', value: parseNumber(top.totalOpenIssues) },
+      { label: 'Closed', value: parseNumber(top.totalClosedIssues) },
+    ],
   };
 };
 
 const pickMostSolvedIssuesMiner = (
   prs: CommitLog[],
   miners: MinerEvaluation[],
+  exclude: Set<string> = new Set(),
 ): DashboardFeaturedContributor | undefined => {
   const top = [...miners]
-    .filter((m) => m.isIssueEligible && (m.totalValidSolvedIssues ?? 0) > 0)
+    .filter(
+      (m) =>
+        m.isIssueEligible &&
+        (m.totalValidSolvedIssues ?? 0) > 0 &&
+        !exclude.has(m.githubId),
+    )
     .sort((a, b) => {
       const diff =
         (b.totalValidSolvedIssues ?? 0) - (a.totalValidSolvedIssues ?? 0);
@@ -1063,15 +988,28 @@ const pickMostSolvedIssuesMiner = (
       ...optionalCredibilityMetrics(top.issueCredibility),
     ],
     repos: getTopContributorRepos(prs, top.githubId),
+    usdPerDay: parseNumber(top.usdPerDay),
+    credibility: parseNumber(top.issueCredibility),
+    segments: [
+      { label: 'Solved', value: parseNumber(top.totalValidSolvedIssues) },
+      { label: 'Open', value: parseNumber(top.totalOpenIssues) },
+      { label: 'Closed', value: parseNumber(top.totalClosedIssues) },
+    ],
   };
 };
 
 const pickHighestIssueTokenScoreMiner = (
   prs: CommitLog[],
   miners: MinerEvaluation[],
+  exclude: Set<string> = new Set(),
 ): DashboardFeaturedContributor | undefined => {
   const top = [...miners]
-    .filter((m) => m.isIssueEligible && parseNumber(m.issueTokenScore) > 0)
+    .filter(
+      (m) =>
+        m.isIssueEligible &&
+        parseNumber(m.issueTokenScore) > 0 &&
+        !exclude.has(m.githubId),
+    )
     .sort((a, b) => {
       const diff =
         parseNumber(b.issueTokenScore) - parseNumber(a.issueTokenScore);
@@ -1090,8 +1028,16 @@ const pickHighestIssueTokenScoreMiner = (
         value: Math.round(parseNumber(top.issueTokenScore)).toLocaleString(),
         unit: 'Score',
       },
+      ...optionalCredibilityMetrics(top.issueCredibility),
     ],
     repos: getTopContributorRepos(prs, top.githubId),
+    usdPerDay: parseNumber(top.usdPerDay),
+    credibility: parseNumber(top.issueCredibility),
+    segments: [
+      { label: 'Solved', value: parseNumber(top.totalValidSolvedIssues) },
+      { label: 'Open', value: parseNumber(top.totalOpenIssues) },
+      { label: 'Closed', value: parseNumber(top.totalClosedIssues) },
+    ],
   };
 };
 
@@ -1099,18 +1045,19 @@ export const buildFeaturedDiscoveryContributors = (
   prs: CommitLog[],
   miners: MinerEvaluation[],
 ): DashboardFeaturedContributor[] => {
-  const topDiscoveryMiner = pickTopDiscoveryMiner(prs, miners);
-  const mostSolvedIssuesMiner = pickMostSolvedIssuesMiner(prs, miners);
-  const highestIssueTokenScoreMiner = pickHighestIssueTokenScoreMiner(
-    prs,
-    miners,
-  );
+  const seen = new Set<string>();
   const contributors: DashboardFeaturedContributor[] = [];
-
-  if (topDiscoveryMiner) contributors.push(topDiscoveryMiner);
-  if (mostSolvedIssuesMiner) contributors.push(mostSolvedIssuesMiner);
-  if (highestIssueTokenScoreMiner)
-    contributors.push(highestIssueTokenScoreMiner);
-
+  const pickers: Array<() => DashboardFeaturedContributor | undefined> = [
+    () => pickTopDiscoveryMiner(prs, miners, seen),
+    () => pickMostSolvedIssuesMiner(prs, miners, seen),
+    () => pickHighestIssueTokenScoreMiner(prs, miners, seen),
+  ];
+  for (const pick of pickers) {
+    const c = pick();
+    if (c) {
+      seen.add(c.githubId);
+      contributors.push(c);
+    }
+  }
   return contributors;
 };

--- a/src/pages/dashboard/useDashboardData.ts
+++ b/src/pages/dashboard/useDashboardData.ts
@@ -8,12 +8,18 @@
  * Keep pure domain/data builders out of this file.
  */
 import { useMemo } from 'react';
-import { useAllMiners, useAllPrs, useIssueDetails, useIssues } from '../../api';
+import {
+  useAllMiners,
+  useAllPrs,
+  useIssues,
+  useReposAndWeights,
+} from '../../api';
 import {
   type CommitLog,
   type DatasetState,
   type IssueBounty,
   type MinerEvaluation,
+  type Repository,
 } from '../../api/models';
 import {
   buildDashboardKpis,
@@ -29,12 +35,14 @@ type DashboardDatasets = {
   prs: DatasetState<CommitLog>;
   miners: DatasetState<MinerEvaluation>;
   issues: DatasetState<IssueBounty>;
+  repos: DatasetState<Repository>;
 };
 
 export const useDashboardData = (range: TrendTimeRange) => {
   const prsQuery = useAllPrs();
   const minersQuery = useAllMiners();
   const issuesQuery = useIssues();
+  const reposQuery = useReposAndWeights();
 
   const datasets: DashboardDatasets = {
     prs: {
@@ -51,6 +59,11 @@ export const useDashboardData = (range: TrendTimeRange) => {
       data: issuesQuery.data ?? [],
       isLoading: issuesQuery.isLoading,
       isError: issuesQuery.isError,
+    },
+    repos: {
+      data: reposQuery.data ?? [],
+      isLoading: reposQuery.isLoading,
+      isError: reposQuery.isError,
     },
   };
 
@@ -80,65 +93,18 @@ export const useDashboardData = (range: TrendTimeRange) => {
     [datasets.miners.data, datasets.prs.data],
   );
 
-  const preliminaryFeaturedWork = useMemo(
-    () => buildFeaturedWork(datasets.prs.data, datasets.issues.data),
-    [datasets.prs.data, datasets.issues.data],
-  );
-
-  const featuredIssueIds = useMemo(
-    () =>
-      preliminaryFeaturedWork
-        .filter((item) => item.kind === 'issue' && item.issueId)
-        .map((item) => item.issueId as number)
-        .slice(0, 2),
-    [preliminaryFeaturedWork],
-  );
-
-  const featuredIssueDetailsQueryA = useIssueDetails(featuredIssueIds[0] ?? 0);
-  const featuredIssueDetailsQueryB = useIssueDetails(featuredIssueIds[1] ?? 0);
-
-  const enrichedIssues = useMemo(() => {
-    const issues = datasets.issues.data;
-    const detailsByIssueId = new Map<number, IssueBounty>();
-    if (featuredIssueIds[0] && featuredIssueDetailsQueryA.data) {
-      detailsByIssueId.set(
-        featuredIssueIds[0],
-        featuredIssueDetailsQueryA.data,
-      );
-    }
-    if (featuredIssueIds[1] && featuredIssueDetailsQueryB.data) {
-      detailsByIssueId.set(
-        featuredIssueIds[1],
-        featuredIssueDetailsQueryB.data,
-      );
-    }
-    if (detailsByIssueId.size === 0) return issues;
-
-    return issues.map((issue): IssueBounty => {
-      const details = detailsByIssueId.get(issue.id);
-      if (!details) return issue;
-      return {
-        ...issue,
-        ...details,
-        authorLogin: details.authorLogin ?? issue.authorLogin ?? null,
-      };
-    });
-  }, [
-    datasets.issues.data,
-    featuredIssueIds,
-    featuredIssueDetailsQueryA.data,
-    featuredIssueDetailsQueryB.data,
-  ]);
-
   const featuredWork = useMemo(
-    () => buildFeaturedWork(datasets.prs.data, enrichedIssues),
-    [datasets.prs.data, enrichedIssues],
+    () => buildFeaturedWork(datasets.prs.data, datasets.repos.data),
+    [datasets.prs.data, datasets.repos.data],
   );
 
   const kpis = useMemo(
     () => buildDashboardKpis(datasets.prs.data, datasets.issues.data, range),
     [datasets.issues.data, datasets.prs.data, range],
   );
+
+  const isFeaturedWorkLoading =
+    datasets.prs.isLoading || datasets.repos.isLoading;
 
   return {
     datasets,
@@ -147,6 +113,7 @@ export const useDashboardData = (range: TrendTimeRange) => {
     trendLabels: trendData.labels,
     trendSeries: trendData.series,
     featuredWork,
+    isFeaturedWorkLoading,
     featuredContributors,
     featuredDiscoveryContributors,
     isLoading:

--- a/src/pages/dashboard/views/DashboardFeaturedWork.tsx
+++ b/src/pages/dashboard/views/DashboardFeaturedWork.tsx
@@ -1,92 +1,42 @@
-import React from 'react';
-import GitHubIcon from '@mui/icons-material/GitHub';
-import {
-  Avatar,
-  Box,
-  CircularProgress,
-  Stack,
-  Typography,
-} from '@mui/material';
-import { alpha, useTheme, type Theme } from '@mui/material/styles';
+import React, { useCallback, useMemo } from 'react';
+import { Box, CircularProgress, Typography } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
 import { useNavigate } from 'react-router-dom';
-import { getGithubAvatarSrc } from '../../../utils';
-import { type DashboardFeaturedWork } from '../dashboardData';
+import { type FeaturedWorkRepo, type FeaturedWorkPr } from '../dashboardData';
+import FeaturedWorkRepoCard from './FeaturedWorkRepoCard';
+import {
+  emptyMessageSx,
+  loaderContainerSx,
+  sectionContainerSx,
+  sectionTitleSx,
+} from './featuredWorkStyles';
 
 interface DashboardFeaturedWorkProps {
-  items: DashboardFeaturedWork[];
+  items: FeaturedWorkRepo[];
   isLoading?: boolean;
 }
 
-const utcFmt = new Intl.DateTimeFormat('en-US', {
-  month: 'short',
-  day: '2-digit',
-  hour12: false,
-  timeZone: 'UTC',
+type NavigateToRepoFn = (repoName: string) => void;
+type NavigateToPrFn = (repoName: string, pr: FeaturedWorkPr) => void;
+
+const FEATURED_WORK_EMPTY_MESSAGE = 'No merged PRs in the last 24 hours.';
+const FEATURED_WORK_TITLE = 'Featured Work';
+const MAX_COLUMNS_SM = 2;
+const MAX_COLUMNS_LG = 3;
+
+const buildPrDetailUrl = (repo: string, prNumber: number): string =>
+  `/miners/pr?repo=${encodeURIComponent(repo)}&number=${encodeURIComponent(String(prNumber))}`;
+
+const buildRepoDetailUrl = (repo: string): string =>
+  `/miners/repository?name=${encodeURIComponent(repo)}`;
+
+const computeGridColumns = (
+  itemCount: number,
+): { xs: string; sm: string; lg: string } => ({
+  xs: '1fr',
+  sm: `repeat(${Math.min(itemCount, MAX_COLUMNS_SM)}, minmax(0, 1fr))`,
+  lg: `repeat(${Math.min(itemCount, MAX_COLUMNS_LG)}, minmax(0, 1fr))`,
 });
-
-const formatUtc = (value: string | null) => {
-  if (!value) return '-';
-  const date = new Date(value);
-  return Number.isNaN(date.getTime())
-    ? '-'
-    : utcFmt.format(date).replace(',', '');
-};
-
-const tonePalette = (theme: Theme) =>
-  ({
-    merged: theme.palette.status.merged,
-    closed: theme.palette.status.closed,
-    open: theme.palette.status.open,
-  }) satisfies Record<DashboardFeaturedWork['statusTone'], string>;
-
-type Align = {
-  alignItems: 'flex-start' | 'center' | 'flex-end';
-  textAlign: 'left' | 'center' | 'right';
-};
-const ALIGN: Align[] = [
-  { alignItems: 'flex-start', textAlign: 'left' },
-  { alignItems: 'center', textAlign: 'center' },
-  { alignItems: 'flex-end', textAlign: 'right' },
-];
-
-const metricAlign = (count: number, i: number): Align =>
-  count === 2 ? (i === 0 ? ALIGN[0] : ALIGN[2]) : (ALIGN[i] ?? ALIGN[2]);
-
-const metricColor = (
-  theme: Theme,
-  tone?: 'positive' | 'negative' | 'neutral',
-) =>
-  tone === 'negative'
-    ? alpha(theme.palette.diff.deletions, 0.82)
-    : tone === 'positive'
-      ? alpha(theme.palette.diff.additions, 0.82)
-      : alpha(theme.palette.text.primary, 0.9);
-
-const CHANGES_SEP = ' / -';
-
-const renderChangesMetric = (theme: Theme, value: string) => {
-  const i = value.indexOf(CHANGES_SEP);
-  if (i === -1) return value;
-  return (
-    <>
-      {value.slice(0, i)}
-      <Box
-        component="span"
-        sx={{ color: alpha(theme.palette.text.primary, 0.9) }}
-      >
-        {' '}
-        /
-      </Box>
-      <Box
-        component="span"
-        sx={{ color: alpha(theme.palette.diff.deletions, 0.86) }}
-      >
-        {' '}
-        -{value.slice(i + CHANGES_SEP.length)}
-      </Box>
-    </>
-  );
-};
 
 const DashboardFeaturedWorkSection: React.FC<DashboardFeaturedWorkProps> = ({
   items,
@@ -94,323 +44,61 @@ const DashboardFeaturedWorkSection: React.FC<DashboardFeaturedWorkProps> = ({
 }) => {
   const theme = useTheme();
   const navigate = useNavigate();
-  const mono = theme.typography.fontFamily;
-  const border = theme.palette.border.light;
-  const divider = {
-    pt: 0.6,
-    borderTop: `1px solid ${alpha(theme.palette.text.primary, 0.2)}`,
-  };
+  const mono: string = theme.typography.fontFamily ?? 'monospace';
 
-  const openDetails = (item: DashboardFeaturedWork) =>
-    item.kind === 'pr'
-      ? navigate(
-          `/miners/pr?repo=${encodeURIComponent(item.repository)}&number=${encodeURIComponent(String(item.prNumber ?? ''))}`,
-        )
-      : navigate(
-          `/bounties/details?id=${encodeURIComponent(String(item.issueId ?? ''))}`,
-        );
+  const navigateToRepo: NavigateToRepoFn = useCallback(
+    (repoName: string): void => {
+      navigate(buildRepoDetailUrl(repoName));
+    },
+    [navigate],
+  );
 
-  const renderCard = (item: DashboardFeaturedWork) => {
-    const toneColor = tonePalette(theme)[item.statusTone];
-    const owner = item.repository.split('/')[0] || '';
-    const metrics = item.metrics.slice(0, 3);
-    const n = metrics.length || 1;
-    const labelTint =
-      item.kind === 'issue'
-        ? alpha(theme.palette.status.award, 0.9)
-        : alpha(theme.palette.status.merged, 0.9);
+  const navigateToPr: NavigateToPrFn = useCallback(
+    (repoName: string, pr: FeaturedWorkPr): void => {
+      navigate(buildPrDetailUrl(repoName, pr.prNumber));
+    },
+    [navigate],
+  );
 
-    return (
-      <Stack
-        key={item.id}
-        role="button"
-        tabIndex={0}
-        onClick={() => openDetails(item)}
-        onKeyDown={(e) => {
-          if (e.key === 'Enter' || e.key === ' ') {
-            e.preventDefault();
-            openDetails(item);
-          }
-        }}
-        sx={{
-          height: '100%',
-          minHeight: 262,
-          p: 0.9,
-          fontFamily: mono,
-          backgroundColor: alpha(theme.palette.common.white, 0.015),
-          borderRadius: 2,
-          border: `1px solid ${border}`,
-          display: 'grid',
-          gridTemplateRows: 'auto auto 2.56em auto auto',
-          rowGap: 0.55,
-          cursor: 'pointer',
-          transition:
-            'transform 0.18s ease, border-color 0.18s ease, box-shadow 0.18s ease',
-          '&:hover': {
-            transform: 'translateY(-1px)',
-            borderColor: alpha(theme.palette.status.merged, 0.3),
-            backgroundColor: theme.palette.surface.subtle,
-            boxShadow: `0 8px 24px ${alpha(theme.palette.common.black, 0.22)}`,
-          },
-          '&:focus-visible': {
-            outline: `2px solid ${alpha(toneColor, 0.45)}`,
-            outlineOffset: '2px',
-          },
-        }}
-      >
-        <Box
-          sx={{
-            display: 'grid',
-            gridTemplateColumns: '56px minmax(0, 1fr)',
-            columnGap: 1.15,
-            alignItems: 'center',
-            minWidth: 0,
-            py: 0.35,
-          }}
-        >
-          <Avatar
-            src={getGithubAvatarSrc(owner)}
-            alt={owner}
-            sx={{
-              width: 56,
-              height: 56,
-              bgcolor: theme.palette.surface.light,
-              border: `1px solid ${border}`,
-              '& .MuiSvgIcon-root': { fontSize: 29 },
-            }}
-          >
-            <GitHubIcon />
-          </Avatar>
-          <Box sx={{ minWidth: 0 }}>
-            <Typography
-              sx={{
-                color: theme.palette.text.primary,
-                fontFamily: 'inherit',
-                fontSize: '1.1rem',
-                fontWeight: 800,
-                letterSpacing: '0.01em',
-                lineHeight: 1.05,
-                whiteSpace: 'nowrap',
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
-                minWidth: 0,
-              }}
-            >
-              {item.repository}
-            </Typography>
-            <Typography
-              sx={{
-                mt: 0.28,
-                color: labelTint,
-                fontFamily: mono,
-                fontSize: '0.72rem',
-                fontWeight: 700,
-                letterSpacing: '0.02em',
-                whiteSpace: 'nowrap',
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
-              }}
-            >
-              {item.featuredLabel}
-            </Typography>
-          </Box>
-        </Box>
+  const gridColumns = useMemo(
+    () => computeGridColumns(items.length),
+    [items.length],
+  );
 
-        <Typography
-          sx={{
-            color: alpha(theme.palette.text.primary, 0.78),
-            fontFamily: 'inherit',
-            fontSize: '0.8rem',
-            fontWeight: 500,
-            lineHeight: 1.28,
-            height: '2.52em',
-            display: '-webkit-box',
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
-            WebkitLineClamp: 2,
-            WebkitBoxOrient: 'vertical',
-            wordBreak: 'break-word',
-            mt: 1.05,
-            mb: -0.35,
-          }}
-        >
-          {item.title}
-        </Typography>
-
-        <Stack
-          direction="row"
-          spacing={0.5}
-          alignItems="center"
-          sx={{ mt: -0.15 }}
-        >
-          <Avatar
-            src={getGithubAvatarSrc(item.githubUsername)}
-            alt={item.authorLabel}
-            sx={{
-              width: 18,
-              height: 18,
-              fontSize: '0.6rem',
-              bgcolor: theme.palette.surface.light,
-              border: `1px solid ${border}`,
-            }}
-          >
-            {item.authorLabel.slice(0, 1).toUpperCase()}
-          </Avatar>
-          <Typography
-            sx={{
-              color: alpha(theme.palette.text.primary, 0.64),
-              fontFamily: mono,
-              fontSize: '0.74rem',
-              fontWeight: 600,
-            }}
-          >
-            by {item.authorLabel}
-          </Typography>
-        </Stack>
-
-        <Stack
-          direction="row"
-          justifyContent="space-between"
-          alignItems="center"
-          sx={divider}
-        >
-          <Box
-            sx={{
-              px: 0.72,
-              py: 0.16,
-              borderRadius: 1.5,
-              border: `1px solid ${alpha(toneColor, 0.55)}`,
-              bgcolor: alpha(toneColor, 0.1),
-            }}
-          >
-            <Typography
-              sx={{
-                color: alpha(toneColor, 0.92),
-                fontFamily: mono,
-                fontSize: '0.74rem',
-                fontWeight: 700,
-                lineHeight: 1.1,
-              }}
-            >
-              {item.statusLabel}
-            </Typography>
-          </Box>
-          <Typography
-            sx={{
-              color: alpha(theme.palette.text.primary, 0.7),
-              fontFamily: mono,
-              fontSize: '0.72rem',
-              whiteSpace: 'nowrap',
-            }}
-          >
-            {formatUtc(item.openedAt)}
-          </Typography>
-        </Stack>
-
-        <Box sx={divider}>
-          <Box
-            sx={{
-              display: 'grid',
-              gridTemplateColumns: `repeat(${n}, minmax(0, 1fr))`,
-              gap: 0,
-            }}
-          >
-            {metrics.map((metric, i) => {
-              const { alignItems, textAlign } = metricAlign(n, i);
-              return (
-                <Stack
-                  key={`${item.id}-${metric.label}`}
-                  spacing={0.2}
-                  sx={{ alignItems, px: 0.65 }}
-                >
-                  <Typography
-                    sx={{
-                      color: alpha(theme.palette.text.primary, 0.58),
-                      fontFamily: mono,
-                      fontSize: '0.74rem',
-                      textAlign,
-                    }}
-                  >
-                    {metric.label}
-                  </Typography>
-                  <Typography
-                    sx={{
-                      color: metricColor(theme, metric.tone),
-                      fontFamily: mono,
-                      fontSize: '0.9rem',
-                      fontWeight: 700,
-                      lineHeight: 1.15,
-                      textAlign,
-                    }}
-                  >
-                    {metric.label === 'Changes' &&
-                    metric.value.includes(CHANGES_SEP)
-                      ? renderChangesMetric(theme, metric.value)
-                      : metric.value}
-                  </Typography>
-                </Stack>
-              );
-            })}
-          </Box>
-        </Box>
-      </Stack>
-    );
-  };
+  const hasItems: boolean = items.length > 0;
 
   return (
-    <Box
-      sx={{
-        width: '100%',
-        p: { xs: 1.45, sm: 1.65 },
-        borderRadius: 3,
-        border: `1px solid ${theme.palette.border.light}`,
-        backgroundColor: 'transparent',
-      }}
-    >
-      <Typography
-        sx={{
-          mb: 1.35,
-          color: theme.palette.text.primary,
-          fontFamily: mono,
-          fontSize: { xs: '1.02rem', sm: '1.1rem' },
-          fontWeight: 700,
-        }}
-      >
-        Featured Work
+    <Box sx={sectionContainerSx(theme)}>
+      <Typography sx={sectionTitleSx(theme, mono)}>
+        {FEATURED_WORK_TITLE}
       </Typography>
 
       {isLoading ? (
-        <Box
-          sx={{
-            minHeight: 170,
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-          }}
-        >
-          <CircularProgress size={28} />
+        <Box sx={loaderContainerSx}>
+          <CircularProgress size={24} />
         </Box>
-      ) : items.length === 0 ? (
-        <Typography
-          sx={{ color: 'text.secondary', fontFamily: mono, fontSize: '0.8rem' }}
-        >
-          No featured PRs or issues available yet.
+      ) : !hasItems ? (
+        <Typography sx={emptyMessageSx(mono)}>
+          {FEATURED_WORK_EMPTY_MESSAGE}
         </Typography>
       ) : (
         <Box
           sx={{
-            width: '100%',
             display: 'grid',
-            gridTemplateColumns: {
-              xs: '1fr',
-              sm: 'repeat(2, minmax(0, 1fr))',
-              lg: 'repeat(3, minmax(0, 1fr))',
-            },
-            gridAutoRows: '1fr',
-            gap: 1.15,
+            gridTemplateColumns: gridColumns,
+            gap: 2,
           }}
         >
-          {items.slice(0, 6).map(renderCard)}
+          {items.map((repo: FeaturedWorkRepo) => (
+            <FeaturedWorkRepoCard
+              key={repo.repository}
+              repo={repo}
+              mono={mono}
+              theme={theme}
+              onNavigateToRepo={navigateToRepo}
+              onNavigateToPr={navigateToPr}
+            />
+          ))}
         </Box>
       )}
     </Box>

--- a/src/pages/dashboard/views/FeaturedWorkPrRow.tsx
+++ b/src/pages/dashboard/views/FeaturedWorkPrRow.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import { Box, Stack, Tooltip, Typography } from '@mui/material';
+import { type Theme } from '@mui/material/styles';
+import { type FeaturedWorkPr } from '../dashboardData';
+import {
+  prAuthorSx,
+  prChangesSx,
+  prDeletionsSx,
+  prNumberSx,
+  prRowContainerSx,
+  prScoreSx,
+  prTitleSx,
+} from './featuredWorkStyles';
+
+export interface FeaturedWorkPrRowProps {
+  repository: string;
+  pr: FeaturedWorkPr;
+  mono: string;
+  theme: Theme;
+  onNavigate: (repo: string, pr: FeaturedWorkPr) => void;
+}
+
+const buildPrTitle = (prNumber: number, title: string): string =>
+  title || `PR #${prNumber}`;
+
+const formatAdditions = (additions: number): string =>
+  `+${additions.toLocaleString()}`;
+
+const formatDeletions = (deletions: number): string =>
+  `-${deletions.toLocaleString()}`;
+
+const formatScore = (score: number): string => score.toFixed(2);
+
+const FeaturedWorkPrRow: React.FC<FeaturedWorkPrRowProps> = ({
+  repository,
+  pr,
+  mono,
+  theme,
+  onNavigate,
+}) => {
+  const handleClick = (): void => onNavigate(repository, pr);
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>): void => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      onNavigate(repository, pr);
+    }
+  };
+
+  const displayTitle: string = buildPrTitle(pr.prNumber, pr.title);
+  const scoreText: string = formatScore(pr.score);
+  const additionsText: string = formatAdditions(pr.additions);
+  const hasDeletions: boolean = pr.deletions > 0;
+  const deletionsText: string = hasDeletions
+    ? formatDeletions(pr.deletions)
+    : '';
+
+  return (
+    <Box
+      role="button"
+      tabIndex={0}
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}
+      sx={prRowContainerSx(theme)}
+    >
+      <Tooltip title={displayTitle} arrow placement="top">
+        <Typography sx={prTitleSx(theme, mono)}>
+          <Box component="span" sx={prNumberSx(theme)}>
+            #{pr.prNumber}
+          </Box>{' '}
+          {displayTitle}
+        </Typography>
+      </Tooltip>
+      <Stack direction="row" spacing={1} alignItems="center" sx={{ mt: 0.25 }}>
+        <Typography sx={prScoreSx(theme, mono)}>{scoreText}</Typography>
+        <Typography sx={prChangesSx(theme, mono)}>
+          {additionsText}
+          {hasDeletions && (
+            <Box component="span" sx={prDeletionsSx(theme)}>
+              {' '}
+              {deletionsText}
+            </Box>
+          )}
+        </Typography>
+        <Typography sx={prAuthorSx(theme, mono)}>{pr.author}</Typography>
+      </Stack>
+    </Box>
+  );
+};
+
+export default FeaturedWorkPrRow;

--- a/src/pages/dashboard/views/FeaturedWorkRepoCard.tsx
+++ b/src/pages/dashboard/views/FeaturedWorkRepoCard.tsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import GitHubIcon from '@mui/icons-material/GitHub';
+import { Avatar, Box, Stack, Tooltip, Typography } from '@mui/material';
+import { type Theme } from '@mui/material/styles';
+import { getGithubAvatarSrc } from '../../../utils';
+import { type FeaturedWorkRepo, type FeaturedWorkPr } from '../dashboardData';
+import FeaturedWorkPrRow from './FeaturedWorkPrRow';
+import {
+  repoAvatarSx,
+  repoCardContainerSx,
+  repoHeaderSx,
+  repoNameSx,
+  repoSubtitleSx,
+  scoreHighlightSx,
+} from './featuredWorkStyles';
+
+export interface FeaturedWorkRepoCardProps {
+  repo: FeaturedWorkRepo;
+  mono: string;
+  theme: Theme;
+  onNavigateToRepo: (repoName: string) => void;
+  onNavigateToPr: (repoName: string, pr: FeaturedWorkPr) => void;
+}
+
+const extractOwner = (repository: string): string =>
+  repository.split('/')[0] || '';
+
+const formatPrCount = (count: number): string =>
+  `${count} PR${count !== 1 ? 's' : ''}`;
+
+const formatTotalScore = (score: number): string => score.toFixed(1);
+
+const FeaturedWorkRepoCard: React.FC<FeaturedWorkRepoCardProps> = ({
+  repo,
+  mono,
+  theme,
+  onNavigateToRepo,
+  onNavigateToPr,
+}) => {
+  const owner: string = extractOwner(repo.repository);
+  const prCountLabel: string = formatPrCount(repo.prCount);
+  const scoreLabel: string = formatTotalScore(repo.totalScore);
+
+  const handleRepoClick = (): void => onNavigateToRepo(repo.repository);
+
+  const handleRepoKeyDown = (
+    event: React.KeyboardEvent<HTMLDivElement>,
+  ): void => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      onNavigateToRepo(repo.repository);
+    }
+  };
+
+  return (
+    <Box sx={repoCardContainerSx(theme)}>
+      <Stack
+        direction="row"
+        spacing={1.25}
+        alignItems="center"
+        role="button"
+        tabIndex={0}
+        onClick={handleRepoClick}
+        onKeyDown={handleRepoKeyDown}
+        sx={repoHeaderSx(theme)}
+      >
+        <Avatar
+          src={getGithubAvatarSrc(owner)}
+          alt={owner}
+          sx={repoAvatarSx(theme, mono)}
+        >
+          <GitHubIcon />
+        </Avatar>
+
+        <Box sx={{ minWidth: 0, flex: 1 }}>
+          <Tooltip title={repo.repository} arrow placement="top">
+            <Typography className="repo-name" sx={repoNameSx(theme, mono)}>
+              {repo.repository}
+            </Typography>
+          </Tooltip>
+          <Typography sx={repoSubtitleSx(theme, mono)}>
+            {prCountLabel} {repo.windowLabel}
+            {' · '}
+            <Box component="span" sx={scoreHighlightSx(theme)}>
+              {scoreLabel}
+            </Box>
+            {' score'}
+          </Typography>
+        </Box>
+      </Stack>
+
+      <Stack spacing={0.25}>
+        {repo.prs.map((pr: FeaturedWorkPr) => (
+          <FeaturedWorkPrRow
+            key={`${repo.repository}-${pr.prNumber}`}
+            repository={repo.repository}
+            pr={pr}
+            mono={mono}
+            theme={theme}
+            onNavigate={onNavigateToPr}
+          />
+        ))}
+      </Stack>
+    </Box>
+  );
+};
+
+export default FeaturedWorkRepoCard;

--- a/src/pages/dashboard/views/featuredWorkStyles.ts
+++ b/src/pages/dashboard/views/featuredWorkStyles.ts
@@ -1,0 +1,168 @@
+import { type SxProps, type Theme, alpha } from '@mui/material/styles';
+
+type ThemeSxFactory = (theme: Theme) => SxProps<Theme>;
+type FontSxFactory = (theme: Theme, mono: string) => SxProps<Theme>;
+
+export const sectionContainerSx: ThemeSxFactory = (
+  theme: Theme,
+): SxProps<Theme> => ({
+  width: '100%',
+  p: { xs: 1.45, sm: 1.65 },
+  borderRadius: 3,
+  border: `1px solid ${theme.palette.border.light}`,
+  backgroundColor: 'transparent',
+});
+
+export const sectionTitleSx: FontSxFactory = (
+  theme: Theme,
+  mono: string,
+): SxProps<Theme> => ({
+  mb: 1.25,
+  color: theme.palette.text.primary,
+  fontFamily: mono,
+  fontSize: { xs: '1.02rem', sm: '1.1rem' },
+  fontWeight: 700,
+});
+
+export const loaderContainerSx: SxProps<Theme> = {
+  minHeight: 120,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+};
+
+export const emptyMessageSx = (mono: string): SxProps<Theme> => ({
+  color: 'text.secondary',
+  fontFamily: mono,
+  fontSize: '0.8rem',
+});
+
+export const repoCardContainerSx: ThemeSxFactory = (
+  theme: Theme,
+): SxProps<Theme> => ({
+  display: 'flex',
+  flexDirection: 'column',
+  minWidth: 0,
+  p: 1.5,
+  borderRadius: 2.5,
+  border: `1px solid ${theme.palette.border.light}`,
+});
+
+export const repoHeaderSx: ThemeSxFactory = (theme: Theme): SxProps<Theme> => ({
+  mb: 1,
+  pb: 1,
+  borderBottom: `1px solid ${theme.palette.border.light}`,
+  cursor: 'pointer',
+  '&:hover .repo-name': { color: theme.palette.status.merged },
+});
+
+export const repoAvatarSx: FontSxFactory = (
+  theme: Theme,
+  mono: string,
+): SxProps<Theme> => ({
+  width: 36,
+  height: 36,
+  fontSize: '0.8rem',
+  fontFamily: mono,
+  bgcolor: theme.palette.surface.light,
+  color: theme.palette.text.primary,
+  border: `1px solid ${theme.palette.border.light}`,
+  flexShrink: 0,
+  '& .MuiSvgIcon-root': { fontSize: 18 },
+});
+
+export const repoNameSx: FontSxFactory = (
+  theme: Theme,
+  mono: string,
+): SxProps<Theme> => ({
+  color: theme.palette.text.primary,
+  fontFamily: mono,
+  fontSize: '0.88rem',
+  fontWeight: 700,
+  whiteSpace: 'nowrap',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  transition: 'color 0.15s',
+});
+
+export const repoSubtitleSx: FontSxFactory = (
+  theme: Theme,
+  mono: string,
+): SxProps<Theme> => ({
+  mt: 0.15,
+  color: alpha(theme.palette.text.primary, 0.45),
+  fontFamily: mono,
+  fontSize: '0.68rem',
+  lineHeight: 1.2,
+});
+
+export const scoreHighlightSx: ThemeSxFactory = (
+  theme: Theme,
+): SxProps<Theme> => ({
+  color: alpha(theme.palette.diff.additions, 0.8),
+  fontWeight: 600,
+});
+
+export const prRowContainerSx: ThemeSxFactory = (
+  theme: Theme,
+): SxProps<Theme> => ({
+  px: 1,
+  py: 0.65,
+  mx: -1,
+  borderRadius: 1.5,
+  cursor: 'pointer',
+  transition: 'background-color 0.15s',
+  '&:hover': { backgroundColor: alpha(theme.palette.text.primary, 0.05) },
+});
+
+export const prTitleSx: FontSxFactory = (
+  theme: Theme,
+  mono: string,
+): SxProps<Theme> => ({
+  color: theme.palette.text.primary,
+  fontFamily: mono,
+  fontSize: '0.78rem',
+  fontWeight: 500,
+  whiteSpace: 'nowrap',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  lineHeight: 1.35,
+});
+
+export const prNumberSx: ThemeSxFactory = (theme: Theme): SxProps<Theme> => ({
+  color: alpha(theme.palette.text.primary, 0.35),
+});
+
+export const prScoreSx: FontSxFactory = (
+  theme: Theme,
+  mono: string,
+): SxProps<Theme> => ({
+  color: alpha(theme.palette.diff.additions, 0.85),
+  fontFamily: mono,
+  fontSize: '0.68rem',
+  fontWeight: 700,
+});
+
+export const prChangesSx: FontSxFactory = (
+  theme: Theme,
+  mono: string,
+): SxProps<Theme> => ({
+  color: alpha(theme.palette.text.primary, 0.35),
+  fontFamily: mono,
+  fontSize: '0.65rem',
+});
+
+export const prDeletionsSx: ThemeSxFactory = (
+  theme: Theme,
+): SxProps<Theme> => ({
+  color: alpha(theme.palette.diff.deletions, 0.7),
+});
+
+export const prAuthorSx: FontSxFactory = (
+  theme: Theme,
+  mono: string,
+): SxProps<Theme> => ({
+  color: alpha(theme.palette.text.primary, 0.4),
+  fontFamily: mono,
+  fontSize: '0.65rem',
+});


### PR DESCRIPTION
## Summary

Redesigns the **Featured Work** dashboard section to show the top 3 most active repositories and their best merged PRs from a rolling 24-hour window.

**Key changes:**

- **Rolling 24h window** — shows only repos with merged PRs in the last 24 hours. If nothing was merged, displays "No merged PRs in the last 24 hours."
- **Inactive repo filtering** — fetches the repos list (`useReposAndWeights`) and excludes any repo with `inactiveAt` set.
- **Repo-centric model** — new `FeaturedWorkRepo` / `FeaturedWorkPr` types replace the old `DashboardFeaturedWork` flat cards. Each repo shows up to 4 top PRs sorted by score.
- **Sort by total score** (primary) then PR count (tiebreak) within the 24h window.
- **3-column card layout** — each repo gets its own bordered card with avatar, repo name, PR count + window label, and total score. Individual PR rows show `#number title`, score, `+additions -deletions`, and author. Responsive: 1 col mobile, 2 tablet, 3 desktop.
- **Clickable navigation** — repo headers link to the repository detail page; PR rows link to the PR detail page.
- **Simplified data flow** — removed old bounty enrichment logic and multi-pass pick system from `useDashboardData`.

## Related Issues

Closes #818

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

<img width="1883" height="932" alt="Screenshot 2026-04-28 122300" src="https://github.com/user-attachments/assets/5fa4c557-c37c-4550-a27c-3f65c001867e" />

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against prod API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
