### PR TITLE
[Bug] Persist filter and tab state across back-navigation

### DIFF
--- a/src/components/miners/MinerOpenDiscoveryIssuesByRepo.tsx
+++ b/src/components/miners/MinerOpenDiscoveryIssuesByRepo.tsx
@@ -32,9 +32,13 @@ import {
   selectMinerIssueScanRepos,
   useMinerRepositoriesOpenIssues,
 } from '../../hooks/useMinerRepositoriesOpenIssues';
+import { useSessionStoredState } from '../../hooks/useSessionStoredState';
 import { type RepositoryIssue } from '../../api/models/Miner';
 
 type IssueFilter = 'all' | 'open' | 'solved' | 'closed';
+const ISSUE_FILTERS: IssueFilter[] = ['all', 'open', 'solved', 'closed'];
+const isIssueFilter = (value: unknown): value is IssueFilter =>
+  typeof value === 'string' && (ISSUE_FILTERS as string[]).includes(value);
 type IssueSortField = 'number' | 'repository' | 'opened';
 type SortDir = 'asc' | 'desc';
 
@@ -223,14 +227,22 @@ const MinerOpenDiscoveryIssuesByRepo: React.FC<
     useMinerGithubData(githubId);
 
   // Mine section state
-  const [mineFilter, setMineFilter] = useState<IssueFilter>('all');
+  const [mineFilter, setMineFilter] = useSessionStoredState<IssueFilter>(
+    'minerOpenIssues:mine:filter',
+    'all',
+    isIssueFilter,
+  );
   const [mineSearch, setMineSearch] = useState('');
   const [mineSortField, setMineSortField] = useState<IssueSortField>('opened');
   const [mineSortDir, setMineSortDir] = useState<SortDir>('desc');
   const [minePage, setMinePage] = useState(0);
 
   // Other section state
-  const [otherFilter, setOtherFilter] = useState<IssueFilter>('all');
+  const [otherFilter, setOtherFilter] = useSessionStoredState<IssueFilter>(
+    'minerOpenIssues:other:filter',
+    'all',
+    isIssueFilter,
+  );
   const [otherSearch, setOtherSearch] = useState('');
   const [otherSortField, setOtherSortField] =
     useState<IssueSortField>('opened');

--- a/src/components/repositories/RepositoryContributorsTable.tsx
+++ b/src/components/repositories/RepositoryContributorsTable.tsx
@@ -16,12 +16,19 @@ import { STATUS_COLORS } from '../../theme';
 import { isMergedPr } from '../../utils/prStatus';
 import { parseNumber } from '../../utils/ExplorerUtils';
 import { DataTable, type DataTableColumn } from '../common/DataTable';
+import { useSessionStoredState } from '../../hooks/useSessionStoredState';
 
 interface RepositoryContributorsTableProps {
   repositoryFullName: string;
 }
 
 type ContributorsProgramTab = 'oss' | 'issues';
