### PR TITLE
feat(home): redesign landing page with live emission pipeline

### DIFF
--- a/src/api/models/Dashboard.ts
+++ b/src/api/models/Dashboard.ts
@@ -39,6 +39,11 @@ export type Stats = {
   recentLinesChanged: string | number;
   totalIssues: number;
   totalCommits: string | number;
+  /**
+   * Live daily alpha emission for subnet 74, sourced from chain state.
+   * Falls back to the hardcoded constant when missing.
+   */
+  dailyAlphaEmissions?: number | string;
   prices?: {
     tao: {
       data: {

--- a/src/hooks/useMonthlyRewards.ts
+++ b/src/hooks/useMonthlyRewards.ts
@@ -1,7 +1,32 @@
 import { useMemo } from 'react';
 import { useStats } from '../api';
+import { type Stats } from '../api/models/Dashboard';
 
-const DAILY_ALPHA_EMISSIONS = 2952;
+/**
+ * Fallback subnet 74 daily alpha emission. Used only when the backend's
+ * /dash/stats response omits `dailyAlphaEmissions`. Update when chain
+ * drift makes this materially wrong, but the live field is preferred.
+ */
+export const DAILY_ALPHA_EMISSIONS_FALLBACK = 3571;
+
+const resolveDailyAlphaEmissions = (stats: Stats | undefined): number => {
+  const raw = stats?.dailyAlphaEmissions;
+  if (typeof raw === 'number' && Number.isFinite(raw) && raw > 0) return raw;
+  if (typeof raw === 'string') {
+    const parsed = parseFloat(raw);
+    if (Number.isFinite(parsed) && parsed > 0) return parsed;
+  }
+  return DAILY_ALPHA_EMISSIONS_FALLBACK;
+};
+
+/**
+ * Daily alpha emissions for subnet 74. Reads from live chain state when
+ * the backend exposes it; falls back to the hardcoded constant otherwise.
+ */
+export const useDailyAlphaEmissions = (): number => {
+  const { data: stats } = useStats();
+  return useMemo(() => resolveDailyAlphaEmissions(stats), [stats]);
+};
 
 export const useMonthlyRewards = (): number | undefined => {
   const { data: stats } = useStats();
@@ -15,12 +40,13 @@ export const useMonthlyRewards = (): number | undefined => {
     }
     const taoPrice = stats.prices.tao.data.price;
     const alphaPrice = stats.prices.alpha.data.price;
+    const dailyEmissions = resolveDailyAlphaEmissions(stats);
     const now = new Date();
     const daysInMonth = new Date(
       now.getFullYear(),
       now.getMonth() + 1,
       0,
     ).getDate();
-    return taoPrice * alphaPrice * DAILY_ALPHA_EMISSIONS * daysInMonth;
-  }, [stats?.prices]);
+    return taoPrice * alphaPrice * dailyEmissions * daysInMonth;
+  }, [stats]);
 };

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -4,6 +4,7 @@ import { Page } from '../components/layout';
 import { SEO } from '../components';
 import HeroFlow from './home/HeroFlow';
 import HowItWorks from './home/HowItWorks';
