### PR TITLE
fix(bounty-card): stop labeling cancelled bounties as green Payout

### DIFF
--- a/src/components/issues/BountyCard.tsx
+++ b/src/components/issues/BountyCard.tsx
@@ -48,14 +48,19 @@ export const BountyCard: React.FC<BountyCardProps> = ({
     alphaPrice ?? 0,
   );
   const isPending = issue.status === 'registered';
-  const isHistory =
-    issue.status === 'completed' || issue.status === 'cancelled';
+  const isCompleted = issue.status === 'completed';
+  const isCancelled = issue.status === 'cancelled';
+  const isHistory = isCompleted || isCancelled;
   const bountyLabel = isPending
     ? 'Target Bounty'
-    : isHistory
+    : isCompleted
       ? 'Payout'
       : 'Bounty';
-  const bountyColor = isPending ? STATUS_COLORS.award : STATUS_COLORS.merged;
+  const bountyColor = isPending
+    ? STATUS_COLORS.award
+    : isCancelled
+      ? 'text.tertiary'
+      : STATUS_COLORS.merged;
 
   const linkProps = useLinkBehavior<HTMLAnchorElement>(href ?? '', {
     state: linkState,


### PR DESCRIPTION
## Summary

`BountyCard` collapsed `completed` and `cancelled` into a single `isHistory` flag, so cancelled bounties rendered the bottom row as "Payout: {amount} ل" in merged-green even though no payout ever happened. The status chip on the same card still read CANCELLED, leaving the two halves of the card contradicting each other.

The label and color logic is now split so that only `completed` keeps the green "Payout" treatment. Cancelled bounties fall back to the neutral "Bounty" label in muted text, matching how `IssueHeaderCard` already handles the same status on the issue details page. The `isHistory` flag is kept (now derived from `isCompleted || isCancelled`) for the solver/date closeout strip, since that block is genuinely shared between both states.

Active and registered bounty cards are unchanged.

## Related Issues

Fixes #925

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

Before: cancelled bounty card showing green "Payout".
<img width="1911" height="932" alt="before" src="https://github.com/user-attachments/assets/ea36de3b-24e4-4fd5-bf30-c0ca2a5e0793" />

After: cancelled bounty card showing neutral "Bounty".
<img width="1903" height="857" alt="after" src="https://github.com/user-attachments/assets/2e803a63-b423-48f0-a6cd-d9a1cc7188aa" />

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
