### PR TITLE
feat(tables): make the watchlist column sortable in tables

### DIFF
--- a/src/components/leaderboard/MinersList.tsx
+++ b/src/components/leaderboard/MinersList.tsx
@@ -165,6 +165,7 @@ export const MinersList: React.FC<MinersListProps> = ({
       header: '\u2605',
       width: '52px',
       align: 'center',
+      sortKey: 'watch',
       cellSx: { p: 0 },
       renderCell: (miner) =>
         miner.githubId ? (

--- a/src/components/leaderboard/TopMinersTable.tsx
+++ b/src/components/leaderboard/TopMinersTable.tsx
@@ -18,7 +18,9 @@ import { MinersList } from './MinersList';
 import { SearchInput } from '../common/SearchInput';
 import { STATUS_COLORS } from '../../theme';
 import { useDataTableParams } from '../../hooks/useDataTableParams';
+import { useWatchlist } from '../../hooks/useWatchlist';
 import { type SortOrder } from '../../utils/ExplorerUtils';
+import { compareByWatchlist } from '../../utils/watchlistSort';
 import {
   type MinerStats,
   type SortOption,
@@ -72,7 +74,7 @@ interface TopMinersTableProps {
 
 const getAllowedSortOptions = (variant: LeaderboardVariant): SortOption[] => {
   if (variant === 'discoveries')
-    return ['totalScore', 'usdPerDay', 'totalIssues', 'credibility'];
+    return ['totalScore', 'usdPerDay', 'totalIssues', 'credibility', 'watch'];
   if (variant === 'watchlist')
     return [
       'totalScore',
@@ -81,8 +83,9 @@ const getAllowedSortOptions = (variant: LeaderboardVariant): SortOption[] => {
       'totalIssues',
       'issueDiscoveryScore',
       'credibility',
+      'watch',
     ];
-  return ['totalScore', 'usdPerDay', 'totalPRs', 'credibility'];
+  return ['totalScore', 'usdPerDay', 'totalPRs', 'credibility', 'watch'];
 };
 
 type EligibilityFilter = 'all' | 'eligible' | 'ineligible';
@@ -139,6 +142,7 @@ const compareMiners = (
   a: MinerStats,
   b: MinerStats,
   option: SortOption,
+  isWatched: (key: string) => boolean,
 ): number => {
   switch (option) {
     case 'totalScore':
@@ -155,6 +159,8 @@ const compareMiners = (
       );
     case 'credibility':
       return (a.credibility ?? 0) - (b.credibility ?? 0);
+    case 'watch':
+      return compareByWatchlist(a, b, (m) => m.githubId, isWatched);
     default:
       return 0;
   }
@@ -172,6 +178,8 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
     () => getAllowedSortOptions(variant),
     [variant],
   );
+
+  const { isWatched } = useWatchlist('miners');
 
   // Stable filter configs — values are destructured below.
   // `view` always writes the URL param (never returns null) — otherwise
@@ -282,11 +290,11 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
   // only hides rows without renumbering the ones that remain. Sort direction
   // is included so the list view's asc/desc toggle ranks consistently.
   const rankedMiners = useMemo(() => {
-    const directionMultiplier = sortDirection === 'asc' ? 1 : -1;
+    const dir = sortDirection === 'asc' ? 1 : -1;
     return [...miners]
-      .sort((a, b) => compareMiners(a, b, sortOption) * directionMultiplier)
+      .sort((a, b) => compareMiners(a, b, sortOption, isWatched) * dir)
       .map((miner, index) => ({ ...miner, rank: index + 1 }));
-  }, [miners, sortOption, sortDirection]);
+  }, [miners, sortOption, sortDirection, isWatched]);
 
   const filteredMiners = useMemo(() => {
     let result = rankedMiners;

--- a/src/components/leaderboard/TopRepositoriesTable.tsx
+++ b/src/components/leaderboard/TopRepositoriesTable.tsx
@@ -57,6 +57,8 @@ import { useNavigate, useSearchParams } from 'react-router-dom';
 import { DataTable, type DataTableColumn } from '../common/DataTable';
 import { WatchlistButton } from '../common';
 import { truncateText } from '../../utils';
+import { useWatchlist } from '../../hooks/useWatchlist';
+import { compareByWatchlist } from '../../utils/watchlistSort';
 import { RankIcon } from './RankIcon';
 import { getRepositoryOwnerAvatarBackground, type RepoStats } from './types';
 import {
@@ -84,7 +86,8 @@ type SortColumn =
   | 'contributors'
   | 'discoveryScore'
   | 'discoveryIssues'
-  | 'discoveryContributors';
+  | 'discoveryContributors'
+  | 'watch';
 type SortDirection = 'asc' | 'desc';
 type ViewMode = RepositoriesViewMode;
 
@@ -115,6 +118,7 @@ const VALID_SORT_COLUMNS: SortColumn[] = [
   'discoveryScore',
   'discoveryIssues',
   'discoveryContributors',
+  'watch',
 ];
 
 /** List view: show numeric zeros when the row has OSS activity (avoids PRs > 0 with OSS score "-"). */
@@ -189,6 +193,7 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
     [searchParams, storedViewMode],
   );
   const isInitialMount = useRef(true);
+  const { isWatched } = useWatchlist('repos');
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
   const trimmedSearch = searchQuery.trim();
@@ -301,6 +306,9 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
           comparison =
             a.discoveryContributors.size - b.discoveryContributors.size;
           break;
+        case 'watch':
+          comparison = compareByWatchlist(a, b, (r) => r.repository, isWatched);
+          break;
         default:
           // Default to totalScore descending (original behavior)
           comparison = b.totalScore - a.totalScore;
@@ -311,7 +319,7 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
 
     // Then add rank based on sorted order
     return sorted.map((repo, index) => ({ ...repo, rank: index + 1 }));
-  }, [repositories, sortColumn, sortDirection]);
+  }, [repositories, sortColumn, sortDirection, isWatched]);
 
   const filteredRepositories = useMemo(() => {
     let filtered = rankedRepositories;
@@ -408,6 +416,11 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
         value: (r) => r.totalScore || 0,
       },
       repository: {
+        title: 'OSS score by repository',
+        yAxis: 'OSS score',
+        value: (r) => r.totalScore || 0,
+      },
+      watch: {
         title: 'OSS score by repository',
         yAxis: 'OSS score',
         value: (r) => r.totalScore || 0,
@@ -714,7 +727,7 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
   const renderSortHeader = (
     column: SortColumn,
     label: string,
-    align: 'left' | 'right' = 'left',
+    align: 'left' | 'right' | 'center' = 'left',
   ) => (
     <Box
       onClick={() => handleSort(column)}
@@ -726,9 +739,14 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
         userSelect: 'none',
         width: '100%',
         height: '100%',
-        px: 2,
+        px: align === 'center' ? 0.5 : 2,
         py: 1,
-        justifyContent: align === 'right' ? 'flex-end' : 'flex-start',
+        justifyContent:
+          align === 'right'
+            ? 'flex-end'
+            : align === 'center'
+              ? 'center'
+              : 'flex-start',
       }}
     >
       {label}
@@ -963,9 +981,10 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
     },
     {
       key: 'watch',
-      header: '★',
+      header: renderSortHeader('watch', '★', 'center'),
       width: '52px',
       align: 'center',
+      headerSx: sortableHeaderSx,
       cellSx: { p: 0 },
       renderCell: (repo) =>
         repo.repository ? (

--- a/src/components/leaderboard/types.ts
+++ b/src/components/leaderboard/types.ts
@@ -68,7 +68,8 @@ export type SortOption =
   | 'totalPRs'
   | 'totalIssues'
   | 'issueDiscoveryScore'
-  | 'credibility';
+  | 'credibility'
+  | 'watch';
 
 export const FONTS = {
   mono: '"JetBrains Mono", monospace',

--- a/src/pages/WatchlistPage.tsx
+++ b/src/pages/WatchlistPage.tsx
@@ -73,6 +73,7 @@ import {
 import { filterPrs, type PrStatusFilter } from '../utils/prTable';
 import { getIssueStatusMeta } from '../utils/issueStatus';
 import { formatTokenAmount } from '../utils/format';
+import { compareByWatchlist } from '../utils/watchlistSort';
 import theme, {
   CHART_COLORS,
   STATUS_COLORS,
@@ -1776,7 +1777,7 @@ const prStatusMeta = (pr: CommitLog) => {
   return { label, color };
 };
 
-type PrSortKey = 'pr' | 'title' | 'repo' | 'author' | 'score';
+type PrSortKey = 'pr' | 'title' | 'repo' | 'author' | 'score' | 'watch';
 
 const prCellSx = { py: 1.5 } as const;
 
@@ -1979,6 +1980,7 @@ const buildPrColumns = (
     header: '★',
     width: '52px',
     align: 'center',
+    sortKey: 'watch',
     cellSx: { p: 0 },
     renderCell: (pr) => (
       <WatchlistButton
@@ -2239,6 +2241,7 @@ const PR_ROWS_OPTIONS = [10, 25, 50] as const;
 const PRsList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
   const { items, sourcesByKey, isLoading } = useWatchedPRs(itemKeys);
   const prColumns = useMemo(() => buildPrColumns(sourcesByKey), [sourcesByKey]);
+  const { isWatched } = useWatchlist('prs');
   const [searchQuery, setSearchQuery] = useState('');
   const [statusFilter, setStatusFilter] = useState<PrStatusFilter>('all');
   const [viewMode, setViewMode] = useState<PRsViewMode>('list');
@@ -2289,11 +2292,16 @@ const PRsList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
           return cmpStr(a.author, b.author);
         case 'score':
           return cmpNum(parseFloat(a.score || '0'), parseFloat(b.score || '0'));
+        case 'watch': {
+          const key = (pr: CommitLog) =>
+            serializePRKey(pr.repository, pr.pullRequestNumber);
+          return compareByWatchlist(a, b, key, isWatched) * dir;
+        }
         default:
           return 0;
       }
     });
-  }, [filtered, sortField, sortOrder]);
+  }, [filtered, sortField, sortOrder, isWatched]);
 
   const paged = useMemo(
     () => sorted.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage),

--- a/src/tests/watchlistSort.test.ts
+++ b/src/tests/watchlistSort.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { compareByWatchlist } from '../utils/watchlistSort';
+
+describe('compareByWatchlist', () => {
+  type Row = { key?: string };
+  const watched = new Set(['a', 'c']);
+  const isWatched = (k: string) => watched.has(k);
+  const getKey = (row: Row) => row.key;
+
+  it('treats undefined keys as not watched', () => {
+    const result = compareByWatchlist(
+      { key: undefined } as Row,
+      { key: 'a' } as Row,
+      getKey,
+      isWatched,
+    );
+    expect(result).toBeLessThan(0);
+  });
+
+  it('puts watched rows on top under desc multiplier', () => {
+    const rows: Row[] = [
+      { key: 'b' },
+      { key: 'a' },
+      { key: 'd' },
+      { key: 'c' },
+    ];
+    const sorted = [...rows].sort(
+      (a, b) => compareByWatchlist(a, b, getKey, isWatched) * -1,
+    );
+    expect(
+      sorted
+        .slice(0, 2)
+        .map((r) => r.key)
+        .sort(),
+    ).toEqual(['a', 'c']);
+    expect(sorted.slice(2).every((r) => !watched.has(r.key ?? ''))).toBe(true);
+  });
+
+  it('puts unwatched rows on top under asc multiplier', () => {
+    const rows: Row[] = [{ key: 'a' }, { key: 'b' }, { key: 'c' }];
+    const sorted = [...rows].sort((a, b) =>
+      compareByWatchlist(a, b, getKey, isWatched),
+    );
+    expect(sorted[0].key).toBe('b');
+  });
+
+  it('preserves stable order between equally-watched rows', () => {
+    const rows: Row[] = [
+      { key: 'a' },
+      { key: 'c' },
+      { key: 'b' },
+      { key: 'd' },
+    ];
+    const sorted = [...rows].sort(
+      (a, b) => compareByWatchlist(a, b, getKey, isWatched) * -1,
+    );
+    expect(
+      sorted
+        .slice(0, 2)
+        .map((r) => r.key)
+        .join(','),
+    ).toBe('a,c');
+  });
+});

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -4,3 +4,4 @@ export * from './prStatus';
 export * from './prTable';
 export * from './issueStatus';
 export * from './multiplierDefs';
+export * from './watchlistSort';

--- a/src/utils/watchlistSort.ts
+++ b/src/utils/watchlistSort.ts
@@ -1,0 +1,10 @@
+export function compareByWatchlist<T>(
+  a: T,
+  b: T,
+  getKey: (item: T) => string | undefined,
+  isWatched: (key: string) => boolean,
+): number {
+  const aK = getKey(a);
+  const bK = getKey(b);
+  return +(aK != null && isWatched(aK)) - +(bK != null && isWatched(bK));
+}


### PR DESCRIPTION
## Summary

Makes the ★ (watchlist) column header click-sortable on the three tables that have it: the Repositories list view (OSS and Issue Discovery), the Top Miners list, and the Watchlist Pull Requests tab.

Before this change, the ★ header looked like every other column header but didn't respond to clicks. Now it sorts the table by watchlist membership — first click pulls your starred rows to the top, second click flips the order, and toggling a star on or off re-sorts the list right away.

The shared comparator lives in a new utility module so all three tables behave the same way:

- `src/utils/watchlistSort.ts` — `compareWatchedFlags` and `compareByWatchlist` helpers (covered by `src/tests/watchlistSort.test.ts`, 7 new tests).
- `TopRepositoriesTable.tsx` — adds `'watch'` to the sort column union, wires `useWatchlist('repos')` into the comparator, and routes the ★ header click through the existing `renderSortHeader`.
- `TopMinersTable.tsx` + `MinersList.tsx` — extends `SortOption` with `'watch'`, threads `isWatched` through `compareMiners`, and marks the ★ column `sortKey: 'watch'`.
- `WatchlistPage.tsx` — extends `PrSortKey` with `'watch'`, marks the ★ column `sortKey: 'watch'`, and adds a `'watch'` case to the PRs sort comparator using `useWatchlist('prs')`.

No backend changes; the watchlist already lives in local storage.

## Related Issues

Closes #833 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

[test.webm](https://github.com/user-attachments/assets/bbbfb4d8-ee98-477b-b734-95ba5deaa39d)


## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