+import TopContributors from './home/TopContributors';
 import StarterBounties from './home/StarterBounties';
 
 const HomePage: React.FC = () => (
@@ -23,6 +24,7 @@ const HomePage: React.FC = () => (
     >
       <HeroFlow />
       <HowItWorks />
+      <TopContributors />
       <StarterBounties />
     </Box>
   </Page>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,140 +1,31 @@
 import React from 'react';
-import { Box, Stack, Typography, alpha } from '@mui/material';
+import { Box } from '@mui/material';
 import { Page } from '../components/layout';
 import { SEO } from '../components';
-import { useMonthlyRewards } from '../hooks/useMonthlyRewards';
+import HeroFlow from './home/HeroFlow';
+import HowItWorks from './home/HowItWorks';
+import StarterBounties from './home/StarterBounties';
 
-const HomePage: React.FC = () => {
-  const monthlyRewards = useMonthlyRewards();
-
-  return (
-    <Page title="Home">
-      <SEO
-        title="Autonomous Software Development"
-        description="The workforce for open source. Compete for rewards by contributing quality code to open source repositories."
-        type="website"
-      />
-      <Box
-        sx={{
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-          justifyContent: 'center',
-          minHeight: { xs: 'calc(100vh - 64px)', md: '100vh' },
-          width: '100%',
-          px: { xs: 2, sm: 3 },
-        }}
-      >
-        <Stack
-          alignItems="center"
-          justifyContent="center"
-          gap={{ xs: 2, sm: 3 }}
-        >
-          <Box
-            component="img"
-            src="/gt-logo.svg"
-            alt="Gittensor"
-            sx={(theme) => ({
-              height: window.innerWidth < 600 ? '96px' : '128px',
-              width: 'auto',
-              filter: `grayscale(100%) invert(1) drop-shadow(0 0 12px ${alpha(
-                theme.palette.text.primary,
-                0.8,
-              )})`,
-            })}
-          />
-          <Typography
-            variant="h1"
-            color="text.primary"
-            fontWeight="bold"
-            sx={{
-              fontSize: { xs: '2rem', sm: '3rem', md: '4rem' },
-              textAlign: 'center',
-            }}
-          >
-            GITTENSOR
-          </Typography>
-          <Typography
-            variant="body1"
-            color="text.secondary"
-            fontWeight="bold"
-            sx={{
-              fontSize: { xs: '0.9rem', sm: '1rem' },
-              textAlign: 'center',
-            }}
-          >
-            The workforce for open source.
-          </Typography>
-
-          {/* Monthly Rewards Banner */}
-          {monthlyRewards && (
-            <Box
-              sx={(theme) => ({
-                mt: { xs: 4, sm: 5 },
-                px: { xs: 3, sm: 5, md: 7 },
-                py: { xs: 2.5, sm: 3.5 },
-                borderRadius: 2,
-                background: alpha(theme.palette.background.default, 0.4),
-                border: '1px solid',
-                borderColor: theme.palette.border.light,
-                backdropFilter: 'blur(10px)',
-                boxShadow: `0 8px 32px ${alpha(theme.palette.background.default, 0.3)}`,
-                transition: 'all 0.3s ease-in-out',
-                '&:hover': {
-                  borderColor: theme.palette.border.medium,
-                  boxShadow: `0 12px 48px ${alpha(theme.palette.background.default, 0.4)}`,
-                  transform: 'translateY(-2px)',
-                },
-              })}
-            >
-              <Stack alignItems="center" gap={{ xs: 1, sm: 1.5 }}>
-                <Typography
-                  variant="body2"
-                  sx={{
-                    color: (theme) => theme.palette.text.secondary,
-                    fontSize: { xs: '0.7rem', sm: '0.75rem' },
-                    textTransform: 'uppercase',
-                    letterSpacing: '0.15em',
-                    fontWeight: 500,
-                  }}
-                >
-                  Monthly Reward Pool
-                </Typography>
-                <Typography
-                  variant="h2"
-                  fontWeight="600"
-                  sx={{
-                    color: (theme) => theme.palette.text.primary,
-                    fontSize: { xs: '2rem', sm: '2.75rem', md: '3.5rem' },
-                    letterSpacing: '-0.02em',
-                  }}
-                >
-                  $
-                  {monthlyRewards.toLocaleString(undefined, {
-                    minimumFractionDigits: 2,
-                    maximumFractionDigits: 2,
-                  })}
-                </Typography>
-                <Typography
-                  variant="body2"
-                  sx={{
-                    color: (theme) => theme.palette.text.tertiary,
-                    fontSize: { xs: '0.75rem', sm: '0.85rem' },
-                    textAlign: 'center',
-                    maxWidth: '400px',
-                    lineHeight: 1.6,
-                  }}
-                >
-                  Compete for rewards by contributing quality code to open
-                  source
-                </Typography>
-              </Stack>
-            </Box>
-          )}
-        </Stack>
-      </Box>
-    </Page>
-  );
-};
+const HomePage: React.FC = () => (
+  <Page title="Home">
+    <SEO
+      title="Autonomous Software Development"
+      description="The workforce for open source. Compete for rewards by contributing quality code to open source repositories."
+      type="website"
+    />
+    <Box
+      sx={{
+        width: '100%',
+        px: { xs: 2, sm: 3 },
+        pb: { xs: 6, sm: 8 },
+        overflow: 'hidden',
+      }}
+    >
+      <HeroFlow />
+      <HowItWorks />
+      <StarterBounties />
+    </Box>
+  </Page>
+);
 
 export default HomePage;

--- a/src/pages/home/HeroFlow.tsx
+++ b/src/pages/home/HeroFlow.tsx
@@ -12,7 +12,10 @@ import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
 import ArrowDropUpIcon from '@mui/icons-material/ArrowDropUp';
 import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
 import { useStats } from '../../api';
-import { useDailyAlphaEmissions } from '../../hooks/useMonthlyRewards';
+import {
+  useDailyAlphaEmissions,
+  useMonthlyRewards,
+} from '../../hooks/useMonthlyRewards';
 
 const VIEWBOX_W = 1200;
 const VIEWBOX_H = 280;
@@ -296,10 +299,16 @@ const HeroFlow: React.FC = () => {
           />
         </Box>
 
+        <MonthlyPoolTile />
+
         <Stack
           direction={{ xs: 'column', sm: 'row' }}
           spacing={1.5}
-          sx={{ mt: { xs: 1, sm: 2 } }}
+          sx={{
+            mt: { xs: 1, sm: 2 },
+            width: '100%',
+            maxWidth: HERO_BLOCK_MAX_WIDTH,
+          }}
         >
           <Button
             component={RouterLink}
@@ -310,7 +319,7 @@ const HeroFlow: React.FC = () => {
             sx={{
               textTransform: 'none',
               fontWeight: 600,
-              px: 3.5,
+              flex: 1,
               borderRadius: 2,
             }}
           >
@@ -324,7 +333,7 @@ const HeroFlow: React.FC = () => {
             sx={{
               textTransform: 'none',
               fontWeight: 600,
-              px: 3.5,
+              flex: 1,
               borderRadius: 2,
             }}
           >
@@ -574,6 +583,71 @@ const OutputNode: React.FC<{
   </Stack>
 );
 
+const HERO_BLOCK_MAX_WIDTH = 480;
+
+const MonthlyPoolTile: React.FC = () => {
+  const monthly = useMonthlyRewards();
+
+  return (
+    <Box
+      sx={(theme) => ({
+        mt: { xs: 2, sm: 2.5 },
+        width: '100%',
+        maxWidth: HERO_BLOCK_MAX_WIDTH,
+        px: { xs: 3, sm: 4 },
+        py: { xs: 2, sm: 2.5 },
+        borderRadius: 2,
+        border: `1px solid ${theme.palette.border.light}`,
+        backgroundColor: alpha(theme.palette.background.default, 0.5),
+        backdropFilter: 'blur(6px)',
+        textAlign: 'center',
+      })}
+    >
+      <Typography
+        sx={{
+          fontSize: '0.7rem',
+          textTransform: 'uppercase',
+          letterSpacing: '0.18em',
+          fontWeight: 700,
+          color: 'text.secondary',
+          mb: 0.75,
+        }}
+      >
+        Monthly emission pool
+      </Typography>
+      <Typography
+        sx={(theme) => ({
+          fontFamily: '"JetBrains Mono", monospace',
+          fontSize: { xs: '2rem', sm: '2.6rem' },
+          fontWeight: 700,
+          color: theme.palette.text.primary,
+          letterSpacing: '-0.02em',
+          lineHeight: 1,
+        })}
+      >
+        {monthly !== undefined
+          ? `$${monthly.toLocaleString(undefined, {
+              minimumFractionDigits: 2,
+              maximumFractionDigits: 2,
+            })}`
+          : '—'}
+      </Typography>
+      <Typography
+        sx={{
+          mt: 0.85,
+          fontSize: { xs: '0.78rem', sm: '0.85rem' },
+          color: 'text.secondary',
+          lineHeight: 1.5,
+          maxWidth: 360,
+          mx: 'auto',
+        }}
+      >
+        Compete for rewards by contributing quality code to open source.
+      </Typography>
+    </Box>
+  );
+};
+
 const MarketStrip: React.FC = () => {
   const { data: stats } = useStats();
   const taoData = stats?.prices?.tao?.data ?? null;
@@ -629,24 +703,34 @@ const MarketChip: React.FC<{
     <Stack
       direction="row"
       alignItems="center"
-      spacing={0.5}
-      sx={{
-        fontSize: { xs: '0.7rem', sm: '0.78rem' },
+      spacing={0.6}
+      sx={(theme) => ({
+        px: 1,
+        py: 0.4,
+        borderRadius: 999,
+        border: `1px solid ${theme.palette.border.light}`,
+        backgroundColor: alpha(theme.palette.background.default, 0.5),
+        fontSize: { xs: '0.78rem', sm: '0.85rem' },
         lineHeight: 1,
-      }}
+      })}
     >
-      <Typography
+      <Box
         component="span"
-        sx={{
+        sx={(theme) => ({
+          px: 0.7,
+          py: 0.2,
+          borderRadius: 999,
+          backgroundColor: alpha(theme.palette.diff.additions, 0.18),
+          color: theme.palette.diff.additions,
           fontFamily: 'inherit',
-          fontSize: 'inherit',
-          fontWeight: 700,
-          color: 'text.tertiary',
-          letterSpacing: '0.05em',
-        }}
+          fontSize: '0.72rem',
+          fontWeight: 800,
+          letterSpacing: '0.06em',
+          textTransform: 'uppercase',
+        })}
       >
         {symbol}
-      </Typography>
+      </Box>
       <Typography
         component="span"
         sx={{
@@ -674,9 +758,9 @@ const MarketChip: React.FC<{
           })}
         >
           {(change as number) >= 0 ? (
-            <ArrowDropUpIcon sx={{ fontSize: '0.95rem', mx: -0.25 }} />
+            <ArrowDropUpIcon sx={{ fontSize: '1rem', mx: -0.25 }} />
           ) : (
-            <ArrowDropDownIcon sx={{ fontSize: '0.95rem', mx: -0.25 }} />
+            <ArrowDropDownIcon sx={{ fontSize: '1rem', mx: -0.25 }} />
           )}
           {Math.abs(change as number).toFixed(2)}%
         </Stack>

--- a/src/pages/home/HeroFlow.tsx
+++ b/src/pages/home/HeroFlow.tsx
@@ -1,0 +1,817 @@
+import React, { useMemo } from 'react';
+import {
+  Box,
+  Button,
+  Stack,
+  Typography,
+  alpha,
+  keyframes,
+} from '@mui/material';
+import { Link as RouterLink } from 'react-router-dom';
+import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
+import ArrowDropUpIcon from '@mui/icons-material/ArrowDropUp';
+import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
+import { useStats } from '../../api';
+
+const DAILY_ALPHA_EMISSIONS = 2952;
+
+const VIEWBOX_W = 1200;
+const VIEWBOX_H = 360;
+const STAGE_X = { code: 180, ai: 600, output: 980 };
+const AI_Y = VIEWBOX_H / 2;
+const OUTPUT_Y = { owner: 70, miners: 180, validators: 290 };
+
+const drift1 = keyframes`
+  0%, 100% { transform: translate3d(-6%, -6%, 0); }
+  50%      { transform: translate3d(6%, 4%, 0); }
+`;
+const drift2 = keyframes`
+  0%, 100% { transform: translate3d(8%, 4%, 0); }
+  50%      { transform: translate3d(-4%, -6%, 0); }
+`;
+const titleShimmer = keyframes`
+  0%, 100% { background-position: 0% 50%; }
+  50%      { background-position: 100% 50%; }
+`;
+const dashFlow = keyframes`
+  0%   { stroke-dashoffset: 0; }
+  100% { stroke-dashoffset: -40; }
+`;
+const haloPulse = keyframes`
+  0%, 100% { opacity: 0.55; transform: scale(1); }
+  50%      { opacity: 0.9;  transform: scale(1.08); }
+`;
+const nodePulse = keyframes`
+  0%, 100% { opacity: 0.7; }
+  50%      { opacity: 1; }
+`;
+
+const aiNodes: Array<{ angle: number; r: number; delay: number }> = [
+  { angle: 200, r: 110, delay: 0 },
+  { angle: 240, r: 130, delay: 0.4 },
+  { angle: 160, r: 130, delay: 0.8 },
+  { angle: 320, r: 110, delay: 1.2 },
+  { angle: 290, r: 140, delay: 1.6 },
+  { angle: 30, r: 130, delay: 2 },
+  { angle: 70, r: 110, delay: 2.4 },
+];
+
+const polar = (cx: number, cy: number, r: number, angleDeg: number) => {
+  const rad = (angleDeg * Math.PI) / 180;
+  return { x: cx + r * Math.cos(rad), y: cy + r * Math.sin(rad) };
+};
+
+type OutputKey = 'owner' | 'miners' | 'validators';
+interface OutputConfig {
+  key: OutputKey;
+  y: number;
+  pct: number;
+  label: string;
+  tone: 'primary' | 'secondary' | 'tertiary';
+  highlight?: boolean;
+}
+
+const OUTPUTS: OutputConfig[] = [
+  {
+    key: 'owner',
+    y: OUTPUT_Y.owner,
+    pct: 0.18,
+    label: 'Subnet owner',
+    tone: 'tertiary',
+  },
+  {
+    key: 'miners',
+    y: OUTPUT_Y.miners,
+    pct: 0.41,
+    label: 'Miners (you)',
+    tone: 'primary',
+    highlight: true,
+  },
+  {
+    key: 'validators',
+    y: OUTPUT_Y.validators,
+    pct: 0.41,
+    label: 'Validators + nominators',
+    tone: 'secondary',
+  },
+];
+
+const HeroFlow: React.FC = () => {
+  const { data: stats } = useStats();
+  const taoPrice = stats?.prices?.tao?.data?.price ?? null;
+  const alphaPrice = stats?.prices?.alpha?.data?.price ?? null;
+
+  const dailyByKey = useMemo(() => {
+    if (!taoPrice || !alphaPrice) {
+      return { owner: null, miners: null, validators: null } as Record<
+        OutputKey,
+        number | null
+      >;
+    }
+    const dailyTotal = taoPrice * alphaPrice * DAILY_ALPHA_EMISSIONS;
+    return {
+      owner: dailyTotal * 0.18,
+      miners: dailyTotal * 0.41,
+      validators: dailyTotal * 0.41,
+    };
+  }, [taoPrice, alphaPrice]);
+
+  const aiCenter = { x: STAGE_X.ai, y: AI_Y };
+  const nodePositions = aiNodes.map((n) => ({
+    ...polar(aiCenter.x, aiCenter.y, n.r, n.angle),
+    delay: n.delay,
+  }));
+
+  return (
+    <Box
+      sx={{
+        position: 'relative',
+        pt: { xs: 6, sm: 10 },
+        pb: { xs: 4, sm: 5 },
+        overflow: 'hidden',
+      }}
+    >
+      <Ambient />
+
+      <Stack
+        alignItems="center"
+        spacing={{ xs: 2, sm: 3 }}
+        sx={{ position: 'relative', zIndex: 1, maxWidth: 1100, mx: 'auto' }}
+      >
+        <Typography
+          variant="h1"
+          fontWeight="bold"
+          sx={(theme) => ({
+            fontSize: { xs: '2.5rem', sm: '4rem', md: '5.5rem' },
+            textAlign: 'center',
+            letterSpacing: '0.02em',
+            lineHeight: 1,
+            background: `linear-gradient(110deg, ${theme.palette.text.primary} 0%, ${alpha(
+              theme.palette.diff.additions,
+              0.95,
+            )} 35%, ${theme.palette.text.primary} 60%, ${alpha(
+              theme.palette.status.award,
+              0.9,
+            )} 85%, ${theme.palette.text.primary} 100%)`,
+            backgroundSize: '200% 100%',
+            WebkitBackgroundClip: 'text',
+            WebkitTextFillColor: 'transparent',
+            backgroundClip: 'text',
+            animation: `${titleShimmer} 8s ease-in-out infinite`,
+          })}
+        >
+          GITTENSOR
+        </Typography>
+        <Stack alignItems="center" spacing={1.25}>
+          <Box
+            sx={(theme) => ({
+              px: 1.25,
+              py: 0.4,
+              borderRadius: 999,
+              border: `1px solid ${alpha(theme.palette.diff.additions, 0.45)}`,
+              backgroundColor: alpha(theme.palette.diff.additions, 0.08),
+              color: theme.palette.diff.additions,
+              fontFamily: '"JetBrains Mono", monospace',
+              fontSize: '0.7rem',
+              fontWeight: 700,
+              letterSpacing: '0.1em',
+              textTransform: 'uppercase',
+            })}
+          >
+            Bittensor · Subnet 74
+          </Box>
+          <MarketStrip />
+          <Typography
+            sx={{
+              fontSize: { xs: '0.95rem', sm: '1.1rem' },
+              textAlign: 'center',
+              color: 'text.secondary',
+              maxWidth: 580,
+              lineHeight: 1.55,
+            }}
+          >
+            Get paid for open source. On-chain AI evaluates every merged pull
+            request and pays you in TAO — block by block.
+          </Typography>
+        </Stack>
+
+        <Box
+          sx={{
+            position: 'relative',
+            width: '100%',
+            maxWidth: 1100,
+            aspectRatio: `${VIEWBOX_W} / ${VIEWBOX_H}`,
+            mt: { xs: 1, sm: 2 },
+          }}
+        >
+          <Box
+            component="svg"
+            viewBox={`0 0 ${VIEWBOX_W} ${VIEWBOX_H}`}
+            preserveAspectRatio="xMidYMid meet"
+            sx={{
+              position: 'absolute',
+              inset: 0,
+              width: '100%',
+              height: '100%',
+            }}
+          >
+            <defs>
+              <radialGradient id="hf-aiHalo" cx="50%" cy="50%" r="50%">
+                <stop offset="0%" stopColor="currentColor" stopOpacity="0.32" />
+                <stop offset="100%" stopColor="currentColor" stopOpacity="0" />
+              </radialGradient>
+            </defs>
+
+            <Box
+              component="g"
+              sx={(theme) => ({ color: theme.palette.diff.additions })}
+            >
+              <circle
+                cx={aiCenter.x}
+                cy={aiCenter.y}
+                r={170}
+                fill="url(#hf-aiHalo)"
+              />
+            </Box>
+
+            <Box
+              component="g"
+              sx={(theme) => ({
+                color: theme.palette.diff.additions,
+                stroke: 'currentColor',
+                strokeWidth: 1.4,
+                strokeOpacity: 0.45,
+              })}
+            >
+              {nodePositions.map((n, i) => (
+                <line
+                  key={`edge-${i}`}
+                  x1={n.x}
+                  y1={n.y}
+                  x2={aiCenter.x}
+                  y2={aiCenter.y}
+                />
+              ))}
+              {nodePositions.map((n, i) => {
+                const next = nodePositions[(i + 2) % nodePositions.length];
+                return (
+                  <line
+                    key={`cross-${i}`}
+                    x1={n.x}
+                    y1={n.y}
+                    x2={next.x}
+                    y2={next.y}
+                    strokeOpacity={0.18}
+                  />
+                );
+              })}
+            </Box>
+
+            {nodePositions.map((n, i) => (
+              <Box
+                key={`node-${i}`}
+                component="circle"
+                cx={n.x}
+                cy={n.y}
+                r={8}
+                sx={(theme) => ({
+                  fill: theme.palette.diff.additions,
+                  animation: `${nodePulse} 2.4s ease-in-out ${n.delay}s infinite`,
+                })}
+              />
+            ))}
+
+            {/* Code → AI: dashed flow line */}
+            <Box
+              component="line"
+              x1={STAGE_X.code + 60}
+              y1={AI_Y}
+              x2={STAGE_X.ai - 150}
+              y2={AI_Y}
+              sx={(theme) => ({
+                stroke: theme.palette.diff.additions,
+                strokeWidth: 2,
+                strokeDasharray: '8 8',
+                animation: `${dashFlow} 1.2s linear infinite`,
+              })}
+            />
+
+            {/* AI → 3 outputs: branching curved paths */}
+            {OUTPUTS.map((out) => (
+              <Box
+                key={`branch-${out.key}`}
+                component="path"
+                d={`M ${STAGE_X.ai + 150} ${AI_Y} C ${
+                  (STAGE_X.ai + STAGE_X.output) / 2
+                } ${AI_Y}, ${(STAGE_X.ai + STAGE_X.output) / 2} ${out.y}, ${
+                  STAGE_X.output - 60
+                } ${out.y}`}
+                fill="none"
+                sx={(theme) => ({
+                  stroke:
+                    out.tone === 'primary'
+                      ? theme.palette.diff.additions
+                      : out.tone === 'secondary'
+                        ? theme.palette.status.award
+                        : alpha(theme.palette.text.primary, 0.45),
+                  strokeWidth: out.highlight ? 2.5 : 1.8,
+                  strokeDasharray: '8 8',
+                  animation: `${dashFlow} 1.2s linear infinite`,
+                })}
+              />
+            ))}
+          </Box>
+
+          {/* Stage overlays */}
+          <StageBlock
+            xPct={(STAGE_X.code / VIEWBOX_W) * 100}
+            yPct={(AI_Y / VIEWBOX_H) * 100}
+          >
+            <CodeIcon />
+            <StageLabel title="Code" sub="git push" />
+          </StageBlock>
+
+          <StageBlock
+            xPct={(STAGE_X.ai / VIEWBOX_W) * 100}
+            yPct={(AI_Y / VIEWBOX_H) * 100}
+          >
+            <LogoCore />
+            <StageLabel title="AI evaluation" sub="subnet 74" />
+          </StageBlock>
+
+          {/* 3 branched output nodes */}
+          {OUTPUTS.map((out) => (
+            <OutputNode
+              key={out.key}
+              xPct={(STAGE_X.output / VIEWBOX_W) * 100}
+              yPct={(out.y / VIEWBOX_H) * 100}
+              pct={out.pct}
+              label={out.label}
+              dailyUsd={dailyByKey[out.key]}
+              tone={out.tone}
+              highlight={out.highlight}
+            />
+          ))}
+        </Box>
+
+        <Stack
+          direction={{ xs: 'column', sm: 'row' }}
+          spacing={1.5}
+          sx={{ mt: { xs: 1, sm: 2 } }}
+        >
+          <Button
+            component={RouterLink}
+            to="/dashboard"
+            variant="contained"
+            size="large"
+            endIcon={<ArrowForwardIcon />}
+            sx={{
+              textTransform: 'none',
+              fontWeight: 600,
+              px: 3.5,
+              borderRadius: 2,
+            }}
+          >
+            Go to dashboard
+          </Button>
+          <Button
+            component={RouterLink}
+            to="/onboard"
+            variant="outlined"
+            size="large"
+            sx={{
+              textTransform: 'none',
+              fontWeight: 600,
+              px: 3.5,
+              borderRadius: 2,
+            }}
+          >
+            How it works
+          </Button>
+        </Stack>
+      </Stack>
+    </Box>
+  );
+};
+
+const Ambient: React.FC = () => (
+  <Box
+    aria-hidden
+    sx={{
+      position: 'absolute',
+      inset: 0,
+      overflow: 'hidden',
+      pointerEvents: 'none',
+      zIndex: 0,
+    }}
+  >
+    <Box
+      sx={(theme) => ({
+        position: 'absolute',
+        top: '-10%',
+        left: '-5%',
+        width: '40vw',
+        height: '40vw',
+        maxWidth: 520,
+        maxHeight: 520,
+        borderRadius: '50%',
+        background: `radial-gradient(circle, ${alpha(
+          theme.palette.diff.additions,
+          0.18,
+        )} 0%, ${alpha(theme.palette.diff.additions, 0)} 70%)`,
+        filter: 'blur(40px)',
+        animation: `${drift1} 30s ease-in-out infinite`,
+        willChange: 'transform',
+      })}
+    />
+    <Box
+      sx={(theme) => ({
+        position: 'absolute',
+        top: '5%',
+        right: '-5%',
+        width: '38vw',
+        height: '38vw',
+        maxWidth: 480,
+        maxHeight: 480,
+        borderRadius: '50%',
+        background: `radial-gradient(circle, ${alpha(
+          theme.palette.status.award,
+          0.14,
+        )} 0%, ${alpha(theme.palette.status.award, 0)} 70%)`,
+        filter: 'blur(40px)',
+        animation: `${drift2} 36s ease-in-out infinite`,
+        willChange: 'transform',
+      })}
+    />
+  </Box>
+);
+
+const StageBlock: React.FC<{
+  xPct: number;
+  yPct: number;
+  children: React.ReactNode;
+}> = ({ xPct, yPct, children }) => (
+  <Stack
+    alignItems="center"
+    spacing={1}
+    sx={{
+      position: 'absolute',
+      left: `${xPct}%`,
+      top: `${yPct}%`,
+      transform: 'translate(-50%, -50%)',
+      pointerEvents: 'none',
+    }}
+  >
+    {children}
+  </Stack>
+);
+
+const StageLabel: React.FC<{
+  title: string;
+  sub: string;
+}> = ({ title, sub }) => (
+  <Stack alignItems="center" spacing={0.25} sx={{ mt: 0.5 }}>
+    <Typography
+      sx={{
+        fontSize: { xs: '0.85rem', sm: '0.95rem' },
+        fontWeight: 700,
+        color: 'text.primary',
+        whiteSpace: 'nowrap',
+        lineHeight: 1,
+      }}
+    >
+      {title}
+    </Typography>
+    <Typography
+      sx={{
+        fontSize: { xs: '0.65rem', sm: '0.7rem' },
+        color: 'text.tertiary',
+        fontFamily: '"JetBrains Mono", monospace',
+        whiteSpace: 'nowrap',
+        lineHeight: 1,
+      }}
+    >
+      {sub}
+    </Typography>
+  </Stack>
+);
+
+const CodeIcon: React.FC = () => (
+  <Box
+    sx={(theme) => ({
+      width: { xs: 52, sm: 64 },
+      height: { xs: 52, sm: 64 },
+      borderRadius: 2,
+      border: `1.5px solid ${alpha(theme.palette.diff.additions, 0.6)}`,
+      display: 'grid',
+      placeItems: 'center',
+      backgroundColor: alpha(theme.palette.diff.additions, 0.08),
+      color: theme.palette.diff.additions,
+      fontFamily: '"JetBrains Mono", monospace',
+      fontWeight: 700,
+      fontSize: { xs: '1.2rem', sm: '1.4rem' },
+    })}
+  >
+    {'</>'}
+  </Box>
+);
+
+const LogoCore: React.FC = () => (
+  <Box
+    sx={{
+      position: 'relative',
+      width: { xs: 88, sm: 120 },
+      height: { xs: 88, sm: 120 },
+      display: 'grid',
+      placeItems: 'center',
+    }}
+  >
+    <Box
+      aria-hidden
+      sx={(theme) => ({
+        position: 'absolute',
+        inset: -10,
+        borderRadius: '50%',
+        background: `radial-gradient(circle, ${alpha(
+          theme.palette.diff.additions,
+          0.45,
+        )} 0%, ${alpha(theme.palette.diff.additions, 0)} 70%)`,
+        animation: `${haloPulse} 4s ease-in-out infinite`,
+        willChange: 'opacity, transform',
+      })}
+    />
+    <Box
+      sx={(theme) => ({
+        position: 'relative',
+        width: '100%',
+        height: '100%',
+        borderRadius: '50%',
+        display: 'grid',
+        placeItems: 'center',
+        border: `1.5px solid ${alpha(theme.palette.diff.additions, 0.55)}`,
+        backgroundColor: alpha(theme.palette.background.default, 0.7),
+      })}
+    >
+      <Box
+        component="img"
+        src="/gt-logo.svg"
+        alt="Gittensor"
+        sx={(theme) => ({
+          width: '60%',
+          height: '60%',
+          filter: `grayscale(100%) invert(1) drop-shadow(0 0 6px ${alpha(
+            theme.palette.diff.additions,
+            0.6,
+          )})`,
+        })}
+      />
+    </Box>
+  </Box>
+);
+
+const formatUsd = (n: number) =>
+  `$${n.toLocaleString(undefined, { maximumFractionDigits: 0 })}`;
+
+const OutputNode: React.FC<{
+  xPct: number;
+  yPct: number;
+  pct: number;
+  label: string;
+  dailyUsd: number | null;
+  tone: 'primary' | 'secondary' | 'tertiary';
+  highlight?: boolean;
+}> = ({ xPct, yPct, pct, label, dailyUsd, tone, highlight }) => (
+  <Stack
+    direction="row"
+    alignItems="center"
+    spacing={1.25}
+    sx={(theme) => ({
+      position: 'absolute',
+      left: `${xPct}%`,
+      top: `${yPct}%`,
+      transform: 'translate(-50%, -50%)',
+      px: { xs: 1.25, sm: 1.5 },
+      py: { xs: 0.75, sm: 0.9 },
+      borderRadius: 2,
+      border: `1px solid ${
+        highlight
+          ? alpha(theme.palette.diff.additions, 0.5)
+          : theme.palette.border.light
+      }`,
+      backgroundColor: highlight
+        ? alpha(theme.palette.diff.additions, 0.08)
+        : alpha(theme.palette.background.default, 0.7),
+      backdropFilter: 'blur(4px)',
+      pointerEvents: 'none',
+      whiteSpace: 'nowrap',
+    })}
+  >
+    <Box
+      sx={(theme) => ({
+        width: 10,
+        height: 10,
+        borderRadius: '50%',
+        backgroundColor:
+          tone === 'primary'
+            ? theme.palette.diff.additions
+            : tone === 'secondary'
+              ? theme.palette.status.award
+              : alpha(theme.palette.text.primary, 0.4),
+        boxShadow:
+          tone === 'primary'
+            ? `0 0 6px ${theme.palette.diff.additions}`
+            : tone === 'secondary'
+              ? `0 0 6px ${theme.palette.status.award}`
+              : 'none',
+        flexShrink: 0,
+      })}
+    />
+    <Stack spacing={0}>
+      <Stack direction="row" alignItems="baseline" spacing={0.75}>
+        <Typography
+          sx={(theme) => ({
+            fontFamily: '"JetBrains Mono", monospace',
+            fontWeight: 700,
+            fontSize: { xs: '0.9rem', sm: '1rem' },
+            color: highlight
+              ? theme.palette.diff.additions
+              : theme.palette.text.primary,
+            lineHeight: 1,
+          })}
+        >
+          {Math.round(pct * 100)}%
+        </Typography>
+        <Typography
+          sx={{
+            fontSize: { xs: '0.72rem', sm: '0.78rem' },
+            color: 'text.secondary',
+            lineHeight: 1,
+          }}
+        >
+          {label}
+        </Typography>
+      </Stack>
+      <Typography
+        sx={(theme) => ({
+          fontFamily: '"JetBrains Mono", monospace',
+          fontSize: { xs: '0.7rem', sm: '0.75rem' },
+          color: highlight
+            ? theme.palette.text.primary
+            : theme.palette.text.tertiary,
+          fontWeight: highlight ? 700 : 500,
+          mt: 0.4,
+          lineHeight: 1,
+        })}
+      >
+        {dailyUsd !== null ? `${formatUsd(dailyUsd)} / day` : '— / day'}
+      </Typography>
+    </Stack>
+  </Stack>
+);
+
+const MarketStrip: React.FC = () => {
+  const { data: stats } = useStats();
+  const taoData = stats?.prices?.tao?.data ?? null;
+  const alphaData = stats?.prices?.alpha?.data ?? null;
+  const taoPrice = taoData?.price ?? null;
+  const alphaPrice = alphaData?.price ?? null;
+
+  const dailyTotalUsd = useMemo(
+    () =>
+      taoPrice && alphaPrice
+        ? taoPrice * alphaPrice * DAILY_ALPHA_EMISSIONS
+        : null,
+    [taoPrice, alphaPrice],
+  );
+
+  if (!taoPrice && !alphaPrice) return null;
+
+  return (
+    <Stack
+      direction="row"
+      flexWrap="wrap"
+      justifyContent="center"
+      alignItems="center"
+      gap={{ xs: 0.75, sm: 1.25 }}
+      sx={{ fontFamily: '"JetBrains Mono", monospace' }}
+    >
+      <MarketChip
+        symbol="TAO"
+        value={taoPrice !== null ? `$${taoPrice.toFixed(2)}` : '—'}
+        change={taoData?.percentChange24h}
+      />
+      <Sep />
+      <MarketChip
+        symbol="α"
+        value={alphaPrice !== null ? `${alphaPrice.toFixed(4)} τ` : '—'}
+        change={alphaData?.percentChange24h}
+      />
+      <Sep />
+      <MarketChip
+        symbol="Emit"
+        value={`${DAILY_ALPHA_EMISSIONS.toLocaleString()} α/day`}
+        hint={
+          dailyTotalUsd !== null
+            ? `≈ $${dailyTotalUsd.toLocaleString(undefined, {
+                maximumFractionDigits: 0,
+              })}`
+            : undefined
+        }
+      />
+    </Stack>
+  );
+};
+
+const Sep: React.FC = () => (
+  <Box
+    sx={(theme) => ({
+      width: 4,
+      height: 4,
+      borderRadius: '50%',
+      backgroundColor: alpha(theme.palette.text.primary, 0.25),
+    })}
+  />
+);
+
+const MarketChip: React.FC<{
+  symbol: string;
+  value: string;
+  change?: number | null;
+  hint?: string;
+}> = ({ symbol, value, change, hint }) => {
+  const hasChange =
+    change !== null && change !== undefined && Number.isFinite(change);
+  return (
+    <Stack
+      direction="row"
+      alignItems="center"
+      spacing={0.5}
+      sx={{
+        fontSize: { xs: '0.7rem', sm: '0.78rem' },
+        lineHeight: 1,
+      }}
+    >
+      <Typography
+        component="span"
+        sx={{
+          fontFamily: 'inherit',
+          fontSize: 'inherit',
+          fontWeight: 700,
+          color: 'text.tertiary',
+          letterSpacing: '0.05em',
+        }}
+      >
+        {symbol}
+      </Typography>
+      <Typography
+        component="span"
+        sx={{
+          fontFamily: 'inherit',
+          fontSize: 'inherit',
+          fontWeight: 700,
+          color: 'text.primary',
+        }}
+      >
+        {value}
+      </Typography>
+      {hasChange ? (
+        <Stack
+          component="span"
+          direction="row"
+          alignItems="center"
+          sx={(theme) => ({
+            color:
+              (change as number) >= 0
+                ? theme.palette.diff.additions
+                : theme.palette.diff.deletions,
+            fontFamily: 'inherit',
+            fontSize: 'inherit',
+            fontWeight: 700,
+          })}
+        >
+          {(change as number) >= 0 ? (
+            <ArrowDropUpIcon sx={{ fontSize: '0.95rem', mx: -0.25 }} />
+          ) : (
+            <ArrowDropDownIcon sx={{ fontSize: '0.95rem', mx: -0.25 }} />
+          )}
+          {Math.abs(change as number).toFixed(2)}%
+        </Stack>
+      ) : null}
+      {hint ? (
+        <Typography
+          component="span"
+          sx={{
+            fontFamily: 'inherit',
+            fontSize: 'inherit',
+            color: 'text.tertiary',
+            ml: 0.25,
+          }}
+        >
+          {hint}
+        </Typography>
+      ) : null}
+    </Stack>
+  );
+};
+
+export default HeroFlow;

--- a/src/pages/home/HeroFlow.tsx
+++ b/src/pages/home/HeroFlow.tsx
@@ -12,14 +12,12 @@ import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
 import ArrowDropUpIcon from '@mui/icons-material/ArrowDropUp';
 import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
 import { useStats } from '../../api';
-
-const DAILY_ALPHA_EMISSIONS = 2952;
+import { useDailyAlphaEmissions } from '../../hooks/useMonthlyRewards';
 
 const VIEWBOX_W = 1200;
-const VIEWBOX_H = 360;
+const VIEWBOX_H = 280;
 const STAGE_X = { code: 180, ai: 600, output: 980 };
 const AI_Y = VIEWBOX_H / 2;
-const OUTPUT_Y = { owner: 70, miners: 180, validators: 290 };
 
 const drift1 = keyframes`
   0%, 100% { transform: translate3d(-6%, -6%, 0); }
@@ -61,60 +59,21 @@ const polar = (cx: number, cy: number, r: number, angleDeg: number) => {
   return { x: cx + r * Math.cos(rad), y: cy + r * Math.sin(rad) };
 };
 
-type OutputKey = 'owner' | 'miners' | 'validators';
-interface OutputConfig {
-  key: OutputKey;
-  y: number;
-  pct: number;
-  label: string;
-  tone: 'primary' | 'secondary' | 'tertiary';
-  highlight?: boolean;
-}
-
-const OUTPUTS: OutputConfig[] = [
-  {
-    key: 'owner',
-    y: OUTPUT_Y.owner,
-    pct: 0.18,
-    label: 'Subnet owner',
-    tone: 'tertiary',
-  },
-  {
-    key: 'miners',
-    y: OUTPUT_Y.miners,
-    pct: 0.41,
-    label: 'Miners (you)',
-    tone: 'primary',
-    highlight: true,
-  },
-  {
-    key: 'validators',
-    y: OUTPUT_Y.validators,
-    pct: 0.41,
-    label: 'Validators + nominators',
-    tone: 'secondary',
-  },
-];
+// Subnet 74 emissions are split 18 / 41 / 41 between subnet owner /
+// miners / validators+nominators on-chain. The hero only surfaces the
+// miner slice — that is the audience for this product.
+const MINER_SHARE = 0.41;
 
 const HeroFlow: React.FC = () => {
   const { data: stats } = useStats();
   const taoPrice = stats?.prices?.tao?.data?.price ?? null;
   const alphaPrice = stats?.prices?.alpha?.data?.price ?? null;
+  const dailyEmissions = useDailyAlphaEmissions();
 
-  const dailyByKey = useMemo(() => {
-    if (!taoPrice || !alphaPrice) {
-      return { owner: null, miners: null, validators: null } as Record<
-        OutputKey,
-        number | null
-      >;
-    }
-    const dailyTotal = taoPrice * alphaPrice * DAILY_ALPHA_EMISSIONS;
-    return {
-      owner: dailyTotal * 0.18,
-      miners: dailyTotal * 0.41,
-      validators: dailyTotal * 0.41,
-    };
-  }, [taoPrice, alphaPrice]);
+  const minerDailyUsd = useMemo(() => {
+    if (!taoPrice || !alphaPrice) return null;
+    return taoPrice * alphaPrice * dailyEmissions * MINER_SHARE;
+  }, [taoPrice, alphaPrice, dailyEmissions]);
 
   const aiCenter = { x: STAGE_X.ai, y: AI_Y };
   const nodePositions = aiNodes.map((n) => ({
@@ -296,30 +255,20 @@ const HeroFlow: React.FC = () => {
               })}
             />
 
-            {/* AI → 3 outputs: branching curved paths */}
-            {OUTPUTS.map((out) => (
-              <Box
-                key={`branch-${out.key}`}
-                component="path"
-                d={`M ${STAGE_X.ai + 150} ${AI_Y} C ${
-                  (STAGE_X.ai + STAGE_X.output) / 2
-                } ${AI_Y}, ${(STAGE_X.ai + STAGE_X.output) / 2} ${out.y}, ${
-                  STAGE_X.output - 60
-                } ${out.y}`}
-                fill="none"
-                sx={(theme) => ({
-                  stroke:
-                    out.tone === 'primary'
-                      ? theme.palette.diff.additions
-                      : out.tone === 'secondary'
-                        ? theme.palette.status.award
-                        : alpha(theme.palette.text.primary, 0.45),
-                  strokeWidth: out.highlight ? 2.5 : 1.8,
-                  strokeDasharray: '8 8',
-                  animation: `${dashFlow} 1.2s linear infinite`,
-                })}
-              />
-            ))}
+            {/* AI → Miners: straight dashed flow line */}
+            <Box
+              component="line"
+              x1={STAGE_X.ai + 150}
+              y1={AI_Y}
+              x2={STAGE_X.output - 60}
+              y2={AI_Y}
+              sx={(theme) => ({
+                stroke: theme.palette.diff.additions,
+                strokeWidth: 2.5,
+                strokeDasharray: '8 8',
+                animation: `${dashFlow} 1.2s linear infinite`,
+              })}
+            />
           </Box>
 
           {/* Stage overlays */}
@@ -339,19 +288,12 @@ const HeroFlow: React.FC = () => {
             <StageLabel title="AI evaluation" sub="subnet 74" />
           </StageBlock>
 
-          {/* 3 branched output nodes */}
-          {OUTPUTS.map((out) => (
-            <OutputNode
-              key={out.key}
-              xPct={(STAGE_X.output / VIEWBOX_W) * 100}
-              yPct={(out.y / VIEWBOX_H) * 100}
-              pct={out.pct}
-              label={out.label}
-              dailyUsd={dailyByKey[out.key]}
-              tone={out.tone}
-              highlight={out.highlight}
-            />
-          ))}
+          <OutputNode
+            xPct={(STAGE_X.output / VIEWBOX_W) * 100}
+            yPct={(AI_Y / VIEWBOX_H) * 100}
+            label="Miners (you)"
+            dailyUsd={minerDailyUsd}
+          />
         </Box>
 
         <Stack
@@ -575,12 +517,9 @@ const formatUsd = (n: number) =>
 const OutputNode: React.FC<{
   xPct: number;
   yPct: number;
-  pct: number;
   label: string;
   dailyUsd: number | null;
-  tone: 'primary' | 'secondary' | 'tertiary';
-  highlight?: boolean;
-}> = ({ xPct, yPct, pct, label, dailyUsd, tone, highlight }) => (
+}> = ({ xPct, yPct, label, dailyUsd }) => (
   <Stack
     direction="row"
     alignItems="center"
@@ -590,17 +529,11 @@ const OutputNode: React.FC<{
       left: `${xPct}%`,
       top: `${yPct}%`,
       transform: 'translate(-50%, -50%)',
-      px: { xs: 1.25, sm: 1.5 },
-      py: { xs: 0.75, sm: 0.9 },
+      px: { xs: 1.5, sm: 1.75 },
+      py: { xs: 1, sm: 1.1 },
       borderRadius: 2,
-      border: `1px solid ${
-        highlight
-          ? alpha(theme.palette.diff.additions, 0.5)
-          : theme.palette.border.light
-      }`,
-      backgroundColor: highlight
-        ? alpha(theme.palette.diff.additions, 0.08)
-        : alpha(theme.palette.background.default, 0.7),
+      border: `1px solid ${alpha(theme.palette.diff.additions, 0.5)}`,
+      backgroundColor: alpha(theme.palette.diff.additions, 0.08),
       backdropFilter: 'blur(4px)',
       pointerEvents: 'none',
       whiteSpace: 'nowrap',
@@ -611,59 +544,31 @@ const OutputNode: React.FC<{
         width: 10,
         height: 10,
         borderRadius: '50%',
-        backgroundColor:
-          tone === 'primary'
-            ? theme.palette.diff.additions
-            : tone === 'secondary'
-              ? theme.palette.status.award
-              : alpha(theme.palette.text.primary, 0.4),
-        boxShadow:
-          tone === 'primary'
-            ? `0 0 6px ${theme.palette.diff.additions}`
-            : tone === 'secondary'
-              ? `0 0 6px ${theme.palette.status.award}`
-              : 'none',
+        backgroundColor: theme.palette.diff.additions,
+        boxShadow: `0 0 6px ${theme.palette.diff.additions}`,
         flexShrink: 0,
       })}
     />
-    <Stack spacing={0}>
-      <Stack direction="row" alignItems="baseline" spacing={0.75}>
-        <Typography
-          sx={(theme) => ({
-            fontFamily: '"JetBrains Mono", monospace',
-            fontWeight: 700,
-            fontSize: { xs: '0.9rem', sm: '1rem' },
-            color: highlight
-              ? theme.palette.diff.additions
-              : theme.palette.text.primary,
-            lineHeight: 1,
-          })}
-        >
-          {Math.round(pct * 100)}%
-        </Typography>
-        <Typography
-          sx={{
-            fontSize: { xs: '0.72rem', sm: '0.78rem' },
-            color: 'text.secondary',
-            lineHeight: 1,
-          }}
-        >
-          {label}
-        </Typography>
-      </Stack>
+    <Stack spacing={0.4}>
+      <Typography
+        sx={{
+          fontSize: { xs: '0.78rem', sm: '0.85rem' },
+          color: 'text.secondary',
+          lineHeight: 1,
+        }}
+      >
+        {label}
+      </Typography>
       <Typography
         sx={(theme) => ({
           fontFamily: '"JetBrains Mono", monospace',
-          fontSize: { xs: '0.7rem', sm: '0.75rem' },
-          color: highlight
-            ? theme.palette.text.primary
-            : theme.palette.text.tertiary,
-          fontWeight: highlight ? 700 : 500,
-          mt: 0.4,
+          fontSize: { xs: '0.95rem', sm: '1.05rem' },
+          fontWeight: 700,
+          color: theme.palette.diff.additions,
           lineHeight: 1,
         })}
       >
-        {dailyUsd !== null ? `${formatUsd(dailyUsd)} / day` : '— / day'}
+        {dailyUsd !== null ? `${formatUsd(dailyUsd)} / day` : '—'}
       </Typography>
     </Stack>
   </Stack>
@@ -675,14 +580,6 @@ const MarketStrip: React.FC = () => {
   const alphaData = stats?.prices?.alpha?.data ?? null;
   const taoPrice = taoData?.price ?? null;
   const alphaPrice = alphaData?.price ?? null;
-
-  const dailyTotalUsd = useMemo(
-    () =>
-      taoPrice && alphaPrice
-        ? taoPrice * alphaPrice * DAILY_ALPHA_EMISSIONS
-        : null,
-    [taoPrice, alphaPrice],
-  );
 
   if (!taoPrice && !alphaPrice) return null;
 
@@ -706,18 +603,6 @@ const MarketStrip: React.FC = () => {
         value={alphaPrice !== null ? `${alphaPrice.toFixed(4)} τ` : '—'}
         change={alphaData?.percentChange24h}
       />
-      <Sep />
-      <MarketChip
-        symbol="Emit"
-        value={`${DAILY_ALPHA_EMISSIONS.toLocaleString()} α/day`}
-        hint={
-          dailyTotalUsd !== null
-            ? `≈ $${dailyTotalUsd.toLocaleString(undefined, {
-                maximumFractionDigits: 0,
-              })}`
-            : undefined
-        }
-      />
     </Stack>
   );
 };
@@ -737,8 +622,7 @@ const MarketChip: React.FC<{
   symbol: string;
   value: string;
   change?: number | null;
-  hint?: string;
-}> = ({ symbol, value, change, hint }) => {
+}> = ({ symbol, value, change }) => {
   const hasChange =
     change !== null && change !== undefined && Number.isFinite(change);
   return (
@@ -796,19 +680,6 @@ const MarketChip: React.FC<{
           )}
           {Math.abs(change as number).toFixed(2)}%
         </Stack>
-      ) : null}
-      {hint ? (
-        <Typography
-          component="span"
-          sx={{
-            fontFamily: 'inherit',
-            fontSize: 'inherit',
-            color: 'text.tertiary',
-            ml: 0.25,
-          }}
-        >
-          {hint}
-        </Typography>
       ) : null}
     </Stack>
   );

--- a/src/pages/home/HeroFlow.tsx
+++ b/src/pages/home/HeroFlow.tsx
@@ -1,14 +1,5 @@
 import React, { useMemo } from 'react';
-import {
-  Box,
-  Button,
-  Stack,
-  Typography,
-  alpha,
-  keyframes,
-} from '@mui/material';
-import { Link as RouterLink } from 'react-router-dom';
-import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
+import { Box, Stack, Typography, alpha, keyframes } from '@mui/material';
 import ArrowDropUpIcon from '@mui/icons-material/ArrowDropUp';
 import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
 import { useStats } from '../../api';
@@ -300,46 +291,6 @@ const HeroFlow: React.FC = () => {
         </Box>
 
         <MonthlyPoolTile />
-
-        <Stack
-          direction={{ xs: 'column', sm: 'row' }}
-          spacing={1.5}
-          sx={{
-            mt: { xs: 1, sm: 2 },
-            width: '100%',
-            maxWidth: HERO_BLOCK_MAX_WIDTH,
-          }}
-        >
-          <Button
-            component={RouterLink}
-            to="/dashboard"
-            variant="contained"
-            size="large"
-            endIcon={<ArrowForwardIcon />}
-            sx={{
-              textTransform: 'none',
-              fontWeight: 600,
-              flex: 1,
-              borderRadius: 2,
-            }}
-          >
-            Go to dashboard
-          </Button>
-          <Button
-            component={RouterLink}
-            to="/onboard"
-            variant="outlined"
-            size="large"
-            sx={{
-              textTransform: 'none',
-              fontWeight: 600,
-              flex: 1,
-              borderRadius: 2,
-            }}
-          >
-            How it works
-          </Button>
-        </Stack>
       </Stack>
     </Box>
   );

--- a/src/pages/home/HowItWorks.tsx
+++ b/src/pages/home/HowItWorks.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import { Box, Grid, Stack, Typography, alpha } from '@mui/material';
+
+const STEPS = [
+  {
+    n: '01',
+    title: 'Code is the work',
+    body: 'You earn for merged pull requests to recognized open-source repos. Not for posts, votes, or hype — just shipped code.',
+    tone: 'primary' as const,
+  },
+  {
+    n: '02',
+    title: 'AI is the judge',
+    body: 'Subnet 74 validators score each PR with on-chain AI: token-level structure, density, language weight, repo weight, credibility.',
+    tone: 'primary' as const,
+  },
+  {
+    n: '03',
+    title: 'TAO is the reward',
+    body: 'Scores translate to alpha tokens emitted by Bittensor every block. Higher score, higher emission share — paid continuously.',
+    tone: 'award' as const,
+  },
+];
+
+const HowItWorks: React.FC = () => (
+  <Box
+    sx={{
+      width: '100%',
+      maxWidth: 1100,
+      mx: 'auto',
+      mt: { xs: 5, sm: 7 },
+    }}
+  >
+    <Typography
+      sx={{
+        fontSize: '0.7rem',
+        textTransform: 'uppercase',
+        letterSpacing: '0.15em',
+        fontWeight: 600,
+        color: 'text.secondary',
+        textAlign: 'center',
+        mb: 2,
+      }}
+    >
+      How it works
+    </Typography>
+    <Grid container spacing={{ xs: 2, md: 3 }}>
+      {STEPS.map((step) => (
+        <Grid item xs={12} md={4} key={step.n}>
+          <Stack
+            spacing={1.25}
+            sx={(theme) => ({
+              height: '100%',
+              p: { xs: 2.5, sm: 3 },
+              borderRadius: 2,
+              border: `1px solid ${theme.palette.border.light}`,
+              backgroundColor: alpha(theme.palette.background.default, 0.4),
+            })}
+          >
+            <Typography
+              sx={(theme) => ({
+                fontFamily: '"JetBrains Mono", monospace',
+                fontSize: '0.78rem',
+                fontWeight: 700,
+                letterSpacing: '0.1em',
+                color:
+                  step.tone === 'award'
+                    ? theme.palette.status.award
+                    : theme.palette.diff.additions,
+              })}
+            >
+              {step.n}
+            </Typography>
+            <Typography
+              sx={{
+                fontSize: { xs: '1.1rem', sm: '1.2rem' },
+                fontWeight: 700,
+                color: 'text.primary',
+                lineHeight: 1.25,
+              }}
+            >
+              {step.title}
+            </Typography>
+            <Typography
+              sx={{
+                fontSize: '0.85rem',
+                color: 'text.secondary',
+                lineHeight: 1.6,
+              }}
+            >
+              {step.body}
+            </Typography>
+          </Stack>
+        </Grid>
+      ))}
+    </Grid>
+  </Box>
+);
+
+export default HowItWorks;

--- a/src/pages/home/StarterBounties.tsx
+++ b/src/pages/home/StarterBounties.tsx
@@ -1,0 +1,146 @@
+import React, { useMemo } from 'react';
+import { Box, Grid, Stack, Typography, alpha } from '@mui/material';
+import { Link as RouterLink } from 'react-router-dom';
+import { useIssues } from '../../api';
+
+const StarterBounties: React.FC = () => {
+  const { data: issues } = useIssues('registered');
+
+  const top = useMemo(() => {
+    if (!issues) return [];
+    return [...issues]
+      .sort(
+        (a, b) =>
+          parseFloat(b.targetBounty || '0') - parseFloat(a.targetBounty || '0'),
+      )
+      .slice(0, 6);
+  }, [issues]);
+
+  if (top.length === 0) return null;
+
+  return (
+    <Box sx={{ width: '100%', maxWidth: 1100, mx: 'auto' }}>
+      <Stack
+        direction="row"
+        alignItems="baseline"
+        justifyContent="space-between"
+        sx={{ mb: 2 }}
+      >
+        <Typography
+          sx={{
+            fontSize: '0.7rem',
+            textTransform: 'uppercase',
+            letterSpacing: '0.15em',
+            fontWeight: 600,
+            color: 'text.secondary',
+          }}
+        >
+          Open bounties — start now
+        </Typography>
+        <Typography
+          component={RouterLink}
+          to="/bounties"
+          sx={{
+            fontSize: '0.78rem',
+            color: 'primary.main',
+            textDecoration: 'none',
+            fontWeight: 600,
+            '&:hover': { textDecoration: 'underline' },
+          }}
+        >
+          See all →
+        </Typography>
+      </Stack>
+      <Grid container spacing={2}>
+        {top.map((b) => {
+          const reward = parseFloat(b.targetBounty || '0');
+          return (
+            <Grid item xs={12} sm={6} md={4} key={b.id}>
+              <Stack
+                component={RouterLink}
+                to={`/bounties/details?id=${b.id}`}
+                spacing={1.25}
+                sx={(theme) => ({
+                  height: '100%',
+                  p: 2,
+                  borderRadius: 2,
+                  border: `1px solid ${theme.palette.border.light}`,
+                  backgroundColor: alpha(theme.palette.background.default, 0.4),
+                  backdropFilter: 'blur(10px)',
+                  textDecoration: 'none',
+                  color: 'inherit',
+                  transition:
+                    'border-color 0.18s, transform 0.18s, box-shadow 0.18s',
+                  '&:hover': {
+                    borderColor: theme.palette.border.medium,
+                    transform: 'translateY(-2px)',
+                    boxShadow: `0 8px 24px ${alpha(
+                      theme.palette.background.default,
+                      0.35,
+                    )}`,
+                  },
+                })}
+              >
+                <Stack
+                  direction="row"
+                  alignItems="baseline"
+                  justifyContent="space-between"
+                  spacing={1}
+                >
+                  <Typography
+                    sx={(theme) => ({
+                      fontFamily: '"JetBrains Mono", monospace',
+                      fontWeight: 700,
+                      fontSize: '1.1rem',
+                      color: theme.palette.status.award,
+                      lineHeight: 1,
+                    })}
+                  >
+                    {reward > 0 ? `${reward.toFixed(2)} τ` : '—'}
+                  </Typography>
+                  <Typography
+                    sx={{
+                      fontSize: '0.7rem',
+                      color: 'text.tertiary',
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
+                      maxWidth: '60%',
+                    }}
+                  >
+                    {b.repositoryFullName}
+                  </Typography>
+                </Stack>
+                <Typography
+                  sx={{
+                    fontSize: '0.88rem',
+                    fontWeight: 600,
+                    color: 'text.primary',
+                    lineHeight: 1.4,
+                    display: '-webkit-box',
+                    WebkitLineClamp: 2,
+                    WebkitBoxOrient: 'vertical',
+                    overflow: 'hidden',
+                  }}
+                >
+                  {b.title || `Issue #${b.issueNumber}`}
+                </Typography>
+                <Typography
+                  sx={{
+                    fontSize: '0.72rem',
+                    color: 'text.tertiary',
+                    mt: 'auto',
+                  }}
+                >
+                  #{b.issueNumber}
+                </Typography>
+              </Stack>
+            </Grid>
+          );
+        })}
+      </Grid>
+    </Box>
+  );
+};
+
+export default StarterBounties;

--- a/src/pages/home/TopContributors.tsx
+++ b/src/pages/home/TopContributors.tsx
@@ -1,0 +1,179 @@
+import React, { useMemo } from 'react';
+import { Avatar, Box, Grid, Stack, Typography, alpha } from '@mui/material';
+import { Link as RouterLink } from 'react-router-dom';
+import { useAllMiners } from '../../api';
+import { getGithubAvatarSrc } from '../../utils/ExplorerUtils';
+
+const TOP_N = 4;
+
+const formatUsd = (n: number) =>
+  `$${n.toLocaleString(undefined, { maximumFractionDigits: 0 })}`;
+
+const TopContributors: React.FC = () => {
+  const { data: miners } = useAllMiners();
+
+  const top = useMemo(() => {
+    if (!miners) return [];
+    return [...miners]
+      .filter((m) => (m.usdPerDay ?? 0) > 0 && (m.githubUsername || m.githubId))
+      .sort((a, b) => (b.usdPerDay ?? 0) - (a.usdPerDay ?? 0))
+      .slice(0, TOP_N);
+  }, [miners]);
+
+  if (top.length === 0) return null;
+
+  return (
+    <Box
+      sx={{
+        width: '100%',
+        maxWidth: 1100,
+        mx: 'auto',
+        mt: { xs: 5, sm: 7 },
+      }}
+    >
+      <Stack
+        direction="row"
+        alignItems="baseline"
+        justifyContent="space-between"
+        flexWrap="wrap"
+        spacing={1}
+        sx={{ mb: 2 }}
+      >
+        <Typography
+          sx={{
+            fontSize: '0.7rem',
+            textTransform: 'uppercase',
+            letterSpacing: '0.15em',
+            fontWeight: 600,
+            color: 'text.secondary',
+          }}
+        >
+          Top contributors right now
+        </Typography>
+        <Typography
+          component={RouterLink}
+          to="/top-miners"
+          sx={{
+            fontSize: '0.78rem',
+            color: 'primary.main',
+            textDecoration: 'none',
+            fontWeight: 600,
+            '&:hover': { textDecoration: 'underline' },
+          }}
+        >
+          See full leaderboard →
+        </Typography>
+      </Stack>
+      <Grid container spacing={{ xs: 1.5, sm: 2 }}>
+        {top.map((miner) => {
+          const username = miner.githubUsername || miner.githubId;
+          const avatar = getGithubAvatarSrc(username);
+          const usd = miner.usdPerDay ?? 0;
+          const merged = miner.totalMergedPrs ?? 0;
+          return (
+            <Grid item xs={12} sm={6} md={3} key={miner.githubId}>
+              <Stack
+                component={RouterLink}
+                to={`/miners/details?githubId=${encodeURIComponent(miner.githubId)}`}
+                spacing={1.25}
+                sx={(theme) => ({
+                  height: '100%',
+                  p: 2,
+                  borderRadius: 2,
+                  border: `1px solid ${theme.palette.border.light}`,
+                  backgroundColor: alpha(theme.palette.background.default, 0.45),
+                  textDecoration: 'none',
+                  color: 'inherit',
+                  transition:
+                    'border-color 0.18s, transform 0.18s, box-shadow 0.18s',
+                  '&:hover': {
+                    borderColor: theme.palette.border.medium,
+                    transform: 'translateY(-2px)',
+                    boxShadow: `0 8px 24px ${alpha(
+                      theme.palette.background.default,
+                      0.35,
+                    )}`,
+                  },
+                })}
+              >
+                <Stack direction="row" alignItems="center" spacing={1.25}>
+                  <Avatar
+                    src={avatar}
+                    alt={username}
+                    sx={(theme) => ({
+                      width: 38,
+                      height: 38,
+                      border: `1px solid ${theme.palette.border.medium}`,
+                    })}
+                  />
+                  <Stack sx={{ minWidth: 0 }}>
+                    <Typography
+                      sx={{
+                        fontSize: '0.88rem',
+                        fontWeight: 700,
+                        color: 'text.primary',
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        whiteSpace: 'nowrap',
+                      }}
+                    >
+                      {username}
+                    </Typography>
+                    <Typography
+                      sx={{
+                        fontSize: '0.7rem',
+                        color: 'text.tertiary',
+                        fontFamily: '"JetBrains Mono", monospace',
+                      }}
+                    >
+                      {merged.toLocaleString()} merged PRs
+                    </Typography>
+                  </Stack>
+                </Stack>
+                <Box>
+                  <Typography
+                    sx={{
+                      fontSize: '0.65rem',
+                      textTransform: 'uppercase',
+                      letterSpacing: '0.1em',
+                      fontWeight: 600,
+                      color: 'text.tertiary',
+                    }}
+                  >
+                    Earning
+                  </Typography>
+                  <Typography
+                    sx={(theme) => ({
+                      fontFamily: '"JetBrains Mono", monospace',
+                      fontSize: '1.25rem',
+                      fontWeight: 700,
+                      color: theme.palette.diff.additions,
+                      letterSpacing: '-0.01em',
+                      lineHeight: 1.1,
+                    })}
+                  >
+                    {formatUsd(usd)}
+                    <Typography
+                      component="span"
+                      sx={{
+                        fontFamily: 'inherit',
+                        fontSize: '0.7rem',
+                        fontWeight: 500,
+                        color: 'text.tertiary',
+                        ml: 0.5,
+                      }}
+                    >
+                      / day
+                    </Typography>
+                  </Typography>
+                </Box>
+              </Stack>
+            </Grid>
+          );
+        })}
+      </Grid>
+    </Box>
+  );
+};
+
+export default TopContributors;

--- a/src/pages/home/TopContributors.tsx
+++ b/src/pages/home/TopContributors.tsx
@@ -52,16 +52,29 @@ const TopContributors: React.FC = () => {
         </Typography>
         <Typography
           component={RouterLink}
-          to="/top-miners"
-          sx={{
+          to="/dashboard"
+          sx={(theme) => ({
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 0.5,
+            px: 1.5,
+            py: 0.6,
+            borderRadius: 999,
             fontSize: '0.78rem',
-            color: 'primary.main',
+            fontWeight: 700,
+            color: theme.palette.status.award,
+            backgroundColor: alpha(theme.palette.status.award, 0.12),
+            border: `1px solid ${alpha(theme.palette.status.award, 0.45)}`,
             textDecoration: 'none',
-            fontWeight: 600,
-            '&:hover': { textDecoration: 'underline' },
-          }}
+            boxShadow: `0 0 12px ${alpha(theme.palette.status.award, 0.25)}`,
+            transition: 'box-shadow 0.18s, background-color 0.18s',
+            '&:hover': {
+              backgroundColor: alpha(theme.palette.status.award, 0.2),
+              boxShadow: `0 0 18px ${alpha(theme.palette.status.award, 0.5)}`,
+            },
+          })}
         >
-          See full leaderboard →
+          Go to dashboard →
         </Typography>
       </Stack>
       <Grid container spacing={{ xs: 1.5, sm: 2 }}>

--- a/src/pages/home/TopContributors.tsx
+++ b/src/pages/home/TopContributors.tsx
@@ -81,7 +81,10 @@ const TopContributors: React.FC = () => {
                   p: 2,
                   borderRadius: 2,
                   border: `1px solid ${theme.palette.border.light}`,
-                  backgroundColor: alpha(theme.palette.background.default, 0.45),
+                  backgroundColor: alpha(
+                    theme.palette.background.default,
+                    0.45,
+                  ),
                   textDecoration: 'none',
                   color: 'inherit',
                   transition:


### PR DESCRIPTION
## Summary

Closes #877.

Replaces the static landing page with a single data-driven hero plus three supporting sections.

### Sections

1. **Hero**
   - `GITTENSOR` title with a shimmering green→gold gradient.
   - `Bittensor · Subnet 74` monospace badge.
   - Inline market ticker pills: **TAO price** and **α price**, each with a green/red 24h-change arrow.
   - Tagline: *Get paid for open source. On-chain AI evaluates every merged pull request and pays you in TAO — block by block.*
   - Animated pipeline: `Code → AI evaluation → Miners (you)` with dashed flowing connector lines. The Gittensor logo sits at the AI core, surrounded by 7 pulsing neural-network nodes. The miner output node shows a live `$/day`.
   - **Monthly emission pool** tile
2. **How it works** — three static columns: *Code is the work · AI is the judge · TAO is the reward*.
3. **Top contributors right now** — 4 leaderboard miner cards (avatar · username · merged PR count · live `$/day`) with a glowing gold **Go to dashboard** pill in the section header.


## Video

https://github.com/user-attachments/assets/8398534f-024b-4fe9-a397-2904fadc4dc4








