### PR TITLE
feat(home): live payout marquee, emission economics ribbon, bounties grid

### DIFF
--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -2,11 +2,12 @@ import React from 'react';
 import { Box, Stack, Typography, alpha } from '@mui/material';
 import { Page } from '../components/layout';
 import { SEO } from '../components';
-import { useMonthlyRewards } from '../hooks/useMonthlyRewards';
+import LivePayoutMarquee from './home/LivePayoutMarquee';
+import MinerEmissionShare from './home/MinerEmissionShare';
+import StarterBounties from './home/StarterBounties';
+import StartMiningCta from './home/StartMiningCta';
 
 const HomePage: React.FC = () => {
-  const monthlyRewards = useMonthlyRewards();
-
   return (
     <Page title="Home">
       <SEO
@@ -16,20 +17,14 @@ const HomePage: React.FC = () => {
       />
       <Box
         sx={{
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-          justifyContent: 'center',
-          minHeight: { xs: 'calc(100vh - 64px)', md: '100vh' },
           width: '100%',
           px: { xs: 2, sm: 3 },
+          pt: { xs: 6, sm: 8 },
+          pb: { xs: 4, sm: 6 },
+          overflow: 'hidden',
         }}
       >
-        <Stack
-          alignItems="center"
-          justifyContent="center"
-          gap={{ xs: 2, sm: 3 }}
-        >
+        <Stack alignItems="center" gap={{ xs: 2, sm: 3 }}>
           <Box
             component="img"
             src="/gt-logo.svg"
@@ -61,77 +56,21 @@ const HomePage: React.FC = () => {
             sx={{
               fontSize: { xs: '0.9rem', sm: '1rem' },
               textAlign: 'center',
+              maxWidth: 480,
             }}
           >
-            The workforce for open source.
+            The workforce for open source. Compete for rewards by contributing
+            quality code.
           </Typography>
-
-          {/* Monthly Rewards Banner */}
-          {monthlyRewards && (
-            <Box
-              sx={(theme) => ({
-                mt: { xs: 4, sm: 5 },
-                px: { xs: 3, sm: 5, md: 7 },
-                py: { xs: 2.5, sm: 3.5 },
-                borderRadius: 2,
-                background: alpha(theme.palette.background.default, 0.4),
-                border: '1px solid',
-                borderColor: theme.palette.border.light,
-                backdropFilter: 'blur(10px)',
-                boxShadow: `0 8px 32px ${alpha(theme.palette.background.default, 0.3)}`,
-                transition: 'all 0.3s ease-in-out',
-                '&:hover': {
-                  borderColor: theme.palette.border.medium,
-                  boxShadow: `0 12px 48px ${alpha(theme.palette.background.default, 0.4)}`,
-                  transform: 'translateY(-2px)',
-                },
-              })}
-            >
-              <Stack alignItems="center" gap={{ xs: 1, sm: 1.5 }}>
-                <Typography
-                  variant="body2"
-                  sx={{
-                    color: (theme) => theme.palette.text.secondary,
-                    fontSize: { xs: '0.7rem', sm: '0.75rem' },
-                    textTransform: 'uppercase',
-                    letterSpacing: '0.15em',
-                    fontWeight: 500,
-                  }}
-                >
-                  Monthly Reward Pool
-                </Typography>
-                <Typography
-                  variant="h2"
-                  fontWeight="600"
-                  sx={{
-                    color: (theme) => theme.palette.text.primary,
-                    fontSize: { xs: '2rem', sm: '2.75rem', md: '3.5rem' },
-                    letterSpacing: '-0.02em',
-                  }}
-                >
-                  $
-                  {monthlyRewards.toLocaleString(undefined, {
-                    minimumFractionDigits: 2,
-                    maximumFractionDigits: 2,
-                  })}
-                </Typography>
-                <Typography
-                  variant="body2"
-                  sx={{
-                    color: (theme) => theme.palette.text.tertiary,
-                    fontSize: { xs: '0.75rem', sm: '0.85rem' },
-                    textAlign: 'center',
-                    maxWidth: '400px',
-                    lineHeight: 1.6,
-                  }}
-                >
-                  Compete for rewards by contributing quality code to open
-                  source
-                </Typography>
-              </Stack>
-            </Box>
-          )}
         </Stack>
+
+        <LivePayoutMarquee />
+
+        <MinerEmissionShare />
+
+        <StarterBounties />
+
+        <StartMiningCta />
       </Box>
     </Page>
   );

--- a/src/pages/home/LivePayoutMarquee.tsx
+++ b/src/pages/home/LivePayoutMarquee.tsx
@@ -1,0 +1,127 @@
+import React, { useMemo } from 'react';
+import { Box, Stack, Typography, alpha, keyframes } from '@mui/material';
+import { useInfiniteCommitLog, useStats } from '../../api';
+
+const scroll = keyframes`
+  from { transform: translateX(0); }
+  to { transform: translateX(-50%); }
+`;
+
+const formatRelative = (iso: string | null) => {
+  if (!iso) return '';
+  const diffMs = Date.now() - new Date(iso).getTime();
+  const s = Math.max(1, Math.floor(diffMs / 1000));
+  if (s < 60) return `${s}s ago`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ago`;
+  return `${Math.floor(h / 24)}d ago`;
+};
+
+const LivePayoutMarquee: React.FC = () => {
+  const { data: stats } = useStats();
+  const { data } = useInfiniteCommitLog({ refetchInterval: 30000 });
+  const taoPrice = stats?.prices?.tao?.data?.price ?? null;
+
+  const items = useMemo(() => {
+    const all = data?.pages.flat() ?? [];
+    return all.filter((pr) => pr.mergedAt).slice(0, 12);
+  }, [data]);
+
+  if (items.length === 0) return null;
+
+  const looped = [...items, ...items];
+
+  return (
+    <Box
+      sx={(theme) => ({
+        width: '100vw',
+        position: 'relative',
+        left: '50%',
+        right: '50%',
+        ml: '-50vw',
+        mr: '-50vw',
+        my: { xs: 4, sm: 5 },
+        py: 1.5,
+        borderTop: `1px solid ${theme.palette.border.light}`,
+        borderBottom: `1px solid ${theme.palette.border.light}`,
+        backgroundColor: alpha(theme.palette.background.default, 0.45),
+        overflow: 'hidden',
+        WebkitMaskImage:
+          'linear-gradient(to right, transparent, black 8%, black 92%, transparent)',
+        maskImage:
+          'linear-gradient(to right, transparent, black 8%, black 92%, transparent)',
+      })}
+    >
+      <Stack
+        direction="row"
+        spacing={4}
+        sx={{
+          width: 'max-content',
+          animation: `${scroll} 60s linear infinite`,
+          '&:hover': { animationPlayState: 'paused' },
+        }}
+      >
+        {looped.map((pr, i) => {
+          const score = parseFloat(pr.score || '0');
+          const usd =
+            pr.predictedUsdPerDay ??
+            (pr.predictedTaoPerDay && taoPrice
+              ? pr.predictedTaoPerDay * taoPrice
+              : null);
+          return (
+            <Stack
+              key={`${pr.repository}-${pr.pullRequestNumber}-${i}`}
+              direction="row"
+              alignItems="center"
+              spacing={1}
+              sx={{ flexShrink: 0 }}
+            >
+              <Typography
+                sx={(theme) => ({
+                  fontFamily: '"JetBrains Mono", monospace',
+                  fontWeight: 700,
+                  fontSize: '0.85rem',
+                  color: theme.palette.diff.additions,
+                })}
+              >
+                +{score.toFixed(2)}
+              </Typography>
+              <Typography
+                sx={{ fontSize: '0.82rem', color: 'text.secondary' }}
+              >
+                {pr.author}/{pr.repository}#{pr.pullRequestNumber}
+              </Typography>
+              {usd && usd > 0 ? (
+                <Typography
+                  sx={(theme) => ({
+                    fontSize: '0.72rem',
+                    color: alpha(theme.palette.text.primary, 0.5),
+                  })}
+                >
+                  ~${usd.toFixed(2)}/day
+                </Typography>
+              ) : null}
+              <Typography
+                sx={{ fontSize: '0.7rem', color: 'text.tertiary' }}
+              >
+                {formatRelative(pr.mergedAt || pr.prCreatedAt)}
+              </Typography>
+              <Box
+                sx={(theme) => ({
+                  width: 4,
+                  height: 4,
+                  borderRadius: '50%',
+                  backgroundColor: alpha(theme.palette.text.primary, 0.25),
+                })}
+              />
+            </Stack>
+          );
+        })}
+      </Stack>
+    </Box>
+  );
+};
+
+export default LivePayoutMarquee;

--- a/src/pages/home/MinerEmissionShare.tsx
+++ b/src/pages/home/MinerEmissionShare.tsx
@@ -1,0 +1,249 @@
+import React, { useMemo } from 'react';
+import { Box, Stack, Tooltip, Typography, alpha } from '@mui/material';
+import { useStats } from '../../api';
+
+const DAILY_ALPHA_EMISSIONS = 2952;
+
+const SEGMENTS = [
+  {
+    key: 'owner',
+    pct: 0.18,
+    label: 'Subnet owner',
+    tone: 'tertiary' as const,
+    tooltip: 'Fixed 18% on-chain allocation to the subnet owner.',
+  },
+  {
+    key: 'miners',
+    pct: 0.41,
+    label: 'Miners',
+    tone: 'primary' as const,
+    tooltip:
+      'Distributed among miners by incentive scoring (PR quality, token score, repo weight).',
+  },
+  {
+    key: 'validators',
+    pct: 0.41,
+    label: 'Validators + nominators',
+    tone: 'secondary' as const,
+    tooltip:
+      'Split by stake. A validator’s "take %" is their cut from nominator rewards — not a slice of the total 41%.',
+  },
+];
+
+const MinerEmissionShare: React.FC = () => {
+  const { data: stats } = useStats();
+  const taoPrice = stats?.prices?.tao?.data?.price ?? null;
+  const alphaPrice = stats?.prices?.alpha?.data?.price ?? null;
+
+  const { dailyMinerUsd, monthlyPoolUsd } = useMemo(() => {
+    if (!taoPrice || !alphaPrice) {
+      return { dailyMinerUsd: null, monthlyPoolUsd: null };
+    }
+    const dailyTotal = taoPrice * alphaPrice * DAILY_ALPHA_EMISSIONS;
+    const now = new Date();
+    const daysInMonth = new Date(
+      now.getFullYear(),
+      now.getMonth() + 1,
+      0,
+    ).getDate();
+    return {
+      dailyMinerUsd: dailyTotal * 0.41,
+      monthlyPoolUsd: dailyTotal * daysInMonth,
+    };
+  }, [taoPrice, alphaPrice]);
+
+  const formatUsd = (n: number, fractionDigits = 0) =>
+    `$${n.toLocaleString(undefined, {
+      maximumFractionDigits: fractionDigits,
+      minimumFractionDigits: fractionDigits,
+    })}`;
+
+  return (
+    <Box
+      sx={(theme) => ({
+        width: '100vw',
+        position: 'relative',
+        left: '50%',
+        right: '50%',
+        ml: '-50vw',
+        mr: '-50vw',
+        my: { xs: 4, sm: 5 },
+        py: { xs: 4, sm: 5 },
+        px: { xs: 2, sm: 4 },
+        borderTop: `1px solid ${theme.palette.border.light}`,
+        borderBottom: `1px solid ${theme.palette.border.light}`,
+        backgroundColor: alpha(theme.palette.background.default, 0.55),
+      })}
+    >
+      <Stack
+        sx={{ maxWidth: 960, mx: 'auto', width: '100%' }}
+        spacing={3}
+      >
+        <Stack
+          direction={{ xs: 'column', sm: 'row' }}
+          spacing={{ xs: 2.5, sm: 4 }}
+          alignItems={{ xs: 'flex-start', sm: 'flex-end' }}
+          justifyContent="space-between"
+        >
+          <Box>
+            <Typography
+              sx={{
+                fontSize: '0.7rem',
+                textTransform: 'uppercase',
+                letterSpacing: '0.15em',
+                fontWeight: 600,
+                color: 'text.secondary',
+                mb: 0.5,
+              }}
+            >
+              Monthly reward pool
+            </Typography>
+            <Typography
+              sx={(theme) => ({
+                fontSize: { xs: '2rem', sm: '2.75rem' },
+                fontWeight: 700,
+                color: theme.palette.text.primary,
+                letterSpacing: '-0.02em',
+                lineHeight: 1,
+              })}
+            >
+              {monthlyPoolUsd !== null ? formatUsd(monthlyPoolUsd, 2) : '—'}
+            </Typography>
+          </Box>
+          <Box sx={{ textAlign: { xs: 'left', sm: 'right' } }}>
+            <Typography
+              sx={{
+                fontSize: '0.7rem',
+                textTransform: 'uppercase',
+                letterSpacing: '0.15em',
+                fontWeight: 600,
+                color: 'text.secondary',
+                mb: 0.5,
+              }}
+            >
+              Flowing to miners
+            </Typography>
+            <Typography
+              sx={(theme) => ({
+                fontSize: { xs: '1.5rem', sm: '1.85rem' },
+                fontWeight: 700,
+                color: theme.palette.diff.additions,
+                letterSpacing: '-0.01em',
+                lineHeight: 1,
+              })}
+            >
+              {dailyMinerUsd !== null ? formatUsd(dailyMinerUsd, 0) : '—'}
+              <Typography
+                component="span"
+                sx={{
+                  fontSize: '0.8rem',
+                  fontWeight: 500,
+                  color: 'text.tertiary',
+                  ml: 0.75,
+                }}
+              >
+                / day
+              </Typography>
+            </Typography>
+          </Box>
+        </Stack>
+
+        <Box>
+          <Stack
+            direction="row"
+            sx={(theme) => ({
+              height: 14,
+              borderRadius: 999,
+              overflow: 'hidden',
+              border: `1px solid ${theme.palette.border.light}`,
+            })}
+          >
+            {SEGMENTS.map((seg) => (
+              <Tooltip
+                key={seg.key}
+                title={`${Math.round(seg.pct * 100)}% — ${seg.label}. ${seg.tooltip}`}
+                placement="top"
+                arrow
+              >
+                <Box
+                  sx={(theme) => ({
+                    flex: seg.pct,
+                    backgroundColor:
+                      seg.tone === 'primary'
+                        ? theme.palette.diff.additions
+                        : seg.tone === 'secondary'
+                          ? theme.palette.status.award
+                          : alpha(theme.palette.text.primary, 0.25),
+                    transition: 'opacity 0.2s',
+                    cursor: 'help',
+                    '&:hover': { opacity: 0.85 },
+                  })}
+                />
+              </Tooltip>
+            ))}
+          </Stack>
+          <Stack direction="row" sx={{ mt: 1.25 }}>
+            {SEGMENTS.map((seg) => (
+              <Box
+                key={seg.key}
+                sx={{ flex: seg.pct, minWidth: 0, pr: 1 }}
+              >
+                <Stack direction="row" alignItems="center" spacing={0.75}>
+                  <Box
+                    sx={(theme) => ({
+                      width: 8,
+                      height: 8,
+                      borderRadius: '50%',
+                      backgroundColor:
+                        seg.tone === 'primary'
+                          ? theme.palette.diff.additions
+                          : seg.tone === 'secondary'
+                            ? theme.palette.status.award
+                            : alpha(theme.palette.text.primary, 0.25),
+                      flexShrink: 0,
+                    })}
+                  />
+                  <Typography
+                    sx={{
+                      fontSize: '0.78rem',
+                      fontWeight: 700,
+                      color: 'text.primary',
+                    }}
+                  >
+                    {Math.round(seg.pct * 100)}%
+                  </Typography>
+                  <Typography
+                    sx={{
+                      fontSize: '0.74rem',
+                      color: 'text.secondary',
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
+                    }}
+                  >
+                    {seg.label}
+                  </Typography>
+                </Stack>
+              </Box>
+            ))}
+          </Stack>
+        </Box>
+
+        <Typography
+          sx={{
+            fontSize: '0.72rem',
+            color: 'text.tertiary',
+            fontStyle: 'italic',
+            lineHeight: 1.5,
+          }}
+        >
+          Validator + nominator share is divided by stake. A validator&rsquo;s
+          &ldquo;take %&rdquo; is the cut they keep from their nominators&rsquo;
+          rewards, not a slice of total emissions.
+        </Typography>
+      </Stack>
+    </Box>
+  );
+};
+
+export default MinerEmissionShare;

--- a/src/pages/home/StartMiningCta.tsx
+++ b/src/pages/home/StartMiningCta.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { Box, Button, Stack, Typography, alpha } from '@mui/material';
+import { Link as RouterLink } from 'react-router-dom';
+import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
+
+const StartMiningCta: React.FC = () => (
+  <Box
+    sx={(theme) => ({
+      width: '100%',
+      maxWidth: 960,
+      mx: 'auto',
+      mt: { xs: 5, sm: 7 },
+      mb: { xs: 4, sm: 6 },
+      p: { xs: 3, sm: 4 },
+      borderRadius: 3,
+      border: `1px solid ${theme.palette.border.medium}`,
+      background: `linear-gradient(135deg, ${alpha(
+        theme.palette.diff.additions,
+        0.12,
+      )} 0%, ${alpha(theme.palette.status.award, 0.08)} 100%)`,
+      backdropFilter: 'blur(12px)',
+    })}
+  >
+    <Stack
+      direction={{ xs: 'column', sm: 'row' }}
+      alignItems={{ xs: 'flex-start', sm: 'center' }}
+      justifyContent="space-between"
+      spacing={{ xs: 2, sm: 3 }}
+    >
+      <Box>
+        <Typography
+          sx={{
+            fontSize: { xs: '1.25rem', sm: '1.5rem' },
+            fontWeight: 700,
+            color: 'text.primary',
+            lineHeight: 1.2,
+            mb: 0.5,
+          }}
+        >
+          Start mining in 60 seconds
+        </Typography>
+        <Typography
+          sx={{
+            fontSize: '0.85rem',
+            color: 'text.secondary',
+            lineHeight: 1.5,
+          }}
+        >
+          Pick a bounty, write a PR, get paid in TAO. No registration required.
+        </Typography>
+      </Box>
+      <Stack direction="row" spacing={1.5} flexShrink={0}>
+        <Button
+          component={RouterLink}
+          to="/bounties"
+          variant="contained"
+          size="large"
+          endIcon={<ArrowForwardIcon />}
+          sx={{
+            textTransform: 'none',
+            fontWeight: 600,
+            px: 3,
+            borderRadius: 2,
+          }}
+        >
+          Browse bounties
+        </Button>
+        <Button
+          component={RouterLink}
+          to="/onboard"
+          variant="outlined"
+          size="large"
+          sx={{
+            textTransform: 'none',
+            fontWeight: 600,
+            px: 3,
+            borderRadius: 2,
+          }}
+        >
+          How it works
+        </Button>
+      </Stack>
+    </Stack>
+  </Box>
+);
+
+export default StartMiningCta;

--- a/src/pages/home/StarterBounties.tsx
+++ b/src/pages/home/StarterBounties.tsx
@@ -1,0 +1,146 @@
+import React, { useMemo } from 'react';
+import { Box, Grid, Stack, Typography, alpha } from '@mui/material';
+import { Link as RouterLink } from 'react-router-dom';
+import { useIssues } from '../../api';
+
+const StarterBounties: React.FC = () => {
+  const { data: issues } = useIssues('registered');
+
+  const top = useMemo(() => {
+    if (!issues) return [];
+    return [...issues]
+      .sort(
+        (a, b) =>
+          parseFloat(b.targetBounty || '0') - parseFloat(a.targetBounty || '0'),
+      )
+      .slice(0, 6);
+  }, [issues]);
+
+  if (top.length === 0) return null;
+
+  return (
+    <Box sx={{ width: '100%', maxWidth: 1100, mx: 'auto' }}>
+      <Stack
+        direction="row"
+        alignItems="baseline"
+        justifyContent="space-between"
+        sx={{ mb: 2 }}
+      >
+        <Typography
+          sx={{
+            fontSize: '0.7rem',
+            textTransform: 'uppercase',
+            letterSpacing: '0.15em',
+            fontWeight: 600,
+            color: 'text.secondary',
+          }}
+        >
+          Open bounties — start now
+        </Typography>
+        <Typography
+          component={RouterLink}
+          to="/bounties"
+          sx={{
+            fontSize: '0.78rem',
+            color: 'primary.main',
+            textDecoration: 'none',
+            fontWeight: 600,
+            '&:hover': { textDecoration: 'underline' },
+          }}
+        >
+          See all →
+        </Typography>
+      </Stack>
+      <Grid container spacing={2}>
+        {top.map((b) => {
+          const reward = parseFloat(b.targetBounty || '0');
+          return (
+            <Grid item xs={12} sm={6} md={4} key={b.id}>
+              <Stack
+                component={RouterLink}
+                to={`/bounties/details?id=${b.id}`}
+                spacing={1.25}
+                sx={(theme) => ({
+                  height: '100%',
+                  p: 2,
+                  borderRadius: 2,
+                  border: `1px solid ${theme.palette.border.light}`,
+                  backgroundColor: alpha(theme.palette.background.default, 0.4),
+                  backdropFilter: 'blur(10px)',
+                  textDecoration: 'none',
+                  color: 'inherit',
+                  transition:
+                    'border-color 0.18s, transform 0.18s, box-shadow 0.18s',
+                  '&:hover': {
+                    borderColor: theme.palette.border.medium,
+                    transform: 'translateY(-2px)',
+                    boxShadow: `0 8px 24px ${alpha(
+                      theme.palette.background.default,
+                      0.35,
+                    )}`,
+                  },
+                })}
+              >
+                <Stack
+                  direction="row"
+                  alignItems="baseline"
+                  justifyContent="space-between"
+                  spacing={1}
+                >
+                  <Typography
+                    sx={(theme) => ({
+                      fontFamily: '"JetBrains Mono", monospace',
+                      fontWeight: 700,
+                      fontSize: '1.1rem',
+                      color: theme.palette.status.award,
+                      lineHeight: 1,
+                    })}
+                  >
+                    {reward > 0 ? `${reward.toFixed(2)} τ` : '—'}
+                  </Typography>
+                  <Typography
+                    sx={{
+                      fontSize: '0.7rem',
+                      color: 'text.tertiary',
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
+                      maxWidth: '60%',
+                    }}
+                  >
+                    {b.repositoryFullName}
+                  </Typography>
+                </Stack>
+                <Typography
+                  sx={{
+                    fontSize: '0.88rem',
+                    fontWeight: 600,
+                    color: 'text.primary',
+                    lineHeight: 1.4,
+                    display: '-webkit-box',
+                    WebkitLineClamp: 2,
+                    WebkitBoxOrient: 'vertical',
+                    overflow: 'hidden',
+                  }}
+                >
+                  {b.title || `Issue #${b.issueNumber}`}
+                </Typography>
+                <Typography
+                  sx={{
+                    fontSize: '0.72rem',
+                    color: 'text.tertiary',
+                    mt: 'auto',
+                  }}
+                >
+                  #{b.issueNumber}
+                </Typography>
+              </Stack>
+            </Grid>
+          );
+        })}
+      </Grid>
+    </Box>
+  );
+};
+
+export default StarterBounties;


