### PR TITLE
fix(bounties): use ل on bounty pool chart Y-axis

### DIFF
--- a/src/components/issues/IssuesList.tsx
+++ b/src/components/issues/IssuesList.tsx
@@ -425,7 +425,7 @@ const IssuesList: React.FC<IssuesListProps> = ({
       },
       yAxis: {
         type: 'value',
-        name: 'Bounty (α)',
+        name: 'Bounty (ل)',
         nameTextStyle: { color: textColor, fontFamily: 'JetBrains Mono' },
         axisLabel: { color: textColor, fontFamily: 'JetBrains Mono' },
         splitLine: { lineStyle: { color: gridColor, type: 'dashed' } },


### PR DESCRIPTION
## Summary

The "Bounty Pool by Repository" chart on `/bounties` labelled its Y-axis `Bounty (α)` while the chart's own tooltip and every neighbouring table cell render the same values with `ل`. Switching the Y-axis label to `Bounty (ل)` so the chart agrees with itself and with `IssueStats`, `BountyCard`, and the issues table.

## Related Issues

Fixes #923

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

before: 
<img width="1908" height="935" alt="before" src="https://github.com/user-attachments/assets/5b260ba4-0d15-4740-a852-efbc1aaf3991" />

after:
<img width="1902" height="861" alt="after" src="https://github.com/user-attachments/assets/cc8548a3-fa8b-42ea-83df-bf0233476273" />

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
