### PR TITLE
fix(issues): Fix warning message for authored issues when GitHub visibility is restricted

### DIFF
--- a/src/components/miners/MinerOpenDiscoveryIssuesByRepo.tsx
+++ b/src/components/miners/MinerOpenDiscoveryIssuesByRepo.tsx
@@ -1011,8 +1011,10 @@ const MinerOpenDiscoveryIssuesByRepo: React.FC<
       )}
       {isAuthorFallbackError && !isDataLoading && (
         <Alert severity="warning" sx={{ borderRadius: 2 }}>
-          Could not load all authored open issues from GitHub right now. Showing
-          indexed results only.
+          Could not load all authored open issues from GitHub right now. This is
+          often caused by restricted visibility (private activity), where the
+          index feed can&apos;t retrieve author details for issues you&apos;ve
+          created. Showing indexed results only.
         </Alert>
       )}
 


### PR DESCRIPTION

## Summary

This PR updates the “authored by you” warning message to explain why the authored open issues list may be missing when GitHub Search is used.

If the user’s GitHub settings are restricted (private activity / limited visibility), GitHub Search returns a 422 error for the authored-issues query. Since we can’t get the complete authenticated author results from GitHub in this state, UI can only show indexed results only for the moment.

## Related Issues

fixes #918 

## Type of Change

- [x] Bug fix

## Screenshots
Before:
<img width="1036" height="508" alt="image" src="https://github.com/user-attachments/assets/d71a5de5-0705-4423-8156-a52760033021" />

After: 
<img width="1001" height="624" alt="image" src="https://github.com/user-attachments/assets/4b3f3c63-660c-4365-ba92-ea227dacd2e4" />


## Checklist

- [ ] New components are modularized/separated where sensible
- [ ] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [ ] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