### PR DESCRIPTION
## Summary

Closes #877.

Replaces the static landing page with a five-section narrative that shows what subnet 74 pays out and how visitors can act on it.

### Sections

1. **Hero** - logo, headline, tagline.
2. **Live payout marquee** *(full-bleed)* - auto-scrolling ticker of the 12 most recent merged PRs with score and `~$X/day` projection. Pauses on hover, refetches every 30s.
3. **Economics ribbon** *(full-bleed)* - monthly reward pool and daily miner share side-by-side, above a stacked `18% / 41% / 41%` bar (subnet owner / miners / validators+nominators) with per-segment tooltips and a footnote on validator take rate.
4. **Open bounties grid** - top 6 registered bounties by reward, 3-column responsive cards linking to `/bounties/details`.
5. **CTA strip** - gradient panel with **Browse bounties** and **How it works** buttons.

### Files

- new - `src/pages/home/LivePayoutMarquee.tsx`
- new - `src/pages/home/MinerEmissionShare.tsx`
- new - `src/pages/home/StarterBounties.tsx`
- new - `src/pages/home/StartMiningCta.tsx`
- modified - `src/pages/HomePage.tsx`

## Test plan

- [ ] Marquee scrolls, pauses on hover, refreshes after 30s
- [ ] Economics ribbon shows sensible monthly pool and daily miner numbers
- [ ] Bounties grid sorted by reward; cards link to correct `/bounties/details?id=…`
- [ ] CTA buttons route to `/bounties` and `/onboard`
- [ ] Mobile: marquee fits, ribbon stats stack, bounties collapse to 1 column
- [ ] `npm run typecheck` and `npm run lint` clean

## Attachment

https://github.com/user-attachments/assets/4b2605ca-7a20-4839-b7a4-161ff72a6f54

