### PR TITLE
fix: use constants for subnet netuids and labels in onboarding steps

### DIFF
--- a/src/components/onboard/GettingStarted.tsx
+++ b/src/components/onboard/GettingStarted.tsx
@@ -17,6 +17,11 @@ import { useClipboardCopy } from '../../hooks/useClipboardCopy';
 
 const MONO = '"JetBrains Mono", monospace';
 
+const MAINNET_NETUID = 74;
+const TESTNET_NETUID = 422;
+const MAINNET_LABEL = `mainnet (subnet ${MAINNET_NETUID})`;
+const TESTNET_LABEL = `testnet (subnet ${TESTNET_NETUID})`;
+
 const steps = [
   {
     step: 1,
@@ -191,11 +196,11 @@ const StepDetail: React.FC<{ step: number }> = ({ step }) => {
           </Typography>
           <NetworkTabs network={network} onChange={setNetwork} />
           {network === 'mainnet' ? (
-            <CodeBlock label="mainnet (subnet 74)">{`btcli subnet register --netuid 74 \\
+            <CodeBlock label={MAINNET_LABEL}>{`btcli subnet register --netuid ${MAINNET_NETUID} \\
   --wallet-name <WALLET_NAME> \\
   --hotkey <HOTKEY_NAME>`}</CodeBlock>
           ) : (
-            <CodeBlock label="testnet (subnet 422)">{`btcli subnet register --netuid 422 \\
+            <CodeBlock label={TESTNET_LABEL}>{`btcli subnet register --netuid ${TESTNET_NETUID} \\
   --wallet-name <WALLET_NAME> \\
   --hotkey <HOTKEY_NAME> \\
   --network test`}</CodeBlock>
@@ -298,15 +303,15 @@ uv pip install -e .`}</CodeBlock>
           </Typography>
           <NetworkTabs network={network} onChange={setNetwork} />
           {network === 'mainnet' ? (
-            <CodeBlock label="mainnet">{`gitt miner post --pat <YOUR_PAT> \\
+            <CodeBlock label={MAINNET_LABEL}>{`gitt miner post --pat <YOUR_PAT> \\
   --wallet <WALLET_NAME> \\
   --hotkey <HOTKEY_NAME> \\
-  --netuid 74`}</CodeBlock>
+  --netuid ${MAINNET_NETUID}`}</CodeBlock>
           ) : (
-            <CodeBlock label="testnet">{`gitt miner post --pat <YOUR_PAT> \\
+            <CodeBlock label={TESTNET_LABEL}>{`gitt miner post --pat <YOUR_PAT> \\
   --wallet <WALLET_NAME> \\
   --hotkey <HOTKEY_NAME> \\
-  --netuid 422 --network test`}</CodeBlock>
+  --netuid ${TESTNET_NETUID} --network test`}</CodeBlock>
           )}
           <Typography
             variant="body2"
@@ -330,15 +335,15 @@ uv pip install -e .`}</CodeBlock>
           </Typography>
           <NetworkTabs network={network} onChange={setNetwork} />
           {network === 'mainnet' ? (
-            <CodeBlock label="mainnet">{`gitt miner check \\
+            <CodeBlock label={MAINNET_LABEL}>{`gitt miner check \\
   --wallet <WALLET_NAME> \\
   --hotkey <HOTKEY_NAME> \\
-  --netuid 74`}</CodeBlock>
+  --netuid ${MAINNET_NETUID}`}</CodeBlock>
           ) : (
-            <CodeBlock label="testnet">{`gitt miner check \\
+            <CodeBlock label={TESTNET_LABEL}>{`gitt miner check \\
   --wallet <WALLET_NAME> \\
   --hotkey <HOTKEY_NAME> \\
-  --netuid 422 --network test`}</CodeBlock>
+  --netuid ${TESTNET_NETUID} --network test`}</CodeBlock>
           )}
           <Typography
             variant="body2"

--- a/src/components/onboard/GettingStarted.tsx
+++ b/src/components/onboard/GettingStarted.tsx
@@ -196,11 +196,15 @@ const StepDetail: React.FC<{ step: number }> = ({ step }) => {
           </Typography>
           <NetworkTabs network={network} onChange={setNetwork} />
           {network === 'mainnet' ? (
-            <CodeBlock label={MAINNET_LABEL}>{`btcli subnet register --netuid ${MAINNET_NETUID} \\
+            <CodeBlock
+              label={MAINNET_LABEL}
+            >{`btcli subnet register --netuid ${MAINNET_NETUID} \\
   --wallet-name <WALLET_NAME> \\
   --hotkey <HOTKEY_NAME>`}</CodeBlock>
           ) : (
-            <CodeBlock label={TESTNET_LABEL}>{`btcli subnet register --netuid ${TESTNET_NETUID} \\
+            <CodeBlock
+              label={TESTNET_LABEL}
+            >{`btcli subnet register --netuid ${TESTNET_NETUID} \\
   --wallet-name <WALLET_NAME> \\
   --hotkey <HOTKEY_NAME> \\
   --network test`}</CodeBlock>
@@ -303,12 +307,16 @@ uv pip install -e .`}</CodeBlock>
           </Typography>
           <NetworkTabs network={network} onChange={setNetwork} />
           {network === 'mainnet' ? (
-            <CodeBlock label={MAINNET_LABEL}>{`gitt miner post --pat <YOUR_PAT> \\
+            <CodeBlock
+              label={MAINNET_LABEL}
+            >{`gitt miner post --pat <YOUR_PAT> \\
   --wallet <WALLET_NAME> \\
   --hotkey <HOTKEY_NAME> \\
   --netuid ${MAINNET_NETUID}`}</CodeBlock>
           ) : (
-            <CodeBlock label={TESTNET_LABEL}>{`gitt miner post --pat <YOUR_PAT> \\
+            <CodeBlock
+              label={TESTNET_LABEL}
+            >{`gitt miner post --pat <YOUR_PAT> \\
   --wallet <WALLET_NAME> \\
   --hotkey <HOTKEY_NAME> \\
   --netuid ${TESTNET_NETUID} --network test`}</CodeBlock>


### PR DESCRIPTION
## Summary

Fix inconsistent network labels in the onboarding Miner Setup flow. Steps 2, 5, and 6 now all display subnet information consistently (e.g. `MAINNET (SUBNET 74)`). Subnet IDs and labels have been extracted into shared constants (`MAINNET_NETUID`, `TESTNET_NETUID`, `MAINNET_LABEL`, `TESTNET_LABEL`) to eliminate duplication and make future updates a single-line change.

## Related Issues

Fixes: https://github.com/entrius/gittensor-ui/issues/736

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

**Step 5 (Broadcast) — Before:**
Label displayed as `MAINNET`
<img width="1221" height="334" alt="Screenshot 2026-04-28 at 5 32 14 PM" src="https://github.com/user-attachments/assets/4403c5ee-6454-4690-9c4f-990ef14dc8c6" />

**Step 6 (Verify) — Before:**
Label displayed as `MAINNET`
<img width="1221" height="334" alt="Screenshot 2026-04-28 at 5 32 23 PM" src="https://github.com/user-attachments/assets/3dc892da-056e-4a94-b28e-50916331e664" />


**Step 5 (Broadcast) — After:**
Label displays as `MAINNET (SUBNET 74)`
<img width="1221" height="334" alt="Screenshot 2026-04-28 at 5 32 32 PM" src="https://github.com/user-attachments/assets/76589530-8296-4f89-af32-e294616b49c5" />

**Step 6 (Verify) — After:**
Label displays as `MAINNET (SUBNET 74)`
<img width="1221" height="334" alt="Screenshot 2026-04-28 at 5 32 44 PM" src="https://github.com/user-attachments/assets/230b32a8-b474-4d1f-93ee-fe9fef01da67" />



## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes