### PR TITLE
fix(conversation): show full GitHub thread with real author chip and verb

### DIFF
--- a/src/components/common/ConversationTimeline.tsx
+++ b/src/components/common/ConversationTimeline.tsx
@@ -1,0 +1,363 @@
+import React from 'react';
+import {
+  Box,
+  Typography,
+  Avatar,
+  Paper,
+  Link,
+  Chip,
+  alpha,
+} from '@mui/material';
+import { useTheme } from '@mui/material/styles';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import rehypeRaw from 'rehype-raw';
+import { formatDate } from '../../utils/format';
+import { getGithubAvatarSrc } from '../../utils/ExplorerUtils';
+import { STATUS_COLORS, scrollbarSx } from '../../theme';
+
+import 'github-markdown-css/github-markdown-dark.css';
+
+/** A comment or the body rendered in the conversation timeline. */
+export type ConversationItem = {
+  id: string;
+  user: {
+    login: string | null;
+    avatarUrl: string;
+    htmlUrl: string;
+  };
+  body: string;
+  createdAt: string;
+  authorAssociation: string;
+  isDescription?: boolean;
+};
+
+/** Shape shared by GitHub's REST issue / PR / comment payloads. */
+export type GithubIssueOrComment = {
+  id: number;
+  body: string | null;
+  created_at: string;
+  author_association?: string | null;
+  user: {
+    login: string;
+    avatar_url: string;
+    html_url: string;
+  } | null;
+};
+
+export const EMPTY_BODY_PLACEHOLDER = '<em>No description provided.</em>';
+
+export const githubProfileUrl = (login: string | null | undefined): string =>
+  login ? `https://github.com/${login}` : 'https://github.com';
+
+/** Map a raw GitHub issue/PR/comment payload to a ConversationItem. */
+export const toConversationItem = (
+  data: GithubIssueOrComment,
+  opts: { idPrefix: string; isDescription?: boolean },
+): ConversationItem => ({
+  id: `${opts.idPrefix}-${data.id}`,
+  user: {
+    login: data.user?.login ?? null,
+    avatarUrl: data.user?.avatar_url ?? getGithubAvatarSrc(data.user?.login),
+    htmlUrl: data.user?.html_url ?? githubProfileUrl(data.user?.login),
+  },
+  body: data.body || EMPTY_BODY_PLACEHOLDER,
+  createdAt: data.created_at,
+  authorAssociation: data.author_association || 'NONE',
+  isDescription: opts.isDescription,
+});
+
+interface ConversationTimelineProps {
+  items: ConversationItem[];
+}
+
+const ConversationTimeline: React.FC<ConversationTimelineProps> = ({
+  items,
+}) => {
+  const theme = useTheme();
+  const colors = {
+    canvas: {
+      box: theme.palette.background.paper,
+      subtle: theme.palette.surface.elevated,
+    },
+    border: {
+      default: theme.palette.border.medium,
+      muted: theme.palette.border.light,
+    },
+    fg: {
+      default: theme.palette.text.primary,
+      muted: STATUS_COLORS.open,
+    },
+    accent: {
+      fg: STATUS_COLORS.info,
+    },
+  };
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 3,
+        pt: 2,
+        maxWidth: '960px',
+        mx: 'auto',
+        position: 'relative',
+      }}
+    >
+      {items.map((item, index) => (
+        <Box
+          key={item.id}
+          sx={{
+            display: 'flex',
+            gap: { xs: 1.25, sm: 2 },
+            position: 'relative',
+            zIndex: 1,
+            '&::before': {
+              content: index !== items.length - 1 ? '""' : 'none',
+              position: 'absolute',
+              top: { xs: '32px', sm: '40px' },
+              bottom: { xs: '-16px', sm: '-24px' },
+              left: { xs: '15px', sm: '20px' },
+              width: '2px',
+              backgroundColor: colors.border.default,
+              zIndex: 0,
+            },
+          }}
+        >
+          <Box sx={{ position: 'relative', zIndex: 1, flexShrink: 0 }}>
+            <Link
+              href={item.user.htmlUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <Avatar
+                src={item.user.avatarUrl}
+                alt={item.user.login ?? undefined}
+                sx={{
+                  width: { xs: 32, sm: 40 },
+                  height: { xs: 32, sm: 40 },
+                  border: `1px solid ${colors.border.muted}`,
+                  backgroundColor: colors.canvas.box,
+                }}
+              />
+            </Link>
+          </Box>
+
+          <Paper
+            elevation={0}
+            sx={{
+              flex: 1,
+              minWidth: 0,
+              backgroundColor: colors.canvas.box,
+              border: `1px solid ${colors.border.default}`,
+              borderRadius: '6px',
+              position: 'relative',
+              '&::after': {
+                content: { xs: 'none', sm: '""' },
+                position: 'absolute',
+                top: '11px',
+                right: '100%',
+                left: '-8px',
+                width: '16px',
+                height: '16px',
+                backgroundColor: colors.canvas.subtle,
+                borderBottom: `1px solid ${colors.border.default}`,
+                borderLeft: `1px solid ${colors.border.default}`,
+                transform: 'rotate(45deg)',
+              },
+            }}
+          >
+            <Box
+              sx={{
+                px: { xs: 1.5, sm: 2 },
+                py: { xs: 1, sm: 1.5 },
+                backgroundColor: colors.canvas.subtle,
+                borderBottom: `1px solid ${colors.border.default}`,
+                borderTopLeftRadius: '6px',
+                borderTopRightRadius: '6px',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                gap: 1,
+                flexWrap: 'wrap',
+                color: colors.fg.muted,
+                fontSize: { xs: '13px', sm: '14px' },
+                position: 'relative',
+                zIndex: 1,
+              }}
+            >
+              <Box
+                sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 1,
+                  flexWrap: 'wrap',
+                  minWidth: 0,
+                }}
+              >
+                <Link
+                  href={item.user.htmlUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  sx={{
+                    color: colors.fg.default,
+                    fontWeight: 600,
+                    textDecoration: 'none',
+                    '&:hover': {
+                      textDecoration: 'underline',
+                      color: colors.accent.fg,
+                    },
+                  }}
+                >
+                  {item.user.login}
+                </Link>
+                <Typography
+                  component="span"
+                  sx={{ fontSize: 'inherit', color: 'inherit' }}
+                >
+                  {item.isDescription ? 'opened this' : 'commented'}
+                </Typography>
+                <Typography
+                  component="span"
+                  sx={{ fontSize: 'inherit', color: 'inherit' }}
+                >
+                  {formatDate(item.createdAt)}
+                </Typography>
+              </Box>
+
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                {item.authorAssociation &&
+                  item.authorAssociation !== 'NONE' && (
+                    <Chip
+                      variant="status"
+                      label={item.authorAssociation
+                        .toLowerCase()
+                        .replace(/_/g, ' ')}
+                      sx={{
+                        color: colors.fg.muted,
+                        borderColor: colors.border.default,
+                        textTransform: 'capitalize',
+                      }}
+                    />
+                  )}
+                {item.isDescription && (
+                  <Chip
+                    variant="status"
+                    label="Description"
+                    sx={{
+                      color: STATUS_COLORS.info,
+                      borderColor: alpha(STATUS_COLORS.info, 0.4),
+                    }}
+                  />
+                )}
+              </Box>
+            </Box>
+
+            <Box
+              sx={{
+                p: { xs: 1.5, sm: 2, md: 3 },
+                color: colors.fg.default,
+                fontSize: { xs: '13px', sm: '14px' },
+                lineHeight: 1.6,
+                fontFamily:
+                  '-apple-system,BlinkMacSystemFont,"Segoe UI","Noto Sans",Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji"',
+                overflowX: 'auto',
+                ...scrollbarSx,
+                '& > *:first-of-type': { mt: 0 },
+                '& > *:last-child': { mb: 0 },
+                '& h1, & h2, & h3, & h4, & h5, & h6': {
+                  mt: 3,
+                  mb: 2,
+                  fontWeight: 600,
+                  lineHeight: 1.25,
+                  color: colors.fg.default,
+                  borderBottom: `1px solid ${colors.border.muted}`,
+                  pb: 0.3,
+                },
+                '& h1': { fontSize: '2em' },
+                '& h2': { fontSize: '1.5em' },
+                '& h3': { fontSize: '1.25em' },
+                '& p': { mb: 2, mt: 0 },
+                '& a': { color: colors.accent.fg, textDecoration: 'none' },
+                '& a:hover': { textDecoration: 'underline' },
+                '& ul': { pl: '2em', mb: 2, listStyleType: 'disc' },
+                '& ol': { pl: '2em', mb: 2, listStyleType: 'decimal' },
+                '& li': { mb: 0.5 },
+                '& li + li': { mt: '0.25em' },
+                '& blockquote': {
+                  padding: '0 1em',
+                  color: colors.fg.muted,
+                  borderLeft: `0.25em solid ${colors.border.default}`,
+                  my: 2,
+                  mx: 0,
+                },
+                '& input[type="checkbox"]': {
+                  mr: 0.5,
+                  verticalAlign: 'middle',
+                },
+                '& code': {
+                  padding: '0.2em 0.4em',
+                  margin: 0,
+                  fontSize: '85%',
+                  backgroundColor: alpha(STATUS_COLORS.neutral, 0.4),
+                  borderRadius: '6px',
+                },
+                '& pre': {
+                  mt: 2,
+                  mb: 2,
+                  p: 2,
+                  borderRadius: '6px',
+                  overflow: 'auto',
+                  backgroundColor: theme.palette.surface.elevated,
+                  border: `1px solid ${colors.border.default}`,
+                  '& code': {
+                    backgroundColor: 'transparent',
+                    p: 0,
+                    fontSize: '100%',
+                  },
+                },
+                '& table': {
+                  borderCollapse: 'collapse',
+                  width: '100%',
+                  mb: 2,
+                  overflowX: 'auto',
+                },
+                '& th, & td': {
+                  border: `1px solid ${colors.border.default}`,
+                  padding: '6px 13px',
+                },
+                '& th': { fontWeight: 600 },
+                '& tr:nth-of-type(2n)': {
+                  backgroundColor: theme.palette.surface.elevated,
+                },
+                '& hr': {
+                  height: '0.25em',
+                  my: 3,
+                  backgroundColor: colors.border.default,
+                  border: 0,
+                },
+                '& img': {
+                  maxWidth: '100%',
+                  borderRadius: '6px',
+                  backgroundColor: 'transparent',
+                },
+              }}
+            >
+              <div className="markdown-body">
+                <ReactMarkdown
+                  remarkPlugins={[remarkGfm]}
+                  rehypePlugins={[rehypeRaw]}
+                >
+                  {item.body}
+                </ReactMarkdown>
+              </div>
+            </Box>
+          </Paper>
+        </Box>
+      ))}
+    </Box>
+  );
+};
+
+export default ConversationTimeline;

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -2,3 +2,5 @@ export * from './SearchInput';
 export * from './linkBehavior';
 export * from './WatchlistButton';
 export * from './DataTable';
