### PR TITLE
feat: Add PR time decay scoring chart

### DIFF
--- a/src/components/prs/PRDetailsCard.tsx
+++ b/src/components/prs/PRDetailsCard.tsx
@@ -20,6 +20,7 @@ import theme, {
 } from '../../theme';
 import { parseNumber } from '../../utils';
 import { buildMultiplierGrid } from '../../utils/multiplierDefs';
+import PRTimeDecayChart from './PRTimeDecayChart';
 
 interface PRDetailsCardProps {
   repository: string;
@@ -428,6 +429,13 @@ const PRDetailsCard: React.FC<PRDetailsCardProps> = ({
           })}
         </Box>
       </Box>
+
+      <PRTimeDecayChart
+        mergedAt={prDetails.mergedAt}
+        prState={prDetails.prState}
+        timeDecayMultiplier={prDetails.timeDecayMultiplier}
+        earnedScore={prDetails.earnedScore}
+      />
 
       <Box
         sx={{

--- a/src/components/prs/PRTimeDecayChart.tsx
+++ b/src/components/prs/PRTimeDecayChart.tsx
@@ -1,0 +1,415 @@
+import React, { useMemo } from 'react';
+import { Box, Typography, alpha, useTheme } from '@mui/material';
+import { type Theme } from '@mui/material/styles';
+import ReactECharts from 'echarts-for-react';
+import { useGeneralConfig } from '../../api';
+import { STATUS_COLORS, TEXT_OPACITY } from '../../theme';
+import {
+  echartsAxisTooltipChrome,
+  echartsFontFamily,
+  echartsMutedCartesianAxisColors,
+  echartsTransparentBackground,
+} from '../../utils/echarts/gittensorChartTheme';
+import {
+  PR_LOOKBACK_DAYS,
+  buildDecayCurve,
+  buildDecayProjection,
+  buildDecaySubline,
+  type DecayParams,
+  type DecayProjection,
+  resolveDecayParams,
+} from './prTimeDecayModel';
+
+interface PRTimeDecayChartProps {
+  mergedAt: string | null;
+  prState: string;
+  timeDecayMultiplier?: string | number | null;
+  earnedScore?: string | number | null;
+}
+
+interface CartesianAxisColors {
+  labelColor: string;
+  axisLineColor: string;
+  splitLineColor: string;
+}
+
+interface NowMarker {
+  day: number;
+  multiplier: number;
+}
+
+const GRADIENT_STOPS = [
+  { offset: 0, color: STATUS_COLORS.success },
+  { offset: 0.3, color: STATUS_COLORS.warning },
+  { offset: 0.65, color: STATUS_COLORS.warningOrange },
+  { offset: 1, color: STATUS_COLORS.error },
+];
+
+const GRADIENT_CSS = `linear-gradient(90deg, ${STATUS_COLORS.success} 0%, ${STATUS_COLORS.warning} 30%, ${STATUS_COLORS.warningOrange} 65%, ${STATUS_COLORS.error} 100%)`;
+
+function buildGradient(opacities?: number[]) {
+  return {
+    type: 'linear' as const,
+    x: 0,
+    y: 0,
+    x2: 1,
+    y2: 0,
+    colorStops: GRADIENT_STOPS.map((stop, index) => ({
+      offset: stop.offset,
+      color: opacities ? alpha(stop.color, opacities[index]) : stop.color,
+    })),
+  };
+}
+
+function resolveNowMarker(projection: DecayProjection): NowMarker | null {
+  if (!projection.isMerged || !projection.inWindow) return null;
+  if (projection.daysSinceMerge == null) return null;
+  if (projection.chartNowMultiplier == null) return null;
+  return {
+    day: +projection.daysSinceMerge.toFixed(2),
+    multiplier: projection.chartNowMultiplier,
+  };
+}
+
+function injectNowPoint(
+  curve: [number, number][],
+  marker: NowMarker | null,
+): [number, number][] {
+  if (marker == null) return curve;
+  const filtered = curve.filter(([x]) => x !== marker.day);
+  filtered.push([marker.day, marker.multiplier]);
+  filtered.sort((a, b) => a[0] - b[0]);
+  return filtered;
+}
+
+function buildMarkPointData(marker: NowMarker | null) {
+  if (marker == null) return [];
+  return [
+    {
+      name: 'Now',
+      coord: [marker.day, marker.multiplier],
+      itemStyle: { color: STATUS_COLORS.success },
+    },
+  ];
+}
+
+function formatPercentTick(value: number): string {
+  return `${(value * 100).toFixed(0)}%`;
+}
+
+function formatNowMarkerLabel(point: {
+  name: string;
+  data: { coord: number[] };
+}): string {
+  const value = point.data?.coord?.[1];
+  if (value == null) return point.name;
+  return `${point.name} ${value.toFixed(2)}×`;
+}
+
+function formatTooltipBody(
+  day: number,
+  multiplier: number,
+  preDecayScore: number | null,
+  mutedHex: string,
+): string {
+  const header = `<div style="font-weight:600;margin-bottom:2px">Day ${day.toFixed(1)}</div>`;
+  const multiplierLine = `<div><span style="color:${mutedHex}">Multiplier</span> <b>${multiplier.toFixed(2)}×</b></div>`;
+  if (preDecayScore == null) return header + multiplierLine;
+  const score = preDecayScore * multiplier;
+  const scoreLine = `<div style="margin-top:2px"><span style="color:${mutedHex}">Score</span> <b>${score.toFixed(2)}</b></div>`;
+  return header + multiplierLine + scoreLine;
+}
+
+function buildTooltipFormatter(preDecayScore: number | null, mutedHex: string) {
+  return function formatChartTooltip(raw: unknown): string {
+    const first = (Array.isArray(raw) ? raw : [raw])[0] as
+      | { data?: [number, number] }
+      | undefined;
+    if (!first?.data) return '';
+    const [day, multiplier] = first.data;
+    return formatTooltipBody(day, multiplier, preDecayScore, mutedHex);
+  };
+}
+
+function buildTooltip(
+  theme: Theme,
+  preDecayScore: number | null,
+  mutedHex: string,
+) {
+  return {
+    trigger: 'axis',
+    ...echartsAxisTooltipChrome(theme),
+    formatter: buildTooltipFormatter(preDecayScore, mutedHex),
+  };
+}
+
+function buildXAxis(axis: CartesianAxisColors, fontFamily: string) {
+  return {
+    type: 'value',
+    min: 0,
+    max: PR_LOOKBACK_DAYS,
+    name: 'days since merge',
+    nameLocation: 'middle',
+    nameGap: 22,
+    nameTextStyle: { color: axis.labelColor, fontSize: 10, fontFamily },
+    axisLine: { lineStyle: { color: axis.axisLineColor } },
+    axisTick: { show: false },
+    axisLabel: { color: axis.labelColor, fontSize: 10 },
+    splitLine: { lineStyle: { color: axis.splitLineColor } },
+  };
+}
+
+function buildYAxis(axis: CartesianAxisColors) {
+  return {
+    type: 'value',
+    min: 0,
+    max: 1,
+    interval: 0.25,
+    axisLine: { show: false },
+    axisTick: { show: false },
+    axisLabel: {
+      color: axis.labelColor,
+      fontSize: 10,
+      formatter: formatPercentTick,
+    },
+    splitLine: { lineStyle: { color: axis.splitLineColor } },
+  };
+}
+
+function buildMarkLine(
+  theme: Theme,
+  axis: CartesianAxisColors,
+  midpoint: number,
+) {
+  return {
+    symbol: 'none',
+    silent: true,
+    lineStyle: {
+      color: alpha(theme.palette.common.white, 0.18),
+      type: 'dashed',
+    },
+    label: { color: axis.labelColor, fontSize: 9, formatter: '{b}' },
+    data: [{ name: '50% @ midpoint', xAxis: midpoint }],
+  };
+}
+
+function buildMarkPoint(theme: Theme, marker: NowMarker | null) {
+  return {
+    symbol: 'circle',
+    symbolSize: 12,
+    label: {
+      show: true,
+      color: theme.palette.text.primary,
+      fontSize: 10,
+      fontWeight: 600,
+      formatter: formatNowMarkerLabel,
+      position: 'top',
+      distance: 10,
+    },
+    data: buildMarkPointData(marker),
+  };
+}
+
+function buildSeries(
+  theme: Theme,
+  axis: CartesianAxisColors,
+  params: DecayParams,
+  seriesData: [number, number][],
+  marker: NowMarker | null,
+) {
+  return {
+    type: 'line',
+    data: seriesData,
+    showSymbol: false,
+    smooth: false,
+    lineStyle: { width: 2.5, color: buildGradient() },
+    areaStyle: { color: buildGradient([0.22, 0.16, 0.12, 0.08]) },
+    markLine: buildMarkLine(theme, axis, params.midpoint),
+    markPoint: buildMarkPoint(theme, marker),
+  };
+}
+
+function buildChartOption(
+  theme: Theme,
+  params: DecayParams,
+  projection: DecayProjection,
+) {
+  const axis = echartsMutedCartesianAxisColors(theme);
+  const fontFamily = echartsFontFamily(theme);
+  const mutedHex = alpha(theme.palette.common.white, TEXT_OPACITY.tertiary);
+  const marker = resolveNowMarker(projection);
+  const seriesData = injectNowPoint(buildDecayCurve(params), marker);
+  return {
+    ...echartsTransparentBackground(),
+    grid: { left: 44, right: 16, top: 28, bottom: 36 },
+    tooltip: buildTooltip(theme, projection.preDecayScore, mutedHex),
+    xAxis: buildXAxis(axis, fontFamily),
+    yAxis: buildYAxis(axis),
+    series: [buildSeries(theme, axis, params, seriesData, marker)],
+  };
+}
+
+function PRTimeDecayChart({
+  mergedAt,
+  prState,
+  timeDecayMultiplier,
+  earnedScore,
+}: PRTimeDecayChartProps) {
+  const theme = useTheme();
+  const { data: generalConfig } = useGeneralConfig();
+  const params = useMemo(
+    () => resolveDecayParams(generalConfig),
+    [generalConfig],
+  );
+  const projection = useMemo(
+    () =>
+      buildDecayProjection(
+        { mergedAt, prState, timeDecayMultiplier, earnedScore },
+        params,
+      ),
+    [earnedScore, mergedAt, params, prState, timeDecayMultiplier],
+  );
+  const option = useMemo(
+    () => buildChartOption(theme, params, projection),
+    [theme, params, projection],
+  );
+  const showNow = projection.isMerged && projection.inWindow;
+  const muted = alpha(theme.palette.common.white, TEXT_OPACITY.muted);
+  const tertiary = alpha(theme.palette.common.white, TEXT_OPACITY.tertiary);
+
+  return (
+    <Box
+      sx={{
+        border: `1px solid ${theme.palette.border.light}`,
+        borderRadius: 3,
+        p: { xs: 2, sm: 2.5 },
+        mb: 3,
+        backgroundColor: alpha(theme.palette.common.white, 0.015),
+      }}
+    >
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          flexWrap: 'wrap',
+          gap: 1,
+          mb: 1.5,
+        }}
+      >
+        <Box>
+          <Typography
+            sx={{
+              color: alpha(theme.palette.common.white, TEXT_OPACITY.secondary),
+              fontSize: '0.8rem',
+              textTransform: 'uppercase',
+              letterSpacing: '1px',
+              fontWeight: 600,
+            }}
+          >
+            Time Decay
+          </Typography>
+          <Typography sx={{ color: tertiary, fontSize: '0.72rem', mt: 0.25 }}>
+            {buildDecaySubline(projection)}
+          </Typography>
+        </Box>
+        <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 1.5 }}>
+          {showNow && projection.chartNowScore != null && (
+            <Box sx={{ textAlign: 'right' }}>
+              <Typography
+                sx={{
+                  color: theme.palette.text.primary,
+                  fontSize: '1.4rem',
+                  fontWeight: 800,
+                  lineHeight: 1.1,
+                }}
+              >
+                {projection.chartNowScore.toFixed(2)}
+              </Typography>
+              <Typography sx={{ color: muted, fontSize: '0.65rem' }}>
+                now score
+              </Typography>
+            </Box>
+          )}
+          {showNow && projection.chartNowMultiplier != null && (
+            <Box sx={{ textAlign: 'right' }}>
+              <Typography
+                sx={{
+                  color: alpha(
+                    theme.palette.common.white,
+                    TEXT_OPACITY.secondary,
+                  ),
+                  fontSize: '1rem',
+                  fontWeight: 700,
+                  lineHeight: 1.1,
+                }}
+              >
+                {projection.chartNowMultiplier.toFixed(2)}×
+              </Typography>
+              <Typography sx={{ color: muted, fontSize: '0.65rem' }}>
+                multiplier
+              </Typography>
+            </Box>
+          )}
+          {!projection.isMerged && (
+            <Typography
+              sx={{ color: tertiary, fontSize: '0.85rem', fontWeight: 600 }}
+            >
+              Decay starts at merge
+            </Typography>
+          )}
+        </Box>
+      </Box>
+      <Box sx={{ width: '100%', height: 200 }}>
+        <ReactECharts
+          option={option}
+          style={{ height: '100%', width: '100%' }}
+          opts={{ renderer: 'svg' }}
+          notMerge
+        />
+      </Box>
+      <Box
+        sx={{
+          display: 'flex',
+          gap: 2,
+          mt: 1,
+          flexWrap: 'wrap',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+        }}
+      >
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
+          <Typography sx={{ color: tertiary, fontSize: '0.7rem' }}>
+            fresh
+          </Typography>
+          <Box
+            sx={{
+              width: 80,
+              height: 6,
+              borderRadius: 3,
+              background: GRADIENT_CSS,
+            }}
+          />
+          <Typography sx={{ color: tertiary, fontSize: '0.7rem' }}>
+            stale
+          </Typography>
+        </Box>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+          <Box
+            sx={{
+              width: 8,
+              height: 8,
+              borderRadius: '50%',
+              backgroundColor: STATUS_COLORS.success,
+            }}
+          />
+          <Typography sx={{ color: tertiary, fontSize: '0.7rem' }}>
+            Now
+          </Typography>
+        </Box>
+      </Box>
+    </Box>
+  );
+}
+
+export default PRTimeDecayChart;

