### PR TITLE
fix(repository-detail): dedup duplicate issues, lock table min-width, restore Discoveries credibility sort

### DIFF
--- a/src/components/repositories/RepositoryIssuesTable.tsx
+++ b/src/components/repositories/RepositoryIssuesTable.tsx
@@ -23,6 +23,7 @@ import {
   type DataTableColumn,
 } from '../../components/common/DataTable';
 import { formatTokenAmount } from '../../utils/format';
+import { dedupeRepositoryIssues } from '../../utils/dedupeRepositoryIssues';
 import {
   getIssueStatusMeta,
   getBountyAmountColor,
@@ -42,21 +43,27 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
   const { data: bounties } = useRepoIssues(repositoryFullName);
   const [filter, setFilter] = useState<'all' | 'open' | 'closed'>('all');
 
-  const counts = useMemo(() => {
-    if (!issues) return { total: 0, open: 0, closed: 0 };
-    return {
-      total: issues.length,
-      open: issues.filter((issue) => !issue.closedAt).length,
-      closed: issues.filter((issue) => issue.closedAt).length,
-    };
-  }, [issues]);
+  // The API can return the same issue multiple times (multiple miners
+  // independently surfaced it); dedup before rendering so filter counts and
+  // React keys agree with the visible row set.
+  const uniqueIssues = useMemo(() => dedupeRepositoryIssues(issues), [issues]);
+
+  const counts = useMemo(
+    () => ({
+      total: uniqueIssues.length,
+      open: uniqueIssues.filter((issue) => !issue.closedAt).length,
+      closed: uniqueIssues.filter((issue) => issue.closedAt).length,
+    }),
+    [uniqueIssues],
+  );
 
   const filteredIssues = useMemo(() => {
-    if (!issues) return [];
-    if (filter === 'open') return issues.filter((issue) => !issue.closedAt);
-    if (filter === 'closed') return issues.filter((issue) => issue.closedAt);
-    return issues;
-  }, [issues, filter]);
+    if (filter === 'open')
+      return uniqueIssues.filter((issue) => !issue.closedAt);
+    if (filter === 'closed')
+      return uniqueIssues.filter((issue) => issue.closedAt);
+    return uniqueIssues;
+  }, [uniqueIssues, filter]);
 
   const sortedIssues = useMemo(
     () =>
@@ -414,6 +421,7 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
           getRowKey={(issue) => `${issue.number}-${issue.repositoryFullName}`}
           stickyHeader
           size="medium"
+          minWidth={720}
           header={headerToolbar}
           emptyState={
             <Box sx={{ p: 4, textAlign: 'center' }}>

--- a/src/components/repositories/RepositoryPRsTable.tsx
+++ b/src/components/repositories/RepositoryPRsTable.tsx
@@ -349,6 +349,7 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
         getRowKey={(pr) => `${pr.repository}-${pr.pullRequestNumber}`}
         stickyHeader
         size="medium"
+        minWidth={820}
         header={headerToolbar}
         emptyState={
           <Box sx={{ p: 4, textAlign: 'center' }}>

--- a/src/pages/DiscoveriesPage.tsx
+++ b/src/pages/DiscoveriesPage.tsx
@@ -39,6 +39,10 @@ const DiscoveriesPage: React.FC = () => {
       linesDeleted: parseNumber(stat.totalDeletions),
       hotkey: stat.hotkey || 'N/A',
       uniqueReposCount: parseNumber(stat.uniqueReposCount),
+      // OSS credibility surfaces as a sortable column in TopMinersTable; the
+      // discoveries-track score lives on issueCredibility so the column
+      // shouldn't read it.
+      credibility: parseNumber(stat.credibility),
       issueCredibility: parseNumber(stat.issueCredibility),
       isEligible: stat.isIssueEligible ?? false,
       ossIsEligible: stat.isEligible ?? false,

--- a/src/tests/dedupeRepositoryIssues.test.ts
+++ b/src/tests/dedupeRepositoryIssues.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { dedupeRepositoryIssues } from '../utils/dedupeRepositoryIssues';
+import type { RepositoryIssue } from '../api';
+
+const makeIssue = (
+  number: number,
+  overrides: Partial<RepositoryIssue> = {},
+): RepositoryIssue => ({
+  number,
+  repositoryFullName: 'opentensor/btcli',
+  prNumber: null,
+  title: `Issue ${number}`,
+  createdAt: '2026-01-01T00:00:00Z',
+  closedAt: null,
+  ...overrides,
+});
+
+describe('dedupeRepositoryIssues', () => {
+  it('returns an empty array for nullish or empty input', () => {
+    expect(dedupeRepositoryIssues(undefined)).toEqual([]);
+    expect(dedupeRepositoryIssues(null)).toEqual([]);
+    expect(dedupeRepositoryIssues([])).toEqual([]);
+  });
+
+  it('passes through a list with no duplicates unchanged in order', () => {
+    const input = [makeIssue(1), makeIssue(2), makeIssue(3)];
+    const result = dedupeRepositoryIssues(input);
+    expect(result).toHaveLength(3);
+    expect(result.map((i) => i.number)).toEqual([1, 2, 3]);
+  });
+
+  it('keeps the first occurrence of each duplicated issue and preserves order', () => {
+    const first = makeIssue(42, { title: 'first' });
+    const second = makeIssue(42, { title: 'duplicate' });
+    const third = makeIssue(7, { title: 'distinct' });
+    const result = dedupeRepositoryIssues([first, second, third]);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toBe(first);
+    expect(result[0].title).toBe('first');
+    expect(result[1].number).toBe(7);
+  });
+
+  it('treats issues with the same number but different repos as distinct', () => {
+    const a = makeIssue(1, { repositoryFullName: 'foo/bar' });
+    const b = makeIssue(1, { repositoryFullName: 'foo/baz' });
+    const result = dedupeRepositoryIssues([a, b]);
+    expect(result).toHaveLength(2);
+    expect(result.map((i) => i.repositoryFullName)).toEqual([
+      'foo/bar',
+      'foo/baz',
+    ]);
+  });
+
+  it('collapses heavy duplication so counts derived downstream are accurate', () => {
+    const issues: RepositoryIssue[] = [
+      makeIssue(1, { closedAt: null }),
+      makeIssue(1, { closedAt: null }),
+      makeIssue(1, { closedAt: null }),
+      makeIssue(2, { closedAt: '2026-02-01T00:00:00Z' }),
+      makeIssue(2, { closedAt: '2026-02-01T00:00:00Z' }),
+    ];
+    const result = dedupeRepositoryIssues(issues);
+    expect(result).toHaveLength(2);
+    const open = result.filter((i) => !i.closedAt).length;
+    const closed = result.filter((i) => i.closedAt).length;
+    expect(open).toBe(1);
+    expect(closed).toBe(1);
+  });
+});

--- a/src/utils/dedupeRepositoryIssues.ts
+++ b/src/utils/dedupeRepositoryIssues.ts
@@ -1,0 +1,21 @@
+import type { RepositoryIssue } from '../api';
+
+/**
+ * Collapse duplicate `RepositoryIssue` entries — the API can return the same
+ * issue more than once (multiple miners independently surfaced it), and
+ * downstream UI uses the issue identity for both rendering and counts.
+ *
+ * Identity = `${repositoryFullName}#${number}`. The first occurrence wins;
+ * the input order is preserved among the surviving rows.
+ */
+export const dedupeRepositoryIssues = (
+  issues: readonly RepositoryIssue[] | undefined | null,
+): RepositoryIssue[] => {
+  if (!issues || issues.length === 0) return [];
+  const seen = new Map<string, RepositoryIssue>();
+  for (const issue of issues) {
+    const key = `${issue.repositoryFullName}#${issue.number}`;
+    if (!seen.has(key)) seen.set(key, issue);
+  }
+  return Array.from(seen.values());
+};


### PR DESCRIPTION
## Summary

Three fixes from #787 — each affects a different surface but they share a single bug shape: data the UI relied on was unavailable, mismatched, or unbounded, so the user-visible result diverged from the underlying truth.

### 1. Duplicate issues in the Repository detail Issues table (sub-bug #2)

The `useRepositoryIssues` API returns the same issue more than once whenever multiple miners independently surfaced it. `RepositoryIssuesTable` rendered each duplicate as its own row — inflating the **Open** / **Closed** counts in the filter buttons (e.g. `Open 12` when only 7 distinct issues were open) and emitting React duplicate-key warnings.

**Fix:** new `dedupeRepositoryIssues` helper keyed on `${repositoryFullName}#${number}` — first occurrence wins, input order preserved among survivors. The `counts` and `filteredIssues` memos in `RepositoryIssuesTable` now both flow through the deduped list.

### 2. Issues / Pull Requests tables collapse on narrow viewports (sub-bug #3)

`Card` had `'& .MuiTableContainer-root': { overflow: 'auto' }` set on both tables, but neither passed a `minWidth` to `DataTable`, so on viewports ≤ 600 px the columns just shrank until **Created** / **Closed** / **Status** were clipped or hidden — the horizontal scroll never engaged because the table was already as wide as its container.

**Fix:** pass `minWidth={720}` to the issues table and `minWidth={820}` to the PRs table. `DataTable` already plumbs this through to the underlying MUI `<Table>` `sx`, so this is a one-prop wiring, not a new feature.

### 3. Sort by Credibility on the Discoveries leaderboard is a no-op (sub-bug #4)

`TopMinersTable`'s sort comparator reads `(a.credibility ?? 0) - (b.credibility ?? 0)`. `DiscoveriesPage`'s mapping populated only `issueCredibility` — `credibility` was never set, so every miner compared as 0 and the column header click did nothing.

**Fix:** map `credibility: parseNumber(stat.credibility)` alongside the existing `issueCredibility` line, so the OSS-credibility column on the discoveries page sorts identically to how it does on the OSS leaderboard. The two fields stay distinct — `issueCredibility` is still what the discoveries-track gating reads.

### What I didn't fix and why

**Sub-bug #1 (Open/Closed filter case-sensitive)** is not reproducible against current `RepositoryIssuesTable`. The filter today reads `!issue.closedAt` ([RepositoryIssuesTable.tsx:54-58](src/components/repositories/RepositoryIssuesTable.tsx#L54-L58)), not `state === 'CLOSED'`, so the casing of `state` does not affect the filter. Likely fixed in a prior cleanup. If a different surface still uses the case-sensitive comparison, happy to take it as a follow-up — please point at it.

## Tests

- New `src/tests/dedupeRepositoryIssues.test.ts` — 5 cases: nullish/empty input, no duplicates, first-occurrence-wins, cross-repo collisions stay distinct, and a heavy-duplication scenario verifying that downstream open/closed counts agree with the deduped row set.
- Existing 66 tests in `ExplorerUtils.test.ts` and `useWatchedPRs.test.ts` continue to pass.

## Test plan

- [x] `pnpm vitest run` — 71 passed (3 files)
- [x] `pnpm lint` — clean (`--max-warnings 0`)
- [x] `pnpm exec tsc --noEmit` — clean
- [x] Visually verified the Discoveries page Credibility column header click now reorders the table.

Refs #787