### PR TITLE
fix top miners sort tabs shift horizontally when changing the active …

### DIFF
--- a/src/components/leaderboard/TopMinersTable.tsx
+++ b/src/components/leaderboard/TopMinersTable.tsx
@@ -566,7 +566,6 @@ const SortButtons: React.FC<SortButtonsProps> = ({
   <Box
     sx={{
       display: 'flex',
-      gap: 0.5,
       flexWrap: 'wrap',
       justifyContent: 'center',
     }}
@@ -607,14 +606,19 @@ const SortButtons: React.FC<SortButtonsProps> = ({
           >
             {option.label}
           </Typography>
-          {isActive && (
-            <Typography
-              component="span"
-              sx={{ fontSize: '0.7rem', opacity: 0.7 }}
-            >
-              {sortDirection === 'asc' ? '▲' : '▼'}
-            </Typography>
-          )}
+          {/* Always render the arrow slot — toggling its presence shifts
+              sibling tabs sideways when the active tab changes. */}
+          <Typography
+            component="span"
+            aria-hidden={!isActive}
+            sx={{
+              fontSize: '0.7rem',
+              opacity: 0.7,
+              visibility: isActive ? 'visible' : 'hidden',
+            }}
+          >
+            {sortDirection === 'asc' ? '▲' : '▼'}
+          </Typography>
         </Box>
       );
     })}


### PR DESCRIPTION
## Summary

Fixes the layout shift on the Top Miners / Discoveries / Watchlist sort-pill row. Previously the ▲/▼ direction arrow was conditionally rendered only on the active tab — clicking a different sort moved the arrow, changing which pill was the "wide" one and pushing every sibling pill a few pixels left or right.

The arrow `<Typography>` is now always rendered for every pill and toggled with `visibility: 'visible' | 'hidden'` (with `aria-hidden` for inactive tabs). Hidden elements still occupy layout width, so all pills measure the same regardless of which one is active and the row stays put when the sort changes.

Also dropped the now-redundant `gap: 0.5` on the pills' flex parent so spacing is owned entirely by each pill.

## Related Issues

Fixes #855

## Type of Change

- [x] Bug fix

## Checklist

- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
