### PR TITLE
fix(watchlist): card-aware rows-per-batch in Repositories sidebar

### DIFF
--- a/src/pages/WatchlistPage.tsx
+++ b/src/pages/WatchlistPage.tsx
@@ -12,11 +12,14 @@ import {
   Chip,
   Collapse,
   CircularProgress,
+  FormControl,
   FormControlLabel,
   Grid,
   IconButton,
   InputAdornment,
+  MenuItem,
   Popover,
+  Select,
   Switch,
   TextField,
   Tooltip,
@@ -91,6 +94,7 @@ import { getRepositoryOwnerAvatarSrc } from '../utils/avatar';
 import theme, {
   CHART_COLORS,
   LABEL_COLORS,
+  MONO_FONT,
   STATUS_COLORS,
   TEXT_OPACITY,
   UI_COLORS,
@@ -1414,6 +1418,15 @@ const RepoCard: React.FC<{ repo: WatchedRepoStats; maxWeight: number }> = ({
 
 const ROWS_PER_PAGE = 50;
 
+// Per-view-mode batch sizes for ReposList's infinite scroll. Card view tiles
+// in 12 / 24 / 48 multiples (3 cols × 4/8/16 rows). List view stays on the
+// flat 10 / 25 / 50 progression.
+const REPO_ROWS_OPTIONS_LIST = [10, 25, 50] as const;
+const REPO_ROWS_OPTIONS_CARDS = [12, 24, 48] as const;
+
+const defaultRepoRowsForView = (mode: 'list' | 'cards') =>
+  mode === 'cards' ? REPO_ROWS_OPTIONS_CARDS[0] : REPO_ROWS_OPTIONS_LIST[0];
+
 const ReposList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
   const { data: repos } = useReposAndWeights();
   const { data: allPrs } = useAllPrs();
@@ -1423,15 +1436,26 @@ const ReposList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
   const [showChart, setShowChart] = useState(false);
   const [useLogScale, setUseLogScale] = useState(false);
   const [page, setPage] = useState(0);
+  const [rowsPerBatch, setRowsPerBatch] = useState<number>(() =>
+    defaultRepoRowsForView(viewMode),
+  );
   const observerTarget = useRef<HTMLDivElement>(null);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
 
   const [sortField, setSortField] = useState<RepoSortKey>('weight');
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc');
 
+  // Keep batch size in sync with view mode: switching modes resets to the
+  // first valid value for that mode (12 for cards, 10 for list).
+  const handleViewModeChange = (next: 'list' | 'cards') => {
+    setViewMode(next);
+    setRowsPerBatch(defaultRepoRowsForView(next));
+    setPage(0);
+  };
+
   useEffect(() => {
     setPage(0);
-  }, [statusFilter, searchQuery, sortField, sortOrder, viewMode]);
+  }, [statusFilter, searchQuery, sortField, sortOrder, viewMode, rowsPerBatch]);
 
   const handleSort = (field: RepoSortKey) => {
     if (sortField === field) {
@@ -1530,8 +1554,8 @@ const ReposList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
   }, [filtered, sortField, sortOrder]);
 
   const paged = useMemo(
-    () => sorted.slice(0, (page + 1) * ROWS_PER_PAGE),
-    [sorted, page],
+    () => sorted.slice(0, (page + 1) * rowsPerBatch),
+    [sorted, page, rowsPerBatch],
   );
 
   useEffect(() => {
@@ -1785,15 +1809,48 @@ const ReposList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
                 )}
               </Box>
             </Box>
+            <Box>
+              <OptionsLabel>Rows per batch</OptionsLabel>
+              <FormControl size="small" sx={{ minWidth: 120 }}>
+                <Select
+                  value={rowsPerBatch}
+                  onChange={(e) => setRowsPerBatch(Number(e.target.value))}
+                  sx={{
+                    color: 'text.primary',
+                    backgroundColor: 'background.default',
+                    fontFamily: MONO_FONT,
+                    fontSize: '0.8rem',
+                    height: 36,
+                    borderRadius: 2,
+                    '& fieldset': { borderColor: 'border.light' },
+                    '&:hover fieldset': { borderColor: 'border.medium' },
+                    '&.Mui-focused fieldset': { borderColor: 'primary.main' },
+                    '& .MuiSelect-select': { py: 0.75 },
+                  }}
+                >
+                  {(viewMode === 'cards'
+                    ? REPO_ROWS_OPTIONS_CARDS
+                    : REPO_ROWS_OPTIONS_LIST
+                  ).map((n) => (
+                    <MenuItem key={n} value={n}>
+                      {n}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+            </Box>
           </>
         }
         searchValue={searchQuery}
         searchPlaceholder="Search repositories..."
         onSearchChange={setSearchQuery}
         viewMode={viewMode}
-        onViewModeChange={setViewMode}
+        onViewModeChange={handleViewModeChange}
         viewModeToggle={
-          <ReposViewModeToggle viewMode={viewMode} onChange={setViewMode} />
+          <ReposViewModeToggle
+            viewMode={viewMode}
+            onChange={handleViewModeChange}
+          />
         }
         hasActiveFilter={statusFilter !== 'all'}
       />
@@ -1874,7 +1931,7 @@ const ReposList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
           )}
         </Box>
       )}
