### PR TITLE
feat(sidebar): focus leaderboard activity panels

### DIFF
--- a/src/components/leaderboard/ActivitySidebarCards.tsx
+++ b/src/components/leaderboard/ActivitySidebarCards.tsx
@@ -1,32 +1,211 @@
 import React, { useMemo } from 'react';
 import { Box, Typography } from '@mui/material';
 import { alpha } from '@mui/material/styles';
+import ReactECharts from 'echarts-for-react';
 import { SectionCard } from './SectionCard';
-import { STATUS_COLORS, DIFF_COLORS, CREDIBILITY_COLORS } from '../../theme';
+import {
+  CHART_COLORS,
+  STATUS_COLORS,
+  DIFF_COLORS,
+  CREDIBILITY_COLORS,
+} from '../../theme';
 import { credibilityColor } from '../../utils/format';
 import { type MinerStats, FONTS } from './types';
 import { useEligibilityFilteredMiners } from './useEligibilityFilteredMiners';
 
 interface ActivitySidebarCardsProps {
   miners: MinerStats[];
+  variant?: 'oss' | 'discoveries' | 'overview';
 }
+
+interface MinerActivityStats {
+  all: number;
+  eligiblePr: number;
+  ineligiblePr: number;
+  eligibleIssue: number;
+  ineligibleIssue: number;
+}
+
+interface PrActivityStats {
+  merged: number;
+  open: number;
+  closed: number;
+  mergeRate: number;
+}
+
+interface IssueActivityStats {
+  solved: number;
+  open: number;
+  closed: number;
+  solveRate: number;
+}
+
+interface CodeImpactStats {
+  linesAdded: number;
+  linesDeleted: number;
+  reposTouched: number;
+  avgCredibility: number;
+}
+
+interface FocusedActivityStats {
+  eligible: number;
+  ineligible: number;
+  trackLabel: string;
+}
+
+interface ActivitySegment {
+  label: string;
+  value: number;
+  color: string;
+}
+
+interface ActivityDonutCardProps {
+  title: string;
+  rateLabel: string;
+  rate: number;
+  rateColor: string;
+  totalUsdPerDay: number;
+  segments: ActivitySegment[];
+}
+
+const sumMinersBy = (
+  miners: MinerStats[],
+  getValue: (miner: MinerStats) => number | undefined,
+) => miners.reduce((acc, miner) => acc + (getValue(miner) || 0), 0);
+
+const percentOf = (value: number, total: number) =>
+  total > 0 ? Math.round((value / total) * 100) : 0;
+
+const completionRate = (completed: number, closed: number) => {
+  const resolved = completed + closed;
+  return resolved > 0 ? Math.round((completed / resolved) * 100) : 0;
+};
+
+const rateColor = (rate: number) =>
+  rate >= 80
+    ? CREDIBILITY_COLORS.excellent
+    : rate >= 50
+      ? CREDIBILITY_COLORS.moderate
+      : STATUS_COLORS.closed;
+
+const getMinerActivityStats = (miners: MinerStats[]): MinerActivityStats => {
+  const all = miners.length;
+  const eligiblePr = miners.filter((m) => m.ossIsEligible).length;
+  const eligibleIssue = miners.filter((m) => m.discoveriesIsEligible).length;
+
+  return {
+    all,
+    eligiblePr,
+    ineligiblePr: Math.max(0, all - eligiblePr),
+    eligibleIssue,
+    ineligibleIssue: Math.max(0, all - eligibleIssue),
+  };
+};
+
+const getPrActivityStats = (miners: MinerStats[]): PrActivityStats => {
+  const merged = sumMinersBy(miners, (m) => m.totalMergedPrs);
+  const open = sumMinersBy(miners, (m) => m.totalOpenPrs);
+  const closed = sumMinersBy(miners, (m) => m.totalClosedPrs);
+
+  return {
+    merged,
+    open,
+    closed,
+    mergeRate: completionRate(merged, closed),
+  };
+};
+
+const getIssueActivityStats = (miners: MinerStats[]): IssueActivityStats => {
+  const solved = sumMinersBy(miners, (m) => m.totalSolvedIssues);
+  const open = sumMinersBy(miners, (m) => m.totalOpenIssues);
+  const closed = sumMinersBy(miners, (m) => m.totalClosedIssues);
+
+  return {
+    solved,
+    open,
+    closed,
+    solveRate: completionRate(solved, closed),
+  };
+};
+
+const getCodeImpactStats = (miners: MinerStats[]): CodeImpactStats => {
+  const credibilityValues = miners
+    .map((m) => m.credibility)
+    .filter((c): c is number => typeof c === 'number');
+  const avgCredibility =
+    credibilityValues.length > 0
+      ? Math.round(
+          (credibilityValues.reduce((acc, c) => acc + c, 0) /
+            credibilityValues.length) *
+            100,
+        )
+      : 0;
+
+  return {
+    linesAdded: sumMinersBy(miners, (m) => m.linesAdded),
+    linesDeleted: sumMinersBy(miners, (m) => m.linesDeleted),
+    reposTouched: sumMinersBy(miners, (m) => m.uniqueReposCount),
+    avgCredibility,
+  };
+};
+
+const getFocusedActivityStats = (
+  stats: MinerActivityStats,
+  variant: 'oss' | 'discoveries',
+): FocusedActivityStats =>
+  variant === 'discoveries'
+    ? {
+        eligible: stats.eligibleIssue,
+        ineligible: Math.max(0, stats.all - stats.eligibleIssue),
+        trackLabel: 'Issue eligible',
+      }
+    : {
+        eligible: stats.eligiblePr,
+        ineligible: Math.max(0, stats.all - stats.eligiblePr),
+        trackLabel: 'OSS eligible',
+      };
+
+const buildPrActivityCard = (
+  stats: PrActivityStats,
+  totalUsdPerDay: number,
+): ActivityDonutCardProps => ({
+  title: 'PR Activity',
+  rateLabel: 'Merge Rate',
+  rate: stats.mergeRate,
+  rateColor: rateColor(stats.mergeRate),
+  totalUsdPerDay,
+  segments: [
+    { label: 'Merged', value: stats.merged, color: CHART_COLORS.merged },
+    { label: 'Open', value: stats.open, color: CHART_COLORS.open },
+    { label: 'Closed', value: stats.closed, color: CHART_COLORS.closed },
+  ],
+});
+
+const buildIssueActivityCard = (
+  stats: IssueActivityStats,
+  totalUsdPerDay: number,
+): ActivityDonutCardProps => ({
+  title: 'Issue Activity',
+  rateLabel: 'Solve Rate',
+  rate: stats.solveRate,
+  rateColor: rateColor(stats.solveRate),
+  totalUsdPerDay,
+  segments: [
+    { label: 'Solved', value: stats.solved, color: CHART_COLORS.merged },
+    { label: 'Open', value: stats.open, color: CHART_COLORS.open },
+    { label: 'Closed', value: stats.closed, color: CHART_COLORS.closed },
+  ],
+});
 
 export const ActivitySidebarCards: React.FC<ActivitySidebarCardsProps> = ({
   miners: allMiners,
+  variant = 'overview',
 }) => {
   const miners = useEligibilityFilteredMiners(allMiners);
-  const minerActivityStats = useMemo(() => {
-    const all = miners.length;
-    const eligiblePr = miners.filter((m) => m.ossIsEligible).length;
-    const eligibleIssue = miners.filter((m) => m.discoveriesIsEligible).length;
-    return {
-      all,
-      eligiblePr,
-      ineligiblePr: Math.max(0, all - eligiblePr),
-      eligibleIssue,
-      ineligibleIssue: Math.max(0, all - eligibleIssue),
-    };
-  }, [miners]);
+  const minerActivityStats = useMemo(
+    () => getMinerActivityStats(miners),
+    [miners],
+  );
 
   const ossUsdPerDay = useMemo(
     () =>
@@ -44,341 +223,38 @@ export const ActivitySidebarCards: React.FC<ActivitySidebarCardsProps> = ({
     [miners],
   );
 
-  const prStats = useMemo(() => {
-    const merged = miners.reduce((acc, m) => acc + (m.totalMergedPrs || 0), 0);
-    const open = miners.reduce((acc, m) => acc + (m.totalOpenPrs || 0), 0);
-    const closed = miners.reduce((acc, m) => acc + (m.totalClosedPrs || 0), 0);
-    const resolved = merged + closed;
-    const mergeRate = resolved > 0 ? Math.round((merged / resolved) * 100) : 0;
-    return { merged, open, closed, mergeRate };
-  }, [miners]);
+  const prStats = useMemo(() => getPrActivityStats(miners), [miners]);
+  const issueStats = useMemo(() => getIssueActivityStats(miners), [miners]);
+  const codeStats = useMemo(() => getCodeImpactStats(miners), [miners]);
 
-  const issueStats = useMemo(() => {
-    const solved = miners.reduce(
-      (acc, m) => acc + (m.totalSolvedIssues || 0),
-      0,
-    );
-    const open = miners.reduce((acc, m) => acc + (m.totalOpenIssues || 0), 0);
-    const closed = miners.reduce(
-      (acc, m) => acc + (m.totalClosedIssues || 0),
-      0,
-    );
-    const resolved = solved + closed;
-    const solveRate = resolved > 0 ? Math.round((solved / resolved) * 100) : 0;
-    return { solved, open, closed, solveRate };
-  }, [miners]);
+  if (variant !== 'overview') {
+    const focusedStats = getFocusedActivityStats(minerActivityStats, variant);
+    const activityStats =
+      variant === 'discoveries'
+        ? buildIssueActivityCard(issueStats, issueUsdPerDay)
+        : buildPrActivityCard(prStats, ossUsdPerDay);
 
-  const codeStats = useMemo(() => {
-    const linesAdded = miners.reduce((acc, m) => acc + (m.linesAdded || 0), 0);
-    const linesDeleted = miners.reduce(
-      (acc, m) => acc + (m.linesDeleted || 0),
-      0,
+    return (
+      <>
+        <FocusedMinersActivityCard
+          total={minerActivityStats.all}
+          eligible={focusedStats.eligible}
+          ineligible={focusedStats.ineligible}
+          trackLabel={focusedStats.trackLabel}
+        />
+        <ActivityDonutCard {...activityStats} />
+      </>
     );
-    const reposTouched = miners.reduce(
-      (acc, m) => acc + (m.uniqueReposCount || 0),
-      0,
-    );
-    const credibilityValues = miners
-      .map((m) => m.credibility)
-      .filter((c): c is number => typeof c === 'number');
-    const avgCredibility =
-      credibilityValues.length > 0
-        ? Math.round(
-            (credibilityValues.reduce((acc, c) => acc + c, 0) /
-              credibilityValues.length) *
-              100,
-          )
-        : 0;
-    return { linesAdded, linesDeleted, reposTouched, avgCredibility };
-  }, [miners]);
-
-  const solveRateColor =
-    issueStats.solveRate >= 80
-      ? CREDIBILITY_COLORS.excellent
-      : issueStats.solveRate >= 50
-        ? CREDIBILITY_COLORS.moderate
-        : STATUS_COLORS.closed;
-
-  const mergeRateColor =
-    prStats.mergeRate >= 80
-      ? CREDIBILITY_COLORS.excellent
-      : prStats.mergeRate >= 50
-        ? CREDIBILITY_COLORS.moderate
-        : STATUS_COLORS.closed;
+  }
 
   return (
     <>
-      {/* CARD 1: Miners Activity */}
-      <SectionCard title="Miners Activity" sx={{ flexShrink: 0 }}>
-        <Box sx={{ px: 2, pt: 1, pb: 2 }}>
-          <Box
-            sx={(theme) => ({
-              display: 'grid',
-              gridTemplateColumns: '1fr 1fr 1fr',
-              gap: 1,
-              alignItems: 'center',
-              pb: 1.5,
-              borderBottom: `1px solid ${theme.palette.border.light}`,
-              mb: 1.5,
-            })}
-          >
-            <Typography
-              sx={{
-                fontFamily: FONTS.mono,
-                fontSize: '0.7rem',
-                color: STATUS_COLORS.open,
-                textTransform: 'uppercase',
-              }}
-            >
-              &nbsp;
-            </Typography>
-            <Typography
-              sx={{
-                fontFamily: FONTS.mono,
-                fontSize: '0.7rem',
-                color: STATUS_COLORS.open,
-                textTransform: 'uppercase',
-                textAlign: 'center',
-              }}
-            >
-              PR
-            </Typography>
-            <Typography
-              sx={{
-                fontFamily: FONTS.mono,
-                fontSize: '0.7rem',
-                color: STATUS_COLORS.open,
-                textTransform: 'uppercase',
-                textAlign: 'center',
-              }}
-            >
-              Issue
-            </Typography>
-          </Box>
-
-          <MinerActivityRow
-            label="All"
-            pr={minerActivityStats.all}
-            issue={minerActivityStats.all}
-          />
-          <MinerActivityRow
-            label="Eligible"
-            pr={minerActivityStats.eligiblePr}
-            issue={minerActivityStats.eligibleIssue}
-          />
-          <MinerActivityRow
-            label="Ineligible"
-            pr={minerActivityStats.ineligiblePr}
-            issue={minerActivityStats.ineligibleIssue}
-          />
-        </Box>
-      </SectionCard>
-
-      {/* CARD 2: PR Activity */}
-      <SectionCard title="PR Activity" sx={{ flexShrink: 0 }}>
-        <Box sx={{ px: 2, pt: 1, pb: 2 }}>
-          <Box
-            sx={(theme) => ({
-              display: 'grid',
-              gridTemplateColumns: '1fr 1fr 1fr',
-              gap: 1,
-              mb: 2,
-              pb: 2,
-              borderBottom: `1px solid ${theme.palette.border.light}`,
-            })}
-          >
-            <PRColumn
-              label="Merged"
-              value={prStats.merged}
-              color={STATUS_COLORS.merged}
-            />
-            <PRColumn
-              label="Open"
-              value={prStats.open}
-              color={STATUS_COLORS.open}
-            />
-            <PRColumn
-              label="Closed"
-              value={prStats.closed}
-              color={STATUS_COLORS.closed}
-            />
-          </Box>
-
-          <Box
-            sx={{
-              display: 'flex',
-              justifyContent: 'space-between',
-              alignItems: 'center',
-            }}
-          >
-            <Typography
-              sx={{
-                fontFamily: FONTS.mono,
-                fontSize: '0.85rem',
-                color: STATUS_COLORS.open,
-              }}
-            >
-              Merge Rate
-            </Typography>
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
-              <RateBar rate={prStats.mergeRate} color={mergeRateColor} />
-              <Typography
-                sx={{
-                  fontFamily: FONTS.mono,
-                  fontWeight: 600,
-                  fontSize: '1.1rem',
-                  color: mergeRateColor,
-                  minWidth: 40,
-                  textAlign: 'right',
-                }}
-              >
-                {prStats.mergeRate}%
-              </Typography>
-            </Box>
-          </Box>
-
-          <StatRow
-            label="Total $/day"
-            value={`$${Math.round(ossUsdPerDay).toLocaleString()}`}
-            valueColor={STATUS_COLORS.merged}
-          />
-        </Box>
-      </SectionCard>
-
-      {/* CARD 3: Issue Activity */}
-      <SectionCard title="Issue Activity" sx={{ flexShrink: 0 }}>
-        <Box sx={{ px: 2, pt: 1, pb: 2 }}>
-          <Box
-            sx={(theme) => ({
-              display: 'grid',
-              gridTemplateColumns: '1fr 1fr 1fr',
-              gap: 1,
-              mb: 2,
-              pb: 2,
-              borderBottom: `1px solid ${theme.palette.border.light}`,
-            })}
-          >
-            <PRColumn
-              label="Solved"
-              value={issueStats.solved}
-              color={STATUS_COLORS.merged}
-            />
-            <PRColumn
-              label="Open"
-              value={issueStats.open}
-              color={STATUS_COLORS.open}
-            />
-            <PRColumn
-              label="Closed"
-              value={issueStats.closed}
-              color={STATUS_COLORS.closed}
-            />
-          </Box>
-
-          <Box
-            sx={{
-              display: 'flex',
-              justifyContent: 'space-between',
-              alignItems: 'center',
-            }}
-          >
-            <Typography
-              sx={{
-                fontFamily: FONTS.mono,
-                fontSize: '0.85rem',
-                color: STATUS_COLORS.open,
-              }}
-            >
-              Solve Rate
-            </Typography>
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
-              <RateBar rate={issueStats.solveRate} color={solveRateColor} />
-              <Typography
-                sx={{
-                  fontFamily: FONTS.mono,
-                  fontWeight: 600,
-                  fontSize: '1.1rem',
-                  color: solveRateColor,
-                  minWidth: 40,
-                  textAlign: 'right',
-                }}
-              >
-                {issueStats.solveRate}%
-              </Typography>
-            </Box>
-          </Box>
-
-          <StatRow
-            label="Total $/day"
-            value={`$${Math.round(issueUsdPerDay).toLocaleString()}`}
-            valueColor={STATUS_COLORS.merged}
-          />
-        </Box>
-      </SectionCard>
-
-      {/* CARD 4: Code Impact */}
-      <SectionCard title="Code Impact" sx={{ flexShrink: 0 }}>
-        <Box
-          sx={{
-            px: 2,
-            pt: 1,
-            pb: 2,
-            display: 'flex',
-            flexDirection: 'column',
-            gap: 2,
-          }}
-        >
-          <StatRow
-            label="Lines Added"
-            value={`+${codeStats.linesAdded.toLocaleString()}`}
-            valueColor={DIFF_COLORS.additions}
-          />
-          <StatRow
-            label="Lines Deleted"
-            value={`-${codeStats.linesDeleted.toLocaleString()}`}
-            valueColor={DIFF_COLORS.deletions}
-          />
-          <StatRow
-            label="Repos Touched"
-            value={codeStats.reposTouched.toLocaleString()}
-          />
-          <Box
-            sx={{
-              display: 'flex',
-              justifyContent: 'space-between',
-              alignItems: 'center',
-            }}
-          >
-            <Typography
-              sx={{
-                fontFamily: FONTS.mono,
-                fontSize: '0.85rem',
-                color: STATUS_COLORS.open,
-              }}
-            >
-              Avg Credibility
-            </Typography>
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
-              <RateBar
-                rate={codeStats.avgCredibility}
-                color={credibilityColor(codeStats.avgCredibility / 100)}
-              />
-              <Typography
-                sx={{
-                  fontFamily: FONTS.mono,
-                  fontWeight: 600,
-                  fontSize: '1.1rem',
-                  color: credibilityColor(codeStats.avgCredibility / 100),
-                  minWidth: 40,
-                  textAlign: 'right',
-                }}
-              >
-                {codeStats.avgCredibility}%
-              </Typography>
-            </Box>
-          </Box>
-        </Box>
-      </SectionCard>
+      <OverviewMinersActivityCard stats={minerActivityStats} />
+      <ActivityDonutCard {...buildPrActivityCard(prStats, ossUsdPerDay)} />
+      <ActivityDonutCard
+        {...buildIssueActivityCard(issueStats, issueUsdPerDay)}
+      />
+      <CodeImpactCard stats={codeStats} />
     </>
   );
 };
@@ -425,123 +301,406 @@ export const StatRow: React.FC<StatRowProps> = ({
   </Box>
 );
 
-interface MinerActivityRowProps {
-  label: string;
-  pr: number;
-  issue: number;
+interface FocusedMinersActivityCardProps {
+  total: number;
+  eligible: number;
+  ineligible: number;
+  trackLabel: string;
 }
 
-const MinerActivityRow: React.FC<MinerActivityRowProps> = ({
+const FocusedMinersActivityCard: React.FC<FocusedMinersActivityCardProps> = ({
+  total,
+  eligible,
+  ineligible,
+  trackLabel,
+}) => {
+  const eligiblePercent = percentOf(eligible, total);
+
+  return (
+    <SectionCard title="Miners Activity" sx={{ flexShrink: 0 }}>
+      <Box sx={{ px: 2, pt: 1, pb: 2 }}>
+        <Box
+          sx={{
+            display: 'grid',
+            gridTemplateColumns: '1fr 1fr',
+            gap: 1,
+            mb: 2,
+          }}
+        >
+          <MinerStatusTile
+            label={trackLabel}
+            value={eligible}
+            percent={eligiblePercent}
+          />
+          <MinerStatusTile
+            label="Ineligible"
+            value={ineligible}
+            percent={Math.max(0, 100 - eligiblePercent)}
+          />
+        </Box>
+
+        <StatRow label="All" value={total.toLocaleString()} />
+      </Box>
+    </SectionCard>
+  );
+};
+
+interface MinerStatusTileProps {
+  label: string;
+  value: number;
+  percent: number;
+}
+
+const MinerStatusTile: React.FC<MinerStatusTileProps> = ({
   label,
-  pr,
-  issue,
+  value,
+  percent,
 }) => (
   <Box
     sx={(theme) => ({
-      display: 'grid',
-      gridTemplateColumns: '1fr 1fr 1fr',
-      gap: 1,
+      p: 1.15,
+      borderRadius: 2,
+      border: `1px solid ${theme.palette.border.light}`,
+      backgroundColor: alpha(theme.palette.text.primary, 0.035),
+      minWidth: 0,
+    })}
+  >
+    <Typography
+      sx={{
+        fontFamily: FONTS.mono,
+        fontSize: '0.68rem',
+        color: STATUS_COLORS.open,
+        textTransform: 'uppercase',
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+        whiteSpace: 'nowrap',
+        mb: 0.75,
+      }}
+    >
+      {label}
+    </Typography>
+    <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 0.8 }}>
+      <Typography
+        sx={{
+          fontFamily: FONTS.mono,
+          fontSize: '1.25rem',
+          fontWeight: 700,
+          color: 'text.primary',
+          lineHeight: 1,
+        }}
+      >
+        {value.toLocaleString()}
+      </Typography>
+      <Typography
+        sx={{
+          fontFamily: FONTS.mono,
+          fontSize: '0.72rem',
+          color: STATUS_COLORS.open,
+        }}
+      >
+        {percent}%
+      </Typography>
+    </Box>
+  </Box>
+);
+
+const ActivityDonutCard: React.FC<ActivityDonutCardProps> = ({
+  title,
+  rateLabel,
+  rate,
+  rateColor,
+  totalUsdPerDay,
+  segments,
+}) => {
+  const total = segments.reduce((acc, segment) => acc + segment.value, 0);
+
+  return (
+    <SectionCard title={title} sx={{ flexShrink: 0 }}>
+      <Box sx={{ px: 2, pt: 1, pb: 2 }}>
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 1.75,
+            mb: 2,
+          }}
+        >
+          <Box
+            sx={{
+              width: 92,
+              height: 92,
+              flexShrink: 0,
+              position: 'relative',
+            }}
+          >
+            <ReactECharts
+              option={{
+                backgroundColor: 'transparent',
+                series: [
+                  {
+                    type: 'pie',
+                    radius: ['65%', '90%'],
+                    silent: true,
+                    label: { show: false },
+                    itemStyle: { borderRadius: 3, borderWidth: 0 },
+                    data:
+                      total > 0
+                        ? segments.map((segment) => ({
+                            value: segment.value,
+                            itemStyle: { color: segment.color },
+                          }))
+                        : [
+                            {
+                              value: 1,
+                              itemStyle: { color: 'rgba(255,255,255,0.08)' },
+                            },
+                          ],
+                  },
+                ],
+              }}
+              style={{ width: '100%', height: '100%' }}
+              opts={{ renderer: 'svg' }}
+            />
+            <Box
+              sx={(theme) => ({
+                position: 'absolute',
+                inset: 0,
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                justifyContent: 'center',
+                pointerEvents: 'none',
+                color: theme.palette.text.primary,
+              })}
+            >
+              <Typography
+                sx={{
+                  fontFamily: FONTS.mono,
+                  fontSize: '1rem',
+                  fontWeight: 700,
+                  color: rateColor,
+                  lineHeight: 1,
+                }}
+              >
+                {rate}%
+              </Typography>
+              <Typography
+                sx={{
+                  fontFamily: FONTS.mono,
+                  fontSize: '0.56rem',
+                  color: STATUS_COLORS.open,
+                  mt: 0.5,
+                  textTransform: 'uppercase',
+                }}
+              >
+                {rateLabel}
+              </Typography>
+            </Box>
+          </Box>
+
+          <Box sx={{ flex: 1, minWidth: 0 }}>
+            {segments.map((segment) => (
+              <ActivityLegendRow key={segment.label} segment={segment} />
+            ))}
+          </Box>
+        </Box>
+
+        <StatRow
+          label="Total $/day"
+          value={`$${Math.round(totalUsdPerDay).toLocaleString()}`}
+          valueColor={STATUS_COLORS.merged}
+        />
+      </Box>
+    </SectionCard>
+  );
+};
+
+const OverviewMinersActivityCard: React.FC<{ stats: MinerActivityStats }> = ({
+  stats,
+}) => {
+  const prPercent = percentOf(stats.eligiblePr, stats.all);
+  const issuePercent = percentOf(stats.eligibleIssue, stats.all);
+
+  return (
+    <SectionCard title="Miners Activity" sx={{ flexShrink: 0 }}>
+      <Box sx={{ px: 2, pt: 1, pb: 2 }}>
+        <Box
+          sx={{
+            display: 'grid',
+            gridTemplateColumns: '1fr 1fr',
+            gap: 1,
+            mb: 2,
+          }}
+        >
+          <MinerStatusTile
+            label="OSS eligible"
+            value={stats.eligiblePr}
+            percent={prPercent}
+          />
+          <MinerStatusTile
+            label="Issue eligible"
+            value={stats.eligibleIssue}
+            percent={issuePercent}
+          />
+        </Box>
+        <StatRow label="All" value={stats.all.toLocaleString()} />
+      </Box>
+    </SectionCard>
+  );
+};
+
+const CodeImpactCard: React.FC<{ stats: CodeImpactStats }> = ({ stats }) => {
+  const maxLines = Math.max(stats.linesAdded, stats.linesDeleted, 1);
+
+  return (
+    <SectionCard title="Code Impact" sx={{ flexShrink: 0 }}>
+      <Box
+        sx={{
+          px: 2,
+          pt: 1,
+          pb: 2,
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 1.6,
+        }}
+      >
+        <ImpactBar
+          label="Lines Added"
+          value={`+${stats.linesAdded.toLocaleString()}`}
+          percent={(stats.linesAdded / maxLines) * 100}
+          color={DIFF_COLORS.additions}
+        />
+        <ImpactBar
+          label="Lines Deleted"
+          value={`-${stats.linesDeleted.toLocaleString()}`}
+          percent={(stats.linesDeleted / maxLines) * 100}
+          color={DIFF_COLORS.deletions}
+        />
+        <StatRow
+          label="Repos Touched"
+          value={stats.reposTouched.toLocaleString()}
+        />
+        <ImpactBar
+          label="Avg Credibility"
+          value={`${stats.avgCredibility}%`}
+          percent={stats.avgCredibility}
+          color={credibilityColor(stats.avgCredibility / 100)}
+        />
+      </Box>
+    </SectionCard>
+  );
+};
+
+interface ImpactBarProps {
+  label: string;
+  value: string;
+  percent: number;
+  color: string;
+}
+
+const ImpactBar: React.FC<ImpactBarProps> = ({
+  label,
+  value,
+  percent,
+  color,
+}) => (
+  <Box>
+    <Box
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        gap: 1,
+        mb: 0.7,
+      }}
+    >
+      <Typography
+        sx={{
+          fontFamily: FONTS.mono,
+          fontSize: '0.78rem',
+          color: STATUS_COLORS.open,
+        }}
+      >
+        {label}
+      </Typography>
+      <Typography
+        sx={{
+          fontFamily: FONTS.mono,
+          fontSize: '0.9rem',
+          fontWeight: 700,
+          color,
+        }}
+      >
+        {value}
+      </Typography>
+    </Box>
+    <Box
+      sx={(theme) => ({
+        height: 5,
+        borderRadius: 999,
+        backgroundColor: alpha(theme.palette.text.primary, 0.08),
+        overflow: 'hidden',
+      })}
+    >
+      <Box
+        sx={{
+          width: `${Math.min(100, Math.max(0, percent))}%`,
+          height: '100%',
+          borderRadius: 999,
+          backgroundColor: color,
+          transition: 'width 0.3s ease',
+        }}
+      />
+    </Box>
+  </Box>
+);
+
+const ActivityLegendRow: React.FC<{ segment: ActivitySegment }> = ({
+  segment,
+}) => (
+  <Box
+    sx={(theme) => ({
+      display: 'flex',
       alignItems: 'center',
-      py: 1.1,
-      borderBottom: `1px solid ${alpha(theme.palette.text.primary, 0.06)}`,
+      justifyContent: 'space-between',
+      gap: 1,
+      py: 0.55,
+      borderBottom: `1px solid ${alpha(theme.palette.text.primary, 0.05)}`,
       '&:last-of-type': { borderBottom: 'none' },
     })}
   >
-    <Typography
-      sx={{
-        fontFamily: FONTS.mono,
-        fontSize: '0.85rem',
-        color: STATUS_COLORS.open,
-      }}
-    >
-      {label}
-    </Typography>
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.8, minWidth: 0 }}>
+      <Box
+        sx={{
+          width: 8,
+          height: 8,
+          borderRadius: '50%',
+          backgroundColor: segment.color,
+          flexShrink: 0,
+        }}
+      />
+      <Typography
+        sx={{
+          fontFamily: FONTS.mono,
+          fontSize: '0.78rem',
+          color: STATUS_COLORS.open,
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {segment.label}
+      </Typography>
+    </Box>
     <Typography
       sx={(theme) => ({
         fontFamily: FONTS.mono,
-        fontWeight: 600,
-        fontSize: '1.1rem',
+        fontSize: '0.9rem',
+        fontWeight: 700,
         color: theme.palette.text.primary,
-        textAlign: 'center',
       })}
     >
-      {pr.toLocaleString()}
+      {segment.value.toLocaleString()}
     </Typography>
-    <Typography
-      sx={(theme) => ({
-        fontFamily: FONTS.mono,
-        fontWeight: 600,
-        fontSize: '1.1rem',
-        color: theme.palette.text.primary,
-        textAlign: 'center',
-      })}
-    >
-      {issue.toLocaleString()}
-    </Typography>
-  </Box>
-);
-
-interface PRColumnProps {
-  label: string;
-  value: number;
-  color: string;
-}
-
-const PRColumn: React.FC<PRColumnProps> = ({ label, value, color }) => (
-  <Box
-    sx={{
-      display: 'flex',
-      flexDirection: 'column',
-      alignItems: 'center',
-      gap: 0.5,
-    }}
-  >
-    <Typography
-      sx={{
-        fontFamily: FONTS.mono,
-        fontSize: '0.7rem',
-        color: STATUS_COLORS.open,
-        textTransform: 'uppercase',
-      }}
-    >
-      {label}
-    </Typography>
-    <Typography
-      sx={{
-        fontFamily: FONTS.mono,
-        fontSize: '1.1rem',
-        fontWeight: 600,
-        color,
-      }}
-    >
-      {value.toLocaleString()}
-    </Typography>
-  </Box>
-);
-
-interface RateBarProps {
-  rate: number;
-  color: string;
-}
-
-const RateBar: React.FC<RateBarProps> = ({ rate, color }) => (
-  <Box
-    sx={(theme) => ({
-      width: 64,
-      height: 6,
-      borderRadius: 3,
-      backgroundColor: alpha(theme.palette.text.primary, 0.1),
-      overflow: 'hidden',
-    })}
-  >
-    <Box
-      sx={{
-        width: `${rate}%`,
-        height: '100%',
-        borderRadius: 3,
-        backgroundColor: color,
-        transition: 'width 0.4s ease',
-      }}
-    />
   </Box>
 );

--- a/src/components/leaderboard/LeaderboardSidebar.tsx
+++ b/src/components/leaderboard/LeaderboardSidebar.tsx
@@ -57,8 +57,7 @@ export const LeaderboardSidebar: React.FC<LeaderboardSidebarProps> = ({
       spacing={2}
       sx={{ height: '100%', overflow: 'auto', pr: 1, ...scrollbarSx }}
     >
-      {/* Activity Cards: PR Activity, Issue Activity, Code Impact */}
-      <ActivitySidebarCards miners={miners} />
+      <ActivitySidebarCards miners={miners} variant={variant} />
 
       {/* Leaderboard Lists (Tabs) */}
       <SectionCard


### PR DESCRIPTION
## Summary

Updated the right sidebar activity panels for leaderboard pages.

- OSS Contributions now shows focused OSS-related activity only.
- Issue Discoveries now shows focused issue-related activity only.
- Watchlist keeps an overview sidebar, but uses the updated chart-style panels.
- Activity donuts now match the existing Miner Card donut style.
- Removed unnecessary red/green emphasis from Miners Activity.

## Related Issues

Closes #901

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

https://github.com/user-attachments/assets/33c8aefa-b5f1-4691-b4e8-eb943a60820b

<!-- Add before/after screenshots for OSS Contributions, Issue Discoveries, and Watchlist sidebars. -->

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
