### PR TITLE
fix(miners): close list tooltips on scroll so they don't float outside the table

### DIFF
--- a/src/components/leaderboard/MinersList.tsx
+++ b/src/components/leaderboard/MinersList.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
-import { Avatar, Box, Card, Tooltip, Typography } from '@mui/material';
+import { Avatar, Box, Card, Typography } from '@mui/material';
 import { useMinerGithubData, useMinerPRs } from '../../api';
 import { CHART_COLORS, scrollbarSx } from '../../theme';
 import { getGithubAvatarSrc, type SortOrder } from '../../utils/ExplorerUtils';
 import { DataTable, type DataTableColumn, WatchlistButton } from '../common';
+import { ScrollAwareTooltip } from '../common/ScrollAwareTooltip';
 import { RankIcon } from './RankIcon';
 import {
   type LeaderboardVariant,
@@ -249,7 +250,7 @@ const MinerIdentityCell: React.FC<MinerIdentityCellProps> = ({ miner }) => {
           borderColor: 'border.medium',
         }}
       />
-      <Tooltip title={username} placement="top">
+      <ScrollAwareTooltip title={username} placement="top">
         <Typography
           component="span"
           sx={{
@@ -265,7 +266,7 @@ const MinerIdentityCell: React.FC<MinerIdentityCellProps> = ({ miner }) => {
         >
           {username}
         </Typography>
-      </Tooltip>
+      </ScrollAwareTooltip>
     </Box>
   );
 };
@@ -302,7 +303,7 @@ const MinerActivitySegments: React.FC<MinerActivitySegmentsProps> = ({
       }}
     >
       {segments.map((segment, i) => (
-        <Tooltip
+        <ScrollAwareTooltip
           key={segment.label}
           title={segment.label}
           arrow
@@ -324,7 +325,7 @@ const MinerActivitySegments: React.FC<MinerActivitySegmentsProps> = ({
               {segment.value}
             </Typography>
           </Box>
-        </Tooltip>
+        </ScrollAwareTooltip>
       ))}
     </Box>
   );


### PR DESCRIPTION
## Summary

## Problem
On the OSS contributions page (miners list view), the username and PR/issue activity-dot tooltips stayed open while the user scrolled the table body. Because the tooltip portal tracks its anchor, the tooltip floated over the sticky toolbar / outside the table once its row scrolled away.

## Fix
Swap the in-table `Tooltip`s in `MinersList.tsx` for `ScrollAwareTooltip` (existing helper from #876) for the username cell and the activity segment dots. It auto-closes any open tooltip on scroll, so a tooltip can no longer outlive the visible position of its anchor.

Sticky-header tooltips (view-mode toggle, eligibility filter) are unchanged — they don't scroll, so the regular `Tooltip` is fine.

## Test plan
- [ ] OSS contributions page → list view
- [ ] Hover a truncated miner username → tooltip shows; scroll the table → tooltip closes immediately
- [ ] Hover a PR/issue activity dot ("Merged"/"Open"/"Closed") → tooltip shows; scroll → tooltip closes
- [ ] View-mode toggle and eligibility filter tooltips in the sticky header still work normally

## Related Issues

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots
Before:

<img width="1920" height="947" alt="Screenshot_2" src="https://github.com/user-attachments/assets/39c12998-00c8-4e6e-9fef-a6074b6683d6" />

<img width="1919" height="940" alt="Screenshot_1" src="https://github.com/user-attachments/assets/26c7ff91-a856-4a4e-8ca3-4dfa8e3d0cb8" />

https://github.com/user-attachments/assets/83198668-b414-4c18-b9ed-50cce7642c42

Now:

https://github.com/user-attachments/assets/0a5ca812-d149-486b-b23e-79ea272b63c4

## Checklist

- [ ] New components are modularized/separated where sensible
- [X] Uses predefined theme (e.g. no hardcoded colors)
- [X] Responsive/mobile checked
- [ ] Tested against the test API
- [X] `npm run format` and `npm run lint:fix` have been run
- [X] `npm run build` passes
- [X] Screenshots included for any UI/visual changes
