### PR TITLE
fix(repository): improve responsiveness on repo-check tab and contributors sidebar

### DIFF
--- a/src/components/repositories/RepositoryCheckTab.tsx
+++ b/src/components/repositories/RepositoryCheckTab.tsx
@@ -10,6 +10,7 @@ import {
   CircularProgress,
   alpha,
   useTheme,
+  type Theme,
 } from '@mui/material';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import CancelIcon from '@mui/icons-material/Cancel';
@@ -30,6 +31,120 @@ interface HealthCheck {
   passed: boolean;
   description: string;
 }
+
+interface StatCardProps {
+  value: number | string;
+  label: string;
+  hint: string;
+  href?: string;
+  theme: Theme;
+}
+
+const StatCard: React.FC<StatCardProps> = ({
+  value,
+  label,
+  hint,
+  href,
+  theme,
+}) => {
+  const isLink = Boolean(href);
+  const linkProps = isLink
+    ? {
+        component: 'a' as const,
+        href,
+        target: '_blank',
+        rel: 'noopener noreferrer',
+      }
+    : {};
+  return (
+    <Box
+      {...linkProps}
+      sx={{
+        p: { xs: 1.5, md: 2 },
+        borderRadius: 1,
+        bgcolor: alpha(theme.palette.common.white, 0.03),
+        border: `1px solid ${alpha(theme.palette.common.white, 0.05)}`,
+        height: '100%',
+        minWidth: 0,
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'space-between',
+        gap: 1,
+        textDecoration: 'none',
+        cursor: isLink ? 'pointer' : 'default',
+        overflow: 'hidden',
+        boxSizing: 'border-box',
+        transition: isLink ? 'all 0.2s' : 'none',
+        ...(isLink && {
+          '&:hover': {
+            bgcolor: alpha(theme.palette.common.white, 0.08),
+            border: `1px solid ${theme.palette.border.light}`,
+            transform: 'translateY(-2px)',
+          },
+        }),
+      }}
+    >
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'flex-start',
+          gap: 1,
+          minWidth: 0,
+        }}
+      >
+        <Box sx={{ minWidth: 0, flex: 1 }}>
+          <Typography
+            sx={{
+              color: 'text.primary',
+              fontSize: { xs: '20px', md: '24px' },
+              fontWeight: 600,
+              lineHeight: 1.2,
+              mb: 0.5,
+              whiteSpace: 'nowrap',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+            }}
+          >
+            {value}
+          </Typography>
+          <Typography
+            sx={{
+              color: STATUS_COLORS.open,
+              fontSize: '12px',
+              fontWeight: 600,
+              lineHeight: 1.25,
+              overflowWrap: 'break-word',
+              hyphens: 'auto',
+            }}
+          >
+            {label}
+          </Typography>
+        </Box>
+        {isLink && (
+          <LaunchIcon
+            sx={{
+              fontSize: 16,
+              color: STATUS_COLORS.open,
+              mt: 0.25,
+              flexShrink: 0,
+            }}
+          />
+        )}
+      </Box>
+      <Typography
+        variant="caption"
+        sx={{
+          color: 'text.secondary',
+          fontSize: '11px',
+          lineHeight: 1.3,
+        }}
+      >
+        {hint}
+      </Typography>
+    </Box>
+  );
+};
 
 const RepositoryCheckTab: React.FC<RepositoryCheckTabProps> = ({
   repositoryFullName,
@@ -204,19 +319,20 @@ const RepositoryCheckTab: React.FC<RepositoryCheckTabProps> = ({
 
       <Grid container spacing={2}>
         {/* Left Column: Health Score & Activity */}
-        <Grid item xs={12} md={4}>
+        <Grid item xs={12} md={4} sx={{ minWidth: 0 }}>
           <Box
             sx={{
               display: 'flex',
-              flexDirection: 'column',
+              flexDirection: { xs: 'column', sm: 'row', md: 'column' },
               gap: 2,
               height: '100%',
+              alignItems: 'stretch',
             }}
           >
             {/* Health Score Card */}
             <Card
               sx={{
-                p: 3,
+                p: { xs: 2, md: 3 },
                 backgroundColor: 'background.default',
                 border: `1px solid ${theme.palette.border.light}`,
                 borderRadius: 2,
@@ -224,7 +340,9 @@ const RepositoryCheckTab: React.FC<RepositoryCheckTabProps> = ({
                 flexDirection: 'column',
                 alignItems: 'center',
                 justifyContent: 'center',
-                minHeight: '280px', // Fixed height for consistency
+                flex: { sm: 1, md: 'unset' },
+                minWidth: 0,
+                minHeight: { xs: 220, sm: 240, md: 280 },
               }}
             >
               <Box
@@ -293,11 +411,14 @@ const RepositoryCheckTab: React.FC<RepositoryCheckTabProps> = ({
             {/* Activity & Feasibility Card */}
             <Card
               sx={{
-                p: 3,
+                p: { xs: 2, md: 3 },
                 backgroundColor: 'background.default',
                 border: `1px solid ${theme.palette.border.light}`,
                 borderRadius: 2,
-                flex: 1, // Fill remaining space
+                flex: 1,
+                minWidth: 0,
+                display: 'flex',
+                flexDirection: 'column',
               }}
             >
               <Typography
@@ -315,10 +436,21 @@ const RepositoryCheckTab: React.FC<RepositoryCheckTabProps> = ({
                 <SpeedIcon sx={{ fontSize: 18 }} /> Activity & Feasibility
               </Typography>
               <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
-                <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
+                <Box
+                  sx={{
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    alignItems: 'center',
+                    gap: 1,
+                  }}
+                >
                   <Typography
                     variant="body2"
-                    sx={{ color: STATUS_COLORS.open, fontSize: '13px' }}
+                    sx={{
+                      color: STATUS_COLORS.open,
+                      fontSize: '13px',
+                      flexShrink: 0,
+                    }}
                   >
                     Last Push
                   </Typography>
@@ -327,15 +459,28 @@ const RepositoryCheckTab: React.FC<RepositoryCheckTabProps> = ({
                     sx={{
                       color: 'text.primary',
                       fontSize: '13px',
+                      textAlign: 'right',
+                      minWidth: 0,
                     }}
                   >
                     {formatDate(repoData.pushed_at)}
                   </Typography>
                 </Box>
-                <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
+                <Box
+                  sx={{
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    alignItems: 'center',
+                    gap: 1,
+                  }}
+                >
                   <Typography
                     variant="body2"
-                    sx={{ color: STATUS_COLORS.open, fontSize: '13px' }}
+                    sx={{
+                      color: STATUS_COLORS.open,
+                      fontSize: '13px',
+                      flexShrink: 0,
+                    }}
                   >
                     Created
                   </Typography>
@@ -344,15 +489,28 @@ const RepositoryCheckTab: React.FC<RepositoryCheckTabProps> = ({
                     sx={{
                       color: 'text.primary',
                       fontSize: '13px',
+                      textAlign: 'right',
+                      minWidth: 0,
                     }}
                   >
                     {formatDate(repoData.created_at)}
                   </Typography>
                 </Box>
-                <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
+                <Box
+                  sx={{
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    alignItems: 'center',
+                    gap: 1,
+                  }}
+                >
                   <Typography
                     variant="body2"
-                    sx={{ color: STATUS_COLORS.open, fontSize: '13px' }}
+                    sx={{
+                      color: STATUS_COLORS.open,
+                      fontSize: '13px',
+                      flexShrink: 0,
+                    }}
                   >
                     Status
                   </Typography>
@@ -366,6 +524,7 @@ const RepositoryCheckTab: React.FC<RepositoryCheckTabProps> = ({
                         ? 'error.dark'
                         : 'success.dark',
                       color: 'text.primary',
+                      flexShrink: 0,
                     }}
                   />
                 </Box>
@@ -388,7 +547,7 @@ const RepositoryCheckTab: React.FC<RepositoryCheckTabProps> = ({
         </Grid>
 
         {/* Right Column: Issue Analysis & Standards */}
-        <Grid item xs={12} md={8}>
+        <Grid item xs={12} md={8} sx={{ minWidth: 0 }}>
           <Box
             sx={{
               display: 'flex',
@@ -400,13 +559,13 @@ const RepositoryCheckTab: React.FC<RepositoryCheckTabProps> = ({
             {/* Issue Analysis Card */}
             <Card
               sx={{
-                p: 3,
+                p: { xs: 2, md: 3 },
                 backgroundColor: 'background.default',
                 border: `1px solid ${theme.palette.border.light}`,
                 borderRadius: 2,
               }}
             >
-              <Box sx={{ mb: 3 }}>
+              <Box sx={{ mb: { xs: 2, md: 3 } }}>
                 <Typography
                   variant="h6"
                   sx={{
@@ -422,235 +581,53 @@ const RepositoryCheckTab: React.FC<RepositoryCheckTabProps> = ({
                 </Typography>
               </Box>
 
-              <Grid container spacing={2}>
-                {/* Stat: Open Issues — 2×2 from md until lg so link cards have room; 4 across on lg+ */}
-                <Grid item xs={6} md={6} lg={3}>
-                  <Box
-                    sx={{
-                      p: 2,
-                      borderRadius: 1,
-                      bgcolor: alpha(theme.palette.common.white, 0.03),
-                      border: `1px solid ${alpha(theme.palette.common.white, 0.05)}`,
-                      height: '100%',
-                      display: 'flex',
-                      flexDirection: 'column',
-                      justifyContent: 'center',
-                    }}
-                  >
-                    <Typography
-                      variant="h4"
-                      sx={{
-                        color: 'text.primary',
-                        fontSize: '24px',
-                        mb: 0.5,
-                      }}
-                    >
-                      {openIssuesCount !== null
+              <Grid container spacing={{ xs: 1.5, md: 2 }}>
+                {/* Stat: Open Issues */}
+                <Grid item xs={6} md={6} xl={3} sx={{ minWidth: 0 }}>
+                  <StatCard
+                    value={
+                      openIssuesCount !== null
                         ? openIssuesCount
-                        : repoData.open_issues_count || '-'}
-                    </Typography>
-                    <Typography
-                      variant="caption"
-                      sx={{ color: STATUS_COLORS.open, fontSize: '12px' }}
-                    >
-                      Open Issues
-                    </Typography>
-                  </Box>
+                        : (repoData.open_issues_count ?? '-')
+                    }
+                    label="Open Issues"
+                    hint="Currently open"
+                    theme={theme}
+                  />
                 </Grid>
 
                 {/* Stat: Forks */}
-                <Grid item xs={6} md={6} lg={3}>
-                  <Box
-                    sx={{
-                      p: 2,
-                      borderRadius: 1,
-                      bgcolor: alpha(theme.palette.common.white, 0.03),
-                      border: `1px solid ${alpha(theme.palette.common.white, 0.05)}`,
-                      height: '100%',
-                      display: 'flex',
-                      flexDirection: 'column',
-                      justifyContent: 'center',
-                    }}
-                  >
-                    <Typography
-                      variant="h4"
-                      sx={{
-                        color: 'text.primary',
-                        fontSize: '24px',
-                        mb: 0.5,
-                      }}
-                    >
-                      {repoData.forks_count}
-                    </Typography>
-                    <Typography
-                      variant="caption"
-                      sx={{ color: STATUS_COLORS.open, fontSize: '12px' }}
-                    >
-                      Forks
-                    </Typography>
-                  </Box>
+                <Grid item xs={6} md={6} xl={3} sx={{ minWidth: 0 }}>
+                  <StatCard
+                    value={repoData.forks_count}
+                    label="Forks"
+                    hint="Total forks"
+                    theme={theme}
+                  />
                 </Grid>
 
                 {/* Action: Good First Issues */}
-                <Grid item xs={6} md={6} lg={3}>
-                  <Box
-                    component="a"
+                <Grid item xs={6} md={6} xl={3} sx={{ minWidth: 0 }}>
+                  <StatCard
+                    value={
+                      goodFirstIssueCount !== null ? goodFirstIssueCount : '-'
+                    }
+                    label="Good First Issues"
+                    hint="Perfect for beginners"
                     href={`https://github.com/${repositoryFullName}/issues?q=is%3Aissue+is%3Aopen+label%3A"good+first+issue"`}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    sx={{
-                      p: 2,
-                      borderRadius: 1,
-                      bgcolor: alpha(theme.palette.common.white, 0.03),
-                      border: `1px solid ${alpha(theme.palette.common.white, 0.05)}`,
-                      height: '100%',
-                      minWidth: 0,
-                      display: 'flex',
-                      flexDirection: 'column',
-                      justifyContent: 'space-between',
-                      textDecoration: 'none',
-                      cursor: 'pointer',
-                      overflow: 'hidden',
-                      boxSizing: 'border-box',
-                      transition: 'all 0.2s',
-                      '&:hover': {
-                        bgcolor: alpha(theme.palette.common.white, 0.08),
-                        border: `1px solid ${theme.palette.border.light}`,
-                        transform: 'translateY(-2px)',
-                      },
-                    }}
-                  >
-                    <Box
-                      sx={{
-                        display: 'flex',
-                        justifyContent: 'space-between',
-                        alignItems: 'flex-start',
-                        gap: 1,
-                        mb: 1,
-                        minWidth: 0,
-                      }}
-                    >
-                      <Box sx={{ minWidth: 0, flex: 1 }}>
-                        <Typography
-                          variant="h4"
-                          sx={{
-                            color: 'text.primary',
-                            fontSize: '24px',
-                            mb: 0.5,
-                          }}
-                        >
-                          {goodFirstIssueCount !== null
-                            ? goodFirstIssueCount
-                            : '-'}
-                        </Typography>
-                        <Typography
-                          sx={{
-                            color: STATUS_COLORS.open,
-                            fontSize: '12px',
-                            fontWeight: 600,
-                            lineHeight: 1.25,
-                            wordBreak: 'break-word',
-                          }}
-                        >
-                          Good First Issues
-                        </Typography>
-                      </Box>
-                      <LaunchIcon
-                        sx={{
-                          fontSize: 16,
-                          color: STATUS_COLORS.open,
-                          mt: 0.25,
-                          flexShrink: 0,
-                        }}
-                      />
-                    </Box>
-                    <Typography
-                      variant="caption"
-                      sx={{ color: 'text.secondary', fontSize: '11px' }}
-                    >
-                      Perfect for beginners
-                    </Typography>
-                  </Box>
+                    theme={theme}
+                  />
                 </Grid>
 
                 {/* Action: Help Wanted */}
-                <Grid item xs={6} md={6} lg={3}>
-                  <Box
-                    component="a"
+                <Grid item xs={6} md={6} xl={3} sx={{ minWidth: 0 }}>
+                  <StatCard
+                    value={helpWantedCount !== null ? helpWantedCount : '-'}
+                    label="Help Wanted"
+                    hint="General contributions"
                     href={`https://github.com/${repositoryFullName}/issues?q=is%3Aissue+is%3Aopen+label%3A"help+wanted"`}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    sx={{
-                      p: 2,
-                      borderRadius: 1,
-                      bgcolor: alpha(theme.palette.common.white, 0.03),
-                      border: `1px solid ${alpha(theme.palette.common.white, 0.05)}`,
-                      height: '100%',
-                      minWidth: 0,
-                      display: 'flex',
-                      flexDirection: 'column',
-                      justifyContent: 'space-between',
-                      textDecoration: 'none',
-                      cursor: 'pointer',
-                      overflow: 'hidden',
-                      boxSizing: 'border-box',
-                      transition: 'all 0.2s',
-                      '&:hover': {
-                        bgcolor: alpha(theme.palette.common.white, 0.08),
-                        border: `1px solid ${theme.palette.border.light}`,
-                        transform: 'translateY(-2px)',
-                      },
-                    }}
-                  >
-                    <Box
-                      sx={{
-                        display: 'flex',
-                        justifyContent: 'space-between',
-                        alignItems: 'flex-start',
-                        gap: 1,
-                        mb: 1,
-                        minWidth: 0,
-                      }}
-                    >
-                      <Box sx={{ minWidth: 0, flex: 1 }}>
-                        <Typography
-                          variant="h4"
-                          sx={{
-                            color: 'text.primary',
-                            fontSize: '24px',
-                            mb: 0.5,
-                          }}
-                        >
-                          {helpWantedCount !== null ? helpWantedCount : '-'}
-                        </Typography>
-                        <Typography
-                          sx={{
-                            color: STATUS_COLORS.open,
-                            fontSize: '12px',
-                            fontWeight: 600,
-                            lineHeight: 1.25,
-                            wordBreak: 'break-word',
-                          }}
-                        >
-                          Help Wanted
-                        </Typography>
-                      </Box>
-                      <LaunchIcon
-                        sx={{
-                          fontSize: 16,
-                          color: STATUS_COLORS.open,
-                          mt: 0.25,
-                          flexShrink: 0,
-                        }}
-                      />
-                    </Box>
-                    <Typography
-                      variant="caption"
-                      sx={{ color: 'text.secondary', fontSize: '11px' }}
-                    >
-                      General contributions
-                    </Typography>
-                  </Box>
+                    theme={theme}
+                  />
                 </Grid>
               </Grid>
             </Card>
@@ -688,27 +665,34 @@ const RepositoryCheckTab: React.FC<RepositoryCheckTabProps> = ({
                 </Typography>
               </Box>
 
-              <Box sx={{ p: 2 }}>
-                <Grid container spacing={2}>
+              <Box sx={{ p: { xs: 1.5, md: 2 } }}>
+                <Grid container spacing={{ xs: 1.5, md: 2 }}>
                   {checks.map((check) => (
-                    <Grid item xs={12} sm={6} key={check.name}>
+                    <Grid
+                      item
+                      xs={12}
+                      sm={6}
+                      key={check.name}
+                      sx={{ minWidth: 0 }}
+                    >
                       <Box
                         sx={{
-                          p: 2,
+                          p: { xs: 1.5, md: 2 },
                           borderRadius: 1,
                           bgcolor: 'surface.subtle',
                           border: `1px solid ${alpha(theme.palette.common.white, 0.05)}`,
                           display: 'flex',
                           alignItems: 'flex-start',
-                          gap: 2,
+                          gap: { xs: 1.5, md: 2 },
                           height: '100%',
+                          minWidth: 0,
                           transition: 'background-color 0.2s',
                           '&:hover': {
                             bgcolor: alpha(theme.palette.common.white, 0.04),
                           },
                         }}
                       >
-                        <Box sx={{ mt: 0.5 }}>
+                        <Box sx={{ mt: 0.5, flexShrink: 0 }}>
                           {check.passed ? (
                             <CheckCircleIcon
                               sx={{
@@ -722,7 +706,7 @@ const RepositoryCheckTab: React.FC<RepositoryCheckTabProps> = ({
                             />
                           )}
                         </Box>
-                        <Box>
+                        <Box sx={{ minWidth: 0 }}>
                           <Typography
                             sx={{
                               color: 'text.primary',

--- a/src/components/repositories/RepositoryContributorsTable.tsx
+++ b/src/components/repositories/RepositoryContributorsTable.tsx
@@ -42,6 +42,17 @@ interface ContributorRow {
 
 const numericCellSx = { fontVariantNumeric: 'tabular-nums' as const };
 
+const compactCellSx = {
+  px: { xs: 0.75, lg: 1 },
+  '&:first-of-type': { pl: { xs: 1, lg: 1.5 } },
+  '&:last-of-type': { pr: { xs: 1, lg: 1.5 } },
+};
+
+const compactNumericCellSx = {
+  ...numericCellSx,
+  ...compactCellSx,
+};
+
 const RepositoryContributorsTable: React.FC<
   RepositoryContributorsTableProps
 > = ({ repositoryFullName }) => {
@@ -193,8 +204,10 @@ const RepositoryContributorsTable: React.FC<
     () => ({
       key: 'rank',
       header: '#',
-      width: '32px',
+      width: '28px',
+      headerSx: compactCellSx,
       cellSx: (c) => ({
+        ...compactCellSx,
         color: c.rank <= 3 ? 'text.primary' : STATUS_COLORS.open,
         fontWeight: c.rank <= 3 ? 600 : 400,
       }),
@@ -207,84 +220,87 @@ const RepositoryContributorsTable: React.FC<
     () => ({
       key: 'miner',
       header: 'Miner',
-      cellSx: { minWidth: 0 },
-      renderCell: (c) => (
-        <LinkBox
-          href={`/miners/details?githubId=${encodeURIComponent(c.githubId)}&mode=${programTab === 'issues' ? 'issues' : 'prs'}`}
-          linkState={{
-            backLabel: `Back to ${repositoryFullName}`,
-          }}
-          sx={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: 1.5,
-            overflow: 'hidden',
-            cursor: 'pointer',
-            '&:hover .contributor-name': {
-              color: STATUS_COLORS.info,
-              textDecoration: 'underline',
-            },
-          }}
-        >
-          <Avatar
-            src={`https://avatars.githubusercontent.com/${c.author}`}
-            sx={{
-              width: 20,
-              height: 20,
-              border: `1px solid ${theme.palette.border.light}`,
-              flexShrink: 0,
-            }}
-          />
-          <Box
-            sx={{
-              display: 'flex',
-              flexDirection: 'column',
-              minWidth: 0,
-            }}
-          >
-            <Typography
-              className="contributor-name"
+      headerSx: compactCellSx,
+      cellSx: { ...compactCellSx, minWidth: 0 },
+      renderCell: (c) => {
+        const subRank =
+          programTab === 'oss'
+            ? c.minerRank != null
+              ? `OSS Rank #${c.minerRank}`
+              : null
+            : c.issueMinerRank != null
+              ? `Discovery rank #${c.issueMinerRank}`
+              : null;
+        return (
+          <Tooltip title={c.author} placement="top" enterDelay={300}>
+            <LinkBox
+              href={`/miners/details?githubId=${encodeURIComponent(c.githubId)}&mode=${programTab === 'issues' ? 'issues' : 'prs'}`}
+              linkState={{
+                backLabel: `Back to ${repositoryFullName}`,
+              }}
               sx={{
-                fontSize: '13px',
-                fontWeight: 500,
-                color: 'text.primary',
-                whiteSpace: 'nowrap',
+                display: 'flex',
+                alignItems: 'center',
+                gap: 1,
+                minWidth: 0,
                 overflow: 'hidden',
-                textOverflow: 'ellipsis',
-                transition: 'color 0.1s',
+                cursor: 'pointer',
+                '&:hover .contributor-name': {
+                  color: STATUS_COLORS.info,
+                  textDecoration: 'underline',
+                },
               }}
             >
-              {c.author}
-            </Typography>
-            {programTab === 'oss' && c.minerRank != null && (
-              <Typography
+              <Avatar
+                src={`https://avatars.githubusercontent.com/${c.author}`}
                 sx={{
-                  fontSize: '10px',
-                  color: STATUS_COLORS.open,
-                  whiteSpace: 'nowrap',
-                  overflow: 'hidden',
-                  textOverflow: 'ellipsis',
+                  width: 18,
+                  height: 18,
+                  border: `1px solid ${theme.palette.border.light}`,
+                  flexShrink: 0,
+                }}
+              />
+              <Box
+                sx={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  minWidth: 0,
+                  flex: 1,
                 }}
               >
-                OSS Rank #{c.minerRank}
-              </Typography>
-            )}
-            {programTab === 'issues' && c.issueMinerRank != null && (
-              <Typography
-                sx={{
-                  fontSize: '10px',
-                  color: STATUS_COLORS.open,
-                  whiteSpace: 'nowrap',
-                  overflow: 'hidden',
-                  textOverflow: 'ellipsis',
-                }}
-              >
-                Discovery rank #{c.issueMinerRank}
-              </Typography>
-            )}
-          </Box>
-        </LinkBox>
-      ),
+                <Typography
+                  className="contributor-name"
+                  sx={{
+                    fontSize: '13px',
+                    fontWeight: 500,
+                    color: 'text.primary',
+                    whiteSpace: 'nowrap',
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    transition: 'color 0.1s',
+                  }}
+                >
+                  {c.author}
+                </Typography>
+                {subRank && (
+                  <Typography
+                    sx={{
+                      fontSize: '10px',
+                      color: STATUS_COLORS.open,
+                      whiteSpace: 'nowrap',
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      display: { xs: 'none', sm: 'block' },
+                    }}
+                  >
+                    {subRank}
+                  </Typography>
+                )}
+              </Box>
+            </LinkBox>
+          </Tooltip>
+        );
+      },
     }),
     [programTab, repositoryFullName, theme.palette.border.light],
   );
@@ -297,19 +313,19 @@ const RepositoryContributorsTable: React.FC<
         {
           key: 'prs',
           header: 'PRs',
-          width: '3rem',
+          width: '2.5rem',
           align: 'right',
-          headerSx: numericCellSx,
-          cellSx: numericCellSx,
+          headerSx: compactNumericCellSx,
+          cellSx: compactNumericCellSx,
           renderCell: (c) => c.prs,
         },
         {
           key: 'score',
           header: 'Score',
-          width: '4.5rem',
+          width: '4rem',
           align: 'right',
-          headerSx: numericCellSx,
-          cellSx: numericCellSx,
+          headerSx: compactNumericCellSx,
+          cellSx: compactNumericCellSx,
           renderCell: (c) => c.score.toFixed(2),
         },
       ];
@@ -324,10 +340,10 @@ const RepositoryContributorsTable: React.FC<
             <span>Issues</span>
           </Tooltip>
         ),
-        width: '3.25rem',
+        width: '2.75rem',
         align: 'right',
-        headerSx: numericCellSx,
-        cellSx: numericCellSx,
+        headerSx: compactNumericCellSx,
+        cellSx: compactNumericCellSx,
         renderCell: (c) => c.discoverySolved,
       },
       {
@@ -335,8 +351,8 @@ const RepositoryContributorsTable: React.FC<
         header: 'Score',
         width: '4rem',
         align: 'right',
-        headerSx: numericCellSx,
-        cellSx: numericCellSx,
+        headerSx: compactNumericCellSx,
+        cellSx: compactNumericCellSx,
         renderCell: (c) => c.issueDiscoveryScore.toFixed(2),
       },
     ];
@@ -376,10 +392,11 @@ const RepositoryContributorsTable: React.FC<
         sx={{
           display: 'flex',
           width: '100%',
-          gap: 0.5,
+          gap: 0.25,
           backgroundColor: 'surface.subtle',
           p: 0.5,
           borderRadius: 2,
+          overflow: 'hidden',
         }}
       >
         {(
@@ -397,7 +414,7 @@ const RepositoryContributorsTable: React.FC<
               aria-pressed={isActive}
               onClick={() => setProgramTab(option.value)}
               sx={{
-                px: 1,
+                px: 0.5,
                 py: 0.65,
                 border: 0,
                 borderRadius: 1.5,
@@ -423,6 +440,9 @@ const RepositoryContributorsTable: React.FC<
                   textAlign: 'center',
                   whiteSpace: 'nowrap',
                   lineHeight: 1.2,
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  display: 'block',
                 }}
               >
                 {option.label}


### PR DESCRIPTION
## Summary

- Repo-check tab: stacked Health Score / Activity cards now lay out side-by-side at `sm`, all cards use responsive padding, and the four Issue Analysis stat cards are normalized into a single `StatCard` component with consistent layout and natural word-level wrapping (no more "Good Firs t Issu es" character-breaks).
- Repo-check tab: stat cards stay 2×2 until the `xl` breakpoint so labels don't get squeezed when the right column is narrow at 1200–1535px viewports.
- Contributors sidebar table: tighter cell padding, slimmer column widths, smaller avatar/gap, and a tooltip on the miner name so usernames stay readable instead of being truncated to single characters in the narrow sidebar.
- Contributors sidebar tabs: reduced pill padding plus an ellipsis fallback so "OSS Contributions" / "Issue Discovery" labels stay inside the pill at all sidebar widths.

## Test plan
- [ ] Visit `/miners/repository?name=<owner>/<repo>&tab=repo-check` and resize the window from ~900px through 1920px — Health Score, Activity, Issue Analysis stat cards, and Community Standards should all stay readable with no clipped text.
- [ ] Verify the four Issue Analysis stat cards have consistent layout (number + label + hint) and labels wrap on word boundaries, never mid-word.
- [ ] Verify the right-side "Top Miner Contributors" table shows full usernames (not "M..." / "b...") at typical desktop widths, and hovering a truncated name reveals the full username via tooltip.
- [ ] Verify the OSS Contributions / Issue Discovery tab pill stays inside its container at narrow sidebar widths.


## Related Issues


## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots
Before:
<img width="1315" height="946" alt="Screenshot_1" src="https://github.com/user-attachments/assets/0bdfe575-db63-4f04-931d-aedd464c8d7f" />

After:
<img width="1290" height="946" alt="Screenshot_2" src="https://github.com/user-attachments/assets/ad4ff198-a5a2-4317-8100-a851ea384d05" />

## Checklist

- [ ] New components are modularized/separated where sensible
- [ ] Uses predefined theme (e.g. no hardcoded colors)
- [X] Responsive/mobile checked
- [ ] Tested against the test API
- [X] `npm run format` and `npm run lint:fix` have been run
- [X] `npm run build` passes
- [X] Screenshots included for any UI/visual changes
