### PR TITLE
add card view in Bounties tab of watchlist page

### DIFF
--- a/src/components/issues/IssuesList.tsx
+++ b/src/components/issues/IssuesList.tsx
@@ -188,10 +188,19 @@ const IssuesList: React.FC<IssuesListProps> = ({
     (overrides: { filter?: FilterType; view?: IssuesViewMode }) => {
       const f = overrides.filter ?? filterType;
       const v = overrides.view ?? viewMode;
-      const params: Record<string, string> = {};
-      if (f !== 'all') params.filter = f;
-      if (v === 'cards') params.view = 'cards';
-      setSearchParams(params, { replace: true });
+      // Preserve unrelated query params (e.g. the watchlist's `tab=bounties`)
+      // by mutating in place instead of replacing the whole search string.
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          if (f === 'all') next.delete('filter');
+          else next.set('filter', f);
+          if (v === 'cards') next.set(ISSUES_VIEW_QUERY_PARAM, 'cards');
+          else next.delete(ISSUES_VIEW_QUERY_PARAM);
+          return next;
+        },
+        { replace: true },
+      );
     },
     [filterType, viewMode, setSearchParams],
   );

--- a/src/pages/WatchlistPage.tsx
+++ b/src/pages/WatchlistPage.tsx
@@ -53,6 +53,7 @@ import {
   SEO,
   WatchlistButton,
 } from '../components';
+import { IssuesList as BountyIssuesList } from '../components/issues';
 import {
   DataTable,
   type DataTableColumn,
@@ -84,8 +85,6 @@ import {
   getPrStatusCounts,
 } from '../utils/prStatus';
 import { filterPrs, type PrStatusFilter } from '../utils/prTable';
-import { getIssueStatusMeta } from '../utils/issueStatus';
-import { formatTokenAmount } from '../utils/format';
 import { compareByWatchlist } from '../utils/watchlistSort';
 import { getRepositoryOwnerAvatarSrc } from '../utils/avatar';
 import theme, {
@@ -515,91 +514,6 @@ const WatchlistPage: React.FC = () => {
     </Page>
   );
 };
-
-const rowSx = {
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'space-between',
-  gap: 2,
-  px: 1.5,
-  py: 1.25,
-  borderRadius: 1,
-  transition: 'background 0.15s',
-  '&:hover': { backgroundColor: 'surface.light' },
-};
-
-const primaryTextSx = {
-  fontSize: '0.85rem',
-  color: 'text.primary',
-  overflow: 'hidden',
-  textOverflow: 'ellipsis',
-  whiteSpace: 'nowrap',
-};
-
-const secondaryTextSx = {
-  fontSize: '0.7rem',
-  color: 'text.secondary',
-  mt: 0.25,
-};
-
-interface WatchedItemRowProps {
-  href: string;
-  primary: React.ReactNode;
-  secondary?: React.ReactNode;
-  actions: React.ReactNode;
-}
-
-// LinkBox wraps only the navigable text area (not the whole row) so the
-// star button — a real <button> — is a sibling of the <a>, not a descendant.
-// Keeps middle-click / Cmd-click / "Open in new tab" working natively while
-// avoiding invalid interactive-inside-anchor HTML.
-const WatchedItemRow: React.FC<WatchedItemRowProps> = ({
-  href,
-  primary,
-  secondary,
-  actions,
-}) => (
-  <Box sx={rowSx}>
-    <LinkBox
-      href={href}
-      linkState={{ backLabel: 'Back to Watchlist' }}
-      sx={{ display: 'block', minWidth: 0, flex: 1 }}
-    >
-      <Typography sx={primaryTextSx}>{primary}</Typography>
-      {secondary !== undefined && (
-        <Typography sx={secondaryTextSx}>{secondary}</Typography>
-      )}
-    </LinkBox>
-    <Stack direction="row" spacing={2} alignItems="center">
-      {actions}
-    </Stack>
-  </Box>
-);
-
-interface StatusPillProps {
-  label: string;
-  color: string;
-  background: string;
-}
-
-const StatusPill: React.FC<StatusPillProps> = ({
-  label,
-  color,
-  background,
-}) => (
-  <Typography
-    sx={{
-      fontSize: '0.72rem',
-      color,
-      backgroundColor: background,
-      px: 1,
-      py: 0.25,
-      borderRadius: 0.75,
-    }}
-  >
-    {label}
-  </Typography>
-);
 
 /* ─── OptionsLabel: section header inside popovers ─── */
 const OptionsLabel: React.FC<{ children: React.ReactNode }> = ({
@@ -1906,8 +1820,12 @@ const ReposList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
   );
 };
 
+const BOUNTIES_LINK_STATE = { backLabel: 'Back to Watchlist' } as const;
+const getBountyHref = (id: number) => `/bounties/details?id=${id}`;
+
 const BountiesList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
-  const { data: allIssues } = useIssues();
+  const { data: allIssues, isLoading } = useIssues();
+
   const items = useMemo(() => {
     if (!allIssues) return [];
     // Stored keys and issue ids are compared as strings to avoid any
@@ -1917,39 +1835,12 @@ const BountiesList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
   }, [allIssues, itemKeys]);
 
   return (
-    <Stack spacing={0.5} sx={{ width: '100%' }}>
-      {items.map((issue) => {
-        const meta = getIssueStatusMeta(issue.status);
-        return (
-          <WatchedItemRow
-            key={issue.id}
-            href={`/bounties/details?id=${issue.id}`}
-            primary={
-              issue.title || `${issue.repositoryFullName} #${issue.issueNumber}`
-            }
-            secondary={`${issue.repositoryFullName} #${issue.issueNumber}`}
-            actions={
-              <>
-                <StatusPill
-                  label={meta.text}
-                  color={meta.color}
-                  background={meta.bgColor}
-                />
-                <Typography
-                  sx={{ fontSize: '0.75rem', color: 'status.success' }}
-                >
-                  {formatTokenAmount(issue.bountyAmount)} ل
-                </Typography>
-                <WatchlistButton
-                  category="bounties"
-                  itemKey={String(issue.id)}
-                />
-              </>
-            }
-          />
-        );
-      })}
-    </Stack>
+    <BountyIssuesList
+      issues={items}
+      isLoading={isLoading}
+      getIssueHref={getBountyHref}
+      linkState={BOUNTIES_LINK_STATE}
+    />
   );
 };
 


### PR DESCRIPTION
## Summary

Brings the Watchlist Bounties tab to parity with the main `/bounties` page. Previously it rendered a plain stack of rows with no filtering, search, pagination, or card view. Now it reuses the existing `IssuesList` component, so users get the full toolbar — All / Available / Pending / History tabs with counts, chart toggle, Rows selector, search, and the list/cards view toggle — and `BountyCard` for the cards layout.

To make `IssuesList` safe to embed inside another page, its URL sync was changed to merge into the existing query string instead of overwriting it (was wiping `?tab=bounties`). Behavior on `/bounties` is unchanged because that page only manages `filter` and `view`.

The watchlist's `tab=bounties` now coexists with `IssuesList`'s `filter` and `view` params, so links like `/watchlist?tab=bounties&filter=history&view=cards` round-trip correctly.

## Related bug report

Closes #858

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

<img width="1900" height="854" alt="image" src="https://github.com/user-attachments/assets/07db2e95-833e-4a24-8784-fa50eb5b04b7" />


## Checklist
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes

