### PR TITLE
fix(ui): bounty card polish + watchlist card view fixes

### DIFF
--- a/src/components/issues/BountyCard.tsx
+++ b/src/components/issues/BountyCard.tsx
@@ -11,6 +11,7 @@ import {
   alpha,
 } from '@mui/material';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
+import GitHubIcon from '@mui/icons-material/GitHub';
 import { IssueBounty } from '../../api/models/Issues';
 import { linkResetSx, useLinkBehavior } from '../common/linkBehavior';
 import { WatchlistButton } from '../common';
@@ -97,9 +98,8 @@ export const BountyCard: React.FC<BountyCardProps> = ({
           src={`https://avatars.githubusercontent.com/${owner}`}
           alt={owner}
           sx={(theme) => ({
-            width: 28,
-            height: 28,
-            borderRadius: 1,
+            width: 36,
+            height: 36,
             flexShrink: 0,
             border: '1px solid',
             borderColor: theme.palette.border.medium,
@@ -139,12 +139,17 @@ export const BountyCard: React.FC<BountyCardProps> = ({
           category="bounties"
           itemKey={String(issue.id)}
           size="small"
+          sx={{
+            backgroundColor: 'rgba(255,255,255,0.08)',
+            borderRadius: '50%',
+            '&:hover': { backgroundColor: 'rgba(255,255,255,0.15)' },
+          }}
         />
       </Box>
 
       {/* Issue title + GitHub link */}
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5, flex: 1 }}>
-        {issue.title && (
+        <Tooltip title={issue.title} placement="bottom" arrow>
           <Typography
             sx={{
               fontSize: '0.85rem',
@@ -156,11 +161,12 @@ export const BountyCard: React.FC<BountyCardProps> = ({
               WebkitLineClamp: 2,
               WebkitBoxOrient: 'vertical',
               lineHeight: 1.4,
+              minHeight: 'calc(2 * 1.4em)',
             }}
           >
             {issue.title}
           </Typography>
-        )}
+        </Tooltip>
         <Link
           href={issue.githubUrl}
           target="_blank"
@@ -169,19 +175,29 @@ export const BountyCard: React.FC<BountyCardProps> = ({
           sx={(theme) => ({
             display: 'inline-flex',
             alignItems: 'center',
-            gap: 0.5,
+            gap: 0.6,
             width: 'fit-content',
-            fontSize: '0.72rem',
-            color: alpha(theme.palette.common.white, TEXT_OPACITY.tertiary),
+            fontSize: '0.78rem',
+            fontWeight: 500,
+            color: alpha(theme.palette.common.white, TEXT_OPACITY.secondary),
             textDecoration: 'none',
+            px: 1,
+            py: 0.5,
+            borderRadius: 1.5,
+            border: `1px solid ${alpha(theme.palette.common.white, 0.12)}`,
+            backgroundColor: alpha(theme.palette.common.white, 0.05),
+            transition: 'all 0.15s',
             '&:hover': {
-              color: STATUS_COLORS.info,
-              textDecoration: 'underline',
+              color: theme.palette.common.white,
+              borderColor: alpha(theme.palette.common.white, 0.28),
+              backgroundColor: alpha(theme.palette.common.white, 0.1),
+              textDecoration: 'none',
             },
           })}
         >
-          #{issue.issueNumber}
-          <OpenInNewIcon sx={{ fontSize: 11, opacity: 0.5 }} />
+          <GitHubIcon sx={{ fontSize: 13 }} />#{issue.issueNumber} Open on
+          GitHub
+          <OpenInNewIcon sx={{ fontSize: 11, opacity: 0.6 }} />
         </Link>
       </Box>
 

--- a/src/pages/WatchlistPage.tsx
+++ b/src/pages/WatchlistPage.tsx
@@ -1,33 +1,32 @@
 import React, { useMemo, useState } from 'react';
 import {
-  alpha,
   Avatar,
-  Badge,
   Box,
-  Button,
   Card,
   Chip,
   Collapse,
   CircularProgress,
-  Dialog,
-  DialogActions,
-  DialogTitle,
   FormControl,
   FormControlLabel,
   Grid,
   IconButton,
   InputAdornment,
   MenuItem,
-  Paper,
   Select,
-  Stack,
   Switch,
-  Tab,
   TablePagination,
-  Tabs,
   TextField,
   Tooltip,
   Typography,
+  Button,
+  alpha,
+  Stack,
+  Dialog,
+  DialogTitle,
+  DialogActions,
+  Tab,
+  Tabs,
+  Badge,
   useMediaQuery,
 } from '@mui/material';
 import SearchIcon from '@mui/icons-material/Search';
@@ -49,7 +48,6 @@ import {
   SEO,
   WatchlistButton,
 } from '../components';
-import { MinerComparisonRadar } from '../components/miners';
 import {
   DataTable,
   type DataTableColumn,
@@ -136,8 +134,6 @@ const tabFromParam = (param: string | null): WatchlistCategory =>
     ? (param as WatchlistCategory)
     : 'miners';
 
-const MAX_COMPARE = 4;
-
 const WatchlistPage: React.FC = () => {
   const [searchParams, setSearchParams] = useSearchParams();
   const activeTab = tabFromParam(searchParams.get('tab'));
@@ -147,7 +143,6 @@ const WatchlistPage: React.FC = () => {
   const counts = useWatchlistCounts();
   const { ids, count, clear } = useWatchlist(activeTab);
   const [confirmOpen, setConfirmOpen] = useState(false);
-  const [compareOpen, setCompareOpen] = useState(false);
 
   const tabHasContent =
     activeTab === 'prs'
@@ -156,7 +151,6 @@ const WatchlistPage: React.FC = () => {
   const isEmpty = !tabHasContent;
   const noun = TAB_NOUN[activeTab];
   const discovery = TAB_DISCOVERY[activeTab];
-  const canCompare = activeTab === 'miners' && count >= 2;
 
   const isLargeScreen = useMediaQuery(theme.breakpoints.up('xl'));
   const showSidebarRight = !isEmpty && isLargeScreen;
@@ -180,7 +174,6 @@ const WatchlistPage: React.FC = () => {
   const handleClear = () => {
     clear();
     setConfirmOpen(false);
-    setCompareOpen(false);
   };
 
   const handleTabChange = (_event: React.SyntheticEvent, next: unknown) => {
@@ -250,31 +243,19 @@ const WatchlistPage: React.FC = () => {
                 ' Also shows PRs from watched miners and repositories.'}{' '}
               Stored locally in this browser.
             </Typography>
-            <Stack direction="row" spacing={1} alignItems="center">
-              {canCompare && (
-                <Button
-                  size="small"
-                  variant={compareOpen ? 'contained' : 'outlined'}
-                  onClick={() => setCompareOpen((v) => !v)}
-                  sx={{ fontSize: '0.75rem', textTransform: 'none' }}
-                >
-                  {compareOpen ? 'Hide comparison' : 'Compare'}
-                </Button>
-              )}
-              {count > 0 && (
-                <Button
-                  size="small"
-                  onClick={() => setConfirmOpen(true)}
-                  sx={{
-                    fontSize: '0.75rem',
-                    textTransform: 'none',
-                    color: 'text.secondary',
-                  }}
-                >
-                  Clear {noun.plural}
-                </Button>
-              )}
-            </Stack>
+            {count > 0 && (
+              <Button
+                size="small"
+                onClick={() => setConfirmOpen(true)}
+                sx={{
+                  fontSize: '0.75rem',
+                  textTransform: 'none',
+                  color: 'text.secondary',
+                }}
+              >
+                Clear {noun.plural}
+              </Button>
+            )}
           </Stack>
 
           <Box sx={{ borderBottom: '1px solid', borderColor: 'border.light' }}>
@@ -363,7 +344,7 @@ const WatchlistPage: React.FC = () => {
               </Button>
             </Box>
           ) : activeTab === 'miners' ? (
-            <MinersList itemKeys={ids} compareOpen={compareOpen} />
+            <MinersList itemKeys={ids} />
           ) : activeTab === 'repos' ? (
             <ReposList itemKeys={ids} />
           ) : activeTab === 'bounties' ? (
@@ -540,141 +521,24 @@ const StatusPill: React.FC<StatusPillProps> = ({
   </Typography>
 );
 
-const MinersList: React.FC<{ itemKeys: string[]; compareOpen: boolean }> = ({
-  itemKeys,
-  compareOpen,
-}) => {
+const MinersList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
   const { data: allMinersStats, isLoading } = useAllMiners();
-  const [selectedIds, setSelectedIds] = useState<string[]>([]);
   const watchedSet = useMemo(() => new Set(itemKeys), [itemKeys]);
 
-  const allMinerStats = useMemo(
-    () => mapAllMinersToStats(allMinersStats ?? []),
-    [allMinersStats],
-  );
-
-  const minerStats = useMemo(
-    () =>
-      allMinerStats
-        .filter((m) => watchedSet.has(m.githubId))
-        .map((m) => ({
-          ...m,
-          // Watchlist cards should be enabled if miner is eligible for either
-          // OSS contributions or Issue Discoveries.
-          isEligible: Boolean(m.ossIsEligible || m.discoveriesIsEligible),
-        })),
-    [allMinerStats, watchedSet],
-  );
-
-  const needsPicker = minerStats.length > MAX_COMPARE;
-
-  const comparisonMiners = useMemo(() => {
-    if (!needsPicker) return minerStats;
-    const picked = selectedIds
-      .map((id) => minerStats.find((m) => m.githubId === id))
-      .filter((m): m is (typeof minerStats)[number] => Boolean(m));
-    if (picked.length === 0) return minerStats.slice(0, MAX_COMPARE);
-    return picked.slice(0, MAX_COMPARE);
-  }, [minerStats, selectedIds, needsPicker]);
-
-  const toggleSelected = (githubId: string) => {
-    setSelectedIds((prev) => {
-      const current =
-        prev.length > 0
-          ? prev
-          : minerStats.slice(0, MAX_COMPARE).map((m) => m.githubId);
-      if (current.includes(githubId)) {
-        return current.filter((id) => id !== githubId);
-      }
-      if (current.length >= MAX_COMPARE) return current;
-      return [...current, githubId];
-    });
-  };
-
-  const colorForMiner = (githubId: string) => {
-    const idx = comparisonMiners.findIndex((m) => m.githubId === githubId);
-    return idx >= 0
-      ? CHART_COLORS.series[idx % CHART_COLORS.series.length]
-      : null;
-  };
-
-  const showCompare = compareOpen && minerStats.length >= 2;
+  const minerStats = useMemo(() => {
+    const all = mapAllMinersToStats(allMinersStats ?? []);
+    return all
+      .filter((m) => watchedSet.has(m.githubId))
+      .map((m) => ({
+        ...m,
+        // Watchlist cards should be enabled if miner is eligible for either
+        // OSS contributions or Issue Discoveries.
+        isEligible: Boolean(m.ossIsEligible || m.discoveriesIsEligible),
+      }));
+  }, [allMinersStats, watchedSet]);
 
   return (
-    <Box
-      sx={{
-        width: '100%',
-        display: 'flex',
-        flexDirection: 'column',
-        gap: { xs: 2, sm: 1.5 },
-      }}
-    >
-      {showCompare && (
-        <Paper
-          variant="outlined"
-          sx={{
-            p: { xs: 2, sm: 2.5 },
-            backgroundColor: 'surface.subtle',
-            display: 'flex',
-            flexDirection: 'column',
-            gap: 1.5,
-          }}
-        >
-          {needsPicker && (
-            <Box
-              sx={{
-                display: 'flex',
-                flexWrap: 'wrap',
-                gap: 0.75,
-                alignItems: 'center',
-              }}
-            >
-              <Typography
-                sx={{
-                  fontSize: '0.75rem',
-                  color: (t) => alpha(t.palette.text.primary, 0.6),
-                  mr: 0.5,
-                }}
-              >
-                Pick up to {MAX_COMPARE}:
-              </Typography>
-              {minerStats.map((m) => {
-                const color = colorForMiner(m.githubId);
-                const active = Boolean(color);
-                return (
-                  <Chip
-                    key={m.githubId}
-                    label={m.author || m.githubId}
-                    size="small"
-                    clickable
-                    onClick={() => toggleSelected(m.githubId)}
-                    sx={{
-                      fontSize: '0.72rem',
-                      height: 24,
-                      borderRadius: 1.5,
-                      border: '1px solid',
-                      borderColor: active
-                        ? color!
-                        : (t) => alpha(t.palette.common.white, 0.15),
-                      backgroundColor: active ? `${color}22` : 'transparent',
-                      color: active ? color! : 'text.secondary',
-                      '&:hover': {
-                        backgroundColor: active
-                          ? `${color}33`
-                          : (t) => alpha(t.palette.common.white, 0.05),
-                      },
-                    }}
-                  />
-                );
-              })}
-            </Box>
-          )}
-          <MinerComparisonRadar
-            miners={comparisonMiners}
-            allMiners={allMinerStats}
-          />
-        </Paper>
-      )}
+    <Box sx={{ width: '100%' }}>
       <TopMinersTable
         miners={minerStats}
         isLoading={isLoading}
@@ -2234,7 +2098,8 @@ const PRCard: React.FC<{
   );
 };
 
-const PR_ROWS_OPTIONS = [10, 25, 50] as const;
+const PR_ROWS_OPTIONS_LIST = [10, 25, 50] as const;
+const PR_ROWS_OPTIONS_CARDS = [12, 24, 48] as const;
 
 const PRsList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
   const { items, sourcesByKey, isLoading } = useWatchedPRs(itemKeys);
@@ -2387,7 +2252,10 @@ const PRsList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
                 '& .MuiSelect-select': { py: 0.75 },
               }}
             >
-              {PR_ROWS_OPTIONS.map((n) => (
+              {(viewMode === 'cards'
+                ? PR_ROWS_OPTIONS_CARDS
+                : PR_ROWS_OPTIONS_LIST
+              ).map((n) => (
                 <MenuItem key={n} value={n}>
                   {n}
                 </MenuItem>
@@ -2422,7 +2290,18 @@ const PRsList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
           }}
         />
         <Box sx={{ ml: 'auto' }}>
-          <PRsViewModeToggle viewMode={viewMode} onChange={setViewMode} />
+          <PRsViewModeToggle
+            viewMode={viewMode}
+            onChange={(next) => {
+              setViewMode(next);
+              setRowsPerPage(
+                next === 'cards'
+                  ? PR_ROWS_OPTIONS_CARDS[0]
+                  : PR_ROWS_OPTIONS_LIST[0],
+              );
+              setPage(0);
+            }}
+          />
         </Box>
       </Box>
 
@@ -2450,6 +2329,8 @@ const PRsList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
         <Box
           sx={{
             p: 2,
+            flex: 1,
+            minHeight: 0,
             overflowY: 'auto',
             ...scrollbarSx,
           }}


### PR DESCRIPTION
### Closes: #831

### Summary

- **BountyCard — "Open on GitHub" pill button**: Replaced the plain `#N` + edit icon link with a styled pill button showing the GitHub logo, issue number, label, and an external-link icon. Increased font size and padding for better readability.
- **BountyCard — circular repo avatar**: Removed `borderRadius: 1` (rounded square) from the owner `Avatar` so it uses MUI's default circular shape, matching `RepositoryCard` and `MinerCard`. Also bumped the avatar size from 28 × 28 → 36 × 36 to match `MinerCard`.
- **BountyCard — aligned button position**: Title `Typography` now always reserves two lines of height (`minHeight: calc(2 * 1.4em)`), keeping the "Open on GitHub" button at a consistent vertical position across all cards regardless of title length.
- **WatchlistPage — card view row counts**: Introduced separate row-count options for list view (`[10, 25, 50]`) and card view (`[12, 24, 48]`). Card view uses multiples of 3 to match the 3-column grid, eliminating blank spaces on the last row.
- **WatchlistPage — card view scrollbar**: Fixed an unnecessary scrollbar appearing in card view by applying `flex: 1 / minHeight: 0 / overflowY: auto` to the card container, keeping the pagination bar visible without triggering outer-page overflow.

### Test plan

- [ ] Bounty cards show a pill-shaped "Open on GitHub" button that opens the correct GitHub issue URL in a new tab
- [ ] Repo avatar is circular and 36 × 36 on every bounty card
- [ ] Cards with 1-line and 2-line titles have the button at the same vertical position
- [ ] Switching Watchlist PRs to card view and selecting 12 / 24 / 48 rows per page produces no blank trailing spaces
- [ ] No extra scrollbar appears in card view; pagination bar remains visible at the bottom
- [ ] Switching between list and card view resets to the first page with the correct default row count

### Screenshots

Before:

<img width="1094" height="879" alt="image" src="https://github.com/user-attachments/assets/b2a2419c-947b-48f6-ba7b-30214add941b" />

<img width="1265" height="839" alt="image" src="https://github.com/user-attachments/assets/590cd66a-2676-4d4d-afe7-8acf8eb8be2f" />

<img width="1310" height="713" alt="image" src="https://github.com/user-attachments/assets/3d191ae2-86b8-43be-a989-50f5494ccbda" />

After:

https://github.com/user-attachments/assets/78f53b29-1a58-4ecf-8336-93a1829e42a4

