### PR TITLE
feat(miners): add monthly USD earnings forecast with decay-aware min/max range

### DIFF
--- a/src/components/leaderboard/MinerCard.tsx
+++ b/src/components/leaderboard/MinerCard.tsx
@@ -3,6 +3,7 @@ import { Box, Card, Typography, Avatar } from '@mui/material';
 import { alpha, useTheme } from '@mui/material/styles';
 import ReactECharts from 'echarts-for-react';
 import { useMinerGithubData, useMinerPRs } from '../../api';
+import { calculateMonthlyUsdRange } from '../../utils/minerEarnings';
 import { CHART_COLORS, STATUS_COLORS } from '../../theme';
 import { getGithubAvatarSrc } from '../../utils/ExplorerUtils';
 import { linkResetSx, useLinkBehavior } from '../common/linkBehavior';
@@ -60,7 +61,7 @@ export const MinerCard: React.FC<MinerCardProps> = ({
   const isNumericId = (value?: string) => !value || /^\d+$/.test(value);
   const shouldFetch = !!miner.githubId && isNumericId(miner.author);
   const { data: githubData } = useMinerGithubData(miner.githubId, shouldFetch);
-  const { data: prs } = useMinerPRs(miner.githubId, shouldFetch);
+  const { data: prs } = useMinerPRs(miner.githubId, !!miner.githubId);
 
   const username =
     githubData?.login ||
@@ -353,7 +354,14 @@ export const MinerCard: React.FC<MinerCardProps> = ({
               mt: 0.2,
             })}
           >
-            ~${Math.round((miner.usdPerDay || 0) * 30).toLocaleString()}/mo
+            {(() => {
+              const daily = miner.usdPerDay || 0;
+              if (!daily) return '$0/mo';
+              const range = calculateMonthlyUsdRange(daily, prs);
+              return range
+                ? `$${Math.round(range.min).toLocaleString()}–$${Math.round(range.max).toLocaleString()}/mo`
+                : `~$${Math.round(daily * 30).toLocaleString()}/mo`;
+            })()}
           </Typography>
         </Box>
 

--- a/src/components/miners/MinerScoreCard.tsx
+++ b/src/components/miners/MinerScoreCard.tsx
@@ -42,6 +42,7 @@ import {
   parseNumber,
 } from '../../utils/ExplorerUtils';
 import { credibilityColor } from '../../utils/format';
+import { calculateMonthlyUsdRange } from '../../utils/minerEarnings';
 
 const formatTimeAgo = (date: Date): string => {
   const now = new Date();
@@ -315,6 +316,11 @@ const MinerScoreCard: React.FC<MinerScoreCardProps> = ({
     };
   }, [allMinersStats, minerStats, githubId]);
 
+  const monthlyUsdRange = useMemo(
+    () => calculateMonthlyUsdRange(minerStats?.usdPerDay ?? 0, prs),
+    [prs, minerStats?.usdPerDay],
+  );
+
   const topPrScore = useMemo(() => {
     if (!prs || prs.length === 0) return null;
     return prs.reduce((max, pr) => {
@@ -434,7 +440,13 @@ const MinerScoreCard: React.FC<MinerScoreCardProps> = ({
     <StatTile
       label="Earnings"
       value={`$${Math.round(minerStats.usdPerDay ?? 0).toLocaleString()}/d`}
-      sub={`$${Math.round((minerStats.usdPerDay ?? 0) * 30).toLocaleString()}/mo · $${Math.round(minerStats.lifetimeUsd ?? 0).toLocaleString()} total`}
+      sub={`${
+        !(minerStats.usdPerDay ?? 0)
+          ? '$0/mo'
+          : monthlyUsdRange
+            ? `$${Math.round(monthlyUsdRange.min).toLocaleString()}–$${Math.round(monthlyUsdRange.max).toLocaleString()}/mo`
+            : `$${Math.round((minerStats.usdPerDay ?? 0) * 30).toLocaleString()}/mo`
+      } · $${Math.round(minerStats.lifetimeUsd ?? 0).toLocaleString()} total`}
       color={
         (minerStats.usdPerDay ?? 0) > 0 ? STATUS_COLORS.success : undefined
       }
@@ -673,7 +685,7 @@ const MinerScoreCard: React.FC<MinerScoreCardProps> = ({
           </Grid>
           <Grid item xs={6} sm={4} md={2}>
             {renderEarningsTile(
-              'Estimated earnings based on current network incentive distribution. Actual payouts depend on validator consensus.',
+              'Estimated earnings based on current network incentive distribution. Monthly range: minimum assumes you stop contributing today (existing PRs continue to time-decay); maximum assumes you sustain the current daily rate. Actual payouts depend on validator consensus.',
             )}
           </Grid>
         </Grid>

--- a/src/utils/minerEarnings.ts
+++ b/src/utils/minerEarnings.ts
@@ -1,0 +1,62 @@
+import type { CommitLog } from '../api/models/Dashboard';
+
+// Mirror of validator constants in
+// gittensor/validator/utils/datetime_utils.py — keep these in sync.
+const TIME_DECAY_MIDPOINT = 10;
+const TIME_DECAY_STEEPNESS = 0.4;
+const TIME_DECAY_FLOOR = 0.05;
+const TIME_DECAY_GRACE_DAYS = 12 / 24;
+
+const decay = (days: number): number => {
+  if (days < TIME_DECAY_GRACE_DAYS) return 1;
+  const sig =
+    1 / (1 + Math.exp(TIME_DECAY_STEEPNESS * (days - TIME_DECAY_MIDPOINT)));
+  return Math.max(sig, TIME_DECAY_FLOOR);
+};
+
+export interface MonthlyUsdRange {
+  min: number;
+  max: number;
+}
+
+/**
+ * Project monthly USD earnings range for a miner.
+ *
+ * - max: dailyUsd × 30 (assumes the miner sustains the current daily rate).
+ * - min: integral over the next 30 days of dailyUsd × ratio(d), where ratio(d)
+ *   is the aggregate sigmoid time-decay of the miner's existing merged PRs at
+ *   day d vs today. Models "if I stop contributing today".
+ */
+export const calculateMonthlyUsdRange = (
+  dailyUsd: number,
+  prs: CommitLog[] | undefined,
+): MonthlyUsdRange | null => {
+  if (!dailyUsd || !prs || prs.length === 0) return null;
+  const now = Date.now();
+  const baseAndAge = prs
+    .filter((p) => p.mergedAt)
+    .map((p) => {
+      const score = parseFloat(p.score || '0');
+      const ageDays =
+        (now - new Date(p.mergedAt as string).getTime()) /
+        (1000 * 60 * 60 * 24);
+      const d = decay(ageDays);
+      return { base: d > 0 ? score / d : 0, ageDays };
+    })
+    .filter((x) => x.base > 0);
+  if (baseAndAge.length === 0) return null;
+  const totalToday = baseAndAge.reduce(
+    (s, x) => s + x.base * decay(x.ageDays),
+    0,
+  );
+  if (totalToday === 0) return null;
+  let monthlyRatio = 0;
+  for (let d = 0; d < 30; d++) {
+    const totalAtD = baseAndAge.reduce(
+      (s, x) => s + x.base * decay(x.ageDays + d),
+      0,
+    );
+    monthlyRatio += totalAtD / totalToday;
+  }
+  return { min: dailyUsd * monthlyRatio, max: dailyUsd * 30 };
+};


### PR DESCRIPTION
## Summary

Introduces a monthly USD earnings forecast on miner cards. The earnings tile previously showed a single static `~$X/mo` extrapolation (`usdPerDay × 30`); this PR adds a forward-looking range that models the validator's sigmoid time-decay curve, giving users a meaningful "if I stop today" lower bound and "if I sustain" upper bound.

## What's new

- **New earnings forecast** — `$min–$max/mo` range rendered on the miner profile earnings tile and on every miner card in the Top Miners cards view.
- **New shared helper** — `src/utils/minerEarnings.ts` → `calculateMonthlyUsdRange(dailyUsd, prs)`, exported for reuse by future surfaces (e.g., watchlist, comparison radar).
- **Decay-aware projection** — replays each merged PR's sigmoid decay (midpoint 10d, steepness 0.4, floor 0.05, 12h grace) over a 30-day window, mirroring the validator's `calculate_time_decay` in `gittensor/validator/utils/datetime_utils.py`.
- **Tooltip explainer** — earnings tile tooltip now describes the bounds so users understand the range semantics.
- **Zero-state handling** — `$0/mo` rendered cleanly when `usdPerDay == 0`; falls back to the legacy single-value `~$X/mo` when PR data is unavailable.

## Behavior

- **max** = `usdPerDay × 30` — sustained daily rate.
- **min** = `Σ_{d=0..29} usdPerDay × ratio(d)`, where `ratio(d) = totalEarnedAtDay(d) / totalEarnedToday`, integrating each merged PR's decay across the projection window.

Side fix: `MinerCard` previously gated `useMinerPRs` on `isNumericId(miner.author)`, which skipped most leaderboard miners. The forecast needs PR data to render, so the gate now only requires `miner.githubId`.

## Test plan

- [ ] Miner profile (`/miners/details?githubId=...`): earnings tile renders `$min–$max/mo`; tooltip explains the range.
- [ ] Top Miners cards view: every card shows the forecast range.
- [ ] Miner with `usdPerDay == 0` shows `$0/mo`.
- [ ] Miner with no merged PRs falls back to `~$X/mo`.
- [ ] No regression on Top Miners list view (still shows `usdPerDay`).

Fixes #826 

<img width="1804" height="742" alt="image" src="https://github.com/user-attachments/assets/eecde0f8-e296-4f28-87d1-b23b79ca3038" />

<img width="1804" height="742" alt="image" src="https://github.com/user-attachments/assets/8b09ea32-2683-4b0e-aade-91190ab50153" />

<img width="1804" height="742" alt="image" src="https://github.com/user-attachments/assets/cc861a2c-aebf-40a7-b1e3-bfa2d2017eea" />