--- a/src/components/prs/index.ts
+++ b/src/components/prs/index.ts
@@ -2,3 +2,4 @@ export { default as PRDetailsCard } from './PRDetailsCard';
 export { default as PRFilesChanged } from './PRFilesChanged';
 export { default as PRHeader } from './PRHeader';
 export { default as PRComments } from './PRComments';
+export { default as PRTimeDecayChart } from './PRTimeDecayChart';

--- a/src/components/prs/prTimeDecayModel.ts
+++ b/src/components/prs/prTimeDecayModel.ts
@@ -1,0 +1,146 @@
+import { type GeneralConfigResponse } from '../../api/models';
+import { parseNumber } from '../../utils';
+
+export const PR_LOOKBACK_DAYS = 35;
+const CURVE_RESOLUTION_DAYS = 0.25;
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+export interface DecayParams {
+  graceHours: number;
+  midpoint: number;
+  steepness: number;
+  floor: number;
+}
+
+export interface DecayProjectionInput {
+  mergedAt: string | null;
+  prState: string;
+  timeDecayMultiplier?: string | number | null;
+  earnedScore?: string | number | null;
+  nowMs?: number;
+}
+
+export interface DecayProjection {
+  isMerged: boolean;
+  inWindow: boolean;
+  daysSinceMerge: number | null;
+  /** Curve multiplier at days since merge (matches the drawn line). */
+  chartNowMultiplier: number | null;
+  /** Subnet-reported multiplier (used to back-derive pre-decay score). */
+  currentMultiplier: number | null;
+  preDecayScore: number | null;
+  chartNowScore: number | null;
+}
+
+const DEFAULT_PARAMS: DecayParams = {
+  graceHours: 12,
+  midpoint: 10,
+  steepness: 0.4,
+  floor: 0.05,
+};
+
+export function resolveDecayParams(
+  config?: GeneralConfigResponse | null,
+): DecayParams {
+  const cfg = config?.repositoryPrScoring;
+  return {
+    graceHours: cfg?.timeDecayGracePeriodHours ?? DEFAULT_PARAMS.graceHours,
+    midpoint: cfg?.timeDecaySigmoidMidpoint ?? DEFAULT_PARAMS.midpoint,
+    steepness: cfg?.timeDecaySigmoidSteepnessScalar ?? DEFAULT_PARAMS.steepness,
+    floor: cfg?.timeDecayMinMultiplier ?? DEFAULT_PARAMS.floor,
+  };
+}
+
+export function decayAt(days: number, params: DecayParams): number {
+  if (days <= params.graceHours / 24) return 1;
+  const sigmoid =
+    1 / (1 + Math.exp(params.steepness * (days - params.midpoint)));
+  return Math.max(sigmoid, params.floor);
+}
+
+export function buildDecayCurve(params: DecayParams): [number, number][] {
+  const points: [number, number][] = [];
+  for (let day = 0; day <= PR_LOOKBACK_DAYS; day += CURVE_RESOLUTION_DAYS) {
+    points.push([+day.toFixed(2), +decayAt(day, params).toFixed(4)]);
+  }
+  return points;
+}
+
+function computeDaysSinceMerge(
+  isMerged: boolean,
+  mergedAt: string | null,
+  nowMs: number,
+): number | null {
+  if (!isMerged || !mergedAt) return null;
+  return Math.max(0, (nowMs - new Date(mergedAt).getTime()) / MS_PER_DAY);
+}
+
+function parseMultiplierValue(
+  raw: string | number | null | undefined,
+): number | null {
+  if (raw == null) return null;
+  return parseNumber(raw);
+}
+
+function backDerivePreDecayScore(
+  isMerged: boolean,
+  earned: number,
+  denominator: number | null,
+): number | null {
+  if (!isMerged || earned <= 0) return null;
+  if (denominator == null || denominator <= 0) return null;
+  return earned / denominator;
+}
+
+function applyMultiplier(
+  score: number | null,
+  multiplier: number | null,
+): number | null {
+  if (score == null || multiplier == null) return null;
+  return score * multiplier;
+}
+
+function isWithinLookbackWindow(daysSinceMerge: number | null): boolean {
+  if (daysSinceMerge == null) return false;
+  return daysSinceMerge <= PR_LOOKBACK_DAYS;
+}
+
+export function buildDecayProjection(
+  input: DecayProjectionInput,
+  params: DecayParams,
+): DecayProjection {
+  const { mergedAt, prState, timeDecayMultiplier, earnedScore, nowMs } = input;
+  const isMerged = prState === 'MERGED' && !!mergedAt;
+  const daysSinceMerge = computeDaysSinceMerge(
+    isMerged,
+    mergedAt,
+    nowMs ?? Date.now(),
+  );
+  const chartNowMultiplier =
+    daysSinceMerge != null ? decayAt(daysSinceMerge, params) : null;
+  const currentMultiplier = parseMultiplierValue(timeDecayMultiplier);
+  const earned = earnedScore == null ? 0 : parseNumber(earnedScore);
+  const preDecayScore = backDerivePreDecayScore(
+    isMerged,
+    earned,
+    currentMultiplier ?? chartNowMultiplier,
+  );
+  return {
+    isMerged,
+    inWindow: isWithinLookbackWindow(daysSinceMerge),
+    daysSinceMerge,
+    chartNowMultiplier,
+    currentMultiplier,
+    preDecayScore,
+    chartNowScore: applyMultiplier(preDecayScore, chartNowMultiplier),
+  };
+}
+
+export function buildDecaySubline(projection: DecayProjection): string {
+  if (!projection.isMerged) return 'Open PRs hold full score until merged.';
+  if (projection.daysSinceMerge == null) return '';
+  if (projection.daysSinceMerge > PR_LOOKBACK_DAYS) {
+    return `Outside ${PR_LOOKBACK_DAYS}-day scoring window.`;
+  }
+  return `${projection.daysSinceMerge.toFixed(1)} days since merge`;
+}

