### PR TITLE
fix Watchlist + Onboard: layout shifts, scroll-to-top, and sticky-tab…

### DIFF
--- a/src/components/repositories/LanguageWeightsTable.tsx
+++ b/src/components/repositories/LanguageWeightsTable.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useRef, useEffect } from 'react';
+import React, { useState, useMemo, useRef } from 'react';
 import {
   Box,
   TablePagination,
@@ -56,6 +56,16 @@ const LanguageWeightsTable: React.FC = () => {
   const [rowsPerPage, setRowsPerPage] = useState(10);
   const containerRef = useRef<HTMLDivElement>(null);
 
+  // Scrolls only the table's own scrollport back to the first row. Avoids the
+  // page-level `scrollIntoView` that used to fire from a `[rowsPerPage]` effect
+  // on mount and yanked the Onboard page to the table when Languages was opened.
+  const scrollTableToTop = () => {
+    const scrollport = containerRef.current?.querySelector(
+      '.MuiTableContainer-root',
+    );
+    scrollport?.scrollTo({ top: 0, behavior: 'smooth' });
+  };
+
   const handleSort = (field: SortField) => {
     if (sortField === field) {
       setSortOrder(sortOrder === 'asc' ? 'desc' : 'asc');
@@ -75,6 +85,7 @@ const LanguageWeightsTable: React.FC = () => {
   ) => {
     setRowsPerPage(parseInt(event.target.value, 10));
     setPage(0);
+    scrollTableToTop();
   };
 
   const handleSearchChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -202,16 +213,6 @@ const LanguageWeightsTable: React.FC = () => {
       ],
     };
   }, [paginatedLanguages, theme]);
-
-  // Scroll to top when rows per page changes
-  useEffect(() => {
-    if (containerRef.current) {
-      containerRef.current.scrollIntoView({
-        behavior: 'smooth',
-        block: 'start',
-      });
-    }
-  }, [rowsPerPage]);
 
   const sortLabelHeaderSx = {
     '& .MuiTableSortLabel-root:hover': { color: 'secondary.main' },
@@ -359,6 +360,7 @@ const LanguageWeightsTable: React.FC = () => {
                 onChange={(e) => {
                   setRowsPerPage(Number(e.target.value));
                   setPage(0);
+                  scrollTableToTop();
                 }}
                 sx={{
                   color: theme.palette.text.primary,

--- a/src/pages/OnboardPage.tsx
+++ b/src/pages/OnboardPage.tsx
@@ -62,7 +62,7 @@ const OnboardPage: React.FC = () => {
           sx={(theme) => ({
             position: 'sticky',
             top: 0,
-            zIndex: 2,
+            zIndex: 10,
             maxWidth: 1200,
             width: '100%',
             px: { xs: 2, sm: 3, md: 0 },


### PR DESCRIPTION
## Summary

- Onboard: stop the page from auto-scrolling when the Languages tab is opened (drop the mount-firing `useEffect([rowsPerPage])` that called `scrollIntoView`).
- Onboard: prevent the Languages table's sticky header from floating above the page tabs (bump the sticky page-tabs `zIndex` above MUI's `stickyHeader` thead).
- Languages table: changing rows-per-page now scrolls only the table's own scrollport back to row 0, not the whole page.

## Related Issues

Fixes #897

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

### Before

[screen-capture (1).webm](https://github.com/user-attachments/assets/bde00553-484b-4d92-a7d6-099cc9db9985)

### After

[screen-capture.webm](https://github.com/user-attachments/assets/beddcd2c-b847-42a9-b02f-5b02120f25fa)