### PR TITLE
feat(issues-table): add sorting functionality to repository issues table

### DIFF
--- a/src/components/repositories/RepositoryIssuesTable.tsx
+++ b/src/components/repositories/RepositoryIssuesTable.tsx
@@ -411,7 +411,9 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
         <DataTable<RepositoryIssue>
           columns={columns}
           rows={sortedIssues}
-          getRowKey={(issue) => `${issue.number}-${issue.repositoryFullName}`}
+          getRowKey={(issue) =>
+            `${issue.number}-${issue.prNumber}-${issue.repositoryFullName}`
+          }
           stickyHeader
           size="medium"
           header={headerToolbar}

--- a/src/components/repositories/RepositoryIssuesTable.tsx
+++ b/src/components/repositories/RepositoryIssuesTable.tsx
@@ -22,7 +22,7 @@ import {
   DataTable,
   type DataTableColumn,
 } from '../../components/common/DataTable';
-import { formatTokenAmount } from '../../utils/format';
+import { formatTokenAmount, getLowerText, type SortOrder } from '../../utils';
 import {
   getIssueStatusMeta,
   getBountyAmountColor,
@@ -34,6 +34,14 @@ interface RepositoryIssuesTableProps {
   repositoryFullName: string;
 }
 
+type SortKey =
+  | 'number'
+  | 'title'
+  | 'status'
+  | 'linkedPr'
+  | 'created'
+  | 'closed';
+
 const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
   repositoryFullName,
 }) => {
@@ -41,6 +49,8 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
   const { data: issues, isLoading } = useRepositoryIssues(repositoryFullName);
   const { data: bounties } = useRepoIssues(repositoryFullName);
   const [filter, setFilter] = useState<'all' | 'open' | 'closed'>('all');
+  const [sortKey, setSortKey] = useState<SortKey>('number');
+  const [sortDirection, setSortDirection] = useState<SortOrder>('desc');
 
   const counts = useMemo(() => {
     if (!issues) return { total: 0, open: 0, closed: 0 };
@@ -58,15 +68,60 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
     return issues;
   }, [issues, filter]);
 
-  const sortedIssues = useMemo(
-    () =>
-      [...filteredIssues].sort((a, b) => {
-        // Sort by creation date, most recent first.
-        const dateA = a.createdAt ? new Date(a.createdAt).getTime() : 0;
-        const dateB = b.createdAt ? new Date(b.createdAt).getTime() : 0;
-        return dateB - dateA;
-      }),
-    [filteredIssues],
+  const sortedIssues = useMemo(() => {
+    const directionFactor = sortDirection === 'asc' ? 1 : -1;
+    const collator = new Intl.Collator(undefined, {
+      sensitivity: 'base',
+      numeric: true,
+    });
+    const decorated = filteredIssues.map((issue) => {
+      let value: number | string;
+      switch (sortKey) {
+        case 'number':
+          value = issue.number;
+          break;
+        case 'title':
+          value = getLowerText(issue.title);
+          break;
+        case 'status':
+          value = !issue.closedAt ? 'open' : 'closed';
+          break;
+        case 'linkedPr':
+          value = issue.prNumber ? String(issue.prNumber) : '';
+          break;
+        case 'created':
+          value = issue.createdAt ? new Date(issue.createdAt).getTime() : 0;
+          break;
+        case 'closed':
+          value = issue.closedAt ? new Date(issue.closedAt).getTime() : 0;
+          break;
+        default:
+          value = issue.createdAt ? new Date(issue.createdAt).getTime() : 0;
+      }
+      return { issue, value };
+    });
+
+    decorated.sort((a, b) => {
+      if (typeof a.value === 'number' && typeof b.value === 'number') {
+        return (a.value - b.value) * directionFactor;
+      }
+      return (
+        collator.compare(String(a.value), String(b.value)) * directionFactor
+      );
+    });
+    return decorated.map((item) => item.issue);
+  }, [filteredIssues, sortKey, sortDirection]);
+
+  const handleSort = useCallback(
+    (key: SortKey) => {
+      if (sortKey === key) {
+        setSortDirection((prev) => (prev === 'asc' ? 'desc' : 'asc'));
+        return;
+      }
+      setSortKey(key);
+      setSortDirection('asc');
+    },
+    [sortKey],
   );
 
   const handleRowClick = useCallback((issue: RepositoryIssue) => {
@@ -101,10 +156,11 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
     );
   }
 
-  const columns: DataTableColumn<RepositoryIssue>[] = [
+  const columns: DataTableColumn<RepositoryIssue, SortKey>[] = [
     {
       key: 'number',
       header: 'Issue #',
+      sortKey: 'number',
       renderCell: (issue) => (
         <a
           href={`https://github.com/${issue.repositoryFullName}/issues/${issue.number}`}
@@ -124,6 +180,7 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
     {
       key: 'title',
       header: 'Title',
+      sortKey: 'title',
       renderCell: (issue) => (
         <Box
           sx={{
@@ -140,6 +197,7 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
     {
       key: 'status',
       header: 'Status',
+      sortKey: 'status',
       renderCell: (issue) => {
         const isOpen = !issue.closedAt;
         return (
@@ -159,6 +217,7 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
     {
       key: 'linkedPr',
       header: 'Linked PR',
+      sortKey: 'linkedPr',
       renderCell: (issue) =>
         issue.prNumber ? (
           <a
@@ -188,6 +247,7 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
       key: 'created',
       header: 'Created',
       align: 'right',
+      sortKey: 'created',
       renderCell: (issue) =>
         issue.createdAt ? new Date(issue.createdAt).toLocaleDateString() : '-',
     },
@@ -195,6 +255,7 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
       key: 'closed',
       header: 'Closed',
       align: 'right',
+      sortKey: 'closed',
       renderCell: (issue) =>
         issue.closedAt ? new Date(issue.closedAt).toLocaleDateString() : '-',
     },
@@ -408,7 +469,7 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
         }}
         elevation={0}
       >
-        <DataTable<RepositoryIssue>
+        <DataTable<RepositoryIssue, SortKey>
           columns={columns}
           rows={sortedIssues}
           getRowKey={(issue) => `${issue.number}-${issue.repositoryFullName}`}
@@ -431,6 +492,11 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
             </Box>
           }
           onRowClick={handleRowClick}
+          sort={{
+            field: sortKey,
+            order: sortDirection,
+            onChange: handleSort,
+          }}
         />
       </Card>
     </Box>

--- a/src/components/repositories/RepositoryIssuesTable.tsx
+++ b/src/components/repositories/RepositoryIssuesTable.tsx
@@ -119,7 +119,7 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
         return;
       }
       setSortKey(key);
-      setSortDirection('asc');
+      setSortDirection(key === 'title' || key === 'status' ? 'asc' : 'desc');
     },
     [sortKey],
   );

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -86,3 +86,6 @@ export const credibilityColor = (cred: number): string => {
   if (cred >= 0.3) return CREDIBILITY_COLORS.low;
   return CREDIBILITY_COLORS.poor;
 };
+
+export const getLowerText = (value: string | null | undefined): string =>
+  (value ?? '').toLowerCase();


### PR DESCRIPTION
## Summary

Implemented column-based sorting for the issues data table on the repository page. Users can now sort issues by fields such as issue number, title, status, and created date in both ascending and descending order.

Improves usability by allowing users to quickly organize and find relevant issues.


## Related Issues

fixes #866
closes #869 

## Related PRs(important)

I’ve linked the previous PR #868 (duplicate key fix in the issues table) as a related PR, since the key collision was causing incorrect behavior when applying sorting in this PR.

## Type of Change

- [x] New feature

## Screenshots
Sorted by number:
<img width="753" height="606" alt="image" src="https://github.com/user-attachments/assets/b06d7ae0-c273-4114-bf40-d2c62c94186e" />
Sorted by status:
<img width="751" height="614" alt="image" src="https://github.com/user-attachments/assets/93d79670-abd2-4d1d-b6c5-d694e5c8d8e8" />


## Checklist

- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
