### PR TITLE
fix(repository): polish PR/issue tables with title tooltips and isolated body scroll

### DIFF
--- a/src/components/common/ScrollAwareTooltip.tsx
+++ b/src/components/common/ScrollAwareTooltip.tsx
@@ -1,0 +1,25 @@
+import React, { useEffect, useState } from 'react';
+import { Tooltip } from '@mui/material';
+
+/** Tooltip that auto-closes on any scroll so it can't float over scrolled-away anchors (e.g. under a sticky page header). */
+export const ScrollAwareTooltip: React.FC<
+  React.ComponentProps<typeof Tooltip>
+> = ({ children, ...props }) => {
+  const [open, setOpen] = useState(false);
+  useEffect(() => {
+    if (!open) return;
+    const close = () => setOpen(false);
+    window.addEventListener('scroll', close, true);
+    return () => window.removeEventListener('scroll', close, true);
+  }, [open]);
+  return (
+    <Tooltip
+      {...props}
+      open={open}
+      onOpen={() => setOpen(true)}
+      onClose={() => setOpen(false)}
+    >
+      {children}
+    </Tooltip>
+  );
+};

--- a/src/components/repositories/RepositoryIssuesTable.tsx
+++ b/src/components/repositories/RepositoryIssuesTable.tsx
@@ -22,6 +22,7 @@ import {
   DataTable,
   type DataTableColumn,
 } from '../../components/common/DataTable';
+import { ScrollAwareTooltip } from '../../components/common/ScrollAwareTooltip';
 import { formatTokenAmount } from '../../utils/format';
 import {
   getIssueStatusMeta,
@@ -125,16 +126,23 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
       key: 'title',
       header: 'Title',
       renderCell: (issue) => (
-        <Box
-          sx={{
-            maxWidth: '400px',
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
-            whiteSpace: 'nowrap',
-          }}
+        <ScrollAwareTooltip
+          title={issue.title}
+          arrow
+          placement="top-start"
+          enterDelay={200}
         >
-          {issue.title}
-        </Box>
+          <Box
+            sx={{
+              maxWidth: '400px',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {issue.title}
+          </Box>
+        </ScrollAwareTooltip>
       ),
     },
     {
@@ -399,11 +407,36 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
           display: 'flex',
           flexDirection: 'column',
           overflow: 'hidden',
-          // Bounded scroll ancestor for the sticky header inside DataTable.
+          // Restructure so only the body scrolls — the header sits above the
+          // scroll area, so the scrollbar never appears next to the header row.
           '& .MuiTableContainer-root': {
+            overflow: 'visible',
+          },
+          '& .MuiTable-root': {
+            display: 'block',
+          },
+          '& .MuiTableHead-root': {
+            display: 'block',
+            // Reserve space matching the body's scrollbar gutter so columns line up.
+            paddingRight: '8px',
+            backgroundColor: theme.palette.surface.tooltip,
+          },
+          '& .MuiTableHead-root .MuiTableRow-root': {
+            display: 'table',
+            tableLayout: 'fixed',
+            width: '100%',
+          },
+          '& .MuiTableBody-root': {
+            display: 'block',
             maxHeight: '500px',
-            overflow: 'auto',
+            overflowY: 'auto',
+            scrollbarGutter: 'stable',
             ...scrollbarSx,
+          },
+          '& .MuiTableBody-root .MuiTableRow-root': {
+            display: 'table',
+            tableLayout: 'fixed',
+            width: '100%',
           },
         }}
         elevation={0}

--- a/src/components/repositories/RepositoryPRsTable.tsx
+++ b/src/components/repositories/RepositoryPRsTable.tsx
@@ -15,6 +15,7 @@ import {
   DataTable,
   type DataTableColumn,
 } from '../../components/common/DataTable';
+import { ScrollAwareTooltip } from '../../components/common/ScrollAwareTooltip';
 import theme, { TEXT_OPACITY, scrollbarSx } from '../../theme';
 import { filterPrs, getPrStatusCounts, type PrStatusFilter } from '../../utils';
 import FilterButton from '../FilterButton';
@@ -208,16 +209,23 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
       header: 'Title',
       sortKey: 'pullRequestTitle',
       renderCell: (pr) => (
-        <Box
-          sx={{
-            maxWidth: '300px',
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
-            whiteSpace: 'nowrap',
-          }}
+        <ScrollAwareTooltip
+          title={pr.pullRequestTitle}
+          arrow
+          placement="top-start"
+          enterDelay={200}
         >
-          {pr.pullRequestTitle}
-        </Box>
+          <Box
+            sx={{
+              maxWidth: '300px',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {pr.pullRequestTitle}
+          </Box>
+        </ScrollAwareTooltip>
       ),
     },
     {
@@ -229,9 +237,14 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
           <Avatar
             src={`https://avatars.githubusercontent.com/${pr.author}`}
             alt={pr.author}
-            sx={{ width: 20, height: 20 }}
+            sx={{ width: 20, height: 20, flexShrink: 0 }}
           />
-          {pr.author}
+          <Box
+            component="span"
+            sx={{ whiteSpace: 'nowrap', wordBreak: 'keep-all' }}
+          >
+            {pr.author}
+          </Box>
         </Box>
       ),
     },
@@ -334,11 +347,36 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
         display: 'flex',
         flexDirection: 'column',
         overflow: 'hidden',
-        // Bounded scroll ancestor for the sticky header inside DataTable.
+        // Restructure so only the body scrolls — the header sits above the
+        // scroll area, so the scrollbar never appears next to the header row.
         '& .MuiTableContainer-root': {
+          overflow: 'visible',
+        },
+        '& .MuiTable-root': {
+          display: 'block',
+        },
+        '& .MuiTableHead-root': {
+          display: 'block',
+          // Reserve space matching the body's scrollbar gutter so columns line up.
+          paddingRight: '8px',
+          backgroundColor: theme.palette.surface.tooltip,
+        },
+        '& .MuiTableHead-root .MuiTableRow-root': {
+          display: 'table',
+          tableLayout: 'fixed',
+          width: '100%',
+        },
+        '& .MuiTableBody-root': {
+          display: 'block',
           maxHeight: '500px',
-          overflow: 'auto',
+          overflowY: 'auto',
+          scrollbarGutter: 'stable',
           ...scrollbarSx,
+        },
+        '& .MuiTableBody-root .MuiTableRow-root': {
+          display: 'table',
+          tableLayout: 'fixed',
+          width: '100%',
         },
       }}
       elevation={0}