--- a/src/tests/prTimeDecayModel.test.ts
+++ b/src/tests/prTimeDecayModel.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import {
+  PR_LOOKBACK_DAYS,
+  buildDecayCurve,
+  buildDecayProjection,
+  decayAt,
+  resolveDecayParams,
+  type DecayParams,
+} from '../components/prs/prTimeDecayModel';
+
+const params: DecayParams = {
+  graceHours: 12,
+  midpoint: 10,
+  steepness: 0.4,
+  floor: 0.05,
+};
+
+describe('prTimeDecayModel', () => {
+  it('falls back to canonical defaults when config is missing', () => {
+    expect(resolveDecayParams(undefined)).toEqual(params);
+  });
+
+  it('honors grace, sigmoid midpoint, and floor', () => {
+    expect(decayAt(0, params)).toBe(1);
+    expect(decayAt(0.5, params)).toBe(1);
+    expect(decayAt(10, params)).toBeCloseTo(0.5, 4);
+    expect(decayAt(35, params)).toBe(params.floor);
+  });
+
+  it('builds a curve spanning the lookback window', () => {
+    const curve = buildDecayCurve(params);
+    expect(curve[0]).toEqual([0, 1]);
+    expect(curve[curve.length - 1]).toEqual([PR_LOOKBACK_DAYS, params.floor]);
+  });
+
+  it('back-derives pre-decay score from the subnet multiplier', () => {
+    const nowMs = Date.parse('2026-04-29T12:00:00Z');
+    const projection = buildDecayProjection(
+      {
+        mergedAt: '2026-04-24T12:00:00Z',
+        prState: 'MERGED',
+        timeDecayMultiplier: '0.8',
+        earnedScore: 8,
+        nowMs,
+      },
+      params,
+    );
+    expect(projection.daysSinceMerge).toBe(5);
+    expect(projection.currentMultiplier).toBe(0.8);
+    expect(projection.preDecayScore).toBe(10);
+    expect(projection.chartNowMultiplier).toBeCloseTo(decayAt(5, params));
+    expect(projection.chartNowScore).toBeCloseTo(10 * decayAt(5, params));
+  });
+
+  it('flags out-of-window PRs and treats unmerged PRs as pre-decay', () => {
+    const nowMs = Date.parse('2026-04-29T00:00:00Z');
+    const old = new Date(nowMs - 40 * 24 * 60 * 60 * 1000).toISOString();
+    expect(
+      buildDecayProjection(
+        {
+          mergedAt: old,
+          prState: 'MERGED',
+          timeDecayMultiplier: '0.05',
+          nowMs,
+        },
+        params,
+      ).inWindow,
+    ).toBe(false);
+    const open = buildDecayProjection(
+      { mergedAt: null, prState: 'OPEN', earnedScore: 12 },
+      params,
+    );
+    expect(open.isMerged).toBe(false);
+    expect(open.chartNowMultiplier).toBe(null);
+    expect(open.preDecayScore).toBe(null);
+  });
+});


