### PR TITLE
fix: Bounty Pool chart Y-axis label inconsistency with tooltip

### DIFF
--- a/src/components/issues/IssuesList.tsx
+++ b/src/components/issues/IssuesList.tsx
@@ -424,7 +424,7 @@ const IssuesList: React.FC<IssuesListProps> = ({
       },
       yAxis: {
         type: 'value',
-        name: 'Bounty (α)',
+        name: 'Bounty (ل)',
         nameTextStyle: { color: textColor, fontFamily: 'JetBrains Mono' },
         axisLabel: { color: textColor, fontFamily: 'JetBrains Mono' },
         splitLine: { lineStyle: { color: gridColor, type: 'dashed' } },


### PR DESCRIPTION
## Summary

Fixes #923

## Problem

The Bounty Pool bar chart on `/bounties` labels the Y-axis `Bounty (α)` but the tooltip and every surrounding table cell use `ل`. Same data, contradictory labels.

## Fix

Changed Y-axis `name` from `'Bounty (α)'` to `'Bounty (ل)'` to match the tooltip formatter and table displays.