-      {filtered.length > (page + 1) * ROWS_PER_PAGE && (
+      {filtered.length > (page + 1) * rowsPerBatch && (
         <Box
           ref={observerTarget}
           sx={{
@@ -1892,7 +1949,7 @@ const ReposList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
                 sx={{
                   color: 'text.secondary',
                   fontSize: '0.85rem',
-                  fontFamily: '"JetBrains Mono", monospace',
+                  fontFamily: MONO_FONT,
                   ml: 1.5,
                 }}
               >
@@ -2722,7 +2779,7 @@ const PRsList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
                 sx={{
                   color: 'text.secondary',
                   fontSize: '0.85rem',
-                  fontFamily: '"JetBrains Mono", monospace',
+                  fontFamily: MONO_FONT,
                   ml: 1.5,
                 }}
               >
@@ -3452,7 +3509,7 @@ const IssuesList: React.FC<{ minerIds: string[] }> = ({ minerIds }) => {
                 sx={{
                   color: 'text.secondary',
                   fontSize: '0.85rem',
-                  fontFamily: '"JetBrains Mono", monospace',
+                  fontFamily: MONO_FONT,
                   ml: 1.5,
                 }}
               >

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -79,6 +79,8 @@ export const CHART_COLORS = {
   ],
 } as const;
 
+export const MONO_FONT = '"JetBrains Mono", monospace';
+
 export const scrollbarSx = {
   '&::-webkit-scrollbar': {
     width: '8px',


### PR DESCRIPTION
## Summary

Rewrites the rows-per-page fix to live within the existing `WatchlistPortal` sidebar + infinite scroll architecture, addressing the review on the previous revision.

**What was wrong** (Repositories card view):
- Rows-per-page dropdown showed list values (`10 / 25 / 50`) instead of card-friendly values (`12 / 24 / 48`).

**What I changed:**

1. **Per-view-mode batch sizes for infinite scroll** (`ReposList`)
   - Added `REPO_ROWS_OPTIONS_LIST = [10, 25, 50]` and `REPO_ROWS_OPTIONS_CARDS = [12, 24, 48]`.
   - Replaced the fixed `ROWS_PER_PAGE` slicing with a `rowsPerBatch` state (initial = first option for the current view mode).
   - `IntersectionObserver` load-more sentinel and condition use `rowsPerBatch` so each scroll-triggered fetch matches the dropdown.
   - Toggling view mode resets `rowsPerBatch` to the first valid value for that mode and `page` to 0.

2. **Dropdown lives in the sidebar, not above the cards**
   - "Rows per batch" `Select` added to `WatchlistPortal`'s `extraContent` (right-hand sidebar on xl, popover otherwise) — same place as the Chart toggle. No new inline toolbar.

3. **`MONO_FONT` constant**
   - Added `MONO_FONT = '"JetBrains Mono", monospace'` to `theme.ts`.
   - Used it in the new `Select` sx and replaced the existing hardcoded font in the load-more "Loading more..." Typography in `ReposList`.

## Notes

- `PRsList` and `IssuesList` still use the shared `ROWS_PER_PAGE = 50`; this PR scopes the per-view-mode batch size to `ReposList` only. Happy to extend if reviewers want it.
- Infinite scroll is preserved exactly as on `test` — no `TablePagination`, no internal Card scroll, no card-mode sort row.

## Test plan

- [ ] Watchlist → Repositories → list view: "Rows per batch" dropdown in the right sidebar shows `10 / 25 / 50`.
- [ ] Switch to card view: dropdown shows `12 / 24 / 48`; first batch resets to 12; scroll loads 12 more at a time.
- [ ] Pick `48` in card view, scroll to bottom: load-more sentinel fires, next batch is +48.
- [ ] Toggle list ↔ cards: batch size resets to the first valid value for that mode (10 / 12); page resets to 0.
- [ ] No regression in Pull Requests / Issues card views (still using `ROWS_PER_PAGE`).
- [ ] No inline toolbar, no pagination, no inline sort row above the cards.