### PR TITLE
fix: search total result count mismatches active table count

### DIFF
--- a/src/pages/search/SearchPage.tsx
+++ b/src/pages/search/SearchPage.tsx
@@ -109,6 +109,7 @@ const SearchPage: React.FC = () => {
 
   const tabState = datasets[tabValue];
   const activeResultCount = resultCountByTab[tabValue];
+  const activeTabLabel = TAB_LABELS[tabValue];
 
   // Reset the active page when the search query changes.
   React.useEffect(() => {
@@ -209,7 +210,7 @@ const SearchPage: React.FC = () => {
             <Typography variant="body2" color="text.secondary">
               {isAnySectionLoading && totalResults === 0
                 ? `Loading search results for "${query}"...`
-                : `${totalResults} result${totalResults === 1 ? '' : 's'} for "${query}"`}
+                : `${activeResultCount} result${activeResultCount === 1 ? '' : 's'} in ${activeTabLabel} for "${query}"`}
             </Typography>
 
             <Box


### PR DESCRIPTION
## Summary

Fixes a count-context mismatch on the full search page where the top "results for query" text can be interpreted as the visible table count, while it is currently derived from a different scope. This PR aligns the count messaging with the active table context to prevent confusion.

## Related bug report

Closes #850

## Type of change

- [x] Bug fix (UI/data presentation consistency)
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Verification checklist

- [ ] Open `/search?q=gittensor` and compare top summary with the active tab table total.
- [ ] Switch tabs and verify top summary updates to that tab's count.
- [ ] Verify pagination count remains consistent with the same tab-specific count.
- [ ] Confirm wording clearly distinguishes active-tab count vs global total (if both are shown).
