### PR TITLE
Fix dashboard donut chart tooltip clipping

### DIFF
--- a/src/pages/dashboard/views/DashboardOverview.tsx
+++ b/src/pages/dashboard/views/DashboardOverview.tsx
@@ -51,6 +51,8 @@ const buildStatusChartOption = (
 ): Record<string, unknown> => {
   const totalValue = segments.reduce((sum, segment) => sum + segment.value, 0);
   const chartFont = echartsFontFamily(theme);
+  const tooltipLabelColor = alpha(theme.palette.text.primary, 0.62);
+  const tooltipBorderColor = alpha(theme.palette.text.primary, 0.12);
 
   return {
     ...echartsTransparentBackground(),
@@ -71,11 +73,30 @@ const buildStatusChartOption = (
         name,
         value,
         percent,
+        color,
       }: {
         name: string;
         value: number;
         percent: number;
-      }) => `${name}: ${Number(value).toLocaleString()} (${percent}%)`,
+        color?: string;
+      }) => `
+        <div style="display:grid;gap:7px;min-width:136px;font-family:${chartFont};">
+          <div style="display:flex;align-items:center;gap:8px;">
+            <span style="width:8px;height:8px;border-radius:999px;background:${color ?? theme.palette.text.secondary};box-shadow:0 0 0 2px ${alpha(theme.palette.text.primary, 0.08)};"></span>
+            <span style="color:${theme.palette.text.primary};font-weight:700;">${name}</span>
+          </div>
+          <div style="border-top:1px solid ${tooltipBorderColor};padding-top:7px;display:grid;gap:5px;">
+            <div style="display:flex;justify-content:space-between;gap:18px;">
+              <span style="color:${tooltipLabelColor};">Count</span>
+              <span style="color:${theme.palette.text.primary};font-weight:700;">${Number(value).toLocaleString()}</span>
+            </div>
+            <div style="display:flex;justify-content:space-between;gap:18px;">
+              <span style="color:${tooltipLabelColor};">Share</span>
+              <span style="color:${theme.palette.text.primary};font-weight:700;">${percent}%</span>
+            </div>
+          </div>
+        </div>
+      `,
       ...echartsItemTooltipChrome(theme),
     },
     series: [

--- a/src/utils/echarts/gittensorChartTheme.ts
+++ b/src/utils/echarts/gittensorChartTheme.ts
@@ -26,6 +26,8 @@ export function echartsAxisTooltipChrome(theme: Theme) {
 /** Tooltip chrome for pie / item charts. Merge with trigger, formatter. */
 export function echartsItemTooltipChrome(theme: Theme) {
   return {
+    renderMode: 'html' as const,
+    appendTo: 'body' as const,
     backgroundColor: theme.palette.surface.tooltip,
     borderColor: alpha(theme.palette.text.primary, 0.15),
     borderWidth: 1,


### PR DESCRIPTION
## Summary

Fixes the dashboard donut chart hover tooltip so it is no longer clipped by the small chart container. The tooltip content was also updated to show `Count` and `Share` in a clearer layout without changing the dashboard layout or Live Activity section.

## Related Issues

Closes https://github.com/entrius/gittensor-ui/issues/837

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

<img width="1128" height="534" alt="image" src="https://github.com/user-attachments/assets/5654bae0-8ed8-4998-b5a1-e7fa53dc8c15" />

## Checklist

- [ ] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [ ] Responsive/mobile checked
- [ ] Tested against the test API
- [ ] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