### PR DESCRIPTION
## Summary

Add a sigmoid time-decay visualization to the PR details view so miners can see how the time-decay multiplier evolves after merge, how much score has already been lost to decay, and where the PR sits inside the 35-day scoring window.

The change includes:

- a new `PRTimeDecayChart` component in the PR details card, with a horizontal gradient (fresh → stale) along the 35-day curve, an injected "Now" marker that snaps exactly to the curve, dual readouts for current score / multiplier, a 50%-midpoint reference line, and a fresh/stale legend
- a `prTimeDecayModel.ts` helper with the canonical decay math (`decayAt`, `buildDecayCurve`), config resolution from `/configurations/general` (`resolveDecayParams`), and a pure projection builder (`buildDecayProjection`) that back-derives the pre-decay score from the subnet-reported multiplier
- reuse of the repo's shared ECharts theme helpers (`echartsAxisTooltipChrome`, `echartsMutedCartesianAxisColors`, `echartsTransparentBackground`, `echartsFontFamily`) instead of re-implementing tooltip / axis chrome
- focused vitest coverage for the sigmoid math, curve span, projection back-derivation, and out-of-window flagging

### Behavior

- **Merged PR, in window** → curve is drawn, `Now` dot sits on the curve, header shows current `score` + `multiplier×`, tooltip values match the header.
- **Merged PR, > 35 days** → curve is drawn, no `Now` marker, subline shows `Outside 35-day scoring window.`
- **Open PR** → curve is drawn, header shows `Decay starts at merge`, subline shows `Open PRs hold full score until merged.`

## Related Issues

Closes #835

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

<img width="1402" height="839" alt="1" src="https://github.com/user-attachments/assets/8921a4f7-3b87-4f7f-a8cc-c0ce10872c60" />

**When hover on graph line**

<img width="1332" height="698" alt="2" src="https://github.com/user-attachments/assets/5c94f78c-fd8d-44ea-b86d-6171e58cdec4" />

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes