### PR TITLE
refactor: consolidate duplicated route builders, view-mode persistence, and theme tokens

### DIFF
--- a/src/components/DayPRsPanel.tsx
+++ b/src/components/DayPRsPanel.tsx
@@ -4,6 +4,7 @@ import { format, parseISO } from 'date-fns';
 import type { CommitLog } from '../api';
 import { LinkBox } from './common/linkBehavior';
 import { STATUS_COLORS, TEXT_OPACITY, scrollbarSx } from '../theme';
+import { getPrHref } from '../routes.helpers';
 
 interface DayPRsPanelProps {
   date: string;
@@ -97,7 +98,7 @@ const DayPRsPanel: React.FC<DayPRsPanelProps> = ({ date, prs, username }) => {
           {dayPRs.map((pr, idx) => {
             const dotColor = prStateColor(pr);
             const stateLabel = prStateLabel(pr);
-            const detailsHref = `/miners/pr?repo=${encodeURIComponent(pr.repository)}&number=${pr.pullRequestNumber}`;
+            const detailsHref = getPrHref(pr.repository, pr.pullRequestNumber);
             const timeLabel = pr.mergedAt
               ? format(new Date(pr.mergedAt), 'h:mm a')
               : '';

--- a/src/components/FilterButton.tsx
+++ b/src/components/FilterButton.tsx
@@ -7,7 +7,13 @@ interface FilterButtonProps {
   onClick: () => void;
   count?: number;
   color: string;
+  /** Color for the label when active. Default: 'text.primary'. */
   activeTextColor?: string;
+  /**
+   * 'compact' shrinks padding/font for dense toolbars (used inside the
+   * miner explorer tables).
+   */
+  variant?: 'default' | 'compact';
 }
 
 const FilterButton: React.FC<FilterButtonProps> = ({
@@ -17,34 +23,54 @@ const FilterButton: React.FC<FilterButtonProps> = ({
   count,
   color,
   activeTextColor = 'text.primary',
-}) => (
-  <Button
-    size="small"
-    onClick={onClick}
-    sx={{
-      color: isActive ? activeTextColor : 'text.tertiary',
-      backgroundColor: isActive ? 'border.subtle' : 'transparent',
-      borderRadius: '6px',
-      px: 2,
-      minWidth: 'auto',
-      textTransform: 'none',
-      fontSize: '0.8rem',
-      border: isActive ? `1px solid ${color}` : '1px solid transparent',
-      '&:hover': {
-        backgroundColor: 'border.light',
-      },
-    }}
-  >
-    {label}{' '}
-    {count !== undefined && (
-      <Box
-        component="span"
-        sx={{ opacity: 0.6, ml: '6px', fontSize: '0.75rem' }}
-      >
-        {count}
-      </Box>
-    )}
-  </Button>
-);
+  variant = 'default',
+}) => {
+  const isCompact = variant === 'compact';
+  return (
+    <Button
+      size="small"
+      onClick={onClick}
+      sx={{
+        color: isActive
+          ? activeTextColor
+          : isCompact
+            ? 'text.secondary'
+            : 'text.tertiary',
+        backgroundColor: isActive
+          ? isCompact
+            ? 'surface.light'
+            : 'border.subtle'
+          : 'transparent',
+        borderRadius: '6px',
+        px: isCompact ? { xs: 1, sm: 1.5 } : 2,
+        py: isCompact ? { xs: 0.5, sm: 0.75 } : undefined,
+        minWidth: 'auto',
+        textTransform: 'none',
+        fontSize: isCompact ? { xs: '0.65rem', sm: '0.75rem' } : '0.8rem',
+        whiteSpace: isCompact ? 'nowrap' : undefined,
+        border: isActive
+          ? `1px solid ${color}`
+          : '1px solid transparent',
+        '&:hover': {
+          backgroundColor: isCompact ? 'border.medium' : 'border.light',
+        },
+      }}
+    >
+      {label}{' '}
+      {count !== undefined && (
+        <Box
+          component="span"
+          sx={{
+            opacity: 0.6,
+            ml: '6px',
+            fontSize: isCompact ? '0.7rem' : '0.75rem',
+          }}
+        >
+          {count}
+        </Box>
+      )}
+    </Button>
+  );
+};
 
 export default FilterButton;

--- a/src/components/common/WatchlistButton.tsx
+++ b/src/components/common/WatchlistButton.tsx
@@ -41,7 +41,7 @@ export const WatchlistButton: React.FC<WatchlistButtonProps> = ({
           '&:hover': {
             color: 'warning.light',
             transform: 'scale(1.08)',
-            backgroundColor: 'rgba(255,255,255,0.06)',
+            backgroundColor: 'surface.light',
           },
           ...sx,
         }}

--- a/src/components/issues/BountyCard.tsx
+++ b/src/components/issues/BountyCard.tsx
@@ -22,7 +22,7 @@ import {
   formatDate,
   formatAlphaToUsd,
 } from '../../utils/format';
-import { STATUS_COLORS, TEXT_OPACITY } from '../../theme';
+import { STATUS_COLORS, SURFACE_OPACITY, TEXT_OPACITY } from '../../theme';
 
 interface BountyCardProps {
   issue: IssueBounty;
@@ -139,11 +139,19 @@ export const BountyCard: React.FC<BountyCardProps> = ({
           category="bounties"
           itemKey={String(issue.id)}
           size="small"
-          sx={{
-            backgroundColor: 'rgba(255,255,255,0.08)',
+          sx={(theme) => ({
+            backgroundColor: alpha(
+              theme.palette.common.white,
+              SURFACE_OPACITY.divider,
+            ),
             borderRadius: '50%',
-            '&:hover': { backgroundColor: 'rgba(255,255,255,0.15)' },
-          }}
+            '&:hover': {
+              backgroundColor: alpha(
+                theme.palette.common.white,
+                SURFACE_OPACITY.emphasis,
+              ),
+            },
+          })}
         />
       </Box>
 

--- a/src/components/issues/IssueSubmissionsTable.tsx
+++ b/src/components/issues/IssueSubmissionsTable.tsx
@@ -17,6 +17,7 @@ import {
   DataTable,
   type DataTableColumn,
 } from '../../components/common/DataTable';
+import { getMinerHref, getPrHref } from '../../routes.helpers';
 
 interface IssueSubmissionsTableProps {
   submissions: IssueSubmission[] | undefined;
@@ -65,7 +66,7 @@ const IssueSubmissionsTable: React.FC<IssueSubmissionsTableProps> = ({
         submission.authorGithubId ? (
           <LinkBox
             component={Typography}
-            href={`/miners/details?githubId=${submission.authorGithubId}`}
+            href={getMinerHref(submission.authorGithubId)}
             linkState={linkState}
             onClick={(e: React.MouseEvent) => e.stopPropagation()}
             sx={{
@@ -192,7 +193,7 @@ const IssueSubmissionsTable: React.FC<IssueSubmissionsTableProps> = ({
             </Box>
           }
           getRowHref={(submission) =>
-            `/miners/pr?repo=${encodeURIComponent(submission.repositoryFullName)}&number=${submission.number}`
+            getPrHref(submission.repositoryFullName, submission.number)
           }
           linkState={linkState}
         />

--- a/src/components/issues/issuesViewMode.ts
+++ b/src/components/issues/issuesViewMode.ts
@@ -1,51 +1,31 @@
-export type IssuesViewMode = 'cards' | 'list';
+import {
+  CARD_LIST_VIEW_QUERY_PARAM,
+  CARD_ROW_SIZES,
+  DEFAULT_CARD_ROWS,
+  DEFAULT_LIST_ROWS,
+  LIST_ROW_SIZES,
+  VALID_ROW_SIZES,
+  cardListViewModeFromQuery,
+  clampCardListRows,
+  createCardListViewModeStorage,
+  type CardListViewMode,
+} from '../../utils/cardListViewMode';
 
-export const ISSUES_VIEW_QUERY_PARAM = 'view';
+export type IssuesViewMode = CardListViewMode;
+
+export const ISSUES_VIEW_QUERY_PARAM = CARD_LIST_VIEW_QUERY_PARAM;
 export const ISSUES_VIEW_STORAGE_KEY = 'issues:viewMode';
 
-export const readStoredIssuesViewMode = (): IssuesViewMode => {
-  try {
-    return window.localStorage.getItem(ISSUES_VIEW_STORAGE_KEY) === 'cards'
-      ? 'cards'
-      : 'list';
-  } catch {
-    return 'list';
-  }
-};
+const storage = createCardListViewModeStorage(ISSUES_VIEW_STORAGE_KEY);
+export const readStoredIssuesViewMode = storage.read;
+export const writeStoredIssuesViewMode = storage.write;
 
-export const writeStoredIssuesViewMode = (mode: IssuesViewMode): void => {
-  try {
-    window.localStorage.setItem(ISSUES_VIEW_STORAGE_KEY, mode);
-  } catch {
-    // localStorage unavailable (private mode, quota) — preference won't persist
-  }
-};
+export const getIssuesViewModeFromQuery = cardListViewModeFromQuery;
 
-export const getIssuesViewModeFromQuery = (
-  value: string | null,
-  fallback: IssuesViewMode,
-): IssuesViewMode => {
-  if (value === 'cards') return 'cards';
-  if (value === 'list') return 'list';
-  return fallback;
-};
+export const ISSUES_LIST_ROWS = LIST_ROW_SIZES;
+export const ISSUES_CARD_ROWS = CARD_ROW_SIZES;
+export const ISSUES_VALID_ROWS = VALID_ROW_SIZES;
+export const ISSUES_DEFAULT_LIST_ROWS = DEFAULT_LIST_ROWS;
+export const ISSUES_DEFAULT_CARD_ROWS = DEFAULT_CARD_ROWS;
 
-// Card grid: 3 cols (lg/md), 2 (sm), 1 (xs). Sizes divisible by 1, 2, 3 so
-// the last row of cards is never partial.
-export const ISSUES_LIST_ROWS = [10, 25, 50] as const;
-export const ISSUES_CARD_ROWS = [12, 24, 48] as const;
-export const ISSUES_VALID_ROWS: readonly number[] = [
-  ...ISSUES_LIST_ROWS,
-  ...ISSUES_CARD_ROWS,
-];
-export const ISSUES_DEFAULT_LIST_ROWS = 10;
-export const ISSUES_DEFAULT_CARD_ROWS = 12;
-
-export const clampRowsForIssuesView = (
-  rows: number,
-  mode: IssuesViewMode,
-): number => {
-  const options = mode === 'cards' ? ISSUES_CARD_ROWS : ISSUES_LIST_ROWS;
-  if ((options as readonly number[]).includes(rows)) return rows;
-  return mode === 'cards' ? ISSUES_DEFAULT_CARD_ROWS : ISSUES_DEFAULT_LIST_ROWS;
-};
+export const clampRowsForIssuesView = clampCardListRows;

--- a/src/components/layout/GlobalSearchBar.tsx
+++ b/src/components/layout/GlobalSearchBar.tsx
@@ -7,6 +7,12 @@ import React, {
 } from 'react';
 import { scrollbarSx } from '../../theme';
 import {
+  getMinerHref,
+  getRepoHref,
+  getPrHref,
+  getBountyHref,
+} from '../../routes.helpers';
+import {
   Box,
   ButtonBase,
   CircularProgress,
@@ -305,7 +311,7 @@ const GlobalSearchBar: React.FC = () => {
   const navItems: NavItem[] = useMemo(() => {
     const items: NavItem[] = [];
     minerResults.forEach((miner) => {
-      const href = `/miners/details?githubId=${encodeURIComponent(miner.githubId)}`;
+      const href = getMinerHref(miner.githubId);
       items.push({
         key: `miner-${miner.githubId}`,
         kind: 'miner',
@@ -316,7 +322,7 @@ const GlobalSearchBar: React.FC = () => {
       });
     });
     repositoryResults.forEach((repo) => {
-      const href = `/miners/repository?name=${encodeURIComponent(repo.fullName)}`;
+      const href = getRepoHref(repo.fullName);
       items.push({
         key: `repo-${repo.fullName}`,
         kind: 'repo',
@@ -327,7 +333,7 @@ const GlobalSearchBar: React.FC = () => {
       });
     });
     prResults.forEach((pr) => {
-      const href = `/miners/pr?repo=${encodeURIComponent(pr.repository)}&number=${pr.pullRequestNumber}`;
+      const href = getPrHref(pr.repository, pr.pullRequestNumber);
       items.push({
         key: `pr-${pr.repository}-${pr.pullRequestNumber}`,
         kind: 'pr',
@@ -338,7 +344,7 @@ const GlobalSearchBar: React.FC = () => {
       });
     });
     issueResults.forEach((issue) => {
-      const href = `/bounties/details?id=${issue.id}`;
+      const href = getBountyHref(issue.id);
       items.push({
         key: `issue-${issue.id}`,
         kind: 'issue',

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -348,7 +348,7 @@ const SidebarNavLink: React.FC<{
         textDecoration: 'none',
         fontSize: NAV_LABEL_FONT,
         textTransform: 'none',
-        backgroundColor: isActive ? 'rgba(255, 255, 255, 0.1)' : 'transparent',
+        backgroundColor: isActive ? 'border.light' : 'transparent',
         borderLeft: collapsed
           ? 'none'
           : isActive
@@ -363,7 +363,7 @@ const SidebarNavLink: React.FC<{
           flexShrink: 0,
         },
         '&:hover': {
-          backgroundColor: 'rgba(255, 255, 255, 0.05)',
+          backgroundColor: 'surface.light',
           color: 'primary.main',
         },
       }}

--- a/src/components/leaderboard/LeaderboardTableSkeleton.tsx
+++ b/src/components/leaderboard/LeaderboardTableSkeleton.tsx
@@ -59,7 +59,7 @@ const LeaderboardTableSkeleton: React.FC<LeaderboardTableSkeletonProps> = ({
                 variant="text"
                 width={col.barWidth}
                 sx={{
-                  bgcolor: 'rgba(255,255,255,0.06)',
+                  bgcolor: 'surface.light',
                   ml: col.align === 'right' ? 'auto' : 0,
                 }}
               />

--- a/src/components/leaderboard/TopMinersTable.tsx
+++ b/src/components/leaderboard/TopMinersTable.tsx
@@ -28,7 +28,12 @@ import {
   FONTS,
 } from './types';
 
-type ViewMode = 'cards' | 'list';
+import {
+  createCardListViewModeStorage,
+  type CardListViewMode,
+} from '../../utils/cardListViewMode';
+
+type ViewMode = CardListViewMode;
 
 // Re-export MinerStats for backward compatibility
 export type { MinerStats } from './types';
@@ -45,23 +50,12 @@ const VIEW_STORAGE_KEY = 'leaderboard:viewMode';
 // Sort state (`sort`, `dir`) is owned by `useDataTableParams`. We reuse the
 // `page` param slot for our "show more" count via the paramKeys override.
 
-const readStoredViewMode = (): ViewMode => {
-  try {
-    return window.localStorage.getItem(VIEW_STORAGE_KEY) === 'list'
-      ? 'list'
-      : 'cards';
-  } catch {
-    return 'cards';
-  }
-};
-
-const writeStoredViewMode = (mode: ViewMode) => {
-  try {
-    window.localStorage.setItem(VIEW_STORAGE_KEY, mode);
-  } catch {
-    // localStorage unavailable (private mode, quota) — preference won't persist
-  }
-};
+const viewModeStorage = createCardListViewModeStorage(
+  VIEW_STORAGE_KEY,
+  'cards',
+);
+const readStoredViewMode = viewModeStorage.read;
+const writeStoredViewMode = viewModeStorage.write;
 
 interface TopMinersTableProps {
   miners: MinerStats[];

--- a/src/components/leaderboard/TopRepositoriesTable.tsx
+++ b/src/components/leaderboard/TopRepositoriesTable.tsx
@@ -63,6 +63,7 @@ import { RankIcon } from './RankIcon';
 import { getRepositoryOwnerAvatarBackground, type RepoStats } from './types';
 import {
   CHART_COLORS,
+  MONO_FONT,
   STATUS_COLORS,
   TEXT_OPACITY,
   UI_COLORS,
@@ -1379,7 +1380,7 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
                 Repository not in tracked list. Open details for{' '}
                 <Typography
                   component="span"
-                  sx={{ fontFamily: '"JetBrains Mono", monospace' }}
+                  sx={{ fontFamily: MONO_FONT }}
                 >
                   {trimmedSearch}
                 </Typography>

--- a/src/components/leaderboard/repositoriesViewMode.ts
+++ b/src/components/leaderboard/repositoriesViewMode.ts
@@ -1,57 +1,31 @@
-export type RepositoriesViewMode = 'cards' | 'list';
+import {
+  CARD_LIST_VIEW_QUERY_PARAM,
+  CARD_ROW_SIZES,
+  DEFAULT_CARD_ROWS,
+  DEFAULT_LIST_ROWS,
+  LIST_ROW_SIZES,
+  VALID_ROW_SIZES,
+  cardListViewModeFromQuery,
+  clampCardListRows,
+  createCardListViewModeStorage,
+  type CardListViewMode,
+} from '../../utils/cardListViewMode';
 
-export const REPOSITORIES_VIEW_QUERY_PARAM = 'view';
+export type RepositoriesViewMode = CardListViewMode;
+
+export const REPOSITORIES_VIEW_QUERY_PARAM = CARD_LIST_VIEW_QUERY_PARAM;
 export const REPOSITORIES_VIEW_STORAGE_KEY = 'repositories:viewMode';
 
-export const readStoredRepositoriesViewMode = (): RepositoriesViewMode => {
-  try {
-    return window.localStorage.getItem(REPOSITORIES_VIEW_STORAGE_KEY) ===
-      'cards'
-      ? 'cards'
-      : 'list';
-  } catch {
-    return 'list';
-  }
-};
+const storage = createCardListViewModeStorage(REPOSITORIES_VIEW_STORAGE_KEY);
+export const readStoredRepositoriesViewMode = storage.read;
+export const writeStoredRepositoriesViewMode = storage.write;
 
-export const writeStoredRepositoriesViewMode = (
-  mode: RepositoriesViewMode,
-): void => {
-  try {
-    window.localStorage.setItem(REPOSITORIES_VIEW_STORAGE_KEY, mode);
-  } catch {
-    // localStorage unavailable (private mode, quota) — preference won't persist
-  }
-};
+export const getRepositoriesViewModeFromQuery = cardListViewModeFromQuery;
 
-export const getRepositoriesViewModeFromQuery = (
-  value: string | null,
-  fallback: RepositoriesViewMode,
-): RepositoriesViewMode => {
-  if (value === 'cards') return 'cards';
-  if (value === 'list') return 'list';
-  return fallback;
-};
+export const REPOSITORIES_LIST_ROWS = LIST_ROW_SIZES;
+export const REPOSITORIES_CARD_ROWS = CARD_ROW_SIZES;
+export const REPOSITORIES_VALID_ROWS = VALID_ROW_SIZES;
+export const REPOSITORIES_DEFAULT_LIST_ROWS = DEFAULT_LIST_ROWS;
+export const REPOSITORIES_DEFAULT_CARD_ROWS = DEFAULT_CARD_ROWS;
 
-// Card grid is up to 3 cols (lg/md), 2 (sm), 1 (xs). These page sizes
-// divide evenly by 1, 2 and 3, so the last row of cards is never partial.
-export const REPOSITORIES_LIST_ROWS = [10, 25, 50] as const;
-export const REPOSITORIES_CARD_ROWS = [12, 24, 48] as const;
-export const REPOSITORIES_VALID_ROWS: readonly number[] = [
-  ...REPOSITORIES_LIST_ROWS,
-  ...REPOSITORIES_CARD_ROWS,
-];
-export const REPOSITORIES_DEFAULT_LIST_ROWS = 10;
-export const REPOSITORIES_DEFAULT_CARD_ROWS = 12;
-
-export const clampRowsForRepositoriesView = (
-  rows: number,
-  mode: RepositoriesViewMode,
-): number => {
-  const options =
-    mode === 'cards' ? REPOSITORIES_CARD_ROWS : REPOSITORIES_LIST_ROWS;
-  if ((options as readonly number[]).includes(rows)) return rows;
-  return mode === 'cards'
-    ? REPOSITORIES_DEFAULT_CARD_ROWS
-    : REPOSITORIES_DEFAULT_LIST_ROWS;
-};
+export const clampRowsForRepositoriesView = clampCardListRows;

--- a/src/components/leaderboard/types.ts
+++ b/src/components/leaderboard/types.ts
@@ -1,4 +1,5 @@
 import {
+  MONO_FONT,
   RANK_COLORS,
   REPO_OWNER_AVATAR_BACKGROUNDS,
   STATUS_COLORS,
@@ -72,7 +73,7 @@ export type SortOption =
   | 'watch';
 
 export const FONTS = {
-  mono: '"JetBrains Mono", monospace',
+  mono: MONO_FONT,
 } as const;
 
 export const getRankColors = (rank: number) => {

--- a/src/components/miners/ExplorerFilterButton.tsx
+++ b/src/components/miners/ExplorerFilterButton.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Button } from '@mui/material';
+import FilterButton from '../FilterButton';
 
 interface ExplorerFilterButtonProps {
   label: string;
@@ -9,39 +9,26 @@ interface ExplorerFilterButtonProps {
   onClick: () => void;
 }
 
+/**
+ * Compact filter button used inside dense miner-explorer toolbars. Thin
+ * wrapper over the shared `FilterButton` (variant="compact") that keeps the
+ * `selected` prop name historically used at call sites.
+ */
 const ExplorerFilterButton: React.FC<ExplorerFilterButtonProps> = ({
   label,
   count,
   color,
   selected,
   onClick,
-}) => {
-  return (
-    <Button
-      size="small"
-      onClick={onClick}
-      sx={{
-        color: selected ? 'text.primary' : (t) => t.palette.text.secondary,
-        backgroundColor: selected ? 'surface.light' : 'surface.transparent',
-        borderRadius: '6px',
-        px: { xs: 1, sm: 1.5 },
-        py: { xs: 0.5, sm: 0.75 },
-        minWidth: 'auto',
-        textTransform: 'none',
-        fontSize: { xs: '0.65rem', sm: '0.75rem' },
-        border: selected ? `1px solid ${color}` : '1px solid transparent',
-        whiteSpace: 'nowrap',
-        '&:hover': {
-          backgroundColor: 'border.medium',
-        },
-      }}
-    >
-      {label}{' '}
-      <span style={{ opacity: 0.6, marginLeft: '6px', fontSize: '0.7rem' }}>
-        {count}
-      </span>
-    </Button>
-  );
-};
+}) => (
+  <FilterButton
+    label={label}
+    count={count}
+    color={color}
+    isActive={selected}
+    onClick={onClick}
+    variant="compact"
+  />
+);
 
 export default ExplorerFilterButton;

--- a/src/components/miners/MinerIssuesTable.tsx
+++ b/src/components/miners/MinerIssuesTable.tsx
@@ -18,6 +18,7 @@ import { useMinerIssues } from '../../api';
 import { type MinerIssue } from '../../api/models/Dashboard';
 import { paginateItems } from '../../utils';
 import { LABEL_COLORS } from '../../theme';
+import { getPrHref } from '../../routes.helpers';
 import {
   DataTable,
   type DataTableColumn,
@@ -308,7 +309,7 @@ const MinerIssuesTable: React.FC<MinerIssuesTableProps> = ({ githubId }) => {
         const repo = issue.solving_pr?.repo_full_name ?? issue.repo_full_name;
         return (
           <RouterLink
-            to={`/miners/pr?repo=${encodeURIComponent(repo)}&number=${prNumber}`}
+            to={getPrHref(repo, prNumber)}
             style={{
               color: 'inherit',
               textDecoration: 'none',

--- a/src/components/miners/MinerPRsTable.tsx
+++ b/src/components/miners/MinerPRsTable.tsx
@@ -28,6 +28,7 @@ import {
 import ExplorerFilterButton from './ExplorerFilterButton';
 import TablePagination from './TablePagination';
 import { tooltipSlotProps } from '../../theme';
+import { getPrHref } from '../../routes.helpers';
 
 type PrSortField = 'number' | 'repository' | 'score' | 'lines' | 'date';
 type SortDir = 'asc' | 'desc';
@@ -207,10 +208,9 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
 
   const handleRowClick = useCallback(
     (pr: CommitLog) => {
-      navigate(
-        `/miners/pr?repo=${encodeURIComponent(pr.repository)}&number=${pr.pullRequestNumber}`,
-        { state: { backLabel: `Back to ${prs?.[0]?.author || githubId}` } },
-      );
+      navigate(getPrHref(pr.repository, pr.pullRequestNumber), {
+        state: { backLabel: `Back to ${prs?.[0]?.author || githubId}` },
+      });
     },
     [navigate, prs, githubId],
   );

--- a/src/components/miners/MinerRepositoriesTable.tsx
+++ b/src/components/miners/MinerRepositoriesTable.tsx
@@ -20,6 +20,7 @@ import RankBadge from './RankBadge';
 import EmptyStateMessage from './EmptyStateMessage';
 import TablePagination from './TablePagination';
 import { searchFieldSx } from './MinerRepositoriesTable.styles';
+import { getRepoHref } from '../../routes.helpers';
 import {
   type RepoSortField,
   type IssueRepoSortField,
@@ -156,7 +157,7 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
     const owner = repository.split('/')[0];
     return (
       <LinkBox
-        href={`/miners/repository?name=${encodeURIComponent(repository)}`}
+        href={getRepoHref(repository)}
         linkState={{ backLabel: `Back to ${backLabel}` }}
         sx={{
           display: 'flex',

--- a/src/components/miners/MinerScoreBreakdown.tsx
+++ b/src/components/miners/MinerScoreBreakdown.tsx
@@ -27,6 +27,7 @@ import {
   type CommitLog,
 } from '../../api';
 import { STATUS_COLORS, tooltipSlotProps } from '../../theme';
+import { getPrHref } from '../../routes.helpers';
 import {
   parseNumber,
   calculateOpenIssueThreshold,
@@ -126,7 +127,7 @@ interface PrScoreRowProps {
 const PrScoreRow: React.FC<PrScoreRowProps> = ({ pr }) => {
   const [expanded, setExpanded] = useState(false);
   const prLinkProps = useLinkBehavior<HTMLAnchorElement>(
-    `/miners/pr?repo=${encodeURIComponent(pr.repository)}&number=${pr.pullRequestNumber}`,
+    getPrHref(pr.repository, pr.pullRequestNumber),
   );
 
   // Fetch full PR details (with all multipliers) — cached by React Query

--- a/src/components/miners/MinerScoreCard.tsx
+++ b/src/components/miners/MinerScoreCard.tsx
@@ -31,6 +31,7 @@ import {
 } from '../../api';
 import { useClipboardCopy } from '../../hooks/useClipboardCopy';
 import {
+  MONO_FONT,
   RANK_COLORS,
   STATUS_COLORS,
   RISK_COLORS,
@@ -212,7 +213,7 @@ const CopyableHotkey: React.FC<{ hotkey: string }> = ({ hotkey }) => {
   const hotkeyTextSx = {
     color: 'inherit',
     fontSize: { xs: '0.55rem', sm: '0.65rem' },
-    fontFamily: '"JetBrains Mono", monospace',
+    fontFamily: MONO_FONT,
     wordBreak: 'normal',
     lineHeight: 1,
   } as const;

--- a/src/components/onboard/GettingStarted.tsx
+++ b/src/components/onboard/GettingStarted.tsx
@@ -12,10 +12,10 @@ import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import CheckIcon from '@mui/icons-material/Check';
 import { alpha, darken } from '@mui/material/styles';
-import { scrollbarSx, tooltipSlotProps } from '../../theme';
+import { MONO_FONT, scrollbarSx, tooltipSlotProps } from '../../theme';
 import { useClipboardCopy } from '../../hooks/useClipboardCopy';
 
-const MONO = '"JetBrains Mono", monospace';
+const MONO = MONO_FONT;
 
 const steps = [
   {

--- a/src/components/prs/PRDetailsCard.tsx
+++ b/src/components/prs/PRDetailsCard.tsx
@@ -21,6 +21,7 @@ import theme, {
 import { parseNumber } from '../../utils';
 import { buildMultiplierGrid } from '../../utils/multiplierDefs';
 import PRTimeDecayChart from './PRTimeDecayChart';
+import { getRepoHref } from '../../routes.helpers';
 
 interface PRDetailsCardProps {
   repository: string;
@@ -38,7 +39,7 @@ const PRDetailsCard: React.FC<PRDetailsCardProps> = ({
     usePullRequestDetails(repository, pullRequestNumber);
 
   const repoLinkProps = useLinkBehavior<HTMLAnchorElement>(
-    `/miners/repository?name=${encodeURIComponent(repository)}`,
+    getRepoHref(repository),
     { state: { backLabel: `Back to PR #${pullRequestNumber}` } },
   );
   if (isDetailsLoading) {

--- a/src/components/prs/PRHeader.tsx
+++ b/src/components/prs/PRHeader.tsx
@@ -6,8 +6,9 @@ import EventAvailableIcon from '@mui/icons-material/EventAvailable';
 import { linkResetSx, useLinkBehavior } from '../common/linkBehavior';
 import { formatDate, formatUsdEstimate } from '../../utils';
 import { type PullRequestDetails } from '../../api/models/Dashboard';
-import { STATUS_COLORS } from '../../theme';
+import { MONO_FONT, STATUS_COLORS } from '../../theme';
 import { getRepositoryOwnerAvatarBackground } from '../leaderboard/types';
+import { getRepoHref, getMinerHref } from '../../routes.helpers';
 interface PRHeaderProps {
   repository: string;
   pullRequestNumber: number;
@@ -21,11 +22,11 @@ const PRHeader: React.FC<PRHeaderProps> = ({
 }) => {
   const [owner] = repository.split('/');
   const repoLinkProps = useLinkBehavior<HTMLAnchorElement>(
-    `/miners/repository?name=${encodeURIComponent(repository)}`,
+    getRepoHref(repository),
     { state: { backLabel: `Back to PR #${pullRequestNumber}` } },
   );
   const authorLinkProps = useLinkBehavior<HTMLAnchorElement>(
-    `/miners/details?githubId=${prDetails.githubId ?? ''}`,
+    getMinerHref(prDetails.githubId ?? ''),
     { state: { backLabel: `Back to PR #${pullRequestNumber}` } },
   );
   const githubPrUrl = `https://github.com/${repository}/pull/${pullRequestNumber}`;
@@ -147,7 +148,7 @@ const PRHeader: React.FC<PRHeaderProps> = ({
               borderColor: alpha(STATUS_COLORS.info, 0.5),
               backgroundColor: alpha(STATUS_COLORS.info, 0.1),
               textTransform: 'none',
-              fontFamily: '"JetBrains Mono", monospace',
+              fontFamily: MONO_FONT,
               fontSize: { xs: '0.75rem', sm: '0.8rem' },
               fontWeight: 600,
               px: { xs: 0.75, sm: 1.5 },

--- a/src/components/repositories/RepositoryContributorsTable.tsx
+++ b/src/components/repositories/RepositoryContributorsTable.tsx
@@ -16,6 +16,7 @@ import { STATUS_COLORS } from '../../theme';
 import { isMergedPr } from '../../utils/prStatus';
 import { parseNumber } from '../../utils/ExplorerUtils';
 import { DataTable, type DataTableColumn } from '../common/DataTable';
+import { getMinerHref } from '../../routes.helpers';
 
 interface RepositoryContributorsTableProps {
   repositoryFullName: string;
@@ -210,7 +211,9 @@ const RepositoryContributorsTable: React.FC<
       cellSx: { minWidth: 0 },
       renderCell: (c) => (
         <LinkBox
-          href={`/miners/details?githubId=${encodeURIComponent(c.githubId)}&mode=${programTab === 'issues' ? 'issues' : 'prs'}`}
+          href={getMinerHref(c.githubId, {
+            mode: programTab === 'issues' ? 'issues' : 'prs',
+          })}
           linkState={{
             backLabel: `Back to ${repositoryFullName}`,
           }}

--- a/src/components/repositories/RepositoryIssuesTable.tsx
+++ b/src/components/repositories/RepositoryIssuesTable.tsx
@@ -30,6 +30,7 @@ import {
 } from '../../utils/issueStatus';
 import { STATUS_COLORS, TEXT_OPACITY, scrollbarSx } from '../../theme';
 import FilterButton from '../FilterButton';
+import { getBountyHref } from '../../routes.helpers';
 
 interface RepositoryIssuesTableProps {
   repositoryFullName: string;
@@ -295,7 +296,7 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
               return (
                 <LinkBox
                   key={bounty.id}
-                  href={`/bounties/details?id=${bounty.id}`}
+                  href={getBountyHref(bounty.id)}
                   linkState={{ backLabel: `Back to ${repositoryFullName}` }}
                   sx={{
                     display: 'flex',

--- a/src/components/repositories/RepositoryPRsTable.tsx
+++ b/src/components/repositories/RepositoryPRsTable.tsx
@@ -19,6 +19,7 @@ import { ScrollAwareTooltip } from '../../components/common/ScrollAwareTooltip';
 import theme, { TEXT_OPACITY, scrollbarSx } from '../../theme';
 import { filterPrs, getPrStatusCounts, type PrStatusFilter } from '../../utils';
 import FilterButton from '../FilterButton';
+import { getPrHref } from '../../routes.helpers';
 
 type PrSortField =
   | 'pullRequestNumber'
@@ -119,7 +120,7 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
   const handleRowClick = useCallback(
     (pr: CommitLog) => {
       navigate(
-        `/miners/pr?repo=${encodeURIComponent(pr.repository)}&number=${pr.pullRequestNumber}`,
+        getPrHref(pr.repository, pr.pullRequestNumber),
         { state: { backLabel: `Back to ${repositoryFullName}` } },
       );
     },

--- a/src/pages/DiscoveriesPage.tsx
+++ b/src/pages/DiscoveriesPage.tsx
@@ -10,10 +10,11 @@ import {
 import { useAllMiners } from '../api';
 import theme, { scrollbarSx } from '../theme';
 import { parseNumber } from '../utils/ExplorerUtils';
+import { getMinerHref as buildMinerHref } from '../routes.helpers';
 
 const MINER_LINK_STATE = { backLabel: 'Back to Discoveries' } as const;
 const getMinerHref = (miner: MinerStats) =>
-  `/miners/details?githubId=${miner.githubId}&mode=issues&tab=open-issues`;
+  buildMinerHref(miner.githubId, { mode: 'issues', tab: 'open-issues' });
 
 const DiscoveriesPage: React.FC = () => {
   const allMinerStatsQuery = useAllMiners();

--- a/src/pages/IssuesPage.tsx
+++ b/src/pages/IssuesPage.tsx
@@ -6,9 +6,9 @@ import { Page } from '../components/layout';
 import { SEO } from '../components';
 import { IssueStats, IssuesList } from '../components/issues';
 import { useIssuesStats, useIssues } from '../api';
+import { getBountyHref as getIssueHref } from '../routes.helpers';
 
 const ISSUE_LINK_STATE = { backLabel: 'Back to Bounties' } as const;
-const getIssueHref = (id: number) => `/bounties/details?id=${id}`;
 
 const IssuesPage: React.FC = () => {
   const navigate = useNavigate();

--- a/src/pages/RepositoriesPage.tsx
+++ b/src/pages/RepositoriesPage.tsx
@@ -10,8 +10,10 @@ import { useAllPrs, useAllMiners, useReposAndWeights } from '../api';
 import { type CommitLog } from '../api/models/Dashboard';
 import { buildRepoDiscoveryRollupFromMiners } from '../utils/ExplorerUtils';
 import { isMergedPr } from '../utils/prStatus';
+import { getRepoHref, getPrHref } from '../routes.helpers';
+import { MONO_FONT } from '../theme';
 
-const FONTS = { mono: '"JetBrains Mono", monospace' } as const;
+const FONTS = { mono: MONO_FONT } as const;
 
 // ── Shared row style ────────────────────────────────────────────────────────
 const ROW_HEIGHT = 40; // px – keeps every row exactly the same across cards
@@ -39,7 +41,7 @@ const HighlightRow: React.FC<{
         cursor: 'pointer',
         transition: 'background 0.15s',
         mx: -1,
-        '&:hover': { backgroundColor: 'rgba(255,255,255,0.05)' },
+        '&:hover': { backgroundColor: 'surface.light' },
       }}
     >
       <Box
@@ -58,7 +60,8 @@ const HighlightRow: React.FC<{
             width: 24,
             height: 24,
             flexShrink: 0,
-            border: '1px solid rgba(255,255,255,0.1)',
+            border: '1px solid',
+            borderColor: 'border.light',
             backgroundColor: avatarBg,
           }}
         />
@@ -116,10 +119,6 @@ const cardSx = (theme: Theme) => ({
 
 // ── Page ────────────────────────────────────────────────────────────────────
 const REPO_LINK_STATE = { backLabel: 'Back to Repositories' } as const;
-const getRepoHref = (name: string) =>
-  `/miners/repository?name=${encodeURIComponent(name)}`;
-const getPrHref = (name: string, number: number) =>
-  `/miners/pr?repo=${encodeURIComponent(name)}&number=${number}`;
 
 const RepositoriesPage: React.FC = () => {
   const formatRelativeTime = (date: Date) => {

--- a/src/pages/TopMinersPage.tsx
+++ b/src/pages/TopMinersPage.tsx
@@ -10,10 +10,10 @@ import {
 import { useAllMiners } from '../api';
 import { mapAllMinersToStats } from '../utils/minerMapper';
 import theme, { scrollbarSx } from '../theme';
+import { getMinerHref as buildMinerHref } from '../routes.helpers';
 
 const MINER_LINK_STATE = { backLabel: 'Back to Leaderboard' } as const;
-const getMinerHref = (miner: MinerStats) =>
-  `/miners/details?githubId=${miner.githubId}`;
+const getMinerHref = (miner: MinerStats) => buildMinerHref(miner.githubId);
 
 const TopMinersPage: React.FC = () => {
   const allMinerStatsQuery = useAllMiners();

--- a/src/pages/WatchlistPage.tsx
+++ b/src/pages/WatchlistPage.tsx
@@ -85,6 +85,7 @@ import { compareByWatchlist } from '../utils/watchlistSort';
 import theme, {
   CHART_COLORS,
   LABEL_COLORS,
+  MONO_FONT,
   STATUS_COLORS,
   TEXT_OPACITY,
   UI_COLORS,
@@ -92,6 +93,7 @@ import theme, {
 } from '../theme';
 import FilterButton from '../components/FilterButton';
 import { getRepositoryOwnerAvatarBackground } from '../components/leaderboard/types';
+import * as routeHelpers from '../routes.helpers';
 
 const TAB_ORDER: readonly WatchlistCategory[] = [
   'miners',
@@ -570,9 +572,7 @@ const MinersList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
       <TopMinersTable
         miners={minerStats}
         isLoading={isLoading}
-        getMinerHref={(m) =>
-          `/miners/details?githubId=${encodeURIComponent(m.githubId)}`
-        }
+        getMinerHref={(m) => routeHelpers.getMinerHref(m.githubId)}
         linkState={{ backLabel: 'Back to Watchlist' }}
         variant="watchlist"
         showDualEligibilityBadges
@@ -610,7 +610,7 @@ const repoStatusMeta = (repo: Repository) => {
 };
 
 const getRepoHref = (repo: Repository) =>
-  `/miners/repository?name=${encodeURIComponent(repo.fullName)}`;
+  routeHelpers.getRepoHref(repo.fullName);
 
 const repoColumns: DataTableColumn<WatchedRepoStats, RepoSortKey>[] = [
   {
@@ -824,7 +824,7 @@ const RepoMetricCell: React.FC<{ label: string; value: string }> = ({
   >
     <Typography
       sx={(theme) => ({
-        fontFamily: '"JetBrains Mono", monospace',
+        fontFamily: MONO_FONT,
         fontSize: '0.65rem',
         color: theme.palette.text.tertiary,
         textTransform: 'uppercase',
@@ -836,7 +836,7 @@ const RepoMetricCell: React.FC<{ label: string; value: string }> = ({
     </Typography>
     <Typography
       sx={{
-        fontFamily: '"JetBrains Mono", monospace',
+        fontFamily: MONO_FONT,
         fontSize: '0.9rem',
         fontWeight: 600,
         color: value === '-' ? 'text.secondary' : 'text.primary',
@@ -903,7 +903,7 @@ const RepoCard: React.FC<{ repo: WatchedRepoStats; maxWeight: number }> = ({
           <Tooltip title={repo.fullName} placement="top" arrow>
             <Typography
               sx={{
-                fontFamily: '"JetBrains Mono", monospace',
+                fontFamily: MONO_FONT,
                 fontSize: '0.85rem',
                 fontWeight: 500,
                 color: 'text.primary',
@@ -919,7 +919,7 @@ const RepoCard: React.FC<{ repo: WatchedRepoStats; maxWeight: number }> = ({
         <Typography
           component="span"
           sx={(theme) => ({
-            fontFamily: '"JetBrains Mono", monospace',
+            fontFamily: MONO_FONT,
             fontSize: '0.65rem',
             fontWeight: 600,
             textTransform: 'uppercase',
@@ -958,7 +958,7 @@ const RepoCard: React.FC<{ repo: WatchedRepoStats; maxWeight: number }> = ({
         >
           <Typography
             sx={(theme) => ({
-              fontFamily: '"JetBrains Mono", monospace',
+              fontFamily: MONO_FONT,
               fontSize: '0.65rem',
               color: theme.palette.text.tertiary,
               textTransform: 'uppercase',
@@ -969,7 +969,7 @@ const RepoCard: React.FC<{ repo: WatchedRepoStats; maxWeight: number }> = ({
           </Typography>
           <Typography
             sx={{
-              fontFamily: '"JetBrains Mono", monospace',
+              fontFamily: MONO_FONT,
               fontSize: '0.75rem',
               fontWeight: 600,
               color: 'text.primary',
@@ -1416,7 +1416,7 @@ const ReposList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
             width: '220px',
             '& .MuiOutlinedInput-root': {
               color: 'text.primary',
-              fontFamily: '"JetBrains Mono", monospace',
+              fontFamily: MONO_FONT,
               backgroundColor: 'background.default',
               fontSize: '0.8rem',
               height: '36px',
@@ -1626,7 +1626,7 @@ const BountiesList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
         return (
           <WatchedItemRow
             key={issue.id}
-            href={`/bounties/details?id=${issue.id}`}
+            href={routeHelpers.getBountyHref(issue.id)}
             primary={
               issue.title || `${issue.repositoryFullName} #${issue.issueNumber}`
             }
@@ -1945,7 +1945,7 @@ const PRsViewModeToggle: React.FC<{
 };
 
 const getPrHref = (pr: CommitLog) =>
-  `/miners/pr?repo=${encodeURIComponent(pr.repository)}&number=${pr.pullRequestNumber}`;
+  routeHelpers.getPrHref(pr.repository, pr.pullRequestNumber);
 
 const PRCard: React.FC<{
   pr: CommitLog;

--- a/src/pages/dashboard/views/DashboardFeaturedWork.tsx
+++ b/src/pages/dashboard/views/DashboardFeaturedWork.tsx
@@ -10,6 +10,7 @@ import {
   sectionContainerSx,
   sectionTitleSx,
 } from './featuredWorkStyles';
+import { getPrHref, getRepoHref } from '../../../routes.helpers';
 
 interface DashboardFeaturedWorkProps {
   items: FeaturedWorkRepo[];
@@ -25,10 +26,9 @@ const MAX_COLUMNS_SM = 2;
 const MAX_COLUMNS_LG = 3;
 
 const buildPrDetailUrl = (repo: string, prNumber: number): string =>
-  `/miners/pr?repo=${encodeURIComponent(repo)}&number=${encodeURIComponent(String(prNumber))}`;
+  getPrHref(repo, prNumber);
 
-const buildRepoDetailUrl = (repo: string): string =>
-  `/miners/repository?name=${encodeURIComponent(repo)}`;
+const buildRepoDetailUrl = (repo: string): string => getRepoHref(repo);
 
 const computeGridColumns = (
   itemCount: number,

--- a/src/pages/dashboard/views/DashboardTopContributors.tsx
+++ b/src/pages/dashboard/views/DashboardTopContributors.tsx
@@ -10,6 +10,7 @@ import { alpha, useTheme } from '@mui/material/styles';
 import { useNavigate } from 'react-router-dom';
 import { getGithubAvatarSrc } from '../../../utils';
 import { type DashboardFeaturedContributor } from '../dashboardData';
+import { getMinerHref, type MinerMode } from '../../../routes.helpers';
 
 interface DashboardTopContributorsProps {
   contributors: DashboardFeaturedContributor[];
@@ -39,13 +40,11 @@ const DashboardTopContributors: React.FC<DashboardTopContributorsProps> = ({
   const monoFontFamily = theme.typography.fontFamily;
 
   const openContributor = (githubId: string) => {
-    const modeParam = mode !== 'prs' ? `&mode=${mode}` : '';
-    navigate(
-      `/miners/details?githubId=${encodeURIComponent(githubId)}${modeParam}`,
-      {
-        state: { backTo: '/dashboard' },
-      },
-    );
+    const opts =
+      mode !== 'prs' ? { mode: mode as MinerMode } : undefined;
+    navigate(getMinerHref(githubId, opts), {
+      state: { backTo: '/dashboard' },
+    });
   };
 
   return (

--- a/src/pages/dashboard/views/LiveCommitLog.tsx
+++ b/src/pages/dashboard/views/LiveCommitLog.tsx
@@ -19,6 +19,7 @@ import theme, {
   REPO_OWNER_AVATAR_BACKGROUNDS,
   scrollbarSx,
 } from '../../../theme';
+import { getPrHref } from '../../../routes.helpers';
 
 const MONTH_SHORT = [
   'Jan',
@@ -147,7 +148,7 @@ const CommitLogItem: React.FC<{
 
   const content = (
     <LinkBox
-      href={`/miners/pr?repo=${entry.repository}&number=${entry.pullRequestNumber}`}
+      href={getPrHref(entry.repository, entry.pullRequestNumber)}
       linkState={{ backLabel: 'Back to Dashboard' }}
       ref={innerRef}
       sx={{

--- a/src/pages/search/SearchPage.tsx
+++ b/src/pages/search/SearchPage.tsx
@@ -8,6 +8,7 @@ import MinerTab from './MinerTab';
 import PullRequestsTab from './PullRequestsTab';
 import RepositoryTab from './RepositoryTab';
 import { MIN_SEARCH_QUERY_LENGTH, useSearchResults } from './searchData';
+import * as routeHelpers from '../../routes.helpers';
 
 const ROWS_PER_PAGE_OPTIONS = [10, 25, 50];
 const SEARCH_TABS = ['miners', 'repositories', 'prs', 'issues'] as const;
@@ -165,16 +166,16 @@ const SearchPage: React.FC = () => {
   };
 
   const getMinerHref = (miner: { githubId: string }) =>
-    `/miners/details?githubId=${encodeURIComponent(miner.githubId)}`;
+    routeHelpers.getMinerHref(miner.githubId);
 
   const getRepositoryHref = (repo: { fullName: string }) =>
-    `/miners/repository?name=${encodeURIComponent(repo.fullName)}`;
+    routeHelpers.getRepoHref(repo.fullName);
 
   const getPrHref = (pr: { repository: string; pullRequestNumber: number }) =>
-    `/miners/pr?repo=${encodeURIComponent(pr.repository)}&number=${pr.pullRequestNumber}`;
+    routeHelpers.getPrHref(pr.repository, pr.pullRequestNumber);
 
   const getIssueHref = (issue: { id: number }) =>
-    `/bounties/details?id=${issue.id}`;
+    routeHelpers.getBountyHref(issue.id);
 
   return (
     <Page title="Search">

--- a/src/routes.helpers.ts
+++ b/src/routes.helpers.ts
@@ -1,0 +1,30 @@
+/**
+ * Centralized URL builders for app routes. Keep route paths and their query
+ * parameter contracts in one place so a path/param rename only requires
+ * editing this file (and `routes.tsx`), instead of 30+ call sites.
+ */
+
+export type MinerMode = 'prs' | 'issues';
+
+export const getMinerHref = (
+  githubId: string | number,
+  opts?: { mode?: MinerMode; tab?: string },
+): string => {
+  const params = new URLSearchParams();
+  params.set('githubId', String(githubId));
+  if (opts?.mode) params.set('mode', opts.mode);
+  if (opts?.tab) params.set('tab', opts.tab);
+  return `/miners/details?${params.toString()}`;
+};
+
+export const getRepoHref = (name: string): string =>
+  `/miners/repository?name=${encodeURIComponent(name)}`;
+
+export const getPrHref = (
+  repo: string,
+  number: number | string,
+): string =>
+  `/miners/pr?repo=${encodeURIComponent(repo)}&number=${encodeURIComponent(String(number))}`;
+
+export const getBountyHref = (id: number | string): string =>
+  `/bounties/details?id=${id}`;

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -6,6 +6,14 @@ import {
 } from '@mui/material/styles';
 
 // Shared Color Constants (exported for use outside MUI components)
+/**
+ * App-wide monospace stack. Body inherits this via `MuiCssBaseline`, but a
+ * handful of components (MUI Typography variants, ECharts, etc.) override
+ * fontFamily and need to opt back in explicitly — import this rather than
+ * re-declaring the string at the call site.
+ */
+export const MONO_FONT = '"JetBrains Mono", monospace';
+
 export const UI_COLORS = {
   white: '#ffffff',
   black: '#000000',
@@ -120,6 +128,22 @@ export const TEXT_OPACITY = {
   ghost: 0.2,
 } as const;
 
+/**
+ * White-on-dark surface opacities for backgrounds and dividers. Use with
+ * `alpha(theme.palette.common.white, SURFACE_OPACITY.X)` rather than
+ * hardcoding `rgba(255,255,255,X)`. Most components should prefer the
+ * already-themed `palette.surface.*` and `palette.border.*` tokens; this
+ * map covers the gaps (e.g. an emphasized hover at 0.15).
+ */
+export const SURFACE_OPACITY = {
+  subtle: 0.02,
+  light: 0.05,
+  hover: 0.06,
+  divider: 0.08,
+  active: 0.1,
+  emphasis: 0.15,
+} as const;
+
 /** Theme-driven markdown document body (README, CONTRIBUTING, etc.). */
 export const markdownDocumentPaperSx = (theme: Theme): SxProps<Theme> => ({
   p: { xs: 2, md: 5 },
@@ -176,7 +200,7 @@ export const markdownDocumentPaperSx = (theme: Theme): SxProps<Theme> => ({
     padding: '0.2em 0.4em',
     borderRadius: '6px',
     fontSize: '85%',
-    fontFamily: '"JetBrains Mono", monospace',
+    fontFamily: MONO_FONT,
   },
   '& pre': {
     backgroundColor: theme.palette.surface.elevated,
@@ -218,7 +242,7 @@ export const headerCellStyle = {
   backgroundColor: 'surface.tooltip',
   backdropFilter: 'blur(8px)',
   color: 'text.secondary',
-  fontFamily: '"JetBrains Mono", monospace',
+  fontFamily: MONO_FONT,
   fontWeight: 500,
   fontSize: '0.75rem',
   borderBottom: '1px solid',
@@ -230,7 +254,7 @@ export const headerCellStyle = {
 
 export const bodyCellStyle = {
   color: 'text.primary',
-  fontFamily: '"JetBrains Mono", monospace',
+  fontFamily: MONO_FONT,
   borderBottom: '1px solid',
   borderColor: 'border.light',
   fontSize: '0.85rem',
@@ -498,7 +522,7 @@ const theme = createTheme({
   typography: {
     // JetBrains Mono is the app-wide default — every component inherits it
     // without needing an explicit fontFamily prop.
-    fontFamily: '"JetBrains Mono", monospace',
+    fontFamily: MONO_FONT,
     dataValue: {
       fontWeight: 500,
       letterSpacing: '0.02em',
@@ -564,7 +588,7 @@ const theme = createTheme({
     MuiCssBaseline: {
       styleOverrides: {
         body: {
-          fontFamily: '"JetBrains Mono", monospace',
+          fontFamily: MONO_FONT,
         },
       },
     },
@@ -592,7 +616,7 @@ const theme = createTheme({
           props: { variant: 'back' },
           style: {
             color: 'rgba(255, 255, 255, 0.7)',
-            fontFamily: '"JetBrains Mono", monospace',
+            fontFamily: MONO_FONT,
             fontSize: '0.8rem',
             fontWeight: 500,
             letterSpacing: '0.5px',
@@ -629,7 +653,7 @@ const theme = createTheme({
       },
       styleOverrides: {
         root: {
-          fontFamily: '"JetBrains Mono", monospace',
+          fontFamily: MONO_FONT,
           fontSize: '0.75rem',
           fontWeight: 600,
           borderRadius: '6px',

--- a/src/utils/cardListViewMode.ts
+++ b/src/utils/cardListViewMode.ts
@@ -1,0 +1,65 @@
+/**
+ * Shared base for "cards vs list" view-mode toggles. Issues, Repositories,
+ * Leaderboard etc. all expose the same toggle with the same row sizes; this
+ * module owns the type, the row constants, the URL-param decoder, and a
+ * storage-key-bound `read`/`write` factory so each per-feature module is a
+ * thin wrapper instead of a copy.
+ */
+
+export type CardListViewMode = 'cards' | 'list';
+
+export const CARD_LIST_VIEW_QUERY_PARAM = 'view';
+
+export const LIST_ROW_SIZES = [10, 25, 50] as const;
+export const CARD_ROW_SIZES = [12, 24, 48] as const;
+export const VALID_ROW_SIZES: readonly number[] = [
+  ...LIST_ROW_SIZES,
+  ...CARD_ROW_SIZES,
+];
+export const DEFAULT_LIST_ROWS = 10;
+export const DEFAULT_CARD_ROWS = 12;
+
+export const cardListViewModeFromQuery = (
+  value: string | null,
+  fallback: CardListViewMode,
+): CardListViewMode => {
+  if (value === 'cards') return 'cards';
+  if (value === 'list') return 'list';
+  return fallback;
+};
+
+export const clampCardListRows = (
+  rows: number,
+  mode: CardListViewMode,
+): number => {
+  const options = mode === 'cards' ? CARD_ROW_SIZES : LIST_ROW_SIZES;
+  if ((options as readonly number[]).includes(rows)) return rows;
+  return mode === 'cards' ? DEFAULT_CARD_ROWS : DEFAULT_LIST_ROWS;
+};
+
+/**
+ * Bind storage helpers to a specific localStorage key. Returns no-throw
+ * read/write functions so callers don't need their own try/catch.
+ */
+export const createCardListViewModeStorage = (
+  storageKey: string,
+  defaultMode: CardListViewMode = 'list',
+) => ({
+  read: (): CardListViewMode => {
+    try {
+      const stored = window.localStorage.getItem(storageKey);
+      if (stored === 'cards') return 'cards';
+      if (stored === 'list') return 'list';
+      return defaultMode;
+    } catch {
+      return defaultMode;
+    }
+  },
+  write: (mode: CardListViewMode): void => {
+    try {
+      window.localStorage.setItem(storageKey, mode);
+    } catch {
+      /* private mode / quota — preference won't persist */
+    }
+  },
+});

--- a/src/utils/echarts/gittensorChartTheme.ts
+++ b/src/utils/echarts/gittensorChartTheme.ts
@@ -1,9 +1,9 @@
 import { alpha, type Theme } from '@mui/material/styles';
-import { TEXT_OPACITY } from '../../theme';
+import { MONO_FONT, TEXT_OPACITY } from '../../theme';
 
 export function echartsFontFamily(theme: Theme): string {
   const ff = theme.typography.fontFamily;
-  return typeof ff === 'string' ? ff : '"JetBrains Mono", monospace';
+  return typeof ff === 'string' ? ff : MONO_FONT;
 }
 
 export function echartsTransparentBackground() {


### PR DESCRIPTION
Extracts a small set of shared helpers and removes ~40 hardcoded copies of the same logic across the app. Three groups of changes:

- src/routes.helpers.ts (new) centralizes URL builders for the four detail routes (`/miners/details`, `/miners/repository`, `/miners/pr`, `/bounties/details`). 30+ inline template strings now route through `getMinerHref` / `getRepoHref` / `getPrHref` / `getBountyHref`, so a path or query-param rename only edits one file.

- src/utils/cardListViewMode.ts (new) owns the cards-vs-list mode type, row-size constants, query parser, row clamper, and a storage-key-bound `read`/`write` factory. issuesViewMode.ts and repositoriesViewMode.ts collapse to thin wrappers that just bind their storage keys; the inline localStorage block in TopMinersTable.tsx uses the same factory with a 'cards' default.

- FilterButton gains a `variant: 'default' | 'compact'` prop that absorbs ExplorerFilterButton's denser sizing; ExplorerFilterButton stays as a thin wrapper preserving the `selected` prop name at its 12 call sites.

Also: exports `MONO_FONT` from theme.ts and removes ~17 inline `'"JetBrains Mono", monospace'` strings; adds `SURFACE_OPACITY` map and migrates 6+ hardcoded `rgba(255,255,255,X)` values to existing `palette.surface.*` / `palette.border.*` tokens.

Type-check and lint clean across all affected files.

## Summary

<!-- Brief description of the changes -->

## Related Issues

<!-- Link to related issues: Fixes #123, Closes #456 -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

<!-- Include before/after screenshots for every UI/visual change. Remove this section if not applicable. -->

## Checklist

- [ ] New components are modularized/separated where sensible
- [ ] Uses predefined theme (e.g. no hardcoded colors)
- [ ] Responsive/mobile checked
- [ ] Tested against the test API
- [ ] `npm run format` and `npm run lint:fix` have been run
- [ ] `npm run build` passes
- [ ] Screenshots included for any UI/visual changes

refactor PR