### PR TITLE
Full search page — column parity, sorting, and data model alignment

### DIFF
--- a/src/api/models/Dashboard.ts
+++ b/src/api/models/Dashboard.ts
@@ -183,6 +183,10 @@ export type CommitLog = {
 
   // Linked issues (from /miners/{id}/pulls — issues this PR closes/references)
   linkedIssues?: LinkedIssue[];
+
+  /** Present on some PR payloads (e.g. miner pulls / discovery-enriched commits). */
+  issueDiscoveryScore?: number;
+  issueTokenScore?: number;
 };
 
 export type MinerEvaluation = {

--- a/src/pages/search/IssuesTab.tsx
+++ b/src/pages/search/IssuesTab.tsx
@@ -1,29 +1,54 @@
 import React from 'react';
-import { alpha } from '@mui/material/styles';
+import { Tooltip, Typography } from '@mui/material';
+import { format } from 'date-fns';
 import { type IssueBounty } from '../../api/models/Issues';
+import { formatDate } from '../../utils/format';
 import { getGithubAvatarSrc, getIssueStatusMeta } from '../../utils';
-import { type DataTableColumn } from '../../components/common/DataTable';
+import {
+  type DataTableColumn,
+  type DataTableSort,
+} from '../../components/common/DataTable';
 import SearchResultsCard from './SearchResultsCard';
+import { type IssueSearchSortKey } from './searchSort';
 import {
   SearchAvatarContentCell,
   SearchStatusChip,
   SearchTruncatedText,
 } from './SearchTableCells';
 
-const issueColumns: DataTableColumn<IssueBounty>[] = [
+const issueColumns: DataTableColumn<IssueBounty, IssueSearchSortKey>[] = [
   {
     key: 'issueNumber',
-    header: 'Issue #',
-    width: 100,
+    header: 'Issue',
+    width: 96,
+    sortKey: 'issueNumber',
     renderCell: (issue: IssueBounty) => `#${issue.issueNumber}`,
     cellSx: {
+      fontWeight: 600,
       color: 'text.secondary',
     },
   },
   {
+    key: 'title',
+    header: 'Title',
+    width: '34%',
+    sortKey: 'title',
+    renderCell: (issue: IssueBounty) => (
+      <SearchTruncatedText
+        tooltip={issue.title || 'Untitled issue'}
+        sx={(theme) => ({
+          color: theme.palette.text.primary,
+          fontWeight: 500,
+        })}
+        text={issue.title || 'Untitled issue'}
+      />
+    ),
+  },
+  {
     key: 'repository',
     header: 'Repository',
-    width: '30%',
+    width: '28%',
+    sortKey: 'repository',
     renderCell: (issue: IssueBounty) => {
       const repositoryOwner = issue.repositoryFullName.split('/')[0];
 
@@ -47,39 +72,52 @@ const issueColumns: DataTableColumn<IssueBounty>[] = [
     },
   },
   {
-    key: 'title',
-    header: 'Issue',
-    width: '42%',
-    renderCell: (issue: IssueBounty) => (
-      <SearchTruncatedText
-        tooltip={issue.title || 'Untitled issue'}
-        sx={(theme) => ({
-          ...theme.typography.mono,
-          color: theme.palette.text.primary,
-        })}
-        text={issue.title || 'Untitled issue'}
-      />
-    ),
-  },
-  {
     key: 'status',
     header: 'Status',
-    width: '18%',
+    width: '12%',
     align: 'center',
+    sortKey: 'status',
     renderCell: (issue: IssueBounty) => {
       const statusMeta = getIssueStatusMeta(issue.status);
-
       return (
         <SearchStatusChip
-          backgroundColor={(theme) =>
-            alpha(theme.palette.status[statusMeta.tone], 0.15)
-          }
-          borderColor={(theme) =>
-            alpha(theme.palette.status[statusMeta.tone], 0.25)
-          }
-          color={(theme) => theme.palette.status[statusMeta.tone]}
+          backgroundColor={statusMeta.bgColor}
+          borderColor={statusMeta.borderColor}
+          color={statusMeta.color}
           label={statusMeta.text}
         />
+      );
+    },
+  },
+  {
+    key: 'date',
+    header: 'Date',
+    width: 132,
+    align: 'right',
+    sortKey: 'date',
+    renderCell: (issue: IssueBounty) => {
+      const raw =
+        issue.completedAt || issue.updatedAt || issue.createdAt || null;
+      const label = raw ? formatDate(raw) : '—';
+      const tooltipTitle = (() => {
+        if (!raw) return label;
+        const d = new Date(raw);
+        if (Number.isNaN(d.getTime())) return label;
+        return format(d, 'PPpp');
+      })();
+      return (
+        <Tooltip title={tooltipTitle} arrow>
+          <Typography
+            component="span"
+            sx={{
+              fontSize: '0.8rem',
+              color: 'text.secondary',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {label}
+          </Typography>
+        </Tooltip>
       );
     },
   },
@@ -97,6 +135,7 @@ type IssuesTabProps = {
   paginatedIssueResults: IssueBounty[];
   rowsPerPage: number;
   rowsPerPageOptions: number[];
+  sort: DataTableSort<IssueSearchSortKey>;
 };
 
 const IssuesTab: React.FC<IssuesTabProps> = ({
@@ -111,6 +150,7 @@ const IssuesTab: React.FC<IssuesTabProps> = ({
   paginatedIssueResults,
   rowsPerPage,
   rowsPerPageOptions,
+  sort,
 }) => (
   <SearchResultsCard
     columns={issueColumns}
@@ -128,6 +168,7 @@ const IssuesTab: React.FC<IssuesTabProps> = ({
     rows={paginatedIssueResults}
     rowsPerPage={rowsPerPage}
     rowsPerPageOptions={rowsPerPageOptions}
+    sort={sort}
     totalCount={issueResults.length}
   />
 );

--- a/src/pages/search/MinerTab.tsx
+++ b/src/pages/search/MinerTab.tsx
@@ -2,13 +2,17 @@ import React from 'react';
 import { Box } from '@mui/material';
 import { type Theme } from '@mui/material/styles';
 import { getGithubAvatarSrc } from '../../utils';
-import { type DataTableColumn } from '../../components/common/DataTable';
+import {
+  type DataTableColumn,
+  type DataTableSort,
+} from '../../components/common/DataTable';
 import SearchResultsCard from './SearchResultsCard';
 import {
   SearchAvatarContentCell,
   SearchTruncatedText,
 } from './SearchTableCells';
 import { type MinerSearchData } from './searchData';
+import { type MinerSearchSortKey } from './searchSort';
 
 const getCredibilityTone = (
   credibility: number,
@@ -25,11 +29,12 @@ const numericCellSx = {
   fontVariantNumeric: 'tabular-nums',
 } as const;
 
-const minerColumns: DataTableColumn<MinerSearchData>[] = [
+const minerColumns: DataTableColumn<MinerSearchData, MinerSearchSortKey>[] = [
   {
     key: 'rank',
     header: 'Rank',
     width: 72,
+    sortKey: 'rank',
     renderCell: (miner: MinerSearchData) =>
       miner.leaderboardRank > 0 ? `#${miner.leaderboardRank}` : '-',
     cellSx: (miner: MinerSearchData) => ({
@@ -41,6 +46,7 @@ const minerColumns: DataTableColumn<MinerSearchData>[] = [
     key: 'miner',
     header: 'Miner',
     width: '28%',
+    sortKey: 'miner',
     renderCell: (miner: MinerSearchData) => (
       <SearchAvatarContentCell
         avatarAlt={miner.githubUsername || miner.githubId}
@@ -76,6 +82,7 @@ const minerColumns: DataTableColumn<MinerSearchData>[] = [
     header: 'Credibility',
     width: '14%',
     align: 'right',
+    sortKey: 'credibility',
     renderCell: (miner: MinerSearchData) =>
       miner.credibility > 0 ? (
         <Box
@@ -97,6 +104,7 @@ const minerColumns: DataTableColumn<MinerSearchData>[] = [
     header: 'Token Score',
     width: '14%',
     align: 'right',
+    sortKey: 'tokenScore',
     renderCell: (miner: MinerSearchData) =>
       miner.totalTokenScore > 0
         ? miner.totalTokenScore.toLocaleString(undefined, {
@@ -113,6 +121,7 @@ const minerColumns: DataTableColumn<MinerSearchData>[] = [
     header: 'PRs',
     width: '12%',
     align: 'right',
+    sortKey: 'prs',
     renderCell: (miner: MinerSearchData) =>
       miner.totalPrs > 0 ? miner.totalPrs.toLocaleString() : '-',
     cellSx: (miner: MinerSearchData) => ({
@@ -125,6 +134,7 @@ const minerColumns: DataTableColumn<MinerSearchData>[] = [
     header: 'Score',
     width: '14%',
     align: 'right',
+    sortKey: 'score',
     renderCell: (miner: MinerSearchData) =>
       miner.totalScore.toLocaleString(undefined, {
         minimumFractionDigits: 2,
@@ -146,6 +156,7 @@ type MinerTabProps = {
   paginatedMinerResults: MinerSearchData[];
   rowsPerPage: number;
   rowsPerPageOptions: number[];
+  sort: DataTableSort<MinerSearchSortKey>;
 };
 
 const MinerTab: React.FC<MinerTabProps> = ({
@@ -160,6 +171,7 @@ const MinerTab: React.FC<MinerTabProps> = ({
   paginatedMinerResults,
   rowsPerPage,
   rowsPerPageOptions,
+  sort,
 }) => (
   <SearchResultsCard
     columns={minerColumns}
@@ -177,6 +189,7 @@ const MinerTab: React.FC<MinerTabProps> = ({
     rows={paginatedMinerResults}
     rowsPerPage={rowsPerPage}
     rowsPerPageOptions={rowsPerPageOptions}
+    sort={sort}
     totalCount={minerResults.length}
   />
 );

--- a/src/pages/search/PullRequestsTab.tsx
+++ b/src/pages/search/PullRequestsTab.tsx
@@ -1,9 +1,17 @@
 import React from 'react';
-import { Box } from '@mui/material';
+import { Chip } from '@mui/material';
 import { type CommitLog } from '../../api/models/Dashboard';
+import { WatchlistButton } from '../../components/common';
 import { getGithubAvatarSrc } from '../../utils';
-import { type DataTableColumn } from '../../components/common/DataTable';
+import {
+  type DataTableColumn,
+  type DataTableSort,
+} from '../../components/common/DataTable';
+import { serializePRKey } from '../../hooks/useWatchlist';
+import { STATUS_COLORS } from '../../theme';
+import { isClosedUnmergedPr, isMergedPr } from '../../utils/prStatus';
 import SearchResultsCard from './SearchResultsCard';
+import { type PrSearchSortKey } from './searchSort';
 import {
   SearchAvatarContentCell,
   SearchTruncatedText,
@@ -16,17 +24,25 @@ const formatPrScore = (pr: CommitLog) => {
   return parseFloat(pr.score).toFixed(4);
 };
 
-const formatPrDateOrStatus = (pr: CommitLog) => {
-  if (pr.mergedAt) return new Date(pr.mergedAt).toLocaleDateString();
-  if (pr.prState === 'CLOSED') return 'Closed';
-  return 'Open';
+/** Matches Watchlist PR table `prStatusMeta` + status `Chip` styling. */
+const prStatusMeta = (pr: CommitLog) => {
+  const merged = isMergedPr(pr);
+  const closed = isClosedUnmergedPr(pr);
+  const label = merged ? 'MERGED' : closed ? 'CLOSED' : 'OPEN';
+  const color = merged
+    ? STATUS_COLORS.merged
+    : closed
+      ? STATUS_COLORS.closed
+      : STATUS_COLORS.open;
+  return { label, color };
 };
 
-const prColumns: DataTableColumn<CommitLog>[] = [
+const prColumns: DataTableColumn<CommitLog, PrSearchSortKey>[] = [
   {
     key: 'prNumber',
-    header: 'PR #',
+    header: 'PR',
     width: 96,
+    sortKey: 'prNumber',
     renderCell: (pr: CommitLog) => `#${pr.pullRequestNumber}`,
     cellSx: {
       fontWeight: 600,
@@ -36,6 +52,7 @@ const prColumns: DataTableColumn<CommitLog>[] = [
     key: 'title',
     header: 'Title',
     width: '40%',
+    sortKey: 'title',
     renderCell: (pr: CommitLog) => {
       const prTitle = pr.pullRequestTitle || 'Untitled pull request';
 
@@ -53,7 +70,8 @@ const prColumns: DataTableColumn<CommitLog>[] = [
   {
     key: 'repository',
     header: 'Repository',
-    width: '20%',
+    width: '23%',
+    sortKey: 'repository',
     renderCell: (pr: CommitLog) => {
       const repositoryOwner = pr.repository.split('/')[0];
 
@@ -75,56 +93,66 @@ const prColumns: DataTableColumn<CommitLog>[] = [
     },
   },
   {
-    key: 'delta',
-    header: '+/-',
-    width: '12%',
-    align: 'right',
+    key: 'author',
+    header: 'Author',
+    width: '13%',
+    sortKey: 'author',
     renderCell: (pr: CommitLog) => (
-      <Box
-        sx={{
-          display: 'inline-flex',
-          alignItems: 'center',
-          gap: 1,
-        }}
+      <SearchAvatarContentCell
+        avatarAlt={pr.author}
+        avatarSrc={getGithubAvatarSrc(pr.author)}
       >
-        <Box
-          component="span"
+        <SearchTruncatedText
+          tooltip={pr.author}
           sx={(theme) => ({
-            color: theme.palette.diff.additions,
+            color: theme.palette.text.primary,
           })}
-        >
-          +{pr.additions || 0}
-        </Box>
-        <Box
-          component="span"
-          sx={(theme) => ({
-            color: theme.palette.diff.deletions,
-          })}
-        >
-          -{pr.deletions || 0}
-        </Box>
-      </Box>
+          text={pr.author || '-'}
+        />
+      </SearchAvatarContentCell>
     ),
+  },
+  {
+    key: 'status',
+    header: 'Status',
+    width: '11%',
+    align: 'center',
+    sortKey: 'status',
+    renderCell: (pr: CommitLog) => {
+      const { label, color } = prStatusMeta(pr);
+      return (
+        <Chip
+          variant="status"
+          label={label}
+          sx={{ color, borderColor: color }}
+        />
+      );
+    },
   },
   {
     key: 'score',
     header: 'Score',
-    width: '12%',
+    width: '10%',
     align: 'right',
+    sortKey: 'score',
     renderCell: (pr: CommitLog) => formatPrScore(pr),
     cellSx: {
       fontWeight: 600,
     },
   },
   {
-    key: 'date',
-    header: 'Date',
-    width: '14%',
-    align: 'right',
-    renderCell: (pr: CommitLog) => formatPrDateOrStatus(pr),
-    cellSx: {
-      color: 'text.secondary',
-    },
+    key: 'watch',
+    header: '★',
+    width: 52,
+    align: 'center',
+    cellSx: { p: 0 },
+    renderCell: (pr: CommitLog) => (
+      <WatchlistButton
+        category="prs"
+        itemKey={serializePRKey(pr.repository, pr.pullRequestNumber)}
+        size="small"
+      />
+    ),
   },
 ];
 
@@ -140,6 +168,7 @@ type PullRequestsTabProps = {
   prResults: CommitLog[];
   rowsPerPage: number;
   rowsPerPageOptions: number[];
+  sort: DataTableSort<PrSearchSortKey>;
 };
 
 const PullRequestsTab: React.FC<PullRequestsTabProps> = ({
@@ -154,6 +183,7 @@ const PullRequestsTab: React.FC<PullRequestsTabProps> = ({
   prResults,
   rowsPerPage,
   rowsPerPageOptions,
+  sort,
 }) => (
   <SearchResultsCard
     columns={prColumns}
@@ -162,7 +192,7 @@ const PullRequestsTab: React.FC<PullRequestsTabProps> = ({
     getRowKey={(pr: CommitLog) => `${pr.repository}-${pr.pullRequestNumber}`}
     isError={isError}
     isLoading={isLoading}
-    minWidth={960}
+    minWidth={1120}
     onPageChange={onPageChange}
     getRowHref={getPrHref}
     linkState={linkState}
@@ -171,6 +201,7 @@ const PullRequestsTab: React.FC<PullRequestsTabProps> = ({
     rows={paginatedPrResults}
     rowsPerPage={rowsPerPage}
     rowsPerPageOptions={rowsPerPageOptions}
+    sort={sort}
     totalCount={prResults.length}
   />
 );

--- a/src/pages/search/RepositoryTab.tsx
+++ b/src/pages/search/RepositoryTab.tsx
@@ -2,14 +2,19 @@ import React from 'react';
 import { Box, Typography } from '@mui/material';
 import { alpha, type Theme } from '@mui/material/styles';
 import { getRankColors } from '../../components/leaderboard/types';
+import { WatchlistButton } from '../../components/common';
 import { getGithubAvatarSrc } from '../../utils';
-import { type DataTableColumn } from '../../components/common/DataTable';
+import {
+  type DataTableColumn,
+  type DataTableSort,
+} from '../../components/common/DataTable';
 import SearchResultsCard from './SearchResultsCard';
 import {
   SearchAvatarContentCell,
   SearchTruncatedText,
 } from './SearchTableCells';
 import { type RepoSearchData } from './searchData';
+import { type RepoSearchSortKey } from './searchSort';
 
 const getRankBadgeSx = (theme: Theme, rank: number) => {
   const rankAccentColor = rank <= 3 ? getRankColors(rank).color : null;
@@ -39,88 +44,143 @@ const getPositiveValueCellSx = (value: number) => ({
   color: value > 0 ? 'text.primary' : 'text.secondary',
 });
 
-const repositoryColumns: DataTableColumn<RepoSearchData>[] = [
-  {
-    key: 'rank',
-    header: 'Rank',
-    width: 56,
-    renderCell: (repo: RepoSearchData) => (
-      <Box sx={(theme) => getRankBadgeSx(theme, repo.rank)}>
-        <Typography
-          component="span"
-          sx={(theme) => ({
-            color:
-              (repo.rank <= 3 ? getRankColors(repo.rank).color : null) ||
-              theme.palette.text.secondary,
+const repositoryColumns: DataTableColumn<RepoSearchData, RepoSearchSortKey>[] =
+  [
+    {
+      key: 'rank',
+      header: 'Rank',
+      width: 56,
+      sortKey: 'rank',
+      renderCell: (repo: RepoSearchData) => (
+        <Box sx={(theme) => getRankBadgeSx(theme, repo.rank)}>
+          <Typography
+            component="span"
+            sx={(theme) => ({
+              color:
+                (repo.rank <= 3 ? getRankColors(repo.rank).color : null) ||
+                theme.palette.text.secondary,
 
-            fontSize: '0.65rem',
-            fontWeight: 600,
-            lineHeight: 1,
-          })}
-        >
-          {repo.rank}
-        </Typography>
-      </Box>
-    ),
-  },
-  {
-    key: 'repository',
-    header: 'Repository',
-    width: '38%',
-    renderCell: (repo: RepoSearchData) => (
-      <SearchAvatarContentCell
-        avatarAlt={repo.owner}
-        avatarSrc={getGithubAvatarSrc(repo.owner)}
-      >
-        <SearchTruncatedText
-          tooltip={repo.fullName}
-          sx={(theme) => ({
-            color: theme.palette.text.primary,
-            fontWeight: 600,
-          })}
-          text={repo.fullName}
-        />
-      </SearchAvatarContentCell>
-    ),
-  },
-  {
-    key: 'weight',
-    header: 'Weight',
-    width: '14%',
-    align: 'right',
-    renderCell: (repo: RepoSearchData) => repo.weight.toFixed(2),
-    cellSx: {
-      fontWeight: 600,
+              fontSize: '0.65rem',
+              fontWeight: 600,
+              lineHeight: 1,
+            })}
+          >
+            {repo.rank}
+          </Typography>
+        </Box>
+      ),
     },
-  },
-  {
-    key: 'totalScore',
-    header: 'Total Score',
-    width: '16%',
-    align: 'right',
-    renderCell: (repo: RepoSearchData) =>
-      repo.totalScore > 0 ? repo.totalScore.toFixed(2) : '-',
-    cellSx: (repo: RepoSearchData) => getPositiveValueCellSx(repo.totalScore),
-  },
-  {
-    key: 'prs',
-    header: 'PRs',
-    width: '12%',
-    align: 'right',
-    renderCell: (repo: RepoSearchData) =>
-      repo.totalPRs > 0 ? repo.totalPRs : '-',
-    cellSx: (repo: RepoSearchData) => getPositiveValueCellSx(repo.totalPRs),
-  },
-  {
-    key: 'contributors',
-    header: 'Contributors',
-    width: '12%',
-    align: 'right',
-    renderCell: (repo: RepoSearchData) =>
-      repo.contributors > 0 ? repo.contributors : '-',
-    cellSx: (repo: RepoSearchData) => getPositiveValueCellSx(repo.contributors),
-  },
-];
+    {
+      key: 'repository',
+      header: 'Repository',
+      width: '38%',
+      sortKey: 'repository',
+      renderCell: (repo: RepoSearchData) => (
+        <SearchAvatarContentCell
+          avatarAlt={repo.owner}
+          avatarSrc={getGithubAvatarSrc(repo.owner)}
+        >
+          <SearchTruncatedText
+            tooltip={repo.fullName}
+            sx={(theme) => ({
+              color: theme.palette.text.primary,
+              fontWeight: 600,
+            })}
+            text={repo.fullName}
+          />
+        </SearchAvatarContentCell>
+      ),
+    },
+    {
+      key: 'weight',
+      header: 'Weight',
+      width: '14%',
+      align: 'right',
+      sortKey: 'weight',
+      renderCell: (repo: RepoSearchData) => repo.weight.toFixed(2),
+      cellSx: {
+        fontWeight: 600,
+      },
+    },
+    {
+      key: 'totalScore',
+      header: 'Oss Score',
+      width: '10%',
+      align: 'right',
+      sortKey: 'totalScore',
+      renderCell: (repo: RepoSearchData) =>
+        repo.totalScore > 0 ? repo.totalScore.toFixed(2) : '-',
+      cellSx: (repo: RepoSearchData) => getPositiveValueCellSx(repo.totalScore),
+    },
+    {
+      key: 'prs',
+      header: 'PRs',
+      width: '7%',
+      align: 'right',
+      sortKey: 'prs',
+      renderCell: (repo: RepoSearchData) =>
+        repo.totalPRs > 0 ? repo.totalPRs : '-',
+      cellSx: (repo: RepoSearchData) => getPositiveValueCellSx(repo.totalPRs),
+    },
+    {
+      key: 'discoveryScore',
+      header: 'Issue Score',
+      width: '10%',
+      align: 'right',
+      sortKey: 'discoveryScore',
+      renderCell: (repo: RepoSearchData) =>
+        repo.discoveryScore > 0 ? repo.discoveryScore.toFixed(2) : '-',
+      cellSx: (repo: RepoSearchData) =>
+        getPositiveValueCellSx(repo.discoveryScore),
+    },
+    {
+      key: 'discoveryIssues',
+      header: 'Issues',
+      width: '7%',
+      align: 'right',
+      sortKey: 'discoveryIssues',
+      renderCell: (repo: RepoSearchData) =>
+        repo.discoveryIssues > 0 ? repo.discoveryIssues : '-',
+      cellSx: (repo: RepoSearchData) =>
+        getPositiveValueCellSx(repo.discoveryIssues),
+    },
+    {
+      key: 'contributors',
+      header: 'Contributors',
+      width: '10%',
+      align: 'right',
+      sortKey: 'contributors',
+      renderCell: (repo: RepoSearchData) =>
+        repo.contributors > 0 ? repo.contributors : '-',
+      cellSx: (repo: RepoSearchData) =>
+        getPositiveValueCellSx(repo.contributors),
+    },
+    {
+      key: 'discoveryContributors',
+      header: 'Issue contrib',
+      width: '10%',
+      align: 'right',
+      sortKey: 'discoveryContributors',
+      renderCell: (repo: RepoSearchData) =>
+        repo.discoveryContributors > 0 ? repo.discoveryContributors : '-',
+      cellSx: (repo: RepoSearchData) =>
+        getPositiveValueCellSx(repo.discoveryContributors),
+    },
+    {
+      key: 'watch',
+      header: '★',
+      width: 52,
+      align: 'center',
+      cellSx: { p: 0 },
+      renderCell: (repo: RepoSearchData) => (
+        <WatchlistButton
+          category="repos"
+          itemKey={repo.fullName}
+          size="small"
+        />
+      ),
+    },
+  ];
 
 type RepositoryTabProps = {
   isError: boolean;
@@ -134,6 +194,7 @@ type RepositoryTabProps = {
   rowsPerPage: number;
   rowsPerPageOptions: number[];
   repositoryResults: RepoSearchData[];
+  sort: DataTableSort<RepoSearchSortKey>;
 };
 
 const RepositoryTab: React.FC<RepositoryTabProps> = ({
@@ -148,6 +209,7 @@ const RepositoryTab: React.FC<RepositoryTabProps> = ({
   rowsPerPage,
   rowsPerPageOptions,
   repositoryResults,
+  sort,
 }) => (
   <SearchResultsCard
     columns={repositoryColumns}
@@ -156,7 +218,7 @@ const RepositoryTab: React.FC<RepositoryTabProps> = ({
     getRowKey={(repo: RepoSearchData) => repo.fullName}
     isError={isError}
     isLoading={isLoading}
-    minWidth={1000}
+    minWidth={1200}
     onPageChange={onPageChange}
     getRowHref={getRepositoryHref}
     linkState={linkState}
@@ -165,6 +227,7 @@ const RepositoryTab: React.FC<RepositoryTabProps> = ({
     rows={paginatedRepositoryResults}
     rowsPerPage={rowsPerPage}
     rowsPerPageOptions={rowsPerPageOptions}
+    sort={sort}
     totalCount={repositoryResults.length}
   />
 );

--- a/src/pages/search/SearchPage.tsx
+++ b/src/pages/search/SearchPage.tsx
@@ -8,6 +8,19 @@ import MinerTab from './MinerTab';
 import PullRequestsTab from './PullRequestsTab';
 import RepositoryTab from './RepositoryTab';
 import { MIN_SEARCH_QUERY_LENGTH, useSearchResults } from './searchData';
+import {
+  getNextSearchSort,
+  parseSearchSort,
+  sortIssueRows,
+  sortMinerRows,
+  sortPrRows,
+  sortRepoRows,
+  type IssueSearchSortKey,
+  type MinerSearchSortKey,
+  type PrSearchSortKey,
+  type RepoSearchSortKey,
+  type SearchSortTab,
+} from './searchSort';
 
 const ROWS_PER_PAGE_OPTIONS = [10, 25, 50];
 const SEARCH_TABS = ['miners', 'repositories', 'prs', 'issues'] as const;
@@ -40,6 +53,8 @@ const SearchPage: React.FC = () => {
   const tabParam = searchParams.get('tab');
   const rowsParam = Number(searchParams.get('rows'));
   const pageParam = Number(searchParams.get('page'));
+  const sortParam = searchParams.get('sort');
+  const orderParam = searchParams.get('order');
 
   const rowsPerPage = ROWS_PER_PAGE_OPTIONS.includes(rowsParam)
     ? rowsParam
@@ -55,7 +70,12 @@ const SearchPage: React.FC = () => {
 
   const updateSearchParams = React.useCallback(
     (
-      updates: Partial<Record<'tab' | 'page' | 'rows', string | number | null>>,
+      updates: Partial<
+        Record<
+          'tab' | 'page' | 'rows' | 'sort' | 'order',
+          string | number | null
+        >
+      >,
     ) => {
       const nextParams = new URLSearchParams(searchParams);
 
@@ -89,11 +109,6 @@ const SearchPage: React.FC = () => {
     issues: issueResults.length,
   };
 
-  const totalResults = Object.values(resultCountByTab).reduce(
-    (sum, count) => sum + count,
-    0,
-  );
-
   // Use the URL param tab, or fall back to the first tab with results.
   const tabValue =
     explicitTabValue ||
@@ -110,15 +125,17 @@ const SearchPage: React.FC = () => {
   const tabState = datasets[tabValue];
   const activeResultCount = resultCountByTab[tabValue];
 
-  // Reset the active page when the search query changes.
+  // Reset the active page and sort when the search query changes.
   React.useEffect(() => {
     if (previousQueryRef.current === query) return;
 
     previousQueryRef.current = query;
 
-    if (page !== 0) {
-      updateSearchParams({ page: null });
-    }
+    updateSearchParams({
+      sort: null,
+      order: null,
+      ...(page !== 0 ? { page: null } : {}),
+    });
   }, [page, query, updateSearchParams]);
 
   // Keep the active tab page within valid bounds as result counts change.
@@ -129,24 +146,58 @@ const SearchPage: React.FC = () => {
     }
   }, [activeResultCount, page, rowsPerPage, updateSearchParams]);
 
+  const minerSortCfg = React.useMemo(
+    () => parseSearchSort('miners', sortParam, orderParam),
+    [sortParam, orderParam],
+  );
+  const repoSortCfg = React.useMemo(
+    () => parseSearchSort('repositories', sortParam, orderParam),
+    [sortParam, orderParam],
+  );
+  const prSortCfg = React.useMemo(
+    () => parseSearchSort('prs', sortParam, orderParam),
+    [sortParam, orderParam],
+  );
+  const issueSortCfg = React.useMemo(
+    () => parseSearchSort('issues', sortParam, orderParam),
+    [sortParam, orderParam],
+  );
+
+  const sortedMinerResults = React.useMemo(
+    () => sortMinerRows(minerResults, minerSortCfg.field, minerSortCfg.order),
+    [minerResults, minerSortCfg],
+  );
+  const sortedRepositoryResults = React.useMemo(
+    () => sortRepoRows(repositoryResults, repoSortCfg.field, repoSortCfg.order),
+    [repositoryResults, repoSortCfg],
+  );
+  const sortedPrResults = React.useMemo(
+    () => sortPrRows(prResults, prSortCfg.field, prSortCfg.order),
+    [prResults, prSortCfg],
+  );
+  const sortedIssueResults = React.useMemo(
+    () => sortIssueRows(issueResults, issueSortCfg.field, issueSortCfg.order),
+    [issueResults, issueSortCfg],
+  );
+
   const paginatedMinerResults = React.useMemo(
-    () => paginateResults(minerResults, page, rowsPerPage),
-    [minerResults, page, rowsPerPage],
+    () => paginateResults(sortedMinerResults, page, rowsPerPage),
+    [sortedMinerResults, page, rowsPerPage],
   );
 
   const paginatedRepositoryResults = React.useMemo(
-    () => paginateResults(repositoryResults, page, rowsPerPage),
-    [page, repositoryResults, rowsPerPage],
+    () => paginateResults(sortedRepositoryResults, page, rowsPerPage),
+    [page, sortedRepositoryResults, rowsPerPage],
   );
 
   const paginatedPrResults = React.useMemo(
-    () => paginateResults(prResults, page, rowsPerPage),
-    [page, prResults, rowsPerPage],
+    () => paginateResults(sortedPrResults, page, rowsPerPage),
+    [page, sortedPrResults, rowsPerPage],
   );
 
   const paginatedIssueResults = React.useMemo(
-    () => paginateResults(issueResults, page, rowsPerPage),
-    [issueResults, page, rowsPerPage],
+    () => paginateResults(sortedIssueResults, page, rowsPerPage),
+    [sortedIssueResults, page, rowsPerPage],
   );
 
   const handlePageChange = (newPage: number) => {
@@ -159,6 +210,20 @@ const SearchPage: React.FC = () => {
       page: null,
     });
   };
+
+  const handleSearchSort = React.useCallback(
+    (field: string) => {
+      const tab = tabValue as SearchSortTab;
+      const current = parseSearchSort(tab, sortParam, orderParam);
+      const next = getNextSearchSort(tab, current.field, current.order, field);
+      updateSearchParams({
+        sort: next.field,
+        order: next.order,
+        page: null,
+      });
+    },
+    [orderParam, sortParam, tabValue, updateSearchParams],
+  );
 
   const searchBackState = {
     backTo: `${location.pathname}${location.search}`,
@@ -207,9 +272,9 @@ const SearchPage: React.FC = () => {
         {hasQuery && (
           <Stack gap={2} sx={{ mt: 2 }}>
             <Typography variant="body2" color="text.secondary">
-              {isAnySectionLoading && totalResults === 0
+              {isAnySectionLoading && activeResultCount === 0
                 ? `Loading search results for "${query}"...`
-                : `${totalResults} result${totalResults === 1 ? '' : 's'} for "${query}"`}
+                : `${activeResultCount} result${activeResultCount === 1 ? '' : 's'} in ${TAB_LABELS[tabValue]} for "${query}"`}
             </Typography>
 
             <Box
@@ -224,6 +289,8 @@ const SearchPage: React.FC = () => {
                   updateSearchParams({
                     tab: newValue,
                     page: null,
+                    sort: null,
+                    order: null,
                   })
                 }
                 aria-label="search categories tabs"
@@ -265,7 +332,12 @@ const SearchPage: React.FC = () => {
                 rowsPerPage={rowsPerPage}
                 rowsPerPageOptions={ROWS_PER_PAGE_OPTIONS}
                 paginatedMinerResults={paginatedMinerResults}
-                minerResults={minerResults}
+                minerResults={sortedMinerResults}
+                sort={{
+                  field: minerSortCfg.field as MinerSearchSortKey,
+                  order: minerSortCfg.order,
+                  onChange: handleSearchSort,
+                }}
               />
             )}
 
@@ -281,7 +353,12 @@ const SearchPage: React.FC = () => {
                 rowsPerPage={rowsPerPage}
                 rowsPerPageOptions={ROWS_PER_PAGE_OPTIONS}
                 paginatedRepositoryResults={paginatedRepositoryResults}
-                repositoryResults={repositoryResults}
+                repositoryResults={sortedRepositoryResults}
+                sort={{
+                  field: repoSortCfg.field as RepoSearchSortKey,
+                  order: repoSortCfg.order,
+                  onChange: handleSearchSort,
+                }}
               />
             )}
 
@@ -297,7 +374,12 @@ const SearchPage: React.FC = () => {
                 rowsPerPage={rowsPerPage}
                 rowsPerPageOptions={ROWS_PER_PAGE_OPTIONS}
                 paginatedPrResults={paginatedPrResults}
-                prResults={prResults}
+                prResults={sortedPrResults}
+                sort={{
+                  field: prSortCfg.field as PrSearchSortKey,
+                  order: prSortCfg.order,
+                  onChange: handleSearchSort,
+                }}
               />
             )}
 
@@ -313,7 +395,12 @@ const SearchPage: React.FC = () => {
                 rowsPerPage={rowsPerPage}
                 rowsPerPageOptions={ROWS_PER_PAGE_OPTIONS}
                 paginatedIssueResults={paginatedIssueResults}
-                issueResults={issueResults}
+                issueResults={sortedIssueResults}
+                sort={{
+                  field: issueSortCfg.field as IssueSearchSortKey,
+                  order: issueSortCfg.order,
+                  onChange: handleSearchSort,
+                }}
               />
             )}
           </Stack>

--- a/src/pages/search/SearchResultsCard.tsx
+++ b/src/pages/search/SearchResultsCard.tsx
@@ -4,6 +4,7 @@ import { type SxProps, type Theme } from '@mui/material/styles';
 import {
   DataTable,
   type DataTableColumn,
+  type DataTableSort,
 } from '../../components/common/DataTable';
 
 /**
@@ -13,8 +14,8 @@ import {
  * each tab.
  */
 
-type SearchResultsCardProps<T> = {
-  columns: DataTableColumn<T>[];
+type SearchResultsCardProps<T, K extends string> = {
+  columns: DataTableColumn<T, K>[];
   rows: T[];
   totalCount: number;
   emptyLabel: string;
@@ -30,6 +31,7 @@ type SearchResultsCardProps<T> = {
   page: number;
   rowsPerPage: number;
   rowsPerPageOptions: number[];
+  sort: DataTableSort<K>;
 };
 
 const cardSx: SxProps<Theme> = (theme) => ({
@@ -50,7 +52,7 @@ const paginationSx: SxProps<Theme> = (theme) => ({
   },
 });
 
-export const SearchResultsCard = <T,>({
+export const SearchResultsCard = <T, K extends string>({
   columns,
   rows,
   totalCount,
@@ -67,9 +69,10 @@ export const SearchResultsCard = <T,>({
   page,
   rowsPerPage,
   rowsPerPageOptions,
-}: SearchResultsCardProps<T>) => (
+  sort,
+}: SearchResultsCardProps<T, K>) => (
   <Card elevation={0} sx={cardSx}>
-    <DataTable
+    <DataTable<T, K>
       columns={columns}
       rows={rows}
       getRowKey={getRowKey}
@@ -80,6 +83,7 @@ export const SearchResultsCard = <T,>({
       minWidth={minWidth}
       getRowHref={getRowHref}
       linkState={linkState}
+      sort={sort}
       pagination={
         totalCount > 0 ? (
           <TablePagination

--- a/src/pages/search/searchData.ts
+++ b/src/pages/search/searchData.ts
@@ -35,6 +35,9 @@ export type RepoSearchData = {
   contributors: number;
   totalPRs: number;
   totalScore: number;
+  discoveryScore: number;
+  discoveryIssues: number;
+  discoveryContributors: number;
 };
 
 type SearchResultLimits = {
@@ -134,6 +137,16 @@ const buildRepoSearchData = (
       uniqueAuthors: Set<string>;
     }
   >();
+  const issueStatsMap = new Map<
+    string,
+    Pick<
+      RepoSearchData,
+      'discoveryScore' | 'discoveryIssues' | 'discoveryContributors'
+    > & {
+      uniqueIssueAuthors: Set<string>;
+      uniqueIssues: Set<string>;
+    }
+  >();
 
   // Aggregate merged PR stats by repository
   prs.forEach((pr) => {
@@ -156,12 +169,41 @@ const buildRepoSearchData = (
     }
 
     prStatsMap.set(repositoryKey, current);
+
+    const linkedIssues = Array.isArray(pr.linkedIssues) ? pr.linkedIssues : [];
+    if (linkedIssues.length > 0) {
+      const issueCurrent = issueStatsMap.get(repositoryKey) || {
+        discoveryScore: 0,
+        discoveryIssues: 0,
+        discoveryContributors: 0,
+        uniqueIssueAuthors: new Set<string>(),
+        uniqueIssues: new Set<string>(),
+      };
+
+      issueCurrent.discoveryScore += parseNumber(pr.issueTokenScore, 0);
+
+      linkedIssues.forEach((issue) => {
+        issueCurrent.uniqueIssues.add(
+          `${pr.repository.toLowerCase()}#${issue.number}`,
+        );
+      });
+      issueCurrent.discoveryIssues = issueCurrent.uniqueIssues.size;
+
+      if (pr.author) {
+        issueCurrent.uniqueIssueAuthors.add(pr.author);
+        issueCurrent.discoveryContributors =
+          issueCurrent.uniqueIssueAuthors.size;
+      }
+
+      issueStatsMap.set(repositoryKey, issueCurrent);
+    }
   });
 
   // Build repository search data ranked by weight, then total score.
   return repositories
     .map((repo) => {
       const stats = prStatsMap.get(repo.fullName.toLowerCase());
+      const issueStats = issueStatsMap.get(repo.fullName.toLowerCase());
 
       return {
         fullName: repo.fullName,
@@ -170,6 +212,9 @@ const buildRepoSearchData = (
         totalScore: stats?.totalScore || 0,
         totalPRs: stats?.totalPRs || 0,
         contributors: stats?.uniqueAuthors.size || 0,
+        discoveryScore: issueStats?.discoveryScore || 0,
+        discoveryIssues: issueStats?.discoveryIssues || 0,
+        discoveryContributors: issueStats?.uniqueIssueAuthors.size || 0,
       };
     })
     .sort((a, b) => {

--- a/src/pages/search/searchSort.ts
+++ b/src/pages/search/searchSort.ts
@@ -1,0 +1,353 @@
+import type { CommitLog } from '../../api/models/Dashboard';
+import type { IssueBounty } from '../../api/models/Issues';
+import type { SortOrder } from '../../utils/ExplorerUtils';
+import { isClosedUnmergedPr, isMergedPr } from '../../utils/prStatus';
+import type { MinerSearchData, RepoSearchData } from './searchData';
+
+export type SearchSortTab = 'miners' | 'repositories' | 'prs' | 'issues';
+
+const DEFAULT_SORT: Record<SearchSortTab, { field: string; order: SortOrder }> =
+  {
+    miners: { field: 'score', order: 'desc' },
+    repositories: { field: 'weight', order: 'desc' },
+    prs: { field: 'score', order: 'desc' },
+    issues: { field: 'date', order: 'desc' },
+  };
+
+const VALID_SORT_KEYS: Record<SearchSortTab, ReadonlySet<string>> = {
+  miners: new Set([
+    'rank',
+    'miner',
+    'credibility',
+    'tokenScore',
+    'prs',
+    'score',
+  ]),
+  repositories: new Set([
+    'rank',
+    'repository',
+    'weight',
+    'totalScore',
+    'prs',
+    'discoveryScore',
+    'discoveryIssues',
+    'contributors',
+    'discoveryContributors',
+  ]),
+  prs: new Set([
+    'prNumber',
+    'title',
+    'repository',
+    'author',
+    'status',
+    'score',
+  ]),
+  issues: new Set(['issueNumber', 'title', 'repository', 'status', 'date']),
+};
+
+export const parseSearchSort = (
+  tab: SearchSortTab,
+  sortParam: string | null,
+  orderParam: string | null,
+): { field: string; order: SortOrder } => {
+  const fallback = DEFAULT_SORT[tab];
+  if (
+    sortParam &&
+    VALID_SORT_KEYS[tab].has(sortParam) &&
+    (orderParam === 'asc' || orderParam === 'desc')
+  ) {
+    return { field: sortParam, order: orderParam };
+  }
+  return fallback;
+};
+
+/** First-click order when switching to a new sort column (matches leaderboard pattern). */
+export const getInitialOrderForColumn = (
+  tab: SearchSortTab,
+  field: string,
+): SortOrder => {
+  if (tab === 'miners') {
+    if (field === 'miner' || field === 'rank') return 'asc';
+  }
+  if (tab === 'repositories') {
+    if (field === 'repository' || field === 'rank') return 'asc';
+  }
+  if (tab === 'prs') {
+    if (['title', 'repository', 'author'].includes(field)) return 'asc';
+  }
+  if (tab === 'issues') {
+    if (['title', 'repository'].includes(field)) return 'asc';
+  }
+  return 'desc';
+};
+
+export const getNextSearchSort = (
+  tab: SearchSortTab,
+  currentField: string,
+  currentOrder: SortOrder,
+  clickedField: string,
+): { field: string; order: SortOrder } => {
+  if (currentField === clickedField) {
+    return {
+      field: clickedField,
+      order: currentOrder === 'asc' ? 'desc' : 'asc',
+    };
+  }
+  return {
+    field: clickedField,
+    order: getInitialOrderForColumn(tab, clickedField),
+  };
+};
+
+const cmpNum = (a: number, b: number, order: SortOrder) =>
+  order === 'asc' ? a - b : b - a;
+
+const cmpStr = (a: string, b: string, order: SortOrder) => {
+  const c = a.localeCompare(b);
+  return order === 'asc' ? c : -c;
+};
+
+const prStatusRank = (pr: CommitLog): number => {
+  if (isMergedPr(pr)) return 2;
+  if (isClosedUnmergedPr(pr)) return 0;
+  return 1;
+};
+
+const issueStatusRank = (status: string): number => {
+  switch (status) {
+    case 'registered':
+      return 0;
+    case 'active':
+      return 1;
+    case 'completed':
+      return 2;
+    case 'cancelled':
+      return 3;
+    default:
+      return -1;
+  }
+};
+
+const issueTimestamp = (issue: IssueBounty): number => {
+  const raw =
+    issue.completedAt || issue.updatedAt || issue.createdAt || '1970-01-01';
+  const t = new Date(raw).getTime();
+  return Number.isNaN(t) ? 0 : t;
+};
+
+const prScoreValue = (pr: CommitLog): number => {
+  if (pr.prState === 'CLOSED' && !pr.mergedAt) return Number.NEGATIVE_INFINITY;
+  const v = parseFloat(pr.score || '0');
+  return Number.isFinite(v) ? v : Number.NEGATIVE_INFINITY;
+};
+
+export const sortMinerRows = (
+  rows: MinerSearchData[],
+  field: string,
+  order: SortOrder,
+): MinerSearchData[] =>
+  [...rows].sort((a, b) => {
+    let primary = 0;
+    switch (field) {
+      case 'rank': {
+        const ar = a.leaderboardRank > 0 ? a.leaderboardRank : 999999;
+        const br = b.leaderboardRank > 0 ? b.leaderboardRank : 999999;
+        primary = cmpNum(ar, br, order);
+        break;
+      }
+      case 'miner':
+        primary = cmpStr(
+          (a.githubUsername || a.githubId).toLowerCase(),
+          (b.githubUsername || b.githubId).toLowerCase(),
+          order,
+        );
+        break;
+      case 'credibility':
+        primary = cmpNum(a.credibility, b.credibility, order);
+        break;
+      case 'tokenScore':
+        primary = cmpNum(a.totalTokenScore, b.totalTokenScore, order);
+        break;
+      case 'prs':
+        primary = cmpNum(a.totalPrs, b.totalPrs, order);
+        break;
+      case 'score':
+      default:
+        primary = cmpNum(a.totalScore, b.totalScore, order);
+        break;
+    }
+    if (primary !== 0) return primary;
+    return a.githubId.localeCompare(b.githubId);
+  });
+
+export const sortRepoRows = (
+  rows: RepoSearchData[],
+  field: string,
+  order: SortOrder,
+): RepoSearchData[] =>
+  [...rows].sort((a, b) => {
+    let primary = 0;
+    switch (field) {
+      case 'rank':
+        primary = cmpNum(a.rank, b.rank, order);
+        break;
+      case 'repository':
+        primary = cmpStr(
+          a.fullName.toLowerCase(),
+          b.fullName.toLowerCase(),
+          order,
+        );
+        break;
+      case 'weight':
+        primary = cmpNum(a.weight, b.weight, order);
+        break;
+      case 'totalScore':
+        primary = cmpNum(a.totalScore, b.totalScore, order);
+        break;
+      case 'prs':
+        primary = cmpNum(a.totalPRs, b.totalPRs, order);
+        break;
+      case 'discoveryScore':
+        primary = cmpNum(a.discoveryScore, b.discoveryScore, order);
+        break;
+      case 'discoveryIssues':
+        primary = cmpNum(a.discoveryIssues, b.discoveryIssues, order);
+        break;
+      case 'contributors':
+        primary = cmpNum(a.contributors, b.contributors, order);
+        break;
+      case 'discoveryContributors':
+        primary = cmpNum(
+          a.discoveryContributors,
+          b.discoveryContributors,
+          order,
+        );
+        break;
+      default:
+        primary = cmpNum(a.weight, b.weight, order);
+        break;
+    }
+    if (primary !== 0) return primary;
+    return a.fullName.localeCompare(b.fullName);
+  });
+
+export const sortPrRows = (
+  rows: CommitLog[],
+  field: string,
+  order: SortOrder,
+): CommitLog[] =>
+  [...rows].sort((a, b) => {
+    let primary = 0;
+    switch (field) {
+      case 'prNumber':
+        primary = cmpNum(a.pullRequestNumber, b.pullRequestNumber, order);
+        break;
+      case 'title':
+        primary = cmpStr(
+          (a.pullRequestTitle || '').toLowerCase(),
+          (b.pullRequestTitle || '').toLowerCase(),
+          order,
+        );
+        break;
+      case 'repository':
+        primary = cmpStr(
+          (a.repository || '').toLowerCase(),
+          (b.repository || '').toLowerCase(),
+          order,
+        );
+        break;
+      case 'author':
+        primary = cmpStr(
+          (a.author || '').toLowerCase(),
+          (b.author || '').toLowerCase(),
+          order,
+        );
+        break;
+      case 'status':
+        primary = cmpNum(prStatusRank(a), prStatusRank(b), order);
+        break;
+      case 'score':
+      default:
+        primary = cmpNum(prScoreValue(a), prScoreValue(b), order);
+        break;
+    }
+    if (primary !== 0) return primary;
+    const ka = `${a.repository}\0${a.pullRequestNumber}`;
+    const kb = `${b.repository}\0${b.pullRequestNumber}`;
+    return ka.localeCompare(kb);
+  });
+
+export const sortIssueRows = (
+  rows: IssueBounty[],
+  field: string,
+  order: SortOrder,
+): IssueBounty[] =>
+  [...rows].sort((a, b) => {
+    let primary = 0;
+    switch (field) {
+      case 'issueNumber':
+        primary = cmpNum(a.issueNumber, b.issueNumber, order);
+        break;
+      case 'title':
+        primary = cmpStr(
+          (a.title || '').toLowerCase(),
+          (b.title || '').toLowerCase(),
+          order,
+        );
+        break;
+      case 'repository':
+        primary = cmpStr(
+          a.repositoryFullName.toLowerCase(),
+          b.repositoryFullName.toLowerCase(),
+          order,
+        );
+        break;
+      case 'status':
+        primary = cmpNum(
+          issueStatusRank(a.status),
+          issueStatusRank(b.status),
+          order,
+        );
+        break;
+      case 'date':
+      default:
+        primary = cmpNum(issueTimestamp(a), issueTimestamp(b), order);
+        break;
+    }
+    if (primary !== 0) return primary;
+    return cmpNum(a.id, b.id, 'asc');
+  });
+
+export type MinerSearchSortKey =
+  | 'rank'
+  | 'miner'
+  | 'credibility'
+  | 'tokenScore'
+  | 'prs'
+  | 'score';
+
+export type RepoSearchSortKey =
+  | 'rank'
+  | 'repository'
+  | 'weight'
+  | 'totalScore'
+  | 'prs'
+  | 'discoveryScore'
+  | 'discoveryIssues'
+  | 'contributors'
+  | 'discoveryContributors';
+
+export type PrSearchSortKey =
+  | 'prNumber'
+  | 'title'
+  | 'repository'
+  | 'author'
+  | 'status'
+  | 'score';
+
+export type IssueSearchSortKey =
+  | 'issueNumber'
+  | 'title'
+  | 'repository'
+  | 'status'
+  | 'date';

--- a/src/utils/issueBountyNormalize.ts
+++ b/src/utils/issueBountyNormalize.ts
@@ -1,0 +1,42 @@
+import type { IssueBounty } from '../api/models/Issues';
+
+const pickTrimmedString = (v: unknown): string | undefined => {
+  if (typeof v !== 'string') return undefined;
+  const t = v.trim();
+  return t || undefined;
+};
+
+const pickUserLogin = (raw: Record<string, unknown>): string | undefined => {
+  const user = raw.user;
+  if (user && typeof user === 'object' && user !== null) {
+    return pickTrimmedString((user as Record<string, unknown>).login);
+  }
+  return undefined;
+};
+
+/**
+ * Coerce `/issues` list payloads into `IssueBounty` (camelCase + author).
+ * Mirrors may send `author_login` or GitHub-shaped `user.login` instead of `authorLogin`.
+ */
+export const normalizeIssueBountyFromApi = (raw: unknown): IssueBounty => {
+  if (!raw || typeof raw !== 'object') {
+    return raw as IssueBounty;
+  }
+  const r = raw as Record<string, unknown>;
+  const base = { ...r } as unknown as IssueBounty;
+
+  const author =
+    pickTrimmedString(base.authorLogin) ??
+    pickTrimmedString(r.author_login) ??
+    pickUserLogin(r);
+
+  if (author) {
+    return { ...base, authorLogin: author };
+  }
+  return base;
+};
+
+export const normalizeIssueBountyList = (raw: unknown): IssueBounty[] => {
+  if (!Array.isArray(raw)) return [];
+  return raw.map((item) => normalizeIssueBountyFromApi(item));
+};


### PR DESCRIPTION
## Summary

Improves the **full search** experience (`/search`): aligns tab tables with sibling pages where appropriate, adds **URL-backed column sorting** for all four tabs (sort applied before pagination), extends **repository search** rows with discovery-oriented aggregates, aligns PR/issue typing and payloads with backend shapes, and adds helpers to **normalize issue bounty** API variants for consistent author fields.

## Type of change

- [x] Feature (search UX + sorting + column parity)
- [x] Bug fix / UX fix 
- [ ] Breaking change

## Related docs

Closes #860

## Checklist

- [ ] Open `/search?q=gittensor`; verify subtitle matches active tab count.
- [ ] On each tab, sort several columns; confirm order updates and persists in URL until reset.
- [ ] Go to page 2 when applicable; change sort; confirm ordering is global, not page-local only.
- [ ] Switch tabs and re-run search; confirm sort resets behave reasonably.
- [ ] Spot-check Repositories star and PRs star against Watchlist expectations.
- [ ] Issues tab: confirm `#` column tracks GitHub issue numbers.
- [ ] `npm run lint` / `npm run build`

## Screenshots

https://github.com/user-attachments/assets/eca77a0b-2c51-40d1-98ff-ddd97be27552