### PR DESCRIPTION
## Summary

- Add hover tooltips for truncated PR and issue titles on the repository details page (above the cell, auto-closing on scroll so they can't float over the sticky page tabs).
- Render PR author names in full on a single line so handles containing hyphens (e.g. `dev-miro26`) no longer wrap or break the row layout.
- Restructure the PRs and Issues tables so only the body scrolls — the column header now stays fixed above the scroll area instead of having the scrollbar run alongside it.

## Related Issues

## Type of Change

- [X] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots
Before:

https://github.com/user-attachments/assets/da9d776d-62ed-4784-881b-713a98a6284b

After:

https://github.com/user-attachments/assets/38af54db-4184-4478-989a-75059c6106ca

Before:
<img width="1925" height="946" alt="Screenshot_1" src="https://github.com/user-attachments/assets/c99f0a9b-53c0-4c9f-ab30-2d01fcca278e" />
After:
<img width="1922" height="944" alt="Screenshot_3" src="https://github.com/user-attachments/assets/a1688b3f-5e6f-44e3-987c-5f55aa8fac83" />
Before:
<img width="1919" height="945" alt="Screenshot_2" src="https://github.com/user-attachments/assets/492713bf-d440-414c-a00d-886fdb2cf395" />
After:
<img width="1922" height="945" alt="Screenshot_4" src="https://github.com/user-attachments/assets/78b163ff-be96-4fbf-acf1-400b648057fe" />

## Checklist

- [ ] New components are modularized/separated where sensible
- [X] Uses predefined theme (e.g. no hardcoded colors)
- [X] Responsive/mobile checked
- [ ] Tested against the test API
- [X] `npm run format` and `npm run lint:fix` have been run
- [X] `npm run build` passes
- [X] Screenshots included for any UI/visual changes
