### PR TITLE
fix: pull request star icon

### DIFF
--- a/src/pages/WatchlistPage.tsx
+++ b/src/pages/WatchlistPage.tsx
@@ -1105,9 +1105,21 @@ const ReposList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
     const q = searchQuery.trim().toLowerCase();
     if (q) result = result.filter((r) => r.fullName.toLowerCase().includes(q));
 
-    setPage(0);
     return result;
   }, [items, statusFilter, searchQuery]);
+
+  useEffect(() => {
+    setPage(0);
+  }, [searchQuery, statusFilter]);
+
+  useEffect(() => {
+    if (filtered.length === 0) {
+      if (page !== 0) setPage(0);
+      return;
+    }
+    const maxPage = Math.max(0, Math.ceil(filtered.length / rowsPerPage) - 1);
+    if (page > maxPage) setPage(maxPage);
+  }, [filtered.length, page, rowsPerPage]);
 
   const sorted = useMemo(() => {
     const dir = sortOrder === 'asc' ? 1 : -1;
@@ -2159,14 +2171,25 @@ const PRsList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
   const counts = useMemo(() => getPrStatusCounts(items), [items]);
 
   const filtered = useMemo(() => {
-    const result = filterPrs(items, {
+    return filterPrs(items, {
       statusFilter,
       searchQuery,
       includeNumber: true,
     });
-    setPage(0);
-    return result;
   }, [items, statusFilter, searchQuery]);
+
+  useEffect(() => {
+    setPage(0);
+  }, [searchQuery, statusFilter]);
+
+  useEffect(() => {
+    if (filtered.length === 0) {
+      if (page !== 0) setPage(0);
+      return;
+    }
+    const maxPage = Math.max(0, Math.ceil(filtered.length / rowsPerPage) - 1);
+    if (page > maxPage) setPage(maxPage);
+  }, [filtered.length, page, rowsPerPage]);
 
   const sorted = useMemo(() => {
     const dir = sortOrder === 'asc' ? 1 : -1;


### PR DESCRIPTION
## Summary

Fix Watchlist pagination resetting to page 1 when toggling the star icon in the Pull Requests tab by removing state updates from derived useMemo computations. Pagination now resets only when filters/search change, and clamps to a valid page when the list shrinks.

## Related Issues

Close #862 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [ ] Screenshots included for any UI/visual changes


https://github.com/user-attachments/assets/b8e9f84f-2663-4e52-85a6-730223880f0d

