### PR TITLE
fix(miners): improve PR table tooltips on miner detail page

### DIFF
--- a/src/components/miners/MinerPRsTable.tsx
+++ b/src/components/miners/MinerPRsTable.tsx
@@ -361,7 +361,8 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
               <Tooltip
                 title={scoreTooltip}
                 arrow
-                placement="left"
+                placement="top"
+                followCursor
                 slotProps={tooltipSlotProps}
               >
                 <Typography

--- a/src/components/miners/MinerPRsTable.tsx
+++ b/src/components/miners/MinerPRsTable.tsx
@@ -246,15 +246,22 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
       width: '25%',
       cellSx: { fontSize: { xs: '0.75rem', sm: '0.85rem' } },
       renderCell: (pr) => (
-        <Box
-          sx={{
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
-            whiteSpace: 'nowrap',
-          }}
+        <Tooltip
+          title={pr.pullRequestTitle}
+          arrow
+          placement="top"
+          slotProps={tooltipSlotProps}
         >
-          {pr.pullRequestTitle}
-        </Box>
+          <Box
+            sx={{
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {pr.pullRequestTitle}
+          </Box>
+        </Tooltip>
       ),
     },
     {


### PR DESCRIPTION
## Summary

Adds a tooltip showing the full PR title when the title cell is truncated, and fixes the score tooltip so it follows the cursor instead of anchoring to the far-left edge of the right-aligned cell.

## Related Issues

## Type of Change

- [X] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots
Before:

https://github.com/user-attachments/assets/ac0ccd1f-6bcc-4180-a58c-17a019257e3d

After:


https://github.com/user-attachments/assets/5a23a763-4629-4f80-8955-b27ab96d553c

Before:

<img width="1919" height="944" alt="Screenshot_1" src="https://github.com/user-attachments/assets/b48af212-5c2c-4725-9e76-7414613263bb" />

After:

<img width="1920" height="946" alt="Screenshot_2" src="https://github.com/user-attachments/assets/a35bf9ec-0a2e-4a62-8502-9db68f06fe75" />


## Checklist

- [ ] New components are modularized/separated where sensible
- [X] Uses predefined theme (e.g. no hardcoded colors)
- [X] Responsive/mobile checked
- [ ] Tested against the test API
- [X] `npm run format` and `npm run lint:fix` have been run
- [X] `npm run build` passes
- [X] Screenshots included for any UI/visual changes
