### PR TITLE
fix: fix repo-owner avatar rendering by centralizing avatar src helper

### DIFF
--- a/src/components/issues/BountyCard.tsx
+++ b/src/components/issues/BountyCard.tsx
@@ -17,6 +17,7 @@ import { linkResetSx, useLinkBehavior } from '../common/linkBehavior';
 import { WatchlistButton } from '../common';
 import BountyProgress from './BountyProgress';
 import { getIssueStatusMeta } from '../../utils/issueStatus';
+import { getRepositoryOwnerAvatarSrc } from '../../utils/avatar';
 import {
   formatTokenAmount,
   formatDate,
@@ -95,7 +96,7 @@ export const BountyCard: React.FC<BountyCardProps> = ({
       {/* Repository header */}
       <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 0 }}>
         <Avatar
-          src={`https://avatars.githubusercontent.com/${owner}`}
+          src={getRepositoryOwnerAvatarSrc(owner)}
           alt={owner}
           sx={(theme) => ({
             width: 36,

--- a/src/components/issues/IssuesList.tsx
+++ b/src/components/issues/IssuesList.tsx
@@ -38,6 +38,7 @@ import {
   formatAlphaToUsd,
 } from '../../utils/format';
 import { getIssueStatusMeta } from '../../utils/issueStatus';
+import { getRepositoryOwnerAvatarSrc } from '../../utils/avatar';
 import { STATUS_COLORS, TEXT_OPACITY } from '../../theme';
 import { DataTable, type DataTableColumn } from '../common/DataTable';
 import BountyProgress from './BountyProgress';
@@ -488,7 +489,9 @@ const IssuesList: React.FC<IssuesListProps> = ({
             }}
           >
             <Avatar
-              src={`https://avatars.githubusercontent.com/${issue.repositoryFullName.split('/')[0]}`}
+              src={getRepositoryOwnerAvatarSrc(
+                issue.repositoryFullName.split('/')[0],
+              )}
               sx={{ width: 24, height: 24, borderRadius: 1, flexShrink: 0 }}
             />
             <Typography

--- a/src/components/leaderboard/RepositoryCard.tsx
+++ b/src/components/leaderboard/RepositoryCard.tsx
@@ -3,6 +3,7 @@ import { Avatar, Box, Card, Divider, Tooltip, Typography } from '@mui/material';
 import { alpha } from '@mui/material/styles';
 import { linkResetSx, useLinkBehavior } from '../common/linkBehavior';
 import { WatchlistButton } from '../common';
+import { getRepositoryOwnerAvatarSrc } from '../../utils';
 import { RankIcon } from './RankIcon';
 import {
   FONTS,
@@ -112,7 +113,7 @@ export const RepositoryCard: React.FC<RepositoryCardProps> = ({
       <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.25 }}>
         <RankIcon rank={repo.rank || 0} />
         <Avatar
-          src={`https://avatars.githubusercontent.com/${owner}`}
+          src={getRepositoryOwnerAvatarSrc(owner) || undefined}
           alt={owner}
           sx={(theme) => ({
             width: 28,
@@ -122,7 +123,9 @@ export const RepositoryCard: React.FC<RepositoryCardProps> = ({
             borderColor: theme.palette.border.medium,
             backgroundColor: getRepositoryOwnerAvatarBackground(owner),
           })}
-        />
+        >
+          {(owner[0] || '?').toUpperCase()}
+        </Avatar>
         <Tooltip title={repo.repository || ''} placement="top" arrow>
           <Typography
             sx={{

--- a/src/components/leaderboard/TopRepositoriesTable.tsx
+++ b/src/components/leaderboard/TopRepositoriesTable.tsx
@@ -63,10 +63,7 @@ import {
 } from '../../utils';
 import { useWatchlist } from '../../hooks/useWatchlist';
 import { RankIcon } from './RankIcon';
-import {
-  getRepositoryOwnerAvatarBackground,
-  type RepoStats,
-} from './types';
+import { getRepositoryOwnerAvatarBackground, type RepoStats } from './types';
 import {
   CHART_COLORS,
   STATUS_COLORS,

--- a/src/components/leaderboard/TopRepositoriesTable.tsx
+++ b/src/components/leaderboard/TopRepositoriesTable.tsx
@@ -56,11 +56,17 @@ import type { TooltipComponentFormatterCallbackParams } from 'echarts';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { DataTable, type DataTableColumn } from '../common/DataTable';
 import { WatchlistButton } from '../common';
-import { truncateText } from '../../utils';
+import {
+  compareByWatchlist,
+  getRepositoryOwnerAvatarSrc,
+  truncateText,
+} from '../../utils';
 import { useWatchlist } from '../../hooks/useWatchlist';
-import { compareByWatchlist } from '../../utils/watchlistSort';
 import { RankIcon } from './RankIcon';
-import { getRepositoryOwnerAvatarBackground, type RepoStats } from './types';
+import {
+  getRepositoryOwnerAvatarBackground,
+  type RepoStats,
+} from './types';
 import {
   CHART_COLORS,
   STATUS_COLORS,
@@ -781,53 +787,56 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
       width: '30%',
       headerSx: sortableHeaderSx,
       cellSx: { pl: 1.5 },
-      renderCell: (repo) => (
-        <Box
-          sx={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: 1,
-            cursor: 'pointer',
-            '&:hover': {
-              '& .MuiTypography-root': {
-                color: 'primary.main',
-                textDecoration: 'underline',
-              },
-            },
-          }}
-        >
-          <Avatar
-            src={`https://avatars.githubusercontent.com/${(repo.repository || '').split('/')[0]}`}
-            alt={(repo.repository || '').split('/')[0]}
+      renderCell: (repo) => {
+        const owner = (repo.repository || '').split('/')[0] || '';
+        return (
+          <Box
             sx={{
-              width: 20,
-              height: 20,
-              border: '1px solid',
-              borderColor: 'border.medium',
-              backgroundColor: getRepositoryOwnerAvatarBackground(
-                (repo.repository || '').split('/')[0],
-              ),
+              display: 'flex',
+              alignItems: 'center',
+              gap: 1,
+              cursor: 'pointer',
+              '&:hover': {
+                '& .MuiTypography-root': {
+                  color: 'primary.main',
+                  textDecoration: 'underline',
+                },
+              },
             }}
-          />
-          <Tooltip title={repo.repository || ''} placement="top">
-            <Typography
-              component="span"
+          >
+            <Avatar
+              src={getRepositoryOwnerAvatarSrc(owner) || undefined}
+              alt={owner}
               sx={{
-                color: 'text.primary',
-                fontWeight: 500,
-                transition: 'color 0.2s',
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
-                whiteSpace: 'nowrap',
-                maxWidth: '100%',
-                display: 'inline-block',
+                width: 20,
+                height: 20,
+                border: '1px solid',
+                borderColor: 'border.medium',
+                backgroundColor: getRepositoryOwnerAvatarBackground(owner),
               }}
             >
-              {truncateText(repo.repository || '', 40)}
-            </Typography>
-          </Tooltip>
-        </Box>
-      ),
+              {(owner[0] || '?').toUpperCase()}
+            </Avatar>
+            <Tooltip title={repo.repository || ''} placement="top">
+              <Typography
+                component="span"
+                sx={{
+                  color: 'text.primary',
+                  fontWeight: 500,
+                  transition: 'color 0.2s',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                  maxWidth: '100%',
+                  display: 'inline-block',
+                }}
+              >
+                {truncateText(repo.repository || '', 40)}
+              </Typography>
+            </Tooltip>
+          </Box>
+        );
+      },
     },
     {
       key: 'weight',

--- a/src/components/miners/MinerIssuesTable.tsx
+++ b/src/components/miners/MinerIssuesTable.tsx
@@ -16,7 +16,7 @@ import { Search as SearchIcon } from '@mui/icons-material';
 import { Link as RouterLink, useSearchParams } from 'react-router-dom';
 import { useMinerIssues } from '../../api';
 import { type MinerIssue } from '../../api/models/Dashboard';
-import { paginateItems } from '../../utils';
+import { getRepositoryOwnerAvatarSrc, paginateItems } from '../../utils';
 import { LABEL_COLORS } from '../../theme';
 import {
   DataTable,
@@ -260,7 +260,7 @@ const MinerIssuesTable: React.FC<MinerIssuesTableProps> = ({ githubId }) => {
             }}
           >
             <Avatar
-              src={`https://avatars.githubusercontent.com/${owner}`}
+              src={getRepositoryOwnerAvatarSrc(owner)}
               alt={owner}
               sx={{
                 width: 20,

--- a/src/components/miners/MinerOpenDiscoveryIssuesByRepo.tsx
+++ b/src/components/miners/MinerOpenDiscoveryIssuesByRepo.tsx
@@ -24,7 +24,7 @@ import {
   OpenInNew as OpenInNewIcon,
 } from '@mui/icons-material';
 import { useMinerGithubData, useMinerPRs } from '../../api';
-import { paginateItems } from '../../utils';
+import { getRepositoryOwnerAvatarSrc, paginateItems } from '../../utils';
 import { DataTable, type DataTableColumn } from '../common/DataTable';
 import ExplorerFilterButton from './ExplorerFilterButton';
 import TablePagination from './TablePagination';
@@ -472,7 +472,7 @@ const MinerOpenDiscoveryIssuesByRepo: React.FC<
                 }}
               >
                 <Avatar
-                  src={`https://avatars.githubusercontent.com/${owner}`}
+                  src={getRepositoryOwnerAvatarSrc(owner)}
                   alt={owner}
                   sx={{
                     width: 20,
@@ -640,7 +640,7 @@ const MinerOpenDiscoveryIssuesByRepo: React.FC<
                 }}
               >
                 <Avatar
-                  src={`https://avatars.githubusercontent.com/${owner}`}
+                  src={getRepositoryOwnerAvatarSrc(owner)}
                   alt={owner}
                   sx={{
                     width: 20,

--- a/src/components/miners/MinerPRsTable.tsx
+++ b/src/components/miners/MinerPRsTable.tsx
@@ -17,6 +17,7 @@ import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useMinerPRs, type CommitLog } from '../../api';
 import {
   filterPrs,
+  getRepositoryOwnerAvatarSrc,
   getPrStatusCounts,
   paginateItems,
   type PrStatusFilter,
@@ -273,7 +274,7 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
             }}
           >
             <Avatar
-              src={`https://avatars.githubusercontent.com/${owner}`}
+              src={getRepositoryOwnerAvatarSrc(owner)}
               alt={owner}
               sx={{
                 width: 20,

--- a/src/components/miners/MinerRepositoriesTable.tsx
+++ b/src/components/miners/MinerRepositoriesTable.tsx
@@ -37,6 +37,7 @@ import {
   isOutsideScoringWindow,
 } from '../../utils/ExplorerUtils';
 import { formatTokenAmount } from '../../utils/format';
+import { getRepositoryOwnerAvatarSrc } from '../../utils/avatar';
 
 type ViewMode = 'prs' | 'issues';
 
@@ -172,7 +173,7 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
         }}
       >
         <Avatar
-          src={`https://avatars.githubusercontent.com/${owner}`}
+          src={getRepositoryOwnerAvatarSrc(owner)}
           alt={owner}
           sx={{
             width: 24,

--- a/src/components/prs/PRDetailsCard.tsx
+++ b/src/components/prs/PRDetailsCard.tsx
@@ -18,7 +18,7 @@ import theme, {
   TEXT_OPACITY,
   tooltipSlotProps,
 } from '../../theme';
-import { parseNumber } from '../../utils';
+import { getRepositoryOwnerAvatarSrc, parseNumber } from '../../utils';
 import { buildMultiplierGrid } from '../../utils/multiplierDefs';
 import PRTimeDecayChart from './PRTimeDecayChart';
 
@@ -219,7 +219,7 @@ const PRDetailsCard: React.FC<PRDetailsCardProps> = ({
             }}
           >
             <Avatar
-              src={`https://avatars.githubusercontent.com/${owner}`}
+              src={getRepositoryOwnerAvatarSrc(owner)}
               alt={owner}
               sx={{
                 width: 64,

--- a/src/components/prs/PRHeader.tsx
+++ b/src/components/prs/PRHeader.tsx
@@ -4,7 +4,11 @@ import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import EventAvailableIcon from '@mui/icons-material/EventAvailable';
 import { linkResetSx, useLinkBehavior } from '../common/linkBehavior';
-import { formatDate, formatUsdEstimate } from '../../utils';
+import {
+  formatDate,
+  formatUsdEstimate,
+  getRepositoryOwnerAvatarSrc,
+} from '../../utils';
 import { type PullRequestDetails } from '../../api/models/Dashboard';
 import { STATUS_COLORS } from '../../theme';
 import { getRepositoryOwnerAvatarBackground } from '../leaderboard/types';
@@ -77,7 +81,7 @@ const PRHeader: React.FC<PRHeaderProps> = ({
         }}
       >
         <Avatar
-          src={`https://avatars.githubusercontent.com/${owner}`}
+          src={getRepositoryOwnerAvatarSrc(owner)}
           alt={owner}
           sx={{
             width: { xs: 48, sm: 64 },

--- a/src/pages/RepositoriesPage.tsx
+++ b/src/pages/RepositoriesPage.tsx
@@ -8,6 +8,7 @@ import { Page } from '../components/layout';
 import { TopRepositoriesTable, SEO } from '../components';
 import { useAllPrs, useAllMiners, useReposAndWeights } from '../api';
 import { type CommitLog } from '../api/models/Dashboard';
+import { getRepositoryOwnerAvatarSrc } from '../utils/avatar';
 import { buildRepoDiscoveryRollupFromMiners } from '../utils/ExplorerUtils';
 import { isMergedPr } from '../utils/prStatus';
 
@@ -379,7 +380,9 @@ const RepositoriesPage: React.FC = () => {
                         key={repo.name}
                         href={getRepoHref(repo.name)}
                         linkState={REPO_LINK_STATE}
-                        avatar={`https://avatars.githubusercontent.com/${repo.name.split('/')[0]}`}
+                        avatar={getRepositoryOwnerAvatarSrc(
+                          repo.name.split('/')[0],
+                        )}
                         avatarBg={getAvatarBg(repo.name)}
                         label={
                           <Tooltip title={repo.name} arrow placement="top">
@@ -448,7 +451,9 @@ const RepositoriesPage: React.FC = () => {
                         key={repo.name}
                         href={getRepoHref(repo.name)}
                         linkState={REPO_LINK_STATE}
-                        avatar={`https://avatars.githubusercontent.com/${repo.name.split('/')[0]}`}
+                        avatar={getRepositoryOwnerAvatarSrc(
+                          repo.name.split('/')[0],
+                        )}
                         avatarBg={getAvatarBg(repo.name)}
                         label={
                           <Tooltip title={repo.name} arrow placement="top">
@@ -511,7 +516,9 @@ const RepositoriesPage: React.FC = () => {
                         key={`${pr.name}-${pr.number}`}
                         href={getPrHref(pr.name, pr.number)}
                         linkState={REPO_LINK_STATE}
-                        avatar={`https://avatars.githubusercontent.com/${pr.name.split('/')[0]}`}
+                        avatar={getRepositoryOwnerAvatarSrc(
+                          pr.name.split('/')[0],
+                        )}
                         avatarBg={getAvatarBg(pr.name)}
                         label={
                           <Box

--- a/src/pages/RepositoryDetailsPage.tsx
+++ b/src/pages/RepositoryDetailsPage.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useSearchParams, useNavigate } from 'react-router-dom';
 import { formatDate } from '../utils/format';
+import { getRepositoryOwnerAvatarSrc } from '../utils/avatar';
 import {
   Alert,
   Box,
@@ -188,7 +189,7 @@ const RepositoryDetailsPage: React.FC = () => {
               <Grid item xs={12} md={8}>
                 <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
                   <Avatar
-                    src={`https://avatars.githubusercontent.com/${owner}`}
+                    src={getRepositoryOwnerAvatarSrc(owner)}
                     variant="rounded"
                     sx={(theme) => ({
                       width: 32,

--- a/src/pages/WatchlistPage.tsx
+++ b/src/pages/WatchlistPage.tsx
@@ -82,6 +82,7 @@ import { filterPrs, type PrStatusFilter } from '../utils/prTable';
 import { getIssueStatusMeta } from '../utils/issueStatus';
 import { formatTokenAmount } from '../utils/format';
 import { compareByWatchlist } from '../utils/watchlistSort';
+import { getRepositoryOwnerAvatarSrc } from '../utils/avatar';
 import theme, {
   CHART_COLORS,
   LABEL_COLORS,
@@ -622,7 +623,7 @@ const repoColumns: DataTableColumn<WatchedRepoStats, RepoSortKey>[] = [
     renderCell: (repo) => (
       <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 0 }}>
         <Avatar
-          src={`https://avatars.githubusercontent.com/${repo.fullName.split('/')[0]}`}
+          src={getRepositoryOwnerAvatarSrc(repo.fullName.split('/')[0])}
           sx={{
             width: 20,
             height: 20,
@@ -884,7 +885,7 @@ const RepoCard: React.FC<{ repo: WatchedRepoStats; maxWeight: number }> = ({
       {/* Header: avatar + full name + status pill + star */}
       <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.25 }}>
         <Avatar
-          src={`https://avatars.githubusercontent.com/${owner}`}
+          src={getRepositoryOwnerAvatarSrc(owner)}
           alt={owner}
           sx={(theme) => ({
             width: 28,
@@ -1993,7 +1994,7 @@ const PRCard: React.FC<{
           sx={{ minWidth: 0 }}
         >
           <Avatar
-            src={`https://avatars.githubusercontent.com/${pr.repository.split('/')[0]}`}
+            src={getRepositoryOwnerAvatarSrc(pr.repository.split('/')[0])}
             sx={{
               width: 20,
               height: 20,

--- a/src/pages/dashboard/views/LiveCommitLog.tsx
+++ b/src/pages/dashboard/views/LiveCommitLog.tsx
@@ -15,6 +15,7 @@ import {
 import { formatDistanceToNow } from 'date-fns';
 import { LinkBox } from '../../../components/common/linkBehavior';
 import { useInfiniteCommitLog } from '../../../api';
+import { getRepositoryOwnerAvatarSrc } from '../../../utils/avatar';
 import theme, {
   REPO_OWNER_AVATAR_BACKGROUNDS,
   scrollbarSx,
@@ -197,7 +198,7 @@ const CommitLogItem: React.FC<{
         >
           <Stack direction="row" alignItems="center" spacing={1}>
             <Avatar
-              src={`https://avatars.githubusercontent.com/${entry.repository.split('/')[0]}`}
+              src={getRepositoryOwnerAvatarSrc(entry.repository.split('/')[0])}
               sx={{
                 width: 16,
                 height: 16,

--- a/src/utils/avatar.ts
+++ b/src/utils/avatar.ts
@@ -5,4 +5,3 @@ export const getRepositoryOwnerAvatarSrc = (
   if (!normalizedOwner) return '';
   return `https://github.com/${encodeURIComponent(normalizedOwner)}.png`;
 };
-

--- a/src/utils/avatar.ts
+++ b/src/utils/avatar.ts
@@ -1,0 +1,8 @@
+export const getRepositoryOwnerAvatarSrc = (
+  owner: string | null | undefined,
+): string => {
+  const normalizedOwner = owner?.trim();
+  if (!normalizedOwner) return '';
+  return `https://github.com/${encodeURIComponent(normalizedOwner)}.png`;
+};
+

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -5,3 +5,4 @@ export * from './prTable';
 export * from './issueStatus';
 export * from './multiplierDefs';
 export * from './watchlistSort';
+export * from './avatar';


### PR DESCRIPTION
## Summary

Repository-owner avatars were being generated via duplicated/varied inline URL logic. This PR centralizes repo-owner avatar URL generation and applies it consistently across repository-focused UI.

## Related Issues

Closes #843 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

### Before
<img width="1943" height="1209" alt="image" src="https://github.com/user-attachments/assets/1cdd33ae-2b97-4d57-8c56-5142c0582fb4" />
<img width="1614" height="1067" alt="image" src="https://github.com/user-attachments/assets/d13ba0a7-23e4-4faa-a166-a89636807436" />
<img width="2030" height="1188" alt="image" src="https://github.com/user-attachments/assets/b2ab35c6-34fb-4237-b6c3-5ac9e7761f32" />

### After
<img width="1975" height="1216" alt="image" src="https://github.com/user-attachments/assets/7f2df12f-462d-465c-b02e-5ca7674903c3" />
<img width="1595" height="1094" alt="image" src="https://github.com/user-attachments/assets/9822513e-8beb-4ef6-8a71-33ec64b421ef" />
<img width="2036" height="1192" alt="image" src="https://github.com/user-attachments/assets/aaeac9f7-c370-444e-b462-b55a416afc0f" />

## Root cause

- Many components built repo owner avatars inline using https://avatars.githubusercontent.com/${owner}.
- That endpoint behavior is not uniform for all org/user owners in this app context, so some repos resolved to generic/incorrect-looking placeholders.
- Avatar logic existed in many files (tables/cards/pages), so behavior diverged by view.
- There was no single shared utility for repo-owner avatar generation, making it easy for regressions and partial fixes.

## Checklist

- [ ] New components are modularized/separated where sensible
- [ ] Uses predefined theme (e.g. no hardcoded colors)
- [ ] Responsive/mobile checked
- [ ] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
