### PR TITLE
fix(issues-table): resolve duplicate React key warning in repository-issues table

### DIFF
--- a/src/components/repositories/RepositoryIssuesTable.tsx
+++ b/src/components/repositories/RepositoryIssuesTable.tsx
@@ -411,7 +411,9 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
         <DataTable<RepositoryIssue>
           columns={columns}
           rows={sortedIssues}
-          getRowKey={(issue) => `${issue.number}-${issue.repositoryFullName}`}
+          getRowKey={(issue) =>
+            `${issue.number}-${issue.prNumber}-${issue.repositoryFullName}`
+          }
           stickyHeader
           size="medium"
           header={headerToolbar}


### PR DESCRIPTION
## Summary

Previously, row keys were generated using issue number and repository name, which could result in duplicate keys when multiple issues shared the same values.

Updated the key generation to include prNumber:
```
`${issue.number}-${issue.prNumber}-${issue.repositoryFullName}`
```

This ensures uniqueness and prevents React rendering warnings and potential UI inconsistencies.

## Related Issues

fixes #866 

## Type of Change

- [x] Bug fix

## Screenshots

Bug:
<img width="1639" height="713" alt="image" src="https://github.com/user-attachments/assets/a5ee9a55-0f0c-4d81-910e-76e68ab2fda3" />
Fixed:
<img width="1654" height="720" alt="image" src="https://github.com/user-attachments/assets/5d020bd3-7a9d-4ad2-a9fc-cfa33854fe9b" />



## Checklist

- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