+const CONTRIBUTORS_PROGRAM_TABS: ContributorsProgramTab[] = ['oss', 'issues'];
+const isContributorsProgramTab = (
+  value: unknown,
+): value is ContributorsProgramTab =>
+  typeof value === 'string' &&
+  (CONTRIBUTORS_PROGRAM_TABS as string[]).includes(value);
 
 interface ContributorRow {
   rank: number;
@@ -50,7 +57,11 @@ const RepositoryContributorsTable: React.FC<
   const { data: allMinersStats, isLoading: isMinersLoading } = useAllMiners();
 
   const [visibleCount, setVisibleCount] = useState(7);
-  const [programTab, setProgramTab] = useState<ContributorsProgramTab>('oss');
+  const [programTab, setProgramTab] = useSessionStoredState<ContributorsProgramTab>(
+    'repository:contributors:programTab',
+    'oss',
+    isContributorsProgramTab,
+  );
 
   useEffect(() => {
     setVisibleCount(7);

--- a/src/components/repositories/RepositoryIssuesTable.tsx
+++ b/src/components/repositories/RepositoryIssuesTable.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import {
   Box,
   Card,
@@ -29,10 +29,17 @@ import {
 } from '../../utils/issueStatus';
 import { STATUS_COLORS, TEXT_OPACITY, scrollbarSx } from '../../theme';
 import FilterButton from '../FilterButton';
+import { useSessionStoredState } from '../../hooks/useSessionStoredState';
 
 interface RepositoryIssuesTableProps {
   repositoryFullName: string;
 }
+
+type RepoIssueFilter = 'all' | 'open' | 'closed';
+const REPO_ISSUE_FILTERS: RepoIssueFilter[] = ['all', 'open', 'closed'];
+const isRepoIssueFilter = (value: unknown): value is RepoIssueFilter =>
+  typeof value === 'string' &&
+  (REPO_ISSUE_FILTERS as string[]).includes(value);
 
 const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
   repositoryFullName,
@@ -40,7 +47,11 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
   const theme = useTheme();
   const { data: issues, isLoading } = useRepositoryIssues(repositoryFullName);
   const { data: bounties } = useRepoIssues(repositoryFullName);
-  const [filter, setFilter] = useState<'all' | 'open' | 'closed'>('all');
+  const [filter, setFilter] = useSessionStoredState<RepoIssueFilter>(
+    'repository:issues:filter',
+    'all',
+    isRepoIssueFilter,
+  );
 
   const counts = useMemo(() => {
     if (!issues) return { total: 0, open: 0, closed: 0 };

--- a/src/hooks/useSessionStoredState.ts
+++ b/src/hooks/useSessionStoredState.ts
@@ -1,0 +1,37 @@
+import { useCallback, useEffect, useState } from 'react';
+
+/**
+ * useState backed by sessionStorage so the value survives unmount/remount
+ * (e.g. navigating to a detail page and back) but resets between sessions.
+ *
+ * `isValid` guards against stale or corrupt values from older builds.
+ */
+export const useSessionStoredState = <T>(
+  storageKey: string,
+  fallback: T,
+  isValid: (value: unknown) => value is T,
+): [T, (value: T) => void] => {
+  const read = useCallback((): T => {
+    if (typeof window === 'undefined') return fallback;
+    try {
+      const raw = window.sessionStorage.getItem(storageKey);
+      if (raw === null) return fallback;
+      const parsed = JSON.parse(raw);
+      return isValid(parsed) ? parsed : fallback;
+    } catch {
+      return fallback;
+    }
+  }, [storageKey, fallback, isValid]);
+
+  const [value, setValue] = useState<T>(read);
+
+  useEffect(() => {
+    try {
+      window.sessionStorage.setItem(storageKey, JSON.stringify(value));
+    } catch {
+      /* ignore (private mode, quota) */
+    }
+  }, [storageKey, value]);
+
+  return [value, setValue];
+};

--- a/src/pages/IssueDetailsPage.tsx
+++ b/src/pages/IssueDetailsPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { useSearchParams, useNavigate } from 'react-router-dom';
 import {
   Box,
@@ -16,7 +16,11 @@ import {
   IssueConversation,
 } from '../components/issues';
 import { useIssueDetails, useIssueSubmissions } from '../api';
+import { useSessionStoredState } from '../hooks/useSessionStoredState';
 import { STATUS_COLORS } from '../theme';
+
+const isIssueDetailsTab = (value: unknown): value is number =>
+  typeof value === 'number' && (value === 0 || value === 1);
 import ChatBubbleOutlineIcon from '@mui/icons-material/ChatBubbleOutline';
 import ListAltIcon from '@mui/icons-material/ListAlt';
 
@@ -25,7 +29,11 @@ const IssueDetailsPage: React.FC = () => {
   const navigate = useNavigate();
   const idParam = searchParams.get('id');
   const id = idParam ? parseInt(idParam, 10) : 0;
-  const [tabValue, setTabValue] = useState(0);
+  const [tabValue, setTabValue] = useSessionStoredState<number>(
+    'issueDetails:tab',
+    0,
+    isIssueDetailsTab,
+  );
 
   const { data: issue, isLoading: isLoadingDetails } = useIssueDetails(id);
   const { data: submissions, isLoading: isLoadingSubmissions } =

--- a/src/pages/PRDetailsPage.tsx
+++ b/src/pages/PRDetailsPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { useSearchParams, useNavigate } from 'react-router-dom';
 import { Box, Tabs, Tab, CircularProgress, Typography } from '@mui/material';
 import { Page } from '../components/layout';
@@ -13,6 +13,10 @@ import {
 } from '../components';
 import { usePullRequestDetails } from '../api';
 import { serializePRKey } from '../hooks/useWatchlist';
+import { useSessionStoredState } from '../hooks/useSessionStoredState';
+
+const isPrDetailsTab = (value: unknown): value is number =>
+  typeof value === 'number' && value >= 0 && value <= 2;
 import { STATUS_COLORS } from '../theme';
 import VisibilityIcon from '@mui/icons-material/Visibility';
 import CodeIcon from '@mui/icons-material/Code';
@@ -23,7 +27,11 @@ const PRDetailsPage: React.FC = () => {
   const navigate = useNavigate();
   const repository = searchParams.get('repo');
   const pullRequestNumber = searchParams.get('number');
-  const [tabValue, setTabValue] = useState(0);
+  const [tabValue, setTabValue] = useSessionStoredState<number>(
+    'prDetails:tab',
+    0,
+    isPrDetailsTab,
+  );
 
   // Call hook unconditionally (React rules of hooks)
   const { data: prDetails, isLoading } = usePullRequestDetails(

--- a/src/pages/WatchlistPage.tsx
+++ b/src/pages/WatchlistPage.tsx
@@ -65,6 +65,7 @@ import {
   type WatchlistCategory,
 } from '../hooks/useWatchlist';
 import { useWatchedPRs, type WatchedPRSource } from '../hooks/useWatchedPRs';
+import { useSessionStoredState } from '../hooks/useSessionStoredState';
 import {
   isMergedPr,
   isClosedUnmergedPr,
@@ -699,6 +700,15 @@ const isRepoActive = (repo: Repository): boolean => !repo.inactiveAt;
 
 type RepoStatusFilter = 'all' | 'active' | 'inactive';
 
+const REPO_STATUS_FILTERS: RepoStatusFilter[] = ['all', 'active', 'inactive'];
+const isRepoStatusFilter = (value: unknown): value is RepoStatusFilter =>
+  typeof value === 'string' &&
+  (REPO_STATUS_FILTERS as string[]).includes(value);
+
+const PR_STATUS_FILTERS: PrStatusFilter[] = ['all', 'open', 'merged', 'closed'];
+const isPrStatusFilter = (value: unknown): value is PrStatusFilter =>
+  typeof value === 'string' && (PR_STATUS_FILTERS as string[]).includes(value);
+
 type RepoSortKey =
   | 'name'
   | 'weight'
@@ -1138,7 +1148,11 @@ const ReposList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
   const { data: repos } = useReposAndWeights();
   const { data: allPrs } = useAllPrs();
   const [searchQuery, setSearchQuery] = useState('');
-  const [statusFilter, setStatusFilter] = useState<RepoStatusFilter>('all');
+  const [statusFilter, setStatusFilter] = useSessionStoredState<RepoStatusFilter>(
+    'watchlist:repos:statusFilter',
+    'all',
+    isRepoStatusFilter,
+  );
   const [viewMode, setViewMode] = useState<ReposViewMode>('list');
   const [showChart, setShowChart] = useState(false);
   const [useLogScale, setUseLogScale] = useState(false);
@@ -2240,7 +2254,11 @@ const PRsList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
   const { items, sourcesByKey, isLoading } = useWatchedPRs(itemKeys);
   const prColumns = useMemo(() => buildPrColumns(sourcesByKey), [sourcesByKey]);
   const [searchQuery, setSearchQuery] = useState('');
-  const [statusFilter, setStatusFilter] = useState<PrStatusFilter>('all');
+  const [statusFilter, setStatusFilter] = useSessionStoredState<PrStatusFilter>(
+    'watchlist:prs:statusFilter',
+    'all',
+    isPrStatusFilter,
+  );
   const [viewMode, setViewMode] = useState<PRsViewMode>('list');
   const [rowsPerPage, setRowsPerPage] = useState(10);
   const [page, setPage] = useState(0);

--- a/src/pages/dashboard/views/LiveCommitLog.tsx
+++ b/src/pages/dashboard/views/LiveCommitLog.tsx
@@ -15,6 +15,7 @@ import {
 import { formatDistanceToNow } from 'date-fns';
 import { LinkBox } from '../../../components/common/linkBehavior';
 import { useInfiniteCommitLog } from '../../../api';
+import { useSessionStoredState } from '../../../hooks/useSessionStoredState';
 import theme, {
   REPO_OWNER_AVATAR_BACKGROUNDS,
   scrollbarSx,
@@ -101,6 +102,12 @@ const COMMIT_STATUS_FILTERS: CommitStatusFilter[] = [
   'open',
   'closed',
 ];
+
+const STATUS_FILTER_STORAGE_KEY = 'liveActivity:statusFilter';
+
+const isCommitStatusFilter = (value: unknown): value is CommitStatusFilter =>
+  typeof value === 'string' &&
+  (COMMIT_STATUS_FILTERS as string[]).includes(value);
 
 const getCommitId = (entry: CommitLogEntry) =>
   `${entry.repository}-${entry.pullRequestNumber}`;
@@ -373,7 +380,11 @@ const LiveCommitLog: React.FC = () => {
   const { data, isLoading, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useInfiniteCommitLog({ refetchInterval: 10000 });
 
-  const [statusFilter, setStatusFilter] = useState<CommitStatusFilter>('all');
+  const [statusFilter, setStatusFilter] = useSessionStoredState<CommitStatusFilter>(
+    STATUS_FILTER_STORAGE_KEY,
+    'all',
+    isCommitStatusFilter,
+  );
   const [logEntries, setLogEntries] = useState<CommitLogEntry[]>([]);
   const [newEntryIds, setNewEntryIds] = useState<Set<string>>(new Set());
   const [, setRelativeTimeTick] = useState(0);


### PR DESCRIPTION
## Summary
Fixes #871
Across several pages, secondary filter and tab selections live in local `useState` and are silently wiped whenever the component unmounts on detail-page navigation. Pressing browser **Back** remounts the source page with default state, forcing users to re-select after every round-trip.

This PR moves the affected state into a shared `sessionStorage`-backed hook so selections survive Back-navigation but still reset between browser sessions (filter state is ephemeral, not a durable preference like view-mode).

## Bug repro (before this PR)

For each location: set a non-default filter/tab → click an item → press browser **Back** → filter/tab resets to its default.

| # | Location | State that resets |
|---|---|---|
| 1 | Dashboard → Live Activity panel | Status filter (`all` / `merged` / `open` / `closed`) |
| 2 | Watchlist → **Repos** tab | Status filter (`all` / `active` / `inactive`) |
| 3 | Watchlist → **PRs** tab | Status filter (`all` / `open` / `merged` / `closed`) |
| 4 | Miner profile → **Open issues** tab → "Mine" + "Others" sections | `mineFilter` and `otherFilter` |
| 5 | Repository page → **Contributors** tab | OSS / Issue Discovery program toggle |
| 6 | Repository page → **Issues** tab | Status filter (`all` / `open` / `closed`) |
| 7 | PR details page | Inner tab (Overview / Files / Comments) |
| 8 | Issue details page | Inner tab (Conversation / Submissions) |

Top-level page tabs (`useSearchParams`-backed) were already correct — this PR only addresses the secondary state inside those pages.

## Changes

- **New shared hook** `src/hooks/useSessionStoredState.ts` — `useState` backed by `sessionStorage` with a type-guard validator, JSON parse error handling, and silent fallback for private mode / quota errors.
- **Persist filter / tab state** at the 8 sites listed above, each with an explicit type guard so stale values from older builds fall back to the default safely.
- **Storage keys** follow the existing `feature:field` convention (e.g. `watchlist:prs:statusFilter`, `repository:issues:filter`).

### Files touched

- `src/hooks/useSessionStoredState.ts` (new)
- `src/pages/dashboard/views/LiveCommitLog.tsx`
- `src/pages/WatchlistPage.tsx`
- `src/components/miners/MinerOpenDiscoveryIssuesByRepo.tsx`
- `src/components/repositories/RepositoryContributorsTable.tsx`
- `src/components/repositories/RepositoryIssuesTable.tsx`
- `src/pages/PRDetailsPage.tsx`
- `src/pages/IssueDetailsPage.tsx`

## Why `sessionStorage` (not `localStorage`)

The existing per-feature persistence helpers (`issuesViewMode.ts`, `repositoriesViewMode.ts`, the inline one in `TopMinersTable.tsx`) use `localStorage` because view-mode is a durable user preference ("I prefer cards"). Filter selections are more ephemeral — `sessionStorage` matches that intent: persists within a session, resets on tab close.

## Test plan

- [ ] **Live Activity** (control case, was already fixed locally): set Merged → click PR → Back → filter stays on Merged.
- [ ] **Watchlist Repos**: set Active → click repo → Back → filter stays on Active.
- [ ] **Watchlist PRs**: set Merged → click PR → Back → filter stays on Merged.
- [ ] **Miner profile / Open issues**: change Mine and Others filters independently → click an issue → Back → both filters retained.
- [ ] **Repository Contributors**: switch to Issue Discovery → click contributor → Back → still on Issue Discovery.
- [ ] **Repository Issues**: set Open → click issue → Back → filter stays on Open.
- [ ] **PR details inner tab**: switch to Files → navigate away → Back → still on Files.
- [ ] **Issue details inner tab**: switch to Submissions → navigate away → Back → still on Submissions.
- [ ] **Session reset**: close the tab and reopen — all filters should be back to defaults (sessionStorage scoping).
- [ ] **Type-check + lint pass**: `npx tsc --noEmit` clean, `npx eslint` clean on touched files.

---

/label ~bug
