### PR TITLE
fix(watchlist): make clear confirmation modal text tab-aware

### DIFF
--- a/src/pages/WatchlistPage.tsx
+++ b/src/pages/WatchlistPage.tsx
@@ -412,7 +412,7 @@ const WatchlistPage: React.FC = () => {
             mb: 3,
           }}
         >
-          Clear all {count} pinned miner(s)?
+          Clear all {count} pinned {count === 1 ? noun.single : noun.plural}?
         </DialogTitle>
         <DialogActions sx={{ p: 0 }}>
           <Button


### PR DESCRIPTION
## Summary


- Fix clear-confirmation modal copy in WatchlistPage.
- Remove hardcoded miner wording from modal title.
- Use tab-aware noun (single/plural) based on active watchlist tab and item count.


## Related Issues

Closes #841

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

<img width="1287" height="630" alt="image" src="https://github.com/user-attachments/assets/55ad4070-b9bf-414d-b4ff-70b13114673f" />
<img width="1307" height="603" alt="image" src="https://github.com/user-attachments/assets/69428946-a76e-4498-8b24-7203e708e77d" />
<img width="1268" height="583" alt="image" src="https://github.com/user-attachments/assets/c3a42a9c-4d94-443e-948b-866d70257e1a" />
<img width="1302" height="642" alt="image" src="https://github.com/user-attachments/assets/41384fd2-6fd1-48fc-a79c-8709f8f1d46c" />


## Checklist

- [ ] New components are modularized/separated where sensible
- [ ] Uses predefined theme (e.g. no hardcoded colors)
- [ ] Responsive/mobile checked
- [ ] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
