### PR TITLE
fix(watchlist): clear confirmation dialog uses correct tab noun

### DIFF
--- a/src/pages/WatchlistPage.tsx
+++ b/src/pages/WatchlistPage.tsx
@@ -421,7 +421,7 @@ const WatchlistPage: React.FC = () => {
             mb: 3,
           }}
         >
-          Clear all {count} pinned miner(s)?
+          Clear all {count} pinned {count === 1 ? noun.single : noun.plural}?
         </DialogTitle>
         <DialogActions sx={{ p: 0 }}>
           <Button


### PR DESCRIPTION
## Summary

The clear confirmation dialog on the Watchlist page hard-coded the title to "miner(s)" regardless of the active tab, which contradicted the button caption right beneath it on Repositories, Bounties, Pull Requests, and Issues tabs.

The title now reuses the same `noun` helper (already in scope from `TAB_NOUN[activeTab]`) that the confirm button uses, and picks `noun.single` or `noun.plural` based on `count`. So a single pinned bounty reads "Clear all 1 pinned bounty?" while five repositories read "Clear all 5 pinned repositories?".

## Related Issues

Fixes #910

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

Before
<img width="1912" height="931" alt="before" src="https://github.com/user-attachments/assets/4c8263f8-6c81-4520-8780-8aba1a70b9b0" />

After
<img width="1907" height="858" alt="after" src="https://github.com/user-attachments/assets/982c26cc-4809-4e99-9cfa-65fd75040dcc" />

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
