### PR TITLE
feat(dashboard): redesign Featured Contributors & Discoverers spotlight with centered row layout

### DIFF
--- a/src/pages/dashboard/DashboardPage.tsx
+++ b/src/pages/dashboard/DashboardPage.tsx
@@ -8,6 +8,7 @@ import useDashboardData from './useDashboardData';
 import ActiveNetwork from './views/ActiveNetwork';
 import DashboardFeaturedWorkSection from './views/DashboardFeaturedWork';
 import DashboardTopContributors from './views/DashboardTopContributors';
+import FeaturedDiscoverersSpotlight from './views/FeaturedDiscoverersSpotlight';
 import LiveSidebar from './views/LiveSidebar';
 
 const DashboardFeaturePage: React.FC = () => {
@@ -87,11 +88,9 @@ const DashboardFeaturePage: React.FC = () => {
               viewAllHref="/top-miners"
             />
 
-            <DashboardTopContributors
-              title="Featured Discoverers"
-              contributors={featuredDiscoveryContributors}
+            <FeaturedDiscoverersSpotlight
+              discoverers={featuredDiscoveryContributors}
               isLoading={isLoading}
-              mode="issues"
               viewAllHref="/discoveries"
             />
 

--- a/src/pages/dashboard/DashboardPage.tsx
+++ b/src/pages/dashboard/DashboardPage.tsx
@@ -7,7 +7,7 @@ import { type TrendTimeRange } from './dashboardData';
 import useDashboardData from './useDashboardData';
 import ActiveNetwork from './views/ActiveNetwork';
 import DashboardFeaturedWorkSection from './views/DashboardFeaturedWork';
-import DashboardTopContributors from './views/DashboardTopContributors';
+import FeaturedContributorsSpotlight from './views/FeaturedContributorsSpotlight';
 import FeaturedDiscoverersSpotlight from './views/FeaturedDiscoverersSpotlight';
 import LiveSidebar from './views/LiveSidebar';
 
@@ -82,7 +82,7 @@ const DashboardFeaturePage: React.FC = () => {
               onRangeChange={setRange}
             />
 
-            <DashboardTopContributors
+            <FeaturedContributorsSpotlight
               contributors={featuredContributors}
               isLoading={isLoading}
               viewAllHref="/top-miners"

--- a/src/pages/dashboard/dashboardData.ts
+++ b/src/pages/dashboard/dashboardData.ts
@@ -68,6 +68,9 @@ export interface DashboardFeaturedContributor {
   credibility?: number;
   /** Segments for the credibility donut (e.g. Merged/Open/Closed). */
   segments?: Array<{ label: string; value: number }>;
+  score?: number;
+  solvedIssues?: number;
+  earnings?: { usdPerDay: number; lifetimeUsd: number };
 }
 
 type FeaturedWorkStatusTone = 'merged' | 'open' | 'closed';
@@ -932,6 +935,12 @@ const pickTopDiscoveryMiner = (
     githubId: top.githubId,
     githubUsername: top.githubUsername,
     name: top.githubUsername ?? top.githubId,
+    score: Math.round(parseNumber(top.issueDiscoveryScore)),
+    solvedIssues: top.totalValidSolvedIssues ?? 0,
+    earnings: {
+      usdPerDay: top.usdPerDay ?? 0,
+      lifetimeUsd: top.lifetimeUsd ?? 0,
+    },
     metrics: [
       {
         value: Math.round(
@@ -980,6 +989,12 @@ const pickMostSolvedIssuesMiner = (
     githubId: top.githubId,
     githubUsername: top.githubUsername,
     name: top.githubUsername ?? top.githubId,
+    score: Math.round(parseNumber(top.issueDiscoveryScore)),
+    solvedIssues: top.totalValidSolvedIssues ?? 0,
+    earnings: {
+      usdPerDay: top.usdPerDay ?? 0,
+      lifetimeUsd: top.lifetimeUsd ?? 0,
+    },
     metrics: [
       {
         value: `${top.totalValidSolvedIssues ?? 0}`,
@@ -1023,6 +1038,12 @@ const pickHighestIssueTokenScoreMiner = (
     githubId: top.githubId,
     githubUsername: top.githubUsername,
     name: top.githubUsername ?? top.githubId,
+    score: Math.round(parseNumber(top.issueTokenScore)),
+    solvedIssues: top.totalValidSolvedIssues ?? 0,
+    earnings: {
+      usdPerDay: top.usdPerDay ?? 0,
+      lifetimeUsd: top.lifetimeUsd ?? 0,
+    },
     metrics: [
       {
         value: Math.round(parseNumber(top.issueTokenScore)).toLocaleString(),

--- a/src/pages/dashboard/dashboardData.ts
+++ b/src/pages/dashboard/dashboardData.ts
@@ -69,6 +69,8 @@ export interface DashboardFeaturedContributor {
   /** Segments for the credibility donut (e.g. Merged/Open/Closed). */
   segments?: Array<{ label: string; value: number }>;
   score?: number;
+  mergedPrs?: number;
+  closedPrs?: number;
   solvedIssues?: number;
   earnings?: { usdPerDay: number; lifetimeUsd: number };
 }
@@ -647,16 +649,21 @@ const getHighestScoringMergedAuthor = (
   if (!topPr?.githubId) return undefined;
 
   const miner = miners.find((m) => m.githubId === topPr.githubId);
+  const prScore = Math.round(parseNumber(topPr.score));
   return {
     githubId: topPr.githubId,
     githubUsername: topPr.author || undefined,
     featuredLabel: 'Highest-Scoring PR Author',
     name: topPr.author ?? topPr.githubId,
+    score: prScore,
+    mergedPrs: miner?.totalMergedPrs ?? 0,
+    closedPrs: miner?.totalClosedPrs ?? 0,
+    earnings: {
+      usdPerDay: miner?.usdPerDay ?? 0,
+      lifetimeUsd: miner?.lifetimeUsd ?? 0,
+    },
     metrics: [
-      {
-        value: Math.round(parseNumber(topPr.score)).toLocaleString(),
-        unit: 'Score',
-      },
+      { value: prScore.toLocaleString(), unit: 'Score' },
       ...optionalCredibilityMetrics(miner?.credibility),
     ],
     repos: topPr.repository ? [topPr.repository] : [],
@@ -697,6 +704,13 @@ const pickTopOssContributor = (
     githubId: topOssMiner.githubId,
     githubUsername: topOssMiner.githubUsername,
     name: topOssMiner.githubUsername ?? topOssMiner.githubId,
+    score: Math.round(parseNumber(topOssMiner.totalScore)),
+    mergedPrs: topOssMiner.totalMergedPrs ?? 0,
+    closedPrs: topOssMiner.totalClosedPrs ?? 0,
+    earnings: {
+      usdPerDay: topOssMiner.usdPerDay ?? 0,
+      lifetimeUsd: topOssMiner.lifetimeUsd ?? 0,
+    },
     metrics: [
       {
         value: Math.round(parseNumber(topOssMiner.totalScore)).toLocaleString(),
@@ -735,6 +749,13 @@ const pickMostMergedPrMiner = (
     githubId: mostMergedPrMiner.githubId,
     githubUsername: mostMergedPrMiner.githubUsername,
     name: mostMergedPrMiner.githubUsername ?? mostMergedPrMiner.githubId,
+    score: Math.round(parseNumber(mostMergedPrMiner.totalScore)),
+    mergedPrs: mostMergedPrMiner.totalMergedPrs ?? 0,
+    closedPrs: mostMergedPrMiner.totalClosedPrs ?? 0,
+    earnings: {
+      usdPerDay: mostMergedPrMiner.usdPerDay ?? 0,
+      lifetimeUsd: mostMergedPrMiner.lifetimeUsd ?? 0,
+    },
     metrics: [
       {
         value: `${mostMergedPrMiner.totalMergedPrs ?? 0}`,

--- a/src/pages/dashboard/dashboardData.ts
+++ b/src/pages/dashboard/dashboardData.ts
@@ -932,7 +932,6 @@ export const buildFeaturedWork = (
 };
 
 const pickTopDiscoveryMiner = (
-  prs: CommitLog[],
   miners: MinerEvaluation[],
   exclude: Set<string> = new Set(),
 ): DashboardFeaturedContributor | undefined => {
@@ -971,7 +970,7 @@ const pickTopDiscoveryMiner = (
       },
       ...optionalCredibilityMetrics(top.issueCredibility),
     ],
-    repos: getTopContributorRepos(prs, top.githubId),
+    repos: [],
     usdPerDay: parseNumber(top.usdPerDay),
     credibility: parseNumber(top.issueCredibility),
     segments: [
@@ -983,7 +982,6 @@ const pickTopDiscoveryMiner = (
 };
 
 const pickMostSolvedIssuesMiner = (
-  prs: CommitLog[],
   miners: MinerEvaluation[],
   exclude: Set<string> = new Set(),
 ): DashboardFeaturedContributor | undefined => {
@@ -1023,7 +1021,7 @@ const pickMostSolvedIssuesMiner = (
       },
       ...optionalCredibilityMetrics(top.issueCredibility),
     ],
-    repos: getTopContributorRepos(prs, top.githubId),
+    repos: [],
     usdPerDay: parseNumber(top.usdPerDay),
     credibility: parseNumber(top.issueCredibility),
     segments: [
@@ -1035,7 +1033,6 @@ const pickMostSolvedIssuesMiner = (
 };
 
 const pickHighestIssueTokenScoreMiner = (
-  prs: CommitLog[],
   miners: MinerEvaluation[],
   exclude: Set<string> = new Set(),
 ): DashboardFeaturedContributor | undefined => {
@@ -1072,7 +1069,7 @@ const pickHighestIssueTokenScoreMiner = (
       },
       ...optionalCredibilityMetrics(top.issueCredibility),
     ],
-    repos: getTopContributorRepos(prs, top.githubId),
+    repos: [],
     usdPerDay: parseNumber(top.usdPerDay),
     credibility: parseNumber(top.issueCredibility),
     segments: [
@@ -1084,15 +1081,14 @@ const pickHighestIssueTokenScoreMiner = (
 };
 
 export const buildFeaturedDiscoveryContributors = (
-  prs: CommitLog[],
   miners: MinerEvaluation[],
 ): DashboardFeaturedContributor[] => {
   const seen = new Set<string>();
   const contributors: DashboardFeaturedContributor[] = [];
   const pickers: Array<() => DashboardFeaturedContributor | undefined> = [
-    () => pickTopDiscoveryMiner(prs, miners, seen),
-    () => pickMostSolvedIssuesMiner(prs, miners, seen),
-    () => pickHighestIssueTokenScoreMiner(prs, miners, seen),
+    () => pickTopDiscoveryMiner(miners, seen),
+    () => pickMostSolvedIssuesMiner(miners, seen),
+    () => pickHighestIssueTokenScoreMiner(miners, seen),
   ];
   for (const pick of pickers) {
     const c = pick();

--- a/src/pages/dashboard/useDashboardData.ts
+++ b/src/pages/dashboard/useDashboardData.ts
@@ -12,6 +12,7 @@ import {
   useAllMiners,
   useAllPrs,
   useIssues,
+  useMinersIssues,
   useReposAndWeights,
 } from '../../api';
 import {
@@ -84,14 +85,43 @@ export const useDashboardData = (range: TrendTimeRange) => {
     [datasets.miners.data, datasets.prs.data],
   );
 
-  const featuredDiscoveryContributors = useMemo(
-    () =>
-      buildFeaturedDiscoveryContributors(
-        datasets.prs.data,
-        datasets.miners.data,
-      ),
-    [datasets.miners.data, datasets.prs.data],
+  // Step 1: pick featured discoverers (repos populated from mirror API below)
+  const discovererCandidates = useMemo(
+    () => buildFeaturedDiscoveryContributors(datasets.miners.data),
+    [datasets.miners.data],
   );
+
+  // Step 2: fan-out per-miner issues from mirror API to get real issue repos
+  const discovererIds = useMemo(
+    () => discovererCandidates.map((d) => d.githubId),
+    [discovererCandidates],
+  );
+  const discovererIssueQueries = useMinersIssues(
+    discovererIds,
+    discovererIds.length > 0,
+  );
+
+  // Step 3: attach repos from MinerIssue.repo_full_name (authoritative source)
+  const featuredDiscoveryContributors = useMemo(() => {
+    return discovererCandidates.map((d, i) => {
+      const minerIssues = discovererIssueQueries[i]?.data ?? [];
+      if (minerIssues.length === 0) return d;
+      const repoCounts = new Map<string, number>();
+      for (const issue of minerIssues) {
+        if (issue.repo_full_name) {
+          repoCounts.set(
+            issue.repo_full_name,
+            (repoCounts.get(issue.repo_full_name) ?? 0) + 1,
+          );
+        }
+      }
+      const repos = [...repoCounts.entries()]
+        .sort((a, b) => b[1] - a[1])
+        .slice(0, 3)
+        .map(([repo]) => repo);
+      return { ...d, repos };
+    });
+  }, [discovererCandidates, discovererIssueQueries]);
 
   const featuredWork = useMemo(
     () => buildFeaturedWork(datasets.prs.data, datasets.repos.data),

--- a/src/pages/dashboard/views/FeaturedContributorsSpotlight.tsx
+++ b/src/pages/dashboard/views/FeaturedContributorsSpotlight.tsx
@@ -4,6 +4,7 @@ import { alpha, useTheme } from '@mui/material/styles';
 import { useNavigate } from 'react-router-dom';
 import { RANK_COLORS } from '../../../theme';
 import { getGithubAvatarSrc } from '../../../utils';
+import { credibilityColor } from '../../../utils/format';
 import { type DashboardFeaturedContributor } from '../dashboardData';
 
 const FONTS = { mono: '"JetBrains Mono", ui-monospace, monospace' } as const;
@@ -74,23 +75,23 @@ const KpiBox: React.FC<{
 };
 
 interface Props {
-  discoverers: DashboardFeaturedContributor[];
+  contributors: DashboardFeaturedContributor[];
   isLoading?: boolean;
   viewAllHref?: string;
 }
 
-const DiscovererCard: React.FC<{
-  d: DashboardFeaturedContributor;
+const ContributorCard: React.FC<{
+  c: DashboardFeaturedContributor;
   rank: number;
   onClick: () => void;
   maxScore: number;
-  maxSolved: number;
-}> = ({ d, rank, onClick, maxScore, maxSolved }) => {
+  maxMerged: number;
+}> = ({ c, rank, onClick, maxScore, maxMerged }) => {
   const theme = useTheme();
   const accent = ACCENT[rank] ?? theme.palette.text.primary;
-  const avatarUsername = d.githubUsername ?? d.githubId;
-  const cred = d.credibility ?? 0;
-  const earn = d.earnings?.usdPerDay ?? 0;
+  const avatarUsername = c.githubUsername ?? c.githubId;
+  const cred = c.credibility ?? 0;
+  const earn = c.earnings?.usdPerDay ?? 0;
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
@@ -104,9 +105,9 @@ const DiscovererCard: React.FC<{
 
   const repoPills = useMemo(
     () =>
-      d.repos.slice(0, 3).map((repo, idx) => (
+      c.repos.slice(0, 3).map((repo, idx) => (
         <Box
-          key={`${d.githubId}-${repo}`}
+          key={`${c.githubId}-${repo}`}
           sx={{
             ...mono,
             fontSize: '0.58rem',
@@ -120,12 +121,12 @@ const DiscovererCard: React.FC<{
             whiteSpace: 'nowrap',
           }}
         >
-          {idx === 2 && d.repos.length > 3
-            ? `+${d.repos.length - 2}`
+          {idx === 2 && c.repos.length > 3
+            ? `+${c.repos.length - 2}`
             : repo.split('/').pop() || repo}
         </Box>
       )),
-    [d.repos, d.githubId, theme],
+    [c.repos, c.githubId, theme],
   );
 
   return (
@@ -160,14 +161,26 @@ const DiscovererCard: React.FC<{
       {/* Left: rank + avatar + identity */}
       <Box sx={{ display: 'flex', alignItems: 'center', gap: { xs: 1, sm: 1.5 }, minWidth: 0 }}>
         <Typography
-          sx={{ ...mono, fontSize: '0.7rem', fontWeight: 700, color: accent, width: 22, flexShrink: 0 }}
+          sx={{
+            ...mono,
+            fontSize: '0.7rem',
+            fontWeight: 700,
+            color: accent,
+            width: 22,
+            flexShrink: 0,
+          }}
         >
           #{rank + 1}
         </Typography>
         <Avatar
           src={getGithubAvatarSrc(avatarUsername)}
           alt={avatarUsername}
-          sx={{ width: 36, height: 36, border: `1.5px solid ${alpha(theme.palette.common.white, 0.14)}`, flexShrink: 0 }}
+          sx={{
+            width: 36,
+            height: 36,
+            border: `1.5px solid ${alpha(theme.palette.common.white, 0.14)}`,
+            flexShrink: 0,
+          }}
         />
         <Box sx={{ minWidth: 0 }}>
           <Typography
@@ -182,10 +195,18 @@ const DiscovererCard: React.FC<{
               mb: 0.2,
             }}
           >
-            {d.name}
+            {c.name}
           </Typography>
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.45, minWidth: 0 }}>
-            <Box sx={{ width: 5, height: 5, borderRadius: '50%', backgroundColor: accent, flexShrink: 0 }} />
+            <Box
+              sx={{
+                width: 5,
+                height: 5,
+                borderRadius: '50%',
+                backgroundColor: accent,
+                flexShrink: 0,
+              }}
+            />
             <Typography
               sx={{
                 ...mono,
@@ -197,9 +218,12 @@ const DiscovererCard: React.FC<{
                 textOverflow: 'ellipsis',
               }}
             >
-              {d.featuredLabel}
+              {c.featuredLabel}
               {earn > 0 && (
-                <Box component="span" sx={{ color: theme.palette.status.success, ml: 0.5 }}>
+                <Box
+                  component="span"
+                  sx={{ color: theme.palette.status.success, ml: 0.5 }}
+                >
                   ${Math.round(earn)}/d
                 </Box>
               )}
@@ -220,32 +244,54 @@ const DiscovererCard: React.FC<{
               backgroundColor: alpha(accent, 0.07),
             }}
           >
-            <Typography sx={{ ...mono, fontSize: '1.05rem', fontWeight: 800, color: accent, lineHeight: 1 }}>
-              {(d.score ?? 0).toLocaleString()}
+            <Typography
+              sx={{ ...mono, fontSize: '1.05rem', fontWeight: 800, color: accent, lineHeight: 1 }}
+            >
+              {(c.score ?? 0).toLocaleString()}
             </Typography>
-            <Typography sx={{ ...mono, fontSize: '0.48rem', color: alpha(theme.palette.text.primary, 0.35), mt: 0.15 }}>
-              discovery score
+            <Typography
+              sx={{ ...mono, fontSize: '0.48rem', color: alpha(theme.palette.text.primary, 0.35), mt: 0.15 }}
+            >
+              contributor score
             </Typography>
           </Box>
           <Box>
-            <Typography sx={{ ...mono, fontSize: '1.05rem', fontWeight: 800, color: theme.palette.text.primary, lineHeight: 1 }}>
-              {d.solvedIssues ?? 0}
+            <Typography
+              sx={{ ...mono, fontSize: '1.05rem', fontWeight: 800, color: theme.palette.text.primary, lineHeight: 1 }}
+            >
+              {c.mergedPrs ?? 0}
             </Typography>
-            <Typography sx={{ ...mono, fontSize: '0.48rem', color: alpha(theme.palette.text.primary, 0.35), mt: 0.15 }}>
-              solved issues
+            <Typography
+              sx={{ ...mono, fontSize: '0.48rem', color: alpha(theme.palette.text.primary, 0.35), mt: 0.15 }}
+            >
+              merged PRs
             </Typography>
           </Box>
         </Box>
         {cred > 0 && (
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
             <Box
-              sx={{ flex: 1, height: 3, borderRadius: 99, backgroundColor: alpha(theme.palette.common.white, 0.07), overflow: 'hidden' }}
+              sx={{
+                flex: 1,
+                height: 3,
+                borderRadius: 99,
+                backgroundColor: alpha(theme.palette.common.white, 0.07),
+                overflow: 'hidden',
+              }}
             >
               <Box
-                sx={{ width: `${Math.round(cred * 100)}%`, height: '100%', borderRadius: 99, backgroundColor: accent, transition: 'width 0.5s ease' }}
+                sx={{
+                  width: `${Math.round(cred * 100)}%`,
+                  height: '100%',
+                  borderRadius: 99,
+                  backgroundColor: accent,
+                  transition: 'width 0.5s ease',
+                }}
               />
             </Box>
-            <Typography sx={{ ...mono, fontSize: '0.52rem', color: alpha(theme.palette.text.primary, 0.38), whiteSpace: 'nowrap' }}>
+            <Typography
+              sx={{ ...mono, fontSize: '0.52rem', color: alpha(theme.palette.text.primary, 0.38), whiteSpace: 'nowrap' }}
+            >
               {Math.round(cred * 100)}% cred
             </Typography>
           </Box>
@@ -259,7 +305,9 @@ const DiscovererCard: React.FC<{
             {repoPills}
           </Box>
         )}
-        <Typography sx={{ ...mono, fontSize: '0.72rem', color: alpha(theme.palette.text.primary, 0.2), flexShrink: 0 }}>
+        <Typography
+          sx={{ ...mono, fontSize: '0.72rem', color: alpha(theme.palette.text.primary, 0.2), flexShrink: 0 }}
+        >
           →
         </Typography>
       </Box>
@@ -267,8 +315,8 @@ const DiscovererCard: React.FC<{
   );
 };
 
-const FeaturedDiscoverersSpotlight: React.FC<Props> = ({
-  discoverers,
+const FeaturedContributorsSpotlight: React.FC<Props> = ({
+  contributors,
   isLoading = false,
   viewAllHref,
 }) => {
@@ -277,32 +325,32 @@ const FeaturedDiscoverersSpotlight: React.FC<Props> = ({
 
   const open = useCallback(
     (githubId: string) =>
-      navigate(
-        `/miners/details?githubId=${encodeURIComponent(githubId)}&mode=issues`,
-        { state: { backTo: '/dashboard' } },
-      ),
+      navigate(`/miners/details?githubId=${encodeURIComponent(githubId)}`, {
+        state: { backTo: '/dashboard' },
+      }),
     [navigate],
   );
 
   const kpis = useMemo(() => {
-    if (discoverers.length === 0) return null;
-    const topScore = Math.max(...discoverers.map((d) => d.score ?? 0));
-    const totalSolved = discoverers.reduce((s, d) => s + (d.solvedIssues ?? 0), 0);
-    const uniqueRepos = new Set(discoverers.flatMap((d) => d.repos)).size;
-    const totalEarnings = discoverers.reduce(
-      (s, d) => s + (d.earnings?.usdPerDay ?? 0),
+    if (contributors.length === 0) return null;
+    const topScore = Math.max(...contributors.map((c) => c.score ?? 0));
+    const totalMerged = contributors.reduce((s, c) => s + (c.mergedPrs ?? 0), 0);
+    const totalClosed = contributors.reduce((s, c) => s + (c.closedPrs ?? 0), 0);
+    const uniqueRepos = new Set(contributors.flatMap((c) => c.repos)).size;
+    const totalEarnings = contributors.reduce(
+      (s, c) => s + (c.earnings?.usdPerDay ?? 0),
       0,
     );
-    return { topScore, totalSolved, uniqueRepos, totalEarnings };
-  }, [discoverers]);
+    return { topScore, totalMerged, totalClosed, uniqueRepos, totalEarnings };
+  }, [contributors]);
 
   const maxScore = useMemo(
-    () => Math.max(...discoverers.map((d) => d.score ?? 0), 1),
-    [discoverers],
+    () => Math.max(...contributors.map((c) => c.score ?? 0), 1),
+    [contributors],
   );
-  const maxSolved = useMemo(
-    () => Math.max(...discoverers.map((d) => d.solvedIssues ?? 0), 1),
-    [discoverers],
+  const maxMerged = useMemo(
+    () => Math.max(...contributors.map((c) => c.mergedPrs ?? 0), 1),
+    [contributors],
   );
 
   return (
@@ -334,7 +382,7 @@ const FeaturedDiscoverersSpotlight: React.FC<Props> = ({
               color: theme.palette.text.primary,
             }}
           >
-            Featured Discoverers
+            Featured Contributors
           </Typography>
           <Box
             sx={{
@@ -343,16 +391,16 @@ const FeaturedDiscoverersSpotlight: React.FC<Props> = ({
               fontWeight: 700,
               textTransform: 'uppercase',
               letterSpacing: '0.06em',
-              color: RANK_COLORS.first,
-              backgroundColor: alpha(RANK_COLORS.first, 0.1),
-              border: `1px solid ${alpha(RANK_COLORS.first, 0.22)}`,
+              color: theme.palette.status.success,
+              backgroundColor: alpha(theme.palette.status.success, 0.1),
+              border: `1px solid ${alpha(theme.palette.status.success, 0.22)}`,
               borderRadius: 99,
               px: 0.8,
               py: 0.22,
               whiteSpace: 'nowrap',
             }}
           >
-            Issues 35d
+            OSS 35d
           </Box>
         </Box>
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
@@ -391,7 +439,7 @@ const FeaturedDiscoverersSpotlight: React.FC<Props> = ({
           mb: 1.25,
         }}
       >
-        Issue discovery leaders by score, solved issues output, and repository impact.
+        OSS contribution leaders by score, merged PR output, and repository impact.
       </Typography>
 
       {/* KPI strip */}
@@ -409,18 +457,18 @@ const FeaturedDiscoverersSpotlight: React.FC<Props> = ({
           <KpiBox
             title="Highlighted score"
             value={kpis.topScore.toLocaleString()}
-            sub={`${discoverers.length} discoverers`}
-            accentColor={RANK_COLORS.first}
+            sub={`${contributors.length} miners`}
+            accentColor={theme.palette.status.success}
           />
           <KpiBox
-            title="Solved Issues"
-            value={kpis.totalSolved.toLocaleString()}
+            title="Merged PRs"
+            value={kpis.totalMerged.toLocaleString()}
             sub="all time"
           />
           <KpiBox
-            title="Active Discoverers"
-            value={String(discoverers.length)}
-            sub="this period"
+            title="Closed PRs"
+            value={kpis.totalClosed.toLocaleString()}
+            sub="reviewed work"
           />
           <KpiBox
             title="Repos touched"
@@ -448,20 +496,20 @@ const FeaturedDiscoverersSpotlight: React.FC<Props> = ({
         >
           <CircularProgress size={28} />
         </Box>
-      ) : discoverers.length === 0 ? (
+      ) : contributors.length === 0 ? (
         <Typography sx={{ color: 'text.secondary', fontSize: '0.8rem' }}>
-          No discoverer highlights available.
+          No contributor highlights available.
         </Typography>
       ) : (
         <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.6 }}>
-          {discoverers.map((d, i) => (
-            <DiscovererCard
-              key={`${d.featuredLabel}-${d.githubId}`}
-              d={d}
+          {contributors.map((c, i) => (
+            <ContributorCard
+              key={`${c.featuredLabel}-${c.githubId}`}
+              c={c}
               rank={i}
-              onClick={() => open(d.githubId)}
+              onClick={() => open(c.githubId)}
               maxScore={maxScore}
-              maxSolved={maxSolved}
+              maxMerged={maxMerged}
             />
           ))}
         </Box>
@@ -470,4 +518,4 @@ const FeaturedDiscoverersSpotlight: React.FC<Props> = ({
   );
 };
 
-export default FeaturedDiscoverersSpotlight;
+export default FeaturedContributorsSpotlight;

--- a/src/pages/dashboard/views/FeaturedContributorsSpotlight.tsx
+++ b/src/pages/dashboard/views/FeaturedContributorsSpotlight.tsx
@@ -155,7 +155,14 @@ const ContributorCard: React.FC<{
       }}
     >
       {/* Left: rank + avatar + identity */}
-      <Box sx={{ display: 'flex', alignItems: 'center', gap: { xs: 1, sm: 1.5 }, minWidth: 0 }}>
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: { xs: 1, sm: 1.5 },
+          minWidth: 0,
+        }}
+      >
         <Typography
           sx={{
             ...mono,
@@ -193,7 +200,14 @@ const ContributorCard: React.FC<{
           >
             {c.name}
           </Typography>
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.45, minWidth: 0 }}>
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 0.45,
+              minWidth: 0,
+            }}
+          >
             <Box
               sx={{
                 width: 5,
@@ -229,8 +243,21 @@ const ContributorCard: React.FC<{
       </Box>
 
       {/* Center: stats + cred */}
-      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.55, minWidth: { xs: 130, sm: 190, md: 210 } }}>
-        <Box sx={{ display: 'flex', gap: { xs: 1.5, sm: 2 }, alignItems: 'flex-end' }}>
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 0.55,
+          minWidth: { xs: 130, sm: 190, md: 210 },
+        }}
+      >
+        <Box
+          sx={{
+            display: 'flex',
+            gap: { xs: 1.5, sm: 2 },
+            alignItems: 'flex-end',
+          }}
+        >
           <Box
             sx={{
               px: 0.7,
@@ -241,24 +268,46 @@ const ContributorCard: React.FC<{
             }}
           >
             <Typography
-              sx={{ ...mono, fontSize: '1.05rem', fontWeight: 800, color: accent, lineHeight: 1 }}
+              sx={{
+                ...mono,
+                fontSize: '1.05rem',
+                fontWeight: 800,
+                color: accent,
+                lineHeight: 1,
+              }}
             >
               {(c.score ?? 0).toLocaleString()}
             </Typography>
             <Typography
-              sx={{ ...mono, fontSize: '0.48rem', color: alpha(theme.palette.text.primary, 0.35), mt: 0.15 }}
+              sx={{
+                ...mono,
+                fontSize: '0.48rem',
+                color: alpha(theme.palette.text.primary, 0.35),
+                mt: 0.15,
+              }}
             >
               contributor score
             </Typography>
           </Box>
           <Box>
             <Typography
-              sx={{ ...mono, fontSize: '1.05rem', fontWeight: 800, color: theme.palette.text.primary, lineHeight: 1 }}
+              sx={{
+                ...mono,
+                fontSize: '1.05rem',
+                fontWeight: 800,
+                color: theme.palette.text.primary,
+                lineHeight: 1,
+              }}
             >
               {c.mergedPrs ?? 0}
             </Typography>
             <Typography
-              sx={{ ...mono, fontSize: '0.48rem', color: alpha(theme.palette.text.primary, 0.35), mt: 0.15 }}
+              sx={{
+                ...mono,
+                fontSize: '0.48rem',
+                color: alpha(theme.palette.text.primary, 0.35),
+                mt: 0.15,
+              }}
             >
               merged PRs
             </Typography>
@@ -286,7 +335,12 @@ const ContributorCard: React.FC<{
               />
             </Box>
             <Typography
-              sx={{ ...mono, fontSize: '0.52rem', color: alpha(theme.palette.text.primary, 0.38), whiteSpace: 'nowrap' }}
+              sx={{
+                ...mono,
+                fontSize: '0.52rem',
+                color: alpha(theme.palette.text.primary, 0.38),
+                whiteSpace: 'nowrap',
+              }}
             >
               {Math.round(cred * 100)}% cred
             </Typography>
@@ -295,14 +349,26 @@ const ContributorCard: React.FC<{
       </Box>
 
       {/* Right: repo pills + arrow */}
-      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'flex-end', gap: 0.4 }}>
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'flex-end',
+          gap: 0.4,
+        }}
+      >
         {repoPills.length > 0 && (
           <Box sx={{ display: { xs: 'none', md: 'flex' }, gap: 0.4 }}>
             {repoPills}
           </Box>
         )}
         <Typography
-          sx={{ ...mono, fontSize: '0.72rem', color: alpha(theme.palette.text.primary, 0.2), flexShrink: 0 }}
+          sx={{
+            ...mono,
+            fontSize: '0.72rem',
+            color: alpha(theme.palette.text.primary, 0.2),
+            flexShrink: 0,
+          }}
         >
           →
         </Typography>
@@ -330,8 +396,14 @@ const FeaturedContributorsSpotlight: React.FC<Props> = ({
   const kpis = useMemo(() => {
     if (contributors.length === 0) return null;
     const topScore = Math.max(...contributors.map((c) => c.score ?? 0));
-    const totalMerged = contributors.reduce((s, c) => s + (c.mergedPrs ?? 0), 0);
-    const totalClosed = contributors.reduce((s, c) => s + (c.closedPrs ?? 0), 0);
+    const totalMerged = contributors.reduce(
+      (s, c) => s + (c.mergedPrs ?? 0),
+      0,
+    );
+    const totalClosed = contributors.reduce(
+      (s, c) => s + (c.closedPrs ?? 0),
+      0,
+    );
     const uniqueRepos = new Set(contributors.flatMap((c) => c.repos)).size;
     const totalEarnings = contributors.reduce(
       (s, c) => s + (c.earnings?.usdPerDay ?? 0),
@@ -339,7 +411,6 @@ const FeaturedContributorsSpotlight: React.FC<Props> = ({
     );
     return { topScore, totalMerged, totalClosed, uniqueRepos, totalEarnings };
   }, [contributors]);
-
 
   return (
     <Box
@@ -361,7 +432,14 @@ const FeaturedContributorsSpotlight: React.FC<Props> = ({
           mb: 0.4,
         }}
       >
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 1,
+            flexWrap: 'wrap',
+          }}
+        >
           <Typography
             sx={{
               ...mono,
@@ -427,7 +505,8 @@ const FeaturedContributorsSpotlight: React.FC<Props> = ({
           mb: 1.25,
         }}
       >
-        OSS contribution leaders by score, merged PR output, and repository impact.
+        OSS contribution leaders by score, merged PR output, and repository
+        impact.
       </Typography>
 
       {/* KPI strip */}

--- a/src/pages/dashboard/views/FeaturedContributorsSpotlight.tsx
+++ b/src/pages/dashboard/views/FeaturedContributorsSpotlight.tsx
@@ -470,7 +470,15 @@ const FeaturedContributorsSpotlight: React.FC<Props> = ({
             OSS 35d
           </Box>
         </Box>
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 1,
+            flex: 1,
+            justifyContent: 'flex-end',
+          }}
+        >
           <Typography
             sx={{
               ...mono,

--- a/src/pages/dashboard/views/FeaturedContributorsSpotlight.tsx
+++ b/src/pages/dashboard/views/FeaturedContributorsSpotlight.tsx
@@ -21,7 +21,8 @@ const KpiBox: React.FC<{
   return (
     <Box
       sx={{
-        flexShrink: 0,
+        flex: 1,
+        minWidth: 'max-content',
         px: { xs: 1, sm: 1.5 },
         py: 0.85,
         borderRight: isLast

--- a/src/pages/dashboard/views/FeaturedContributorsSpotlight.tsx
+++ b/src/pages/dashboard/views/FeaturedContributorsSpotlight.tsx
@@ -4,7 +4,6 @@ import { alpha, useTheme } from '@mui/material/styles';
 import { useNavigate } from 'react-router-dom';
 import { RANK_COLORS } from '../../../theme';
 import { getGithubAvatarSrc } from '../../../utils';
-import { credibilityColor } from '../../../utils/format';
 import { type DashboardFeaturedContributor } from '../dashboardData';
 
 const FONTS = { mono: '"JetBrains Mono", ui-monospace, monospace' } as const;
@@ -22,8 +21,7 @@ const KpiBox: React.FC<{
   return (
     <Box
       sx={{
-        flex: 1,
-        minWidth: 0,
+        flexShrink: 0,
         px: { xs: 1, sm: 1.5 },
         py: 0.85,
         borderRight: isLast
@@ -84,9 +82,7 @@ const ContributorCard: React.FC<{
   c: DashboardFeaturedContributor;
   rank: number;
   onClick: () => void;
-  maxScore: number;
-  maxMerged: number;
-}> = ({ c, rank, onClick, maxScore, maxMerged }) => {
+}> = ({ c, rank, onClick }) => {
   const theme = useTheme();
   const accent = ACCENT[rank] ?? theme.palette.text.primary;
   const avatarUsername = c.githubUsername ?? c.githubId;
@@ -137,7 +133,7 @@ const ContributorCard: React.FC<{
       onKeyDown={handleKeyDown}
       sx={{
         display: 'grid',
-        gridTemplateColumns: '1fr auto 1fr',
+        gridTemplateColumns: { xs: '1fr auto auto', sm: '1fr auto 1fr' },
         alignItems: 'center',
         columnGap: { xs: 1, sm: 1.5 },
         px: 1.25,
@@ -344,14 +340,6 @@ const FeaturedContributorsSpotlight: React.FC<Props> = ({
     return { topScore, totalMerged, totalClosed, uniqueRepos, totalEarnings };
   }, [contributors]);
 
-  const maxScore = useMemo(
-    () => Math.max(...contributors.map((c) => c.score ?? 0), 1),
-    [contributors],
-  );
-  const maxMerged = useMemo(
-    () => Math.max(...contributors.map((c) => c.mergedPrs ?? 0), 1),
-    [contributors],
-  );
 
   return (
     <Box
@@ -451,7 +439,8 @@ const FeaturedContributorsSpotlight: React.FC<Props> = ({
             borderRadius: 1.5,
             border: `1px solid ${alpha(theme.palette.common.white, 0.08)}`,
             backgroundColor: alpha(theme.palette.common.white, 0.02),
-            overflow: 'hidden',
+            overflowX: 'auto',
+            overflowY: 'hidden',
           }}
         >
           <KpiBox
@@ -508,8 +497,6 @@ const FeaturedContributorsSpotlight: React.FC<Props> = ({
               c={c}
               rank={i}
               onClick={() => open(c.githubId)}
-              maxScore={maxScore}
-              maxMerged={maxMerged}
             />
           ))}
         </Box>

--- a/src/pages/dashboard/views/FeaturedContributorsSpotlight.tsx
+++ b/src/pages/dashboard/views/FeaturedContributorsSpotlight.tsx
@@ -35,7 +35,7 @@ const KpiBox: React.FC<{
           ...mono,
           fontSize: '0.5rem',
           fontWeight: 600,
-          color: alpha(theme.palette.text.primary, 0.35),
+          color: alpha(theme.palette.text.primary, 0.7),
           textTransform: 'uppercase',
           letterSpacing: '0.08em',
           mb: 0.25,
@@ -63,7 +63,7 @@ const KpiBox: React.FC<{
           fontSize: '0.5rem',
           color: accentColor
             ? alpha(accentColor, 0.7)
-            : alpha(theme.palette.text.primary, 0.3),
+            : alpha(theme.palette.text.primary, 0.65),
           whiteSpace: 'nowrap',
         }}
       >
@@ -109,7 +109,7 @@ const ContributorCard: React.FC<{
             ...mono,
             fontSize: '0.58rem',
             fontWeight: 600,
-            color: alpha(theme.palette.text.primary, 0.45),
+            color: alpha(theme.palette.text.primary, 0.8),
             backgroundColor: alpha(theme.palette.common.white, 0.04),
             border: `1px solid ${alpha(theme.palette.common.white, 0.08)}`,
             borderRadius: 99,
@@ -223,7 +223,7 @@ const ContributorCard: React.FC<{
                 ...mono,
                 fontSize: '0.58rem',
                 fontWeight: 500,
-                color: alpha(theme.palette.text.primary, 0.4),
+                color: alpha(theme.palette.text.primary, 0.75),
                 whiteSpace: 'nowrap',
                 overflow: 'hidden',
                 textOverflow: 'ellipsis',
@@ -283,7 +283,7 @@ const ContributorCard: React.FC<{
               sx={{
                 ...mono,
                 fontSize: '0.48rem',
-                color: alpha(theme.palette.text.primary, 0.35),
+                color: alpha(theme.palette.text.primary, 0.7),
                 mt: 0.15,
               }}
             >
@@ -306,7 +306,7 @@ const ContributorCard: React.FC<{
               sx={{
                 ...mono,
                 fontSize: '0.48rem',
-                color: alpha(theme.palette.text.primary, 0.35),
+                color: alpha(theme.palette.text.primary, 0.7),
                 mt: 0.15,
               }}
             >
@@ -339,7 +339,7 @@ const ContributorCard: React.FC<{
               sx={{
                 ...mono,
                 fontSize: '0.52rem',
-                color: alpha(theme.palette.text.primary, 0.38),
+                color: alpha(theme.palette.text.primary, 0.72),
                 whiteSpace: 'nowrap',
               }}
             >
@@ -367,7 +367,7 @@ const ContributorCard: React.FC<{
           sx={{
             ...mono,
             fontSize: '0.72rem',
-            color: alpha(theme.palette.text.primary, 0.2),
+            color: alpha(theme.palette.text.primary, 0.55),
             flexShrink: 0,
           }}
         >
@@ -483,7 +483,7 @@ const FeaturedContributorsSpotlight: React.FC<Props> = ({
             sx={{
               ...mono,
               fontSize: '0.55rem',
-              color: alpha(theme.palette.text.primary, 0.28),
+              color: alpha(theme.palette.text.primary, 0.6),
             }}
           >
             Updated with dashboard data
@@ -510,7 +510,7 @@ const FeaturedContributorsSpotlight: React.FC<Props> = ({
         sx={{
           ...mono,
           fontSize: '0.58rem',
-          color: alpha(theme.palette.text.primary, 0.3),
+          color: alpha(theme.palette.text.primary, 0.65),
           mb: 1.25,
         }}
       >

--- a/src/pages/dashboard/views/FeaturedContributorsSpotlight.tsx
+++ b/src/pages/dashboard/views/FeaturedContributorsSpotlight.tsx
@@ -1,5 +1,11 @@
 import React, { useCallback, useMemo } from 'react';
-import { Avatar, Box, CircularProgress, Typography } from '@mui/material';
+import {
+  Avatar,
+  Box,
+  CircularProgress,
+  Tooltip,
+  Typography,
+} from '@mui/material';
 import { alpha, useTheme } from '@mui/material/styles';
 import { useNavigate } from 'react-router-dom';
 import { RANK_COLORS } from '../../../theme';
@@ -14,62 +20,66 @@ const KpiBox: React.FC<{
   title: string;
   value: string;
   sub: string;
+  tooltip: string;
   accentColor?: string;
   isLast?: boolean;
-}> = ({ title, value, sub, accentColor, isLast }) => {
+}> = ({ title, value, sub, tooltip, accentColor, isLast }) => {
   const theme = useTheme();
   return (
-    <Box
-      sx={{
-        flex: 1,
-        minWidth: 'max-content',
-        px: { xs: 1, sm: 1.5 },
-        py: 0.85,
-        borderRight: isLast
-          ? 'none'
-          : `1px solid ${alpha(theme.palette.common.white, 0.07)}`,
-      }}
-    >
-      <Typography
+    <Tooltip title={tooltip} placement="top" arrow>
+      <Box
         sx={{
-          ...mono,
-          fontSize: '0.5rem',
-          fontWeight: 600,
-          color: alpha(theme.palette.text.primary, 0.7),
-          textTransform: 'uppercase',
-          letterSpacing: '0.08em',
-          mb: 0.25,
-          whiteSpace: 'nowrap',
+          flex: 1,
+          minWidth: 'max-content',
+          px: { xs: 1, sm: 1.5 },
+          py: 0.85,
+          borderRight: isLast
+            ? 'none'
+            : `1px solid ${alpha(theme.palette.common.white, 0.07)}`,
+          cursor: 'default',
         }}
       >
-        {title}
-      </Typography>
-      <Typography
-        sx={{
-          ...mono,
-          fontSize: { xs: '0.88rem', sm: '0.96rem' },
-          fontWeight: 800,
-          color: accentColor ?? theme.palette.text.primary,
-          lineHeight: 1,
-          mb: 0.2,
-          whiteSpace: 'nowrap',
-        }}
-      >
-        {value}
-      </Typography>
-      <Typography
-        sx={{
-          ...mono,
-          fontSize: '0.5rem',
-          color: accentColor
-            ? alpha(accentColor, 0.7)
-            : alpha(theme.palette.text.primary, 0.65),
-          whiteSpace: 'nowrap',
-        }}
-      >
-        {sub}
-      </Typography>
-    </Box>
+        <Typography
+          sx={{
+            ...mono,
+            fontSize: '0.5rem',
+            fontWeight: 600,
+            color: alpha(theme.palette.text.primary, 0.7),
+            textTransform: 'uppercase',
+            letterSpacing: '0.08em',
+            mb: 0.25,
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {title}
+        </Typography>
+        <Typography
+          sx={{
+            ...mono,
+            fontSize: { xs: '0.88rem', sm: '0.96rem' },
+            fontWeight: 800,
+            color: accentColor ?? theme.palette.text.primary,
+            lineHeight: 1,
+            mb: 0.2,
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {value}
+        </Typography>
+        <Typography
+          sx={{
+            ...mono,
+            fontSize: '0.5rem',
+            color: accentColor
+              ? alpha(accentColor, 0.7)
+              : alpha(theme.palette.text.primary, 0.65),
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {sub}
+        </Typography>
+      </Box>
+    </Tooltip>
   );
 };
 
@@ -100,31 +110,62 @@ const ContributorCard: React.FC<{
     [onClick],
   );
 
-  const repoPills = useMemo(
-    () =>
-      c.repos.slice(0, 3).map((repo, idx) => (
-        <Box
-          key={`${c.githubId}-${repo}`}
-          sx={{
-            ...mono,
-            fontSize: '0.58rem',
-            fontWeight: 600,
-            color: alpha(theme.palette.text.primary, 0.8),
-            backgroundColor: alpha(theme.palette.common.white, 0.04),
-            border: `1px solid ${alpha(theme.palette.common.white, 0.08)}`,
-            borderRadius: 99,
-            px: 0.85,
-            py: 0.2,
-            whiteSpace: 'nowrap',
-          }}
-        >
-          {idx === 2 && c.repos.length > 3
-            ? `+${c.repos.length - 2}`
-            : repo.split('/').pop() || repo}
-        </Box>
-      )),
-    [c.repos, c.githubId, theme],
-  );
+  const repoAvatars = useMemo(() => {
+    const show = c.repos.slice(0, 3);
+    const extra = c.repos.length > 3 ? c.repos.length - 2 : 0;
+    return show.map((repo, idx) => {
+      const owner = repo.split('/')[0];
+      if (idx === 2 && extra > 0) {
+        return (
+          <Tooltip
+            key={repo}
+            title={`+${extra} more repos`}
+            placement="top"
+            arrow
+          >
+            <Box
+              sx={{
+                width: 28,
+                height: 28,
+                borderRadius: '50%',
+                backgroundColor: alpha(theme.palette.common.white, 0.1),
+                border: `1px solid ${alpha(theme.palette.common.white, 0.18)}`,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                flexShrink: 0,
+              }}
+            >
+              <Typography
+                sx={{
+                  ...mono,
+                  fontSize: '0.44rem',
+                  fontWeight: 700,
+                  color: alpha(theme.palette.text.primary, 0.8),
+                }}
+              >
+                +{extra}
+              </Typography>
+            </Box>
+          </Tooltip>
+        );
+      }
+      return (
+        <Tooltip key={repo} title={repo} placement="top" arrow>
+          <Avatar
+            src={`https://github.com/${owner}.png`}
+            alt={repo}
+            sx={{
+              width: 28,
+              height: 28,
+              border: `1px solid ${alpha(theme.palette.common.white, 0.14)}`,
+              flexShrink: 0,
+            }}
+          />
+        </Tooltip>
+      );
+    });
+  }, [c.repos, theme]);
 
   return (
     <Box
@@ -259,37 +300,44 @@ const ContributorCard: React.FC<{
             alignItems: 'flex-end',
           }}
         >
-          <Box
-            sx={{
-              px: 0.7,
-              py: 0.28,
-              borderRadius: 1,
-              border: `1px solid ${alpha(accent, 0.22)}`,
-              backgroundColor: alpha(accent, 0.07),
-            }}
+          <Tooltip
+            title="Composite score based on merged PR quality, token coverage, repo weight, and credibility multipliers."
+            placement="top"
+            arrow
           >
-            <Typography
+            <Box
               sx={{
-                ...mono,
-                fontSize: '1.05rem',
-                fontWeight: 800,
-                color: accent,
-                lineHeight: 1,
+                px: 0.7,
+                py: 0.28,
+                borderRadius: 1,
+                border: `1px solid ${alpha(accent, 0.22)}`,
+                backgroundColor: alpha(accent, 0.07),
+                cursor: 'default',
               }}
             >
-              {(c.score ?? 0).toLocaleString()}
-            </Typography>
-            <Typography
-              sx={{
-                ...mono,
-                fontSize: '0.48rem',
-                color: alpha(theme.palette.text.primary, 0.7),
-                mt: 0.15,
-              }}
-            >
-              contributor score
-            </Typography>
-          </Box>
+              <Typography
+                sx={{
+                  ...mono,
+                  fontSize: '1.05rem',
+                  fontWeight: 800,
+                  color: accent,
+                  lineHeight: 1,
+                }}
+              >
+                {(c.score ?? 0).toLocaleString()}
+              </Typography>
+              <Typography
+                sx={{
+                  ...mono,
+                  fontSize: '0.48rem',
+                  color: alpha(theme.palette.text.primary, 0.7),
+                  mt: 0.15,
+                }}
+              >
+                contributor score
+              </Typography>
+            </Box>
+          </Tooltip>
           <Box>
             <Typography
               sx={{
@@ -315,41 +363,54 @@ const ContributorCard: React.FC<{
           </Box>
         </Box>
         {cred > 0 && (
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          <Tooltip
+            title="Credibility score: reflects consistency of high-quality contributions over time. Higher means the miner has a proven track record."
+            placement="top"
+            arrow
+          >
             <Box
               sx={{
-                flex: 1,
-                height: 3,
-                borderRadius: 99,
-                backgroundColor: alpha(theme.palette.common.white, 0.07),
-                overflow: 'hidden',
+                display: 'flex',
+                alignItems: 'center',
+                gap: 1,
+                cursor: 'default',
               }}
             >
               <Box
                 sx={{
-                  width: `${Math.round(cred * 100)}%`,
-                  height: '100%',
+                  flex: 1,
+                  height: 3,
                   borderRadius: 99,
-                  backgroundColor: accent,
-                  transition: 'width 0.5s ease',
+                  backgroundColor: alpha(theme.palette.common.white, 0.07),
+                  overflow: 'hidden',
                 }}
-              />
+              >
+                <Box
+                  sx={{
+                    width: `${Math.round(cred * 100)}%`,
+                    height: '100%',
+                    borderRadius: 99,
+                    backgroundColor: accent,
+                    transition: 'width 0.5s ease',
+                  }}
+                />
+              </Box>
+              <Typography
+                sx={{
+                  ...mono,
+                  fontSize: '0.52rem',
+                  color: alpha(theme.palette.text.primary, 0.72),
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                {Math.round(cred * 100)}% cred
+              </Typography>
             </Box>
-            <Typography
-              sx={{
-                ...mono,
-                fontSize: '0.52rem',
-                color: alpha(theme.palette.text.primary, 0.72),
-                whiteSpace: 'nowrap',
-              }}
-            >
-              {Math.round(cred * 100)}% cred
-            </Typography>
-          </Box>
+          </Tooltip>
         )}
       </Box>
 
-      {/* Right: repo pills + arrow */}
+      {/* Right: owner avatars + arrow */}
       <Box
         sx={{
           display: 'flex',
@@ -358,9 +419,15 @@ const ContributorCard: React.FC<{
           gap: 0.4,
         }}
       >
-        {repoPills.length > 0 && (
-          <Box sx={{ display: { xs: 'none', md: 'flex' }, gap: 0.4 }}>
-            {repoPills}
+        {repoAvatars.length > 0 && (
+          <Box
+            sx={{
+              display: { xs: 'none', md: 'flex' },
+              gap: 0.5,
+              alignItems: 'center',
+            }}
+          >
+            {repoAvatars}
           </Box>
         )}
         <Typography
@@ -430,7 +497,7 @@ const FeaturedContributorsSpotlight: React.FC<Props> = ({
           justifyContent: 'space-between',
           flexWrap: 'wrap',
           gap: 0.5,
-          mb: 0.4,
+          mb: 1.25,
         }}
       >
         <Box
@@ -451,24 +518,31 @@ const FeaturedContributorsSpotlight: React.FC<Props> = ({
           >
             Featured Contributors
           </Typography>
-          <Box
-            sx={{
-              ...mono,
-              fontSize: '0.52rem',
-              fontWeight: 700,
-              textTransform: 'uppercase',
-              letterSpacing: '0.06em',
-              color: theme.palette.status.success,
-              backgroundColor: alpha(theme.palette.status.success, 0.1),
-              border: `1px solid ${alpha(theme.palette.status.success, 0.22)}`,
-              borderRadius: 99,
-              px: 0.8,
-              py: 0.22,
-              whiteSpace: 'nowrap',
-            }}
+          <Tooltip
+            title="Showing top OSS contributors from the last 35 days based on merged PR score, token coverage, and repository impact."
+            placement="top"
+            arrow
           >
-            OSS 35d
-          </Box>
+            <Box
+              sx={{
+                ...mono,
+                fontSize: '0.52rem',
+                fontWeight: 700,
+                textTransform: 'uppercase',
+                letterSpacing: '0.06em',
+                color: theme.palette.status.success,
+                backgroundColor: alpha(theme.palette.status.success, 0.1),
+                border: `1px solid ${alpha(theme.palette.status.success, 0.22)}`,
+                borderRadius: 99,
+                px: 0.8,
+                py: 0.22,
+                whiteSpace: 'nowrap',
+                cursor: 'default',
+              }}
+            >
+              OSS 35d
+            </Box>
+          </Tooltip>
         </Box>
         <Box
           sx={{
@@ -505,19 +579,6 @@ const FeaturedContributorsSpotlight: React.FC<Props> = ({
         </Box>
       </Box>
 
-      {/* Subtitle */}
-      <Typography
-        sx={{
-          ...mono,
-          fontSize: '0.58rem',
-          color: alpha(theme.palette.text.primary, 0.65),
-          mb: 1.25,
-        }}
-      >
-        OSS contribution leaders by score, merged PR output, and repository
-        impact.
-      </Typography>
-
       {/* KPI strip */}
       {!isLoading && kpis && (
         <Box
@@ -535,27 +596,32 @@ const FeaturedContributorsSpotlight: React.FC<Props> = ({
             title="Highlighted score"
             value={kpis.topScore.toLocaleString()}
             sub={`${contributors.length} miners`}
+            tooltip="Highest contributor score among the highlighted miners in this 35-day window."
             accentColor={theme.palette.status.success}
           />
           <KpiBox
             title="Merged PRs"
             value={kpis.totalMerged.toLocaleString()}
             sub="all time"
+            tooltip="Total merged pull requests across all highlighted contributors, all time."
           />
           <KpiBox
             title="Closed PRs"
             value={kpis.totalClosed.toLocaleString()}
             sub="reviewed work"
+            tooltip="Total closed (not merged) pull requests — includes reviewed, declined, or superseded PRs."
           />
           <KpiBox
             title="Repos touched"
             value={String(kpis.uniqueRepos)}
             sub="35d context"
+            tooltip="Number of unique repositories these contributors have merged PRs into during the 35-day window."
           />
           <KpiBox
             title="Daily earnings"
             value={`$${Math.round(kpis.totalEarnings)}/d`}
             sub="highlighted total"
+            tooltip="Estimated combined daily USD earnings across all highlighted contributors based on recent scoring."
             accentColor={theme.palette.status.success}
             isLast
           />

--- a/src/pages/dashboard/views/FeaturedDiscoverersSpotlight.tsx
+++ b/src/pages/dashboard/views/FeaturedDiscoverersSpotlight.tsx
@@ -21,8 +21,7 @@ const KpiBox: React.FC<{
   return (
     <Box
       sx={{
-        flex: 1,
-        minWidth: 0,
+        flexShrink: 0,
         px: { xs: 1, sm: 1.5 },
         py: 0.85,
         borderRight: isLast
@@ -83,9 +82,7 @@ const DiscovererCard: React.FC<{
   d: DashboardFeaturedContributor;
   rank: number;
   onClick: () => void;
-  maxScore: number;
-  maxSolved: number;
-}> = ({ d, rank, onClick, maxScore, maxSolved }) => {
+}> = ({ d, rank, onClick }) => {
   const theme = useTheme();
   const accent = ACCENT[rank] ?? theme.palette.text.primary;
   const avatarUsername = d.githubUsername ?? d.githubId;
@@ -136,7 +133,7 @@ const DiscovererCard: React.FC<{
       onKeyDown={handleKeyDown}
       sx={{
         display: 'grid',
-        gridTemplateColumns: '1fr auto 1fr',
+        gridTemplateColumns: { xs: '1fr auto auto', sm: '1fr auto 1fr' },
         alignItems: 'center',
         columnGap: { xs: 1, sm: 1.5 },
         px: 1.25,
@@ -296,14 +293,6 @@ const FeaturedDiscoverersSpotlight: React.FC<Props> = ({
     return { topScore, totalSolved, uniqueRepos, totalEarnings };
   }, [discoverers]);
 
-  const maxScore = useMemo(
-    () => Math.max(...discoverers.map((d) => d.score ?? 0), 1),
-    [discoverers],
-  );
-  const maxSolved = useMemo(
-    () => Math.max(...discoverers.map((d) => d.solvedIssues ?? 0), 1),
-    [discoverers],
-  );
 
   return (
     <Box
@@ -403,7 +392,8 @@ const FeaturedDiscoverersSpotlight: React.FC<Props> = ({
             borderRadius: 1.5,
             border: `1px solid ${alpha(theme.palette.common.white, 0.08)}`,
             backgroundColor: alpha(theme.palette.common.white, 0.02),
-            overflow: 'hidden',
+            overflowX: 'auto',
+            overflowY: 'hidden',
           }}
         >
           <KpiBox
@@ -460,8 +450,6 @@ const FeaturedDiscoverersSpotlight: React.FC<Props> = ({
               d={d}
               rank={i}
               onClick={() => open(d.githubId)}
-              maxScore={maxScore}
-              maxSolved={maxSolved}
             />
           ))}
         </Box>

--- a/src/pages/dashboard/views/FeaturedDiscoverersSpotlight.tsx
+++ b/src/pages/dashboard/views/FeaturedDiscoverersSpotlight.tsx
@@ -35,7 +35,7 @@ const KpiBox: React.FC<{
           ...mono,
           fontSize: '0.5rem',
           fontWeight: 600,
-          color: alpha(theme.palette.text.primary, 0.35),
+          color: alpha(theme.palette.text.primary, 0.7),
           textTransform: 'uppercase',
           letterSpacing: '0.08em',
           mb: 0.25,
@@ -63,7 +63,7 @@ const KpiBox: React.FC<{
           fontSize: '0.5rem',
           color: accentColor
             ? alpha(accentColor, 0.7)
-            : alpha(theme.palette.text.primary, 0.3),
+            : alpha(theme.palette.text.primary, 0.65),
           whiteSpace: 'nowrap',
         }}
       >
@@ -109,7 +109,7 @@ const DiscovererCard: React.FC<{
             ...mono,
             fontSize: '0.58rem',
             fontWeight: 600,
-            color: alpha(theme.palette.text.primary, 0.45),
+            color: alpha(theme.palette.text.primary, 0.8),
             backgroundColor: alpha(theme.palette.common.white, 0.04),
             border: `1px solid ${alpha(theme.palette.common.white, 0.08)}`,
             borderRadius: 99,
@@ -223,7 +223,7 @@ const DiscovererCard: React.FC<{
                 ...mono,
                 fontSize: '0.58rem',
                 fontWeight: 500,
-                color: alpha(theme.palette.text.primary, 0.4),
+                color: alpha(theme.palette.text.primary, 0.75),
                 whiteSpace: 'nowrap',
                 overflow: 'hidden',
                 textOverflow: 'ellipsis',
@@ -283,7 +283,7 @@ const DiscovererCard: React.FC<{
               sx={{
                 ...mono,
                 fontSize: '0.48rem',
-                color: alpha(theme.palette.text.primary, 0.35),
+                color: alpha(theme.palette.text.primary, 0.7),
                 mt: 0.15,
               }}
             >
@@ -306,7 +306,7 @@ const DiscovererCard: React.FC<{
               sx={{
                 ...mono,
                 fontSize: '0.48rem',
-                color: alpha(theme.palette.text.primary, 0.35),
+                color: alpha(theme.palette.text.primary, 0.7),
                 mt: 0.15,
               }}
             >
@@ -339,7 +339,7 @@ const DiscovererCard: React.FC<{
               sx={{
                 ...mono,
                 fontSize: '0.52rem',
-                color: alpha(theme.palette.text.primary, 0.38),
+                color: alpha(theme.palette.text.primary, 0.72),
                 whiteSpace: 'nowrap',
               }}
             >
@@ -367,7 +367,7 @@ const DiscovererCard: React.FC<{
           sx={{
             ...mono,
             fontSize: '0.72rem',
-            color: alpha(theme.palette.text.primary, 0.2),
+            color: alpha(theme.palette.text.primary, 0.55),
             flexShrink: 0,
           }}
         >
@@ -480,7 +480,7 @@ const FeaturedDiscoverersSpotlight: React.FC<Props> = ({
             sx={{
               ...mono,
               fontSize: '0.55rem',
-              color: alpha(theme.palette.text.primary, 0.28),
+              color: alpha(theme.palette.text.primary, 0.6),
             }}
           >
             Updated with dashboard data
@@ -507,7 +507,7 @@ const FeaturedDiscoverersSpotlight: React.FC<Props> = ({
         sx={{
           ...mono,
           fontSize: '0.58rem',
-          color: alpha(theme.palette.text.primary, 0.3),
+          color: alpha(theme.palette.text.primary, 0.65),
           mb: 1.25,
         }}
       >

--- a/src/pages/dashboard/views/FeaturedDiscoverersSpotlight.tsx
+++ b/src/pages/dashboard/views/FeaturedDiscoverersSpotlight.tsx
@@ -21,7 +21,8 @@ const KpiBox: React.FC<{
   return (
     <Box
       sx={{
-        flexShrink: 0,
+        flex: 1,
+        minWidth: 'max-content',
         px: { xs: 1, sm: 1.5 },
         py: 0.85,
         borderRight: isLast

--- a/src/pages/dashboard/views/FeaturedDiscoverersSpotlight.tsx
+++ b/src/pages/dashboard/views/FeaturedDiscoverersSpotlight.tsx
@@ -467,7 +467,15 @@ const FeaturedDiscoverersSpotlight: React.FC<Props> = ({
             Issues 35d
           </Box>
         </Box>
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 1,
+            flex: 1,
+            justifyContent: 'flex-end',
+          }}
+        >
           <Typography
             sx={{
               ...mono,

--- a/src/pages/dashboard/views/FeaturedDiscoverersSpotlight.tsx
+++ b/src/pages/dashboard/views/FeaturedDiscoverersSpotlight.tsx
@@ -155,16 +155,35 @@ const DiscovererCard: React.FC<{
       }}
     >
       {/* Left: rank + avatar + identity */}
-      <Box sx={{ display: 'flex', alignItems: 'center', gap: { xs: 1, sm: 1.5 }, minWidth: 0 }}>
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: { xs: 1, sm: 1.5 },
+          minWidth: 0,
+        }}
+      >
         <Typography
-          sx={{ ...mono, fontSize: '0.7rem', fontWeight: 700, color: accent, width: 22, flexShrink: 0 }}
+          sx={{
+            ...mono,
+            fontSize: '0.7rem',
+            fontWeight: 700,
+            color: accent,
+            width: 22,
+            flexShrink: 0,
+          }}
         >
           #{rank + 1}
         </Typography>
         <Avatar
           src={getGithubAvatarSrc(avatarUsername)}
           alt={avatarUsername}
-          sx={{ width: 36, height: 36, border: `1.5px solid ${alpha(theme.palette.common.white, 0.14)}`, flexShrink: 0 }}
+          sx={{
+            width: 36,
+            height: 36,
+            border: `1.5px solid ${alpha(theme.palette.common.white, 0.14)}`,
+            flexShrink: 0,
+          }}
         />
         <Box sx={{ minWidth: 0 }}>
           <Typography
@@ -181,8 +200,23 @@ const DiscovererCard: React.FC<{
           >
             {d.name}
           </Typography>
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.45, minWidth: 0 }}>
-            <Box sx={{ width: 5, height: 5, borderRadius: '50%', backgroundColor: accent, flexShrink: 0 }} />
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 0.45,
+              minWidth: 0,
+            }}
+          >
+            <Box
+              sx={{
+                width: 5,
+                height: 5,
+                borderRadius: '50%',
+                backgroundColor: accent,
+                flexShrink: 0,
+              }}
+            />
             <Typography
               sx={{
                 ...mono,
@@ -196,7 +230,10 @@ const DiscovererCard: React.FC<{
             >
               {d.featuredLabel}
               {earn > 0 && (
-                <Box component="span" sx={{ color: theme.palette.status.success, ml: 0.5 }}>
+                <Box
+                  component="span"
+                  sx={{ color: theme.palette.status.success, ml: 0.5 }}
+                >
                   ${Math.round(earn)}/d
                 </Box>
               )}
@@ -206,8 +243,21 @@ const DiscovererCard: React.FC<{
       </Box>
 
       {/* Center: stats + cred */}
-      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.55, minWidth: { xs: 130, sm: 190, md: 210 } }}>
-        <Box sx={{ display: 'flex', gap: { xs: 1.5, sm: 2 }, alignItems: 'flex-end' }}>
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 0.55,
+          minWidth: { xs: 130, sm: 190, md: 210 },
+        }}
+      >
+        <Box
+          sx={{
+            display: 'flex',
+            gap: { xs: 1.5, sm: 2 },
+            alignItems: 'flex-end',
+          }}
+        >
           <Box
             sx={{
               px: 0.7,
@@ -217,18 +267,48 @@ const DiscovererCard: React.FC<{
               backgroundColor: alpha(accent, 0.07),
             }}
           >
-            <Typography sx={{ ...mono, fontSize: '1.05rem', fontWeight: 800, color: accent, lineHeight: 1 }}>
+            <Typography
+              sx={{
+                ...mono,
+                fontSize: '1.05rem',
+                fontWeight: 800,
+                color: accent,
+                lineHeight: 1,
+              }}
+            >
               {(d.score ?? 0).toLocaleString()}
             </Typography>
-            <Typography sx={{ ...mono, fontSize: '0.48rem', color: alpha(theme.palette.text.primary, 0.35), mt: 0.15 }}>
+            <Typography
+              sx={{
+                ...mono,
+                fontSize: '0.48rem',
+                color: alpha(theme.palette.text.primary, 0.35),
+                mt: 0.15,
+              }}
+            >
               discovery score
             </Typography>
           </Box>
           <Box>
-            <Typography sx={{ ...mono, fontSize: '1.05rem', fontWeight: 800, color: theme.palette.text.primary, lineHeight: 1 }}>
+            <Typography
+              sx={{
+                ...mono,
+                fontSize: '1.05rem',
+                fontWeight: 800,
+                color: theme.palette.text.primary,
+                lineHeight: 1,
+              }}
+            >
               {d.solvedIssues ?? 0}
             </Typography>
-            <Typography sx={{ ...mono, fontSize: '0.48rem', color: alpha(theme.palette.text.primary, 0.35), mt: 0.15 }}>
+            <Typography
+              sx={{
+                ...mono,
+                fontSize: '0.48rem',
+                color: alpha(theme.palette.text.primary, 0.35),
+                mt: 0.15,
+              }}
+            >
               solved issues
             </Typography>
           </Box>
@@ -236,13 +316,32 @@ const DiscovererCard: React.FC<{
         {cred > 0 && (
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
             <Box
-              sx={{ flex: 1, height: 3, borderRadius: 99, backgroundColor: alpha(theme.palette.common.white, 0.07), overflow: 'hidden' }}
+              sx={{
+                flex: 1,
+                height: 3,
+                borderRadius: 99,
+                backgroundColor: alpha(theme.palette.common.white, 0.07),
+                overflow: 'hidden',
+              }}
             >
               <Box
-                sx={{ width: `${Math.round(cred * 100)}%`, height: '100%', borderRadius: 99, backgroundColor: accent, transition: 'width 0.5s ease' }}
+                sx={{
+                  width: `${Math.round(cred * 100)}%`,
+                  height: '100%',
+                  borderRadius: 99,
+                  backgroundColor: accent,
+                  transition: 'width 0.5s ease',
+                }}
               />
             </Box>
-            <Typography sx={{ ...mono, fontSize: '0.52rem', color: alpha(theme.palette.text.primary, 0.38), whiteSpace: 'nowrap' }}>
+            <Typography
+              sx={{
+                ...mono,
+                fontSize: '0.52rem',
+                color: alpha(theme.palette.text.primary, 0.38),
+                whiteSpace: 'nowrap',
+              }}
+            >
               {Math.round(cred * 100)}% cred
             </Typography>
           </Box>
@@ -250,13 +349,27 @@ const DiscovererCard: React.FC<{
       </Box>
 
       {/* Right: repo pills + arrow */}
-      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'flex-end', gap: 0.4 }}>
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'flex-end',
+          gap: 0.4,
+        }}
+      >
         {repoPills.length > 0 && (
           <Box sx={{ display: { xs: 'none', md: 'flex' }, gap: 0.4 }}>
             {repoPills}
           </Box>
         )}
-        <Typography sx={{ ...mono, fontSize: '0.72rem', color: alpha(theme.palette.text.primary, 0.2), flexShrink: 0 }}>
+        <Typography
+          sx={{
+            ...mono,
+            fontSize: '0.72rem',
+            color: alpha(theme.palette.text.primary, 0.2),
+            flexShrink: 0,
+          }}
+        >
           →
         </Typography>
       </Box>
@@ -284,7 +397,10 @@ const FeaturedDiscoverersSpotlight: React.FC<Props> = ({
   const kpis = useMemo(() => {
     if (discoverers.length === 0) return null;
     const topScore = Math.max(...discoverers.map((d) => d.score ?? 0));
-    const totalSolved = discoverers.reduce((s, d) => s + (d.solvedIssues ?? 0), 0);
+    const totalSolved = discoverers.reduce(
+      (s, d) => s + (d.solvedIssues ?? 0),
+      0,
+    );
     const uniqueRepos = new Set(discoverers.flatMap((d) => d.repos)).size;
     const totalEarnings = discoverers.reduce(
       (s, d) => s + (d.earnings?.usdPerDay ?? 0),
@@ -292,7 +408,6 @@ const FeaturedDiscoverersSpotlight: React.FC<Props> = ({
     );
     return { topScore, totalSolved, uniqueRepos, totalEarnings };
   }, [discoverers]);
-
 
   return (
     <Box
@@ -314,7 +429,14 @@ const FeaturedDiscoverersSpotlight: React.FC<Props> = ({
           mb: 0.4,
         }}
       >
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 1,
+            flexWrap: 'wrap',
+          }}
+        >
           <Typography
             sx={{
               ...mono,
@@ -380,7 +502,8 @@ const FeaturedDiscoverersSpotlight: React.FC<Props> = ({
           mb: 1.25,
         }}
       >
-        Issue discovery leaders by score, solved issues output, and repository impact.
+        Issue discovery leaders by score, solved issues output, and repository
+        impact.
       </Typography>
 
       {/* KPI strip */}

--- a/src/pages/dashboard/views/FeaturedDiscoverersSpotlight.tsx
+++ b/src/pages/dashboard/views/FeaturedDiscoverersSpotlight.tsx
@@ -1,0 +1,524 @@
+import React, { useCallback, useMemo } from 'react';
+import { Avatar, Box, CircularProgress, Typography } from '@mui/material';
+import { alpha, useTheme } from '@mui/material/styles';
+import { useNavigate } from 'react-router-dom';
+import { RANK_COLORS } from '../../../theme';
+import { getGithubAvatarSrc } from '../../../utils';
+import { credibilityColor } from '../../../utils/format';
+import { type DashboardFeaturedContributor } from '../dashboardData';
+
+interface Props {
+  discoverers: DashboardFeaturedContributor[];
+  isLoading?: boolean;
+  viewAllHref?: string;
+}
+
+const FONTS = { mono: '"JetBrains Mono", ui-monospace, monospace' } as const;
+const ACCENT = [RANK_COLORS.first, RANK_COLORS.second, RANK_COLORS.third];
+const mono = { fontFamily: FONTS.mono } as const;
+const clamp = (v: number) => Math.min(Math.max(v, 0), 1);
+const formatEarn = (usd: number) => `$${Math.round(usd)}/d`;
+
+const CredRing: React.FC<{ value: number }> = ({ value }) => {
+  const theme = useTheme();
+  const pct = clamp(value);
+  const color = pct > 0 ? credibilityColor(pct) : theme.palette.border.light;
+  const size = 48;
+  const stroke = 4;
+  const radius = (size - stroke) / 2;
+  const circ = 2 * Math.PI * radius;
+  const offset = circ * (1 - pct);
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        gap: 0.5,
+      }}
+    >
+      <Box sx={{ position: 'relative', width: size, height: size }}>
+        <svg width={size} height={size} style={{ transform: 'rotate(-90deg)' }}>
+          <circle
+            cx={size / 2}
+            cy={size / 2}
+            r={radius}
+            fill="none"
+            stroke={alpha(theme.palette.common.white, 0.07)}
+            strokeWidth={stroke}
+          />
+          <circle
+            cx={size / 2}
+            cy={size / 2}
+            r={radius}
+            fill="none"
+            stroke={color}
+            strokeWidth={stroke}
+            strokeDasharray={circ}
+            strokeDashoffset={offset}
+            strokeLinecap="round"
+            style={{ transition: 'stroke-dashoffset 0.45s ease' }}
+          />
+        </svg>
+        <Box
+          sx={{
+            position: 'absolute',
+            inset: 0,
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: 0.2,
+          }}
+        >
+          <Typography
+            sx={{
+              ...mono,
+              fontSize: '0.82rem',
+              fontWeight: 800,
+              color,
+              lineHeight: 1,
+            }}
+          >
+            {Math.round(pct * 100)}%
+          </Typography>
+        </Box>
+      </Box>
+      <Typography
+        sx={{
+          ...mono,
+          fontSize: '0.58rem',
+          fontWeight: 700,
+          color: alpha(theme.palette.text.primary, 0.35),
+          textTransform: 'uppercase',
+          letterSpacing: '0.1em',
+        }}
+      >
+        Cred
+      </Typography>
+    </Box>
+  );
+};
+
+const Stat: React.FC<{ label: string; value: string; color?: string }> = ({
+  label,
+  value,
+  color,
+}) => {
+  const theme = useTheme();
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        gap: 0.4,
+      }}
+    >
+      <Typography
+        sx={{
+          ...mono,
+          fontSize: '1.2rem',
+          fontWeight: 800,
+          color: color ?? theme.palette.text.primary,
+          lineHeight: 1,
+        }}
+      >
+        {value}
+      </Typography>
+      <Typography
+        sx={{
+          ...mono,
+          fontSize: '0.6rem',
+          fontWeight: 700,
+          color: alpha(theme.palette.text.primary, 0.35),
+          textTransform: 'uppercase',
+          letterSpacing: '0.1em',
+        }}
+      >
+        {label}
+      </Typography>
+    </Box>
+  );
+};
+
+const Divider: React.FC<{ accent: string }> = ({ accent }) => (
+  <Box
+    sx={{
+      width: '1px',
+      alignSelf: 'stretch',
+      backgroundColor: alpha(accent, 0.18),
+      mx: 0.5,
+    }}
+  />
+);
+
+const DiscovererCard: React.FC<{
+  d: DashboardFeaturedContributor;
+  rank: number;
+  onClick: () => void;
+}> = ({ d, rank, onClick }) => {
+  const theme = useTheme();
+  const accent = ACCENT[rank] ?? alpha(theme.palette.status.award, 0.5);
+  const avatarUsername = d.githubUsername ?? d.githubId;
+  const cred = d.credibility ?? 0;
+  const earn = d.earnings?.usdPerDay ?? 0;
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        onClick();
+      }
+    },
+    [onClick],
+  );
+
+  const repoPills = useMemo(
+    () =>
+      d.repos.map((repo) => (
+        <Box
+          key={`${d.githubId}-${repo}`}
+          sx={{
+            ...mono,
+            fontSize: '0.68rem',
+            fontWeight: 600,
+            color: alpha(accent, 0.85),
+            backgroundColor: alpha(accent, 0.08),
+            border: `1px solid ${alpha(accent, 0.2)}`,
+            borderRadius: 99,
+            px: 1.1,
+            py: 0.4,
+            whiteSpace: 'nowrap',
+            lineHeight: 1.4,
+          }}
+        >
+          {repo.split('/').pop() || repo}
+        </Box>
+      )),
+    [d.repos, d.githubId, accent],
+  );
+
+  const hasStats = (d.solvedIssues ?? 0) > 0 || earn > 0 || cred > 0;
+
+  return (
+    <Box
+      role="button"
+      tabIndex={0}
+      onClick={onClick}
+      onKeyDown={handleKeyDown}
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        borderRadius: 3,
+        overflow: 'hidden',
+        border: `1px solid ${alpha(accent, 0.3)}`,
+        backgroundColor: theme.palette.common.black,
+        cursor: 'pointer',
+        transition:
+          'transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease',
+        '&:hover': {
+          transform: 'translateY(-4px)',
+          borderColor: alpha(accent, 0.6),
+          boxShadow: `0 12px 40px ${alpha(accent, 0.18)}, 0 2px 8px ${alpha(accent, 0.1)}`,
+        },
+        '&:focus-visible': {
+          outline: `2px solid ${alpha(accent, 0.7)}`,
+          outlineOffset: 3,
+        },
+      }}
+    >
+      {/* ── Top section: gradient bg + avatar ─────────────────── */}
+      <Box
+        sx={{
+          position: 'relative',
+          pt: 2,
+          pb: 1.5,
+          px: 1.75,
+          background: `linear-gradient(175deg, ${alpha(accent, 0.24)} 0%, ${alpha(accent, 0.06)} 60%, transparent 100%)`,
+          borderBottom: `1px solid ${alpha(accent, 0.12)}`,
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          gap: 0.75,
+        }}
+      >
+        {/* Rank badge */}
+        <Box
+          sx={{
+            position: 'absolute',
+            top: 10,
+            left: 12,
+            width: 26,
+            height: 26,
+            borderRadius: '50%',
+            backgroundColor: accent,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            boxShadow: `0 0 14px ${alpha(accent, 0.55)}, 0 0 28px ${alpha(accent, 0.2)}`,
+            zIndex: 1,
+          }}
+        >
+          <Typography
+            sx={{
+              ...mono,
+              fontSize: '0.65rem',
+              fontWeight: 900,
+              color: '#000',
+              lineHeight: 1,
+            }}
+          >
+            {rank + 1}
+          </Typography>
+        </Box>
+
+        {/* Avatar */}
+        <Avatar
+          src={getGithubAvatarSrc(avatarUsername)}
+          alt={avatarUsername}
+          sx={{
+            width: 52,
+            height: 52,
+            border: `2px solid ${accent}`,
+            boxShadow: `0 0 0 3px ${alpha(accent, 0.15)}, 0 0 16px ${alpha(accent, 0.28)}`,
+          }}
+        />
+
+        {/* Name */}
+        <Typography
+          sx={{
+            ...mono,
+            fontSize: '0.92rem',
+            fontWeight: 700,
+            color: theme.palette.text.primary,
+            whiteSpace: 'nowrap',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            maxWidth: '100%',
+          }}
+        >
+          {d.name}
+        </Typography>
+
+        {/* Label pill */}
+        <Box
+          sx={{
+            ...mono,
+            fontSize: '0.65rem',
+            fontWeight: 700,
+            textTransform: 'uppercase',
+            letterSpacing: '0.06em',
+            color: alpha(accent, 0.95),
+            backgroundColor: alpha(accent, 0.13),
+            border: `1px solid ${alpha(accent, 0.28)}`,
+            borderRadius: 99,
+            px: 1,
+            py: 0.3,
+            whiteSpace: 'nowrap',
+            maxWidth: '90%',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+          }}
+        >
+          {d.featuredLabel}
+        </Box>
+      </Box>
+
+      {/* ── Score hero ────────────────────────────────────────── */}
+      <Box
+        sx={{
+          px: 1.75,
+          pt: 1.5,
+          pb: 1,
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          gap: 0.5,
+        }}
+      >
+        <Typography
+          sx={{
+            ...mono,
+            fontSize: '0.6rem',
+            fontWeight: 700,
+            color: alpha(theme.palette.text.primary, 0.35),
+            textTransform: 'uppercase',
+            letterSpacing: '0.12em',
+          }}
+        >
+          Score
+        </Typography>
+        <Typography
+          sx={{
+            ...mono,
+            fontSize: { xs: '2.6rem', sm: '3rem' },
+            fontWeight: 900,
+            color: accent,
+            lineHeight: 1,
+            textShadow: `0 0 32px ${alpha(accent, 0.45)}, 0 0 64px ${alpha(accent, 0.18)}`,
+            letterSpacing: '-0.02em',
+          }}
+        >
+          {d.score?.toLocaleString() ?? '0'}
+        </Typography>
+      </Box>
+
+      {/* ── Stats row ─────────────────────────────────────────── */}
+      {hasStats && (
+        <Box
+          sx={{
+            mx: 1.5,
+            mb: 1.5,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-evenly',
+            borderRadius: 2,
+            border: `1px solid ${alpha(accent, 0.12)}`,
+            backgroundColor: alpha(accent, 0.04),
+            py: 1,
+            px: 1,
+            gap: 0.5,
+          }}
+        >
+          {(d.solvedIssues ?? 0) > 0 && (
+            <>
+              <Stat label="Solved" value={`${d.solvedIssues}`} />
+              {(earn > 0 || cred > 0) && <Divider accent={accent} />}
+            </>
+          )}
+          {earn > 0 && (
+            <>
+              <Stat
+                label="Earn"
+                value={formatEarn(earn)}
+                color={theme.palette.status.success}
+              />
+              {cred > 0 && <Divider accent={accent} />}
+            </>
+          )}
+          {cred > 0 && <CredRing value={cred} />}
+        </Box>
+      )}
+
+      {/* ── Repo pills ────────────────────────────────────────── */}
+      {repoPills.length > 0 && (
+        <Box
+          sx={{
+            px: 1.5,
+            pb: 1.5,
+            display: 'flex',
+            flexWrap: 'wrap',
+            gap: 0.5,
+          }}
+        >
+          {repoPills}
+        </Box>
+      )}
+    </Box>
+  );
+};
+
+const FeaturedDiscoverersSpotlight: React.FC<Props> = ({
+  discoverers,
+  isLoading = false,
+  viewAllHref,
+}) => {
+  const theme = useTheme();
+  const navigate = useNavigate();
+
+  const open = useCallback(
+    (githubId: string) =>
+      navigate(
+        `/miners/details?githubId=${encodeURIComponent(githubId)}&mode=issues`,
+        { state: { backTo: '/dashboard' } },
+      ),
+    [navigate],
+  );
+
+  return (
+    <Box
+      sx={{
+        width: '100%',
+        p: { xs: 1.25, sm: 1.5 },
+        borderRadius: 3,
+        border: `1px solid ${theme.palette.border.light}`,
+      }}
+    >
+      <Box
+        sx={{
+          mb: 1.75,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+        }}
+      >
+        <Typography
+          sx={{
+            ...mono,
+            fontSize: { xs: '1.02rem', sm: '1.1rem' },
+            fontWeight: 700,
+            color: theme.palette.text.primary,
+          }}
+        >
+          Featured Discoverers
+        </Typography>
+        {viewAllHref && (
+          <Typography
+            onClick={() => navigate(viewAllHref)}
+            sx={{
+              ...theme.typography.tooltipLabel,
+              color: alpha(theme.palette.text.primary, 0.45),
+              cursor: 'pointer',
+              '&:hover': { color: theme.palette.text.primary },
+            }}
+          >
+            view all →
+          </Typography>
+        )}
+      </Box>
+
+      {isLoading ? (
+        <Box
+          sx={{
+            minHeight: 260,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          <CircularProgress size={28} />
+        </Box>
+      ) : discoverers.length === 0 ? (
+        <Typography sx={{ color: 'text.secondary', fontSize: '0.8rem' }}>
+          No discoverer highlights available.
+        </Typography>
+      ) : (
+        <Box
+          sx={{
+            display: 'grid',
+            gridTemplateColumns: {
+              xs: '1fr',
+              sm: `repeat(${Math.min(discoverers.length, 2)}, 1fr)`,
+              md: `repeat(${Math.min(discoverers.length, 3)}, 1fr)`,
+            },
+            gap: 1.5,
+            alignItems: 'stretch',
+          }}
+        >
+          {discoverers.map((d, i) => (
+            <DiscovererCard
+              key={`${d.featuredLabel}-${d.githubId}`}
+              d={d}
+              rank={i}
+              onClick={() => open(d.githubId)}
+            />
+          ))}
+        </Box>
+      )}
+    </Box>
+  );
+};
+
+export default FeaturedDiscoverersSpotlight;

--- a/src/pages/dashboard/views/FeaturedDiscoverersSpotlight.tsx
+++ b/src/pages/dashboard/views/FeaturedDiscoverersSpotlight.tsx
@@ -1,5 +1,11 @@
 import React, { useCallback, useMemo } from 'react';
-import { Avatar, Box, CircularProgress, Typography } from '@mui/material';
+import {
+  Avatar,
+  Box,
+  CircularProgress,
+  Tooltip,
+  Typography,
+} from '@mui/material';
 import { alpha, useTheme } from '@mui/material/styles';
 import { useNavigate } from 'react-router-dom';
 import { RANK_COLORS } from '../../../theme';
@@ -14,62 +20,66 @@ const KpiBox: React.FC<{
   title: string;
   value: string;
   sub: string;
+  tooltip: string;
   accentColor?: string;
   isLast?: boolean;
-}> = ({ title, value, sub, accentColor, isLast }) => {
+}> = ({ title, value, sub, tooltip, accentColor, isLast }) => {
   const theme = useTheme();
   return (
-    <Box
-      sx={{
-        flex: 1,
-        minWidth: 'max-content',
-        px: { xs: 1, sm: 1.5 },
-        py: 0.85,
-        borderRight: isLast
-          ? 'none'
-          : `1px solid ${alpha(theme.palette.common.white, 0.07)}`,
-      }}
-    >
-      <Typography
+    <Tooltip title={tooltip} placement="top" arrow>
+      <Box
         sx={{
-          ...mono,
-          fontSize: '0.5rem',
-          fontWeight: 600,
-          color: alpha(theme.palette.text.primary, 0.7),
-          textTransform: 'uppercase',
-          letterSpacing: '0.08em',
-          mb: 0.25,
-          whiteSpace: 'nowrap',
+          flex: 1,
+          minWidth: 'max-content',
+          px: { xs: 1, sm: 1.5 },
+          py: 0.85,
+          borderRight: isLast
+            ? 'none'
+            : `1px solid ${alpha(theme.palette.common.white, 0.07)}`,
+          cursor: 'default',
         }}
       >
-        {title}
-      </Typography>
-      <Typography
-        sx={{
-          ...mono,
-          fontSize: { xs: '0.88rem', sm: '0.96rem' },
-          fontWeight: 800,
-          color: accentColor ?? theme.palette.text.primary,
-          lineHeight: 1,
-          mb: 0.2,
-          whiteSpace: 'nowrap',
-        }}
-      >
-        {value}
-      </Typography>
-      <Typography
-        sx={{
-          ...mono,
-          fontSize: '0.5rem',
-          color: accentColor
-            ? alpha(accentColor, 0.7)
-            : alpha(theme.palette.text.primary, 0.65),
-          whiteSpace: 'nowrap',
-        }}
-      >
-        {sub}
-      </Typography>
-    </Box>
+        <Typography
+          sx={{
+            ...mono,
+            fontSize: '0.5rem',
+            fontWeight: 600,
+            color: alpha(theme.palette.text.primary, 0.7),
+            textTransform: 'uppercase',
+            letterSpacing: '0.08em',
+            mb: 0.25,
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {title}
+        </Typography>
+        <Typography
+          sx={{
+            ...mono,
+            fontSize: { xs: '0.88rem', sm: '0.96rem' },
+            fontWeight: 800,
+            color: accentColor ?? theme.palette.text.primary,
+            lineHeight: 1,
+            mb: 0.2,
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {value}
+        </Typography>
+        <Typography
+          sx={{
+            ...mono,
+            fontSize: '0.5rem',
+            color: accentColor
+              ? alpha(accentColor, 0.7)
+              : alpha(theme.palette.text.primary, 0.65),
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {sub}
+        </Typography>
+      </Box>
+    </Tooltip>
   );
 };
 
@@ -100,31 +110,62 @@ const DiscovererCard: React.FC<{
     [onClick],
   );
 
-  const repoPills = useMemo(
-    () =>
-      d.repos.slice(0, 3).map((repo, idx) => (
-        <Box
-          key={`${d.githubId}-${repo}`}
-          sx={{
-            ...mono,
-            fontSize: '0.58rem',
-            fontWeight: 600,
-            color: alpha(theme.palette.text.primary, 0.8),
-            backgroundColor: alpha(theme.palette.common.white, 0.04),
-            border: `1px solid ${alpha(theme.palette.common.white, 0.08)}`,
-            borderRadius: 99,
-            px: 0.85,
-            py: 0.2,
-            whiteSpace: 'nowrap',
-          }}
-        >
-          {idx === 2 && d.repos.length > 3
-            ? `+${d.repos.length - 2}`
-            : repo.split('/').pop() || repo}
-        </Box>
-      )),
-    [d.repos, d.githubId, theme],
-  );
+  const repoAvatars = useMemo(() => {
+    const show = d.repos.slice(0, 3);
+    const extra = d.repos.length > 3 ? d.repos.length - 2 : 0;
+    return show.map((repo, idx) => {
+      const owner = repo.split('/')[0];
+      if (idx === 2 && extra > 0) {
+        return (
+          <Tooltip
+            key={repo}
+            title={`+${extra} more repos`}
+            placement="top"
+            arrow
+          >
+            <Box
+              sx={{
+                width: 28,
+                height: 28,
+                borderRadius: '50%',
+                backgroundColor: alpha(theme.palette.common.white, 0.1),
+                border: `1px solid ${alpha(theme.palette.common.white, 0.18)}`,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                flexShrink: 0,
+              }}
+            >
+              <Typography
+                sx={{
+                  ...mono,
+                  fontSize: '0.44rem',
+                  fontWeight: 700,
+                  color: alpha(theme.palette.text.primary, 0.8),
+                }}
+              >
+                +{extra}
+              </Typography>
+            </Box>
+          </Tooltip>
+        );
+      }
+      return (
+        <Tooltip key={repo} title={repo} placement="top" arrow>
+          <Avatar
+            src={`https://github.com/${owner}.png`}
+            alt={repo}
+            sx={{
+              width: 28,
+              height: 28,
+              border: `1px solid ${alpha(theme.palette.common.white, 0.14)}`,
+              flexShrink: 0,
+            }}
+          />
+        </Tooltip>
+      );
+    });
+  }, [d.repos, theme]);
 
   return (
     <Box
@@ -259,37 +300,44 @@ const DiscovererCard: React.FC<{
             alignItems: 'flex-end',
           }}
         >
-          <Box
-            sx={{
-              px: 0.7,
-              py: 0.28,
-              borderRadius: 1,
-              border: `1px solid ${alpha(accent, 0.22)}`,
-              backgroundColor: alpha(accent, 0.07),
-            }}
+          <Tooltip
+            title="Composite issue discovery score based on the quality, reach, and solver activity of issues this miner opened."
+            placement="top"
+            arrow
           >
-            <Typography
+            <Box
               sx={{
-                ...mono,
-                fontSize: '1.05rem',
-                fontWeight: 800,
-                color: accent,
-                lineHeight: 1,
+                px: 0.7,
+                py: 0.28,
+                borderRadius: 1,
+                border: `1px solid ${alpha(accent, 0.22)}`,
+                backgroundColor: alpha(accent, 0.07),
+                cursor: 'default',
               }}
             >
-              {(d.score ?? 0).toLocaleString()}
-            </Typography>
-            <Typography
-              sx={{
-                ...mono,
-                fontSize: '0.48rem',
-                color: alpha(theme.palette.text.primary, 0.7),
-                mt: 0.15,
-              }}
-            >
-              discovery score
-            </Typography>
-          </Box>
+              <Typography
+                sx={{
+                  ...mono,
+                  fontSize: '1.05rem',
+                  fontWeight: 800,
+                  color: accent,
+                  lineHeight: 1,
+                }}
+              >
+                {(d.score ?? 0).toLocaleString()}
+              </Typography>
+              <Typography
+                sx={{
+                  ...mono,
+                  fontSize: '0.48rem',
+                  color: alpha(theme.palette.text.primary, 0.7),
+                  mt: 0.15,
+                }}
+              >
+                discovery score
+              </Typography>
+            </Box>
+          </Tooltip>
           <Box>
             <Typography
               sx={{
@@ -315,41 +363,54 @@ const DiscovererCard: React.FC<{
           </Box>
         </Box>
         {cred > 0 && (
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          <Tooltip
+            title="Issue credibility: reflects how reliably this miner opens issues that get solved. Higher means consistently high-value discoveries."
+            placement="top"
+            arrow
+          >
             <Box
               sx={{
-                flex: 1,
-                height: 3,
-                borderRadius: 99,
-                backgroundColor: alpha(theme.palette.common.white, 0.07),
-                overflow: 'hidden',
+                display: 'flex',
+                alignItems: 'center',
+                gap: 1,
+                cursor: 'default',
               }}
             >
               <Box
                 sx={{
-                  width: `${Math.round(cred * 100)}%`,
-                  height: '100%',
+                  flex: 1,
+                  height: 3,
                   borderRadius: 99,
-                  backgroundColor: accent,
-                  transition: 'width 0.5s ease',
+                  backgroundColor: alpha(theme.palette.common.white, 0.07),
+                  overflow: 'hidden',
                 }}
-              />
+              >
+                <Box
+                  sx={{
+                    width: `${Math.round(cred * 100)}%`,
+                    height: '100%',
+                    borderRadius: 99,
+                    backgroundColor: accent,
+                    transition: 'width 0.5s ease',
+                  }}
+                />
+              </Box>
+              <Typography
+                sx={{
+                  ...mono,
+                  fontSize: '0.52rem',
+                  color: alpha(theme.palette.text.primary, 0.72),
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                {Math.round(cred * 100)}% cred
+              </Typography>
             </Box>
-            <Typography
-              sx={{
-                ...mono,
-                fontSize: '0.52rem',
-                color: alpha(theme.palette.text.primary, 0.72),
-                whiteSpace: 'nowrap',
-              }}
-            >
-              {Math.round(cred * 100)}% cred
-            </Typography>
-          </Box>
+          </Tooltip>
         )}
       </Box>
 
-      {/* Right: repo pills + arrow */}
+      {/* Right: owner avatars + arrow */}
       <Box
         sx={{
           display: 'flex',
@@ -358,9 +419,15 @@ const DiscovererCard: React.FC<{
           gap: 0.4,
         }}
       >
-        {repoPills.length > 0 && (
-          <Box sx={{ display: { xs: 'none', md: 'flex' }, gap: 0.4 }}>
-            {repoPills}
+        {repoAvatars.length > 0 && (
+          <Box
+            sx={{
+              display: { xs: 'none', md: 'flex' },
+              gap: 0.5,
+              alignItems: 'center',
+            }}
+          >
+            {repoAvatars}
           </Box>
         )}
         <Typography
@@ -427,7 +494,7 @@ const FeaturedDiscoverersSpotlight: React.FC<Props> = ({
           justifyContent: 'space-between',
           flexWrap: 'wrap',
           gap: 0.5,
-          mb: 0.4,
+          mb: 1.25,
         }}
       >
         <Box
@@ -448,24 +515,31 @@ const FeaturedDiscoverersSpotlight: React.FC<Props> = ({
           >
             Featured Discoverers
           </Typography>
-          <Box
-            sx={{
-              ...mono,
-              fontSize: '0.52rem',
-              fontWeight: 700,
-              textTransform: 'uppercase',
-              letterSpacing: '0.06em',
-              color: RANK_COLORS.first,
-              backgroundColor: alpha(RANK_COLORS.first, 0.1),
-              border: `1px solid ${alpha(RANK_COLORS.first, 0.22)}`,
-              borderRadius: 99,
-              px: 0.8,
-              py: 0.22,
-              whiteSpace: 'nowrap',
-            }}
+          <Tooltip
+            title="Showing top issue discoverers from the last 35 days based on discovery score, solved issues, and repository reach."
+            placement="top"
+            arrow
           >
-            Issues 35d
-          </Box>
+            <Box
+              sx={{
+                ...mono,
+                fontSize: '0.52rem',
+                fontWeight: 700,
+                textTransform: 'uppercase',
+                letterSpacing: '0.06em',
+                color: RANK_COLORS.first,
+                backgroundColor: alpha(RANK_COLORS.first, 0.1),
+                border: `1px solid ${alpha(RANK_COLORS.first, 0.22)}`,
+                borderRadius: 99,
+                px: 0.8,
+                py: 0.22,
+                whiteSpace: 'nowrap',
+                cursor: 'default',
+              }}
+            >
+              Issues 35d
+            </Box>
+          </Tooltip>
         </Box>
         <Box
           sx={{
@@ -502,19 +576,6 @@ const FeaturedDiscoverersSpotlight: React.FC<Props> = ({
         </Box>
       </Box>
 
-      {/* Subtitle */}
-      <Typography
-        sx={{
-          ...mono,
-          fontSize: '0.58rem',
-          color: alpha(theme.palette.text.primary, 0.65),
-          mb: 1.25,
-        }}
-      >
-        Issue discovery leaders by score, solved issues output, and repository
-        impact.
-      </Typography>
-
       {/* KPI strip */}
       {!isLoading && kpis && (
         <Box
@@ -532,27 +593,32 @@ const FeaturedDiscoverersSpotlight: React.FC<Props> = ({
             title="Highlighted score"
             value={kpis.topScore.toLocaleString()}
             sub={`${discoverers.length} discoverers`}
+            tooltip="Highest discovery score among the highlighted miners in this 35-day window."
             accentColor={RANK_COLORS.first}
           />
           <KpiBox
             title="Solved Issues"
             value={kpis.totalSolved.toLocaleString()}
             sub="all time"
+            tooltip="Total issues opened by these discoverers that were subsequently solved by a PR, all time."
           />
           <KpiBox
             title="Active Discoverers"
             value={String(discoverers.length)}
             sub="this period"
+            tooltip="Number of highlighted discoverers active in this 35-day scoring window."
           />
           <KpiBox
             title="Repos touched"
             value={String(kpis.uniqueRepos)}
-            sub="35d context"
+            sub="issue repos"
+            tooltip="Unique repositories where these discoverers opened registered issues."
           />
           <KpiBox
             title="Daily earnings"
             value={`$${Math.round(kpis.totalEarnings)}/d`}
             sub="highlighted total"
+            tooltip="Estimated combined daily USD earnings across all highlighted discoverers based on recent scoring."
             accentColor={theme.palette.status.success}
             isLast
           />


### PR DESCRIPTION
### Summary

- Replaced the old `DashboardTopContributors` 3-column grid with a clean horizontal row card layout for both `FeaturedContributorsSpotlight` and `FeaturedDiscoverersSpotlight`
- Each card uses a 3-column CSS grid (`1fr auto 1fr`) so the stats block is always visually centered and vertically aligned across all rows
- Added rank-accent left strip per card (gold/silver/bronze) as a visual differentiator
- Score value rendered in a subtle boxed chip with rank accent color; cred progress bar also uses rank color
- Full-width KPI strip added below each section header showing aggregated metrics
- Removed left border section indicator from both spotlight wrappers for a cleaner look
- Extended `dashboardData.ts` contributor builders with `score`, `mergedPrs`, `closedPrs`, and `earnings` fields to supply the new UI
- Wired `FeaturedContributorsSpotlight` into `DashboardPage` replacing the old component
- Fixed mobile responsive layout: KPI strip scrolls horizontally instead of overlapping; stats column right-aligns on small screens (`xs: 1fr auto auto`, `sm+: 1fr auto 1fr`)
- Removed all unused imports and props; passes lint, TypeScript, and build checks

### Test plan

- [ ] Featured Contributors renders 3 rows with gold/silver/bronze left strips
- [ ] Featured Discoverers renders 3 rows with gold/silver/bronze left strips
- [ ] Stats column (score chip + count + cred bar) is vertically aligned across all 3 rows in both sections
- [ ] KPI strip shows correct aggregated values
- [ ] On mobile: KPI strip scrolls horizontally, stats are right-aligned
- [ ] On desktop (`sm+`): stats are centered between identity and repo pills
- [ ] Repo pills visible on `md+` screens, hidden on smaller
- [ ] Clicking a row navigates to the correct miner detail page
- [ ] Loading and empty states render correctly
- [ ] `npm run lint`, `tsc --noEmit`, and `npm run build` all pass

### Closes: #873

## Screenshots


<img width="1852" height="879" alt="image" src="https://github.com/user-attachments/assets/f8eb7b09-29e9-449d-9972-9b6c17ea27c4" />