+export { default as ConversationTimeline } from './ConversationTimeline';
+export * from './ConversationTimeline';

--- a/src/components/issues/IssueConversation.tsx
+++ b/src/components/issues/IssueConversation.tsx
@@ -1,360 +1,87 @@
-import React from 'react';
-import { formatDate } from '../../utils/format';
-import {
-  Box,
-  Typography,
-  Avatar,
-  Paper,
-  Link,
-  Chip,
-  alpha,
-} from '@mui/material';
-import { useTheme } from '@mui/material/styles';
-import ReactMarkdown from 'react-markdown';
-import remarkGfm from 'remark-gfm';
-import rehypeRaw from 'rehype-raw';
+import React, { useEffect, useMemo, useState } from 'react';
+import axios from 'axios';
 import { type IssueDetails } from '../../api/models/Issues';
-import { STATUS_COLORS, scrollbarSx } from '../../theme';
-
-import 'github-markdown-css/github-markdown-dark.css';
-
-/** An issue comment or the issue body rendered in the conversation timeline. */
-type ConversationItem = {
-  id: string;
-  user: {
-    login: string | null;
-    avatarUrl: string;
-    htmlUrl: string;
-  };
-  body: string;
-  createdAt: string;
-  authorAssociation: string;
-  isDescription?: boolean;
-};
+import { getGithubAvatarSrc } from '../../utils/ExplorerUtils';
+import {
+  ConversationTimeline,
+  EMPTY_BODY_PLACEHOLDER,
+  githubProfileUrl,
+  toConversationItem,
+  type ConversationItem,
+  type GithubIssueOrComment,
+} from '../common';
 
 interface IssueConversationProps {
   issue: IssueDetails;
 }
 
 const IssueConversation: React.FC<IssueConversationProps> = ({ issue }) => {
-  const theme = useTheme();
-  const allItems: ConversationItem[] = [
-    {
-      id: 'issue-description',
-      user: {
-        login: issue.authorLogin,
-        avatarUrl: `https://avatars.githubusercontent.com/${issue.authorLogin}`,
-        htmlUrl: `https://github.com/${issue.authorLogin}`,
-      },
-      body: issue.body || '<em>No description provided.</em>',
-      createdAt: issue.createdAt,
-      authorAssociation: 'OWNER', // Assuming creator is owner for display purposes, or fetch actual association if available
-      isDescription: true,
-    },
-  ];
-
-  const colors = {
-    canvas: {
-      default: theme.palette.background.paper,
-      subtle: theme.palette.surface.elevated,
-      box: theme.palette.background.paper,
-    },
-    border: {
-      default: theme.palette.border.medium,
-      muted: theme.palette.border.light,
-    },
-    fg: {
-      default: theme.palette.text.primary,
-      muted: STATUS_COLORS.open,
-    },
-    accent: {
-      fg: STATUS_COLORS.info,
-    },
-    timeline: {
-      line: theme.palette.border.medium,
-    },
-  };
-
-  return (
-    <Box
-      sx={{
-        display: 'flex',
-        flexDirection: 'column',
-        gap: 3,
-        pt: 2,
-        maxWidth: '960px',
-        mx: 'auto',
-        position: 'relative',
-      }}
-    >
-      {allItems.map((item, index) => (
-        <Box
-          key={item.id}
-          sx={{
-            display: 'flex',
-            gap: 2,
-            position: 'relative',
-            zIndex: 1,
-            '&::before': {
-              content: index !== allItems.length - 1 ? '""' : 'none',
-              position: 'absolute',
-              top: '40px',
-              bottom: '-24px',
-              left: '20px',
-              width: '2px',
-              backgroundColor: colors.timeline.line,
-              zIndex: 0,
-            },
-          }}
-        >
-          {/* Avatar Area */}
-          <Box sx={{ position: 'relative', zIndex: 1 }}>
-            <Link
-              href={item.user.htmlUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              <Avatar
-                src={item.user.avatarUrl}
-                alt={item.user.login ?? undefined}
-                sx={{
-                  width: 40,
-                  height: 40,
-                  border: `1px solid ${theme.palette.border.light}`,
-                  backgroundColor: theme.palette.background.paper, // Avoid transparency issues over the line
-                }}
-              />
-            </Link>
-          </Box>
-
-          {/* Comment Bubble */}
-          <Paper
-            elevation={0}
-            sx={{
-              flex: 1,
-              minWidth: 0,
-              backgroundColor: colors.canvas.box,
-              border: `1px solid ${colors.border.default}`,
-              borderRadius: '6px',
-              position: 'relative',
-              '&::after': {
-                content: '""',
-                position: 'absolute',
-                top: '11px',
-                right: '100%',
-                left: '-8px',
-                width: '16px',
-                height: '16px',
-                backgroundColor: colors.canvas.subtle, // Match the header background
-                borderBottom: `1px solid ${colors.border.default}`, // Only bottom and left create the visible arrow borders
-                borderLeft: `1px solid ${colors.border.default}`,
-                transform: 'rotate(45deg)',
-              },
-            }}
-          >
-            {/* Header */}
-            <Box
-              sx={{
-                px: 2,
-                py: 1.5, // Slightly more vertical padding
-                backgroundColor: colors.canvas.subtle,
-                borderBottom: `1px solid ${colors.border.default}`,
-                borderTopLeftRadius: '6px',
-                borderTopRightRadius: '6px',
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'space-between',
-                color: colors.fg.muted,
-                fontSize: '14px',
-                position: 'relative',
-                zIndex: 1, // Ensure above the arrow pseudo-element's main body
-              }}
-            >
-              <Box
-                sx={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: 1,
-                  flexWrap: 'wrap',
-                }}
-              >
-                <Link
-                  href={item.user.htmlUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  sx={{
-                    color: colors.fg.default,
-                    fontWeight: 600,
-                    textDecoration: 'none',
-                    '&:hover': {
-                      textDecoration: 'underline',
-                      color: colors.accent.fg,
-                    },
-                  }}
-                >
-                  {item.user.login}
-                </Link>
-                <Typography
-                  component="span"
-                  sx={{ fontSize: 'inherit', color: 'inherit' }}
-                >
-                  commented
-                </Typography>
-                <Typography
-                  component="span"
-                  sx={{ fontSize: 'inherit', color: 'inherit' }}
-                >
-                  {formatDate(item.createdAt)}
-                </Typography>
-              </Box>
-
-              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                {/* Author Association Badge */}
-                {item.authorAssociation &&
-                  item.authorAssociation !== 'NONE' && (
-                    <Chip
-                      variant="status"
-                      label={item.authorAssociation
-                        .toLowerCase()
-                        .replace('_', ' ')}
-                      sx={{
-                        color: colors.fg.muted,
-                        borderColor: colors.border.default,
-                        textTransform: 'capitalize',
-                      }}
-                    />
-                  )}
-                {/* Description Badge - Special styling */}
-                {item.isDescription && (
-                  <Chip
-                    variant="status"
-                    label="Description"
-                    sx={{
-                      color: STATUS_COLORS.info,
-                      borderColor: alpha(STATUS_COLORS.info, 0.4),
-                    }}
-                  />
-                )}
-              </Box>
-            </Box>
-
-            {/* Markdown Content */}
-            <Box
-              sx={{
-                p: { xs: 2, md: 3 }, // More padding on larger screens
-                color: colors.fg.default,
-                fontSize: '14px',
-                lineHeight: 1.6,
-                fontFamily:
-                  '-apple-system,BlinkMacSystemFont,"Segoe UI","Noto Sans",Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji"', // GitHub's exact font stack
-                overflowX: 'auto',
-                ...scrollbarSx,
-                // Typography refinements
-                '& > *:first-of-type': { mt: 0 },
-                '& > *:last-child': { mb: 0 },
-                '& h1, & h2, & h3, & h4, & h5, & h6': {
-                  mt: 3,
-                  mb: 2,
-                  fontWeight: 600,
-                  lineHeight: 1.25,
-                  color: colors.fg.default,
-                  borderBottom: `1px solid ${colors.border.muted}`,
-                  pb: 0.3,
-                },
-                '& h1': { fontSize: '2em' },
-                '& h2': { fontSize: '1.5em' },
-                '& h3': { fontSize: '1.25em' },
-                '& p': { mb: 2, mt: 0 },
-                '& a': { color: colors.accent.fg, textDecoration: 'none' },
-                '& a:hover': { textDecoration: 'underline' },
-                '& ul, & ol': {
-                  pl: '2em',
-                  mb: 2,
-                  listStyleType: 'disc',
-                },
-                '& ol': { listStyleType: 'decimal' },
-                '& li': { mb: 0.5 },
-                '& li + li': { mt: '0.25em' },
-                '& blockquote': {
-                  padding: '0 1em',
-                  color: colors.fg.muted,
-                  borderLeft: `0.25em solid ${colors.border.default}`,
-                  my: 2,
-                  mx: 0,
-                },
-                '& input[type="checkbox"]': {
-                  mr: 0.5,
-                  verticalAlign: 'middle',
-                },
-                '& code': {
-                  padding: '0.2em 0.4em',
-                  margin: 0,
-                  fontSize: '85%',
-                  backgroundColor: alpha(STATUS_COLORS.neutral, 0.4),
-                  borderRadius: '6px',
-                },
-                '& pre': {
-                  mt: 2,
-                  mb: 2,
-                  p: 2,
-                  borderRadius: '6px',
-                  overflow: 'auto',
-                  backgroundColor: theme.palette.surface.elevated,
-                  border: `1px solid ${colors.border.default}`,
-                  '& code': {
-                    backgroundColor: 'transparent',
-                    p: 0,
-                    fontSize: '100%',
-                  },
-                },
-                '& table': {
-                  borderCollapse: 'collapse',
-                  width: '100%',
-                  mb: 2,
-                  overflowX: 'auto',
-                },
-                '& th, & td': {
-                  border: `1px solid ${colors.border.default}`,
-                  padding: '6px 13px',
-                },
-                '& th': { fontWeight: 600 },
-                '& tr:nth-of-type(2n)': {
-                  backgroundColor: theme.palette.surface.elevated,
-                },
-                '& hr': {
-                  height: '0.25em',
-                  my: 3,
-                  backgroundColor: colors.border.default,
-                  border: 0,
-                },
-                '& img': {
-                  maxWidth: '100%',
-                  borderRadius: '6px',
-                  backgroundColor: 'transparent',
-                },
-                '& .markdown-body': {
-                  backgroundColor: 'transparent',
-                  color: colors.fg.default,
-                  fontFamily: 'inherit',
-                  fontSize: '14px',
-                  lineHeight: 1.6,
-                },
-              }}
-            >
-              <div className="markdown-body" style={{ fontSize: '14px' }}>
-                <ReactMarkdown
-                  remarkPlugins={[remarkGfm]}
-                  rehypePlugins={[rehypeRaw]}
-                >
-                  {item.body}
-                </ReactMarkdown>
-              </div>
-            </Box>
-          </Paper>
-        </Box>
-      ))}
-    </Box>
+  const [fetchedItems, setFetchedItems] = useState<ConversationItem[] | null>(
+    null,
   );
+
+  useEffect(() => {
+    const repo = issue.repositoryFullName;
+    const number = issue.issueNumber;
+    setFetchedItems(null);
+    if (!repo || !number) return;
+
+    let cancelled = false;
+    const fetchConversation = async () => {
+      try {
+        const [issueRes, commentsRes] = await Promise.all([
+          axios.get<GithubIssueOrComment>(
+            `https://api.github.com/repos/${repo}/issues/${number}`,
+          ),
+          axios.get<GithubIssueOrComment[]>(
+            `https://api.github.com/repos/${repo}/issues/${number}/comments?per_page=100`,
+          ),
+        ]);
+        if (cancelled) return;
+        const body = toConversationItem(issueRes.data, {
+          idPrefix: 'issue',
+          isDescription: true,
+        });
+        const comments = (commentsRes.data || []).map((c) =>
+          toConversationItem(c, { idPrefix: 'comment' }),
+        );
+        const sorted = [body, ...comments].sort(
+          (a, b) =>
+            new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(),
+        );
+        setFetchedItems(sorted);
+      } catch (err) {
+        if (!cancelled) {
+          console.error('Failed to fetch issue conversation', err);
+        }
+      }
+    };
+
+    fetchConversation();
+    return () => {
+      cancelled = true;
+    };
+  }, [issue.repositoryFullName, issue.issueNumber]);
+
+  const fallbackItems = useMemo<ConversationItem[]>(
+    () => [
+      {
+        id: 'issue-description',
+        user: {
+          login: issue.authorLogin,
+          avatarUrl: getGithubAvatarSrc(issue.authorLogin),
+          htmlUrl: githubProfileUrl(issue.authorLogin),
+        },
+        body: issue.body || EMPTY_BODY_PLACEHOLDER,
+        createdAt: issue.createdAt,
+        authorAssociation: 'NONE',
+        isDescription: true,
+      },
+    ],
+    [issue.authorLogin, issue.body, issue.createdAt],
+  );
+
+  return <ConversationTimeline items={fetchedItems ?? fallbackItems} />;
 };
 
 export default IssueConversation;

--- a/src/components/prs/PRComments.tsx
+++ b/src/components/prs/PRComments.tsx
@@ -1,40 +1,32 @@
-import React from 'react';
-import { formatDate } from '../../utils/format';
-import {
-  Box,
-  Typography,
-  Avatar,
-  Paper,
-  Link,
-  CircularProgress,
-  Chip,
-} from '@mui/material';
-import { alpha } from '@mui/material/styles';
-import ReactMarkdown from 'react-markdown';
-import remarkGfm from 'remark-gfm';
-import rehypeRaw from 'rehype-raw';
+import React, { useEffect, useMemo, useState } from 'react';
+import axios from 'axios';
+import { Box, Typography, CircularProgress } from '@mui/material';
 import { usePullRequestComments } from '../../api';
 import {
   type PullRequestComment,
   type PullRequestDetails,
 } from '../../api/models/Dashboard';
-import { STATUS_COLORS, UI_COLORS, scrollbarSx } from '../../theme';
-import 'github-markdown-css/github-markdown-dark.css'; // Import standard GitHub Dark styles
-
-/** A comment or the PR description rendered in the conversation timeline. */
-type ConversationItem = Omit<
-  PullRequestComment,
-  'id' | 'updatedAt' | 'htmlUrl'
-> & {
-  id: number | string;
-  isDescription?: boolean;
-};
+import { getGithubAvatarSrc } from '../../utils/ExplorerUtils';
+import {
+  ConversationTimeline,
+  EMPTY_BODY_PLACEHOLDER,
+  githubProfileUrl,
+  type ConversationItem,
+} from '../common';
 
 interface PRCommentsProps {
   repository: string;
   pullRequestNumber: number;
   prDetails: PullRequestDetails;
 }
+
+const commentToItem = (c: PullRequestComment): ConversationItem => ({
+  id: `comment-${c.id}`,
+  user: c.user,
+  body: c.body || EMPTY_BODY_PLACEHOLDER,
+  createdAt: c.createdAt,
+  authorAssociation: c.authorAssociation || 'NONE',
+});
 
 const PRComments: React.FC<PRCommentsProps> = ({
   repository,
@@ -46,6 +38,51 @@ const PRComments: React.FC<PRCommentsProps> = ({
     isLoading,
     error,
   } = usePullRequestComments(repository, pullRequestNumber);
+  const [bodyAssociation, setBodyAssociation] = useState<string>('NONE');
+
+  useEffect(() => {
+    setBodyAssociation('NONE');
+    if (!repository || !pullRequestNumber) return;
+    let cancelled = false;
+    axios
+      .get<{ author_association?: string | null }>(
+        `https://api.github.com/repos/${repository}/pulls/${pullRequestNumber}`,
+      )
+      .then((res) => {
+        if (cancelled) return;
+        setBodyAssociation(res.data.author_association || 'NONE');
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          console.error('Failed to fetch PR author_association', err);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [repository, pullRequestNumber]);
+
+  const items = useMemo<ConversationItem[]>(() => {
+    const body: ConversationItem = {
+      id: 'pr-description',
+      user: {
+        login: prDetails.authorLogin,
+        avatarUrl: getGithubAvatarSrc(prDetails.authorLogin),
+        htmlUrl: githubProfileUrl(prDetails.authorLogin),
+      },
+      body: prDetails.description || EMPTY_BODY_PLACEHOLDER,
+      createdAt: prDetails.createdAt,
+      authorAssociation: bodyAssociation,
+      isDescription: true,
+    };
+    return [body, ...(comments ?? []).map(commentToItem)];
+  }, [
+    prDetails.authorLogin,
+    prDetails.description,
+    prDetails.createdAt,
+    bodyAssociation,
+    comments,
+  ]);
 
   if (isLoading) {
     return (
@@ -65,327 +102,7 @@ const PRComments: React.FC<PRCommentsProps> = ({
     );
   }
 
-  const allItems: ConversationItem[] = [
-    {
-      id: 'pr-description',
-      user: {
-        login: prDetails.authorLogin,
-        avatarUrl: `https://avatars.githubusercontent.com/${prDetails.authorLogin}`,
-        htmlUrl: `https://github.com/${prDetails.authorLogin}`,
-      },
-      body: prDetails.description || '<em>No description provided.</em>',
-      createdAt: prDetails.createdAt,
-      authorAssociation: 'OWNER',
-      isDescription: true,
-    },
-    ...comments,
-  ];
-
-  const colors = {
-    canvas: {
-      default: UI_COLORS.black,
-      subtle: UI_COLORS.surfaceElevated,
-      box: UI_COLORS.black,
-    },
-    border: {
-      default: alpha(UI_COLORS.white, 0.1),
-      muted: alpha(UI_COLORS.white, 0.08),
-    },
-    fg: {
-      default: alpha(UI_COLORS.white, 0.85),
-      muted: STATUS_COLORS.open,
-    },
-    accent: {
-      fg: STATUS_COLORS.info,
-    },
-    timeline: {
-      line: alpha(UI_COLORS.white, 0.1),
-    },
-  };
-
-  return (
-    <Box
-      sx={{
-        display: 'flex',
-        flexDirection: 'column',
-        gap: 3,
-        pt: 2,
-        maxWidth: '960px',
-        mx: 'auto',
-        position: 'relative',
-      }}
-    >
-      {allItems.map((item, index) => (
-        <Box
-          key={item.id}
-          sx={{
-            display: 'flex',
-            gap: { xs: 1.25, sm: 2 },
-            position: 'relative',
-            zIndex: 1,
-            '&::before': {
-              content: index !== allItems.length - 1 ? '""' : 'none',
-              position: 'absolute',
-              top: { xs: '32px', sm: '40px' },
-              bottom: { xs: '-16px', sm: '-24px' },
-              left: { xs: '15px', sm: '20px' },
-              width: '2px',
-              backgroundColor: colors.timeline.line,
-              zIndex: 0,
-            },
-          }}
-        >
-          {/* Avatar Area */}
-          <Box sx={{ position: 'relative', zIndex: 1, flexShrink: 0 }}>
-            <Link
-              href={item.user.htmlUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              <Avatar
-                src={item.user.avatarUrl}
-                alt={item.user.login}
-                sx={{
-                  width: { xs: 32, sm: 40 },
-                  height: { xs: 32, sm: 40 },
-                  border: `1px solid ${alpha(UI_COLORS.white, 0.1)}`,
-                  backgroundColor: UI_COLORS.black,
-                }}
-              />
-            </Link>
-          </Box>
-
-          {/* Comment Bubble */}
-          <Paper
-            elevation={0}
-            sx={{
-              flex: 1,
-              minWidth: 0,
-              backgroundColor: colors.canvas.box,
-              border: `1px solid ${colors.border.default}`,
-              borderRadius: '6px',
-              position: 'relative',
-              '&::after': {
-                content: { xs: 'none', sm: '""' },
-                position: 'absolute',
-                top: '11px',
-                right: '100%',
-                left: '-8px',
-                width: '16px',
-                height: '16px',
-                backgroundColor: colors.canvas.subtle, // Match the header background
-                borderBottom: `1px solid ${colors.border.default}`, // Only bottom and left create the visible arrow borders
-                borderLeft: `1px solid ${colors.border.default}`,
-                transform: 'rotate(45deg)',
-              },
-            }}
-          >
-            {/* Header */}
-            <Box
-              sx={{
-                px: { xs: 1.5, sm: 2 },
-                py: { xs: 1, sm: 1.5 }, // Slightly more vertical padding on larger screens
-                backgroundColor: colors.canvas.subtle,
-                borderBottom: `1px solid ${colors.border.default}`,
-                borderTopLeftRadius: '6px',
-                borderTopRightRadius: '6px',
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'space-between',
-                gap: 1,
-                flexWrap: 'wrap',
-                color: colors.fg.muted,
-                fontSize: { xs: '13px', sm: '14px' },
-                position: 'relative',
-                zIndex: 1, // Ensure above the arrow pseudo-element's main body
-              }}
-            >
-              <Box
-                sx={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: 1,
-                  flexWrap: 'wrap',
-                  minWidth: 0,
-                }}
-              >
-                <Link
-                  href={item.user.htmlUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  sx={{
-                    color: colors.fg.default,
-                    fontWeight: 600,
-                    textDecoration: 'none',
-                    '&:hover': {
-                      textDecoration: 'underline',
-                      color: colors.accent.fg,
-                    },
-                  }}
-                >
-                  {item.user.login}
-                </Link>
-                <Typography
-                  component="span"
-                  sx={{ fontSize: 'inherit', color: 'inherit' }}
-                >
-                  commented
-                </Typography>
-                <Typography
-                  component="span"
-                  sx={{ fontSize: 'inherit', color: 'inherit' }}
-                >
-                  {formatDate(item.createdAt)}
-                </Typography>
-              </Box>
-
-              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                {/* Author Association Badge */}
-                {item.authorAssociation &&
-                  item.authorAssociation !== 'NONE' && (
-                    <Chip
-                      variant="status"
-                      label={item.authorAssociation
-                        .toLowerCase()
-                        .replace('_', ' ')}
-                      sx={{
-                        color: colors.fg.muted,
-                        borderColor: colors.border.default,
-                        textTransform: 'capitalize',
-                      }}
-                    />
-                  )}
-                {/* Description Badge - Special styling */}
-                {item.isDescription && (
-                  <Chip
-                    variant="status"
-                    label="Description"
-                    sx={{
-                      color: STATUS_COLORS.info,
-                      borderColor: alpha(STATUS_COLORS.info, 0.4),
-                    }}
-                  />
-                )}
-              </Box>
-            </Box>
-
-            {/* Markdown Content */}
-            <Box
-              sx={{
-                p: { xs: 1.5, sm: 2, md: 3 }, // More padding on larger screens
-                color: colors.fg.default,
-                fontSize: { xs: '13px', sm: '14px' },
-                lineHeight: 1.6,
-                fontFamily:
-                  '-apple-system,BlinkMacSystemFont,"Segoe UI","Noto Sans",Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji"', // GitHub's exact font stack
-                overflowX: 'auto',
-                ...scrollbarSx,
-                // Typography refinements
-                '& > *:first-of-type': { mt: 0 },
-                '& > *:last-child': { mb: 0 },
-                '& h1, & h2, & h3, & h4, & h5, & h6': {
-                  mt: 3,
-                  mb: 2,
-                  fontWeight: 600,
-                  lineHeight: 1.25,
-                  color: colors.fg.default,
-                  borderBottom: `1px solid ${colors.border.muted}`,
-                  pb: 0.3,
-                },
-                '& h1': { fontSize: '2em' },
-                '& h2': { fontSize: '1.5em' },
-                '& h3': { fontSize: '1.25em' },
-                '& p': { mb: 2, mt: 0 },
-                '& a': { color: colors.accent.fg, textDecoration: 'none' },
-                '& a:hover': { textDecoration: 'underline' },
-                '& ul, & ol': {
-                  pl: '2em',
-                  mb: 2,
-                  listStyleType: 'disc',
-                },
-                '& ol': { listStyleType: 'decimal' },
-                '& li': { mb: 0.5 },
-                '& li + li': { mt: '0.25em' },
-                '& blockquote': {
-                  padding: '0 1em',
-                  color: colors.fg.muted,
-                  borderLeft: `0.25em solid ${colors.border.default}`,
-                  my: 2,
-                  mx: 0,
-                },
-                '& input[type="checkbox"]': {
-                  mr: 0.5,
-                  verticalAlign: 'middle',
-                },
-                '& code': {
-                  padding: '0.2em 0.4em',
-                  margin: 0,
-                  fontSize: '85%',
-                  backgroundColor: alpha(STATUS_COLORS.neutral, 0.4),
-                  borderRadius: '6px',
-                },
-                '& pre': {
-                  mt: 2,
-                  mb: 2,
-                  p: 2,
-                  borderRadius: '6px',
-                  overflow: 'auto',
-                  backgroundColor: UI_COLORS.surfaceElevated,
-                  border: `1px solid ${colors.border.default}`,
-                  '& code': {
-                    backgroundColor: 'transparent',
-                    p: 0,
-                    fontSize: '100%',
-                  },
-                },
-                '& table': {
-                  borderCollapse: 'collapse',
-                  width: '100%',
-                  mb: 2,
-                  overflowX: 'auto',
-                },
-                '& th, & td': {
-                  border: `1px solid ${colors.border.default}`,
-                  padding: '6px 13px',
-                },
-                '& th': { fontWeight: 600 },
-                '& tr:nth-of-type(2n)': {
-                  backgroundColor: UI_COLORS.surfaceElevated,
-                },
-                '& hr': {
-                  height: '0.25em',
-                  my: 3,
-                  backgroundColor: colors.border.default,
-                  border: 0,
-                },
-                '& img': {
-                  maxWidth: '100%',
-                  borderRadius: '6px',
-                  backgroundColor: 'transparent',
-                },
-                '& .markdown-body': {
-                  backgroundColor: 'transparent',
-                  color: colors.fg.default,
-                  fontFamily: 'inherit',
-                  fontSize: '14px',
-                  lineHeight: 1.6,
-                },
-              }}
-            >
-              <div className="markdown-body" style={{ fontSize: '14px' }}>
-                <ReactMarkdown
-                  remarkPlugins={[remarkGfm]}
-                  rehypePlugins={[rehypeRaw]}
-                >
-                  {item.body}
-                </ReactMarkdown>
-              </div>
-            </Box>
-          </Paper>
-        </Box>
-      ))}
-    </Box>
-  );
+  return <ConversationTimeline items={items} />;
 };
 
 export default PRComments;


### PR DESCRIPTION
## Summary

On the bounty issue page, the conversation tab now loads the full GitHub thread (the body plus all comments) instead of a single body card. Comments come from GitHub's REST API, so tables and other rich markdown render correctly.

Both the issue page and the PR details page now render the body card with the real `author_association` from GitHub, and the header verb switches based on whether the card is the body (`opened this`) or a comment (`commented`).

A shared `ConversationTimeline` component lives in `src/components/common/`. The two pages were duplicating the same timeline UI, so each one now reduces to a small data-fetching wrapper that produces `ConversationItem[]` and hands it off to the shared component.

## Related Issues

Fixes #921 

## Type of Change

- [x] Bug fix
- [x] Refactor
- [ ] New feature
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

Before:
<img width="1912" height="936" alt="before1" src="https://github.com/user-attachments/assets/5fcfb400-578c-478f-bd5c-06a40bb80d73" />
<img width="1912" height="932" alt="before2" src="https://github.com/user-attachments/assets/1c423a1d-f99e-4198-95fa-aa38c96b82d8" />

After:
<img width="1902" height="857" alt="after1" src="https://github.com/user-attachments/assets/a7dd0c12-59a0-49ff-8065-9218c1be1b71" />
[after.webm](https://github.com/user-attachments/assets/035334b0-92c0-4574-b455-ccdabce30a95)


## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
