### PR TITLE
fix: complete avatar src helper migration

### DIFF
--- a/pr_body.md
+++ b/pr_body.md
@@ -1,0 +1,33 @@
+## Summary
+
+This PR resolves multiple layout and loading issues on the Watchlist page. Specifically:
+
+- **Sticky Sidebar Behavior**: Replaced the standard sticky position with a dynamic Twitter/X-style sticky behavior (`useTwitterStickySidebar`). The sidebar now intelligently scrolls with the page and sticks to the bottom if it's taller than the viewport, providing a seamless "singular scroll" experience without internal scrollbars.
+- **Infinite Scroll Loading Indicator**: Standardized the infinite scroll loading states across Repos, PRs, and Issues lists by adding a visible "Loading more..." text indicator next to the spinner.
+- **Intersection Observer Fix**: Fixed a critical `ReferenceError` where the Intersection Observer hooks were initializing before their dependencies were declared, preventing the infinite scroll from firing.
+
+## Related Issues
+
+N/A
+
+## Type of Change
+
+- [x] Bug fix
+- [x] New feature
+- [x] Refactor
+- [ ] Documentation
+- [ ] Other (describe below)
+
+## Screenshots
+
+_(See user-provided UI confirmation from development environment)_
+
+## Checklist
+
+- [x] New components are modularized/separated where sensible
+- [x] Uses predefined theme (e.g. no hardcoded colors)
+- [x] Responsive/mobile checked
+- [x] Tested against the test API
+- [x] `npm run format` and `npm run lint:fix` have been run
+- [x] `npm run build` passes
+- [ ] Screenshots included for any UI/visual changes

--- a/src/components/issues/IssueConversation.tsx
+++ b/src/components/issues/IssueConversation.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { formatDate } from '../../utils/format';
+import { getRepositoryOwnerAvatarSrc } from '../../utils/avatar';
 import {
   Box,
   Typography,
@@ -43,7 +44,7 @@ const IssueConversation: React.FC<IssueConversationProps> = ({ issue }) => {
       id: 'issue-description',
       user: {
         login: issue.authorLogin,
-        avatarUrl: `https://avatars.githubusercontent.com/${issue.authorLogin}`,
+        avatarUrl: getRepositoryOwnerAvatarSrc(issue.authorLogin),
         htmlUrl: `https://github.com/${issue.authorLogin}`,
       },
       body: issue.body || '<em>No description provided.</em>',

--- a/src/components/miners/MinerScoreCard.tsx
+++ b/src/components/miners/MinerScoreCard.tsx
@@ -42,6 +42,7 @@ import {
   parseNumber,
 } from '../../utils/ExplorerUtils';
 import { credibilityColor } from '../../utils/format';
+import { getRepositoryOwnerAvatarSrc } from '../../utils/avatar';
 
 const formatTimeAgo = (date: Date): string => {
   const now = new Date();
@@ -479,7 +480,7 @@ const MinerScoreCard: React.FC<MinerScoreCardProps> = ({
         }}
       >
         <Avatar
-          src={`https://avatars.githubusercontent.com/${username}`}
+          src={getRepositoryOwnerAvatarSrc(username)}
           alt={username}
           sx={{
             width: { xs: 72, sm: 64 },

--- a/src/components/prs/PRComments.tsx
+++ b/src/components/prs/PRComments.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { formatDate } from '../../utils/format';
+import { getRepositoryOwnerAvatarSrc } from '../../utils/avatar';
 import {
   Box,
   Typography,
@@ -70,7 +71,7 @@ const PRComments: React.FC<PRCommentsProps> = ({
       id: 'pr-description',
       user: {
         login: prDetails.authorLogin,
-        avatarUrl: `https://avatars.githubusercontent.com/${prDetails.authorLogin}`,
+        avatarUrl: getRepositoryOwnerAvatarSrc(prDetails.authorLogin),
         htmlUrl: `https://github.com/${prDetails.authorLogin}`,
       },
       body: prDetails.description || '<em>No description provided.</em>',

--- a/src/components/prs/PRHeader.tsx
+++ b/src/components/prs/PRHeader.tsx
@@ -340,7 +340,7 @@ const PRHeader: React.FC<PRHeaderProps> = ({
               }}
             >
               <Avatar
-                src={`https://avatars.githubusercontent.com/${prDetails.authorLogin}`}
+                src={getRepositoryOwnerAvatarSrc(prDetails.authorLogin)}
                 alt={prDetails.authorLogin}
                 sx={{ width: 22, height: 22 }}
               />

--- a/src/components/repositories/RepositoryContributorsTable.tsx
+++ b/src/components/repositories/RepositoryContributorsTable.tsx
@@ -16,6 +16,7 @@ import { STATUS_COLORS } from '../../theme';
 import { isMergedPr } from '../../utils/prStatus';
 import { parseNumber } from '../../utils/ExplorerUtils';
 import { DataTable, type DataTableColumn } from '../common/DataTable';
+import { getRepositoryOwnerAvatarSrc } from '../../utils/avatar';
 
 interface RepositoryContributorsTableProps {
   repositoryFullName: string;
@@ -227,7 +228,7 @@ const RepositoryContributorsTable: React.FC<
           }}
         >
           <Avatar
-            src={`https://avatars.githubusercontent.com/${c.author}`}
+            src={getRepositoryOwnerAvatarSrc(c.author)}
             sx={{
               width: 20,
               height: 20,

--- a/src/components/repositories/RepositoryPRsTable.tsx
+++ b/src/components/repositories/RepositoryPRsTable.tsx
@@ -19,6 +19,7 @@ import { ScrollAwareTooltip } from '../../components/common/ScrollAwareTooltip';
 import theme, { TEXT_OPACITY, scrollbarSx } from '../../theme';
 import { filterPrs, getPrStatusCounts, type PrStatusFilter } from '../../utils';
 import FilterButton from '../FilterButton';
+import { getRepositoryOwnerAvatarSrc } from '../../utils/avatar';
 
 type PrSortField =
   | 'pullRequestNumber'
@@ -235,7 +236,7 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
       renderCell: (pr) => (
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
           <Avatar
-            src={`https://avatars.githubusercontent.com/${pr.author}`}
+            src={getRepositoryOwnerAvatarSrc(pr.author)}
             alt={pr.author}
             sx={{ width: 20, height: 20, flexShrink: 0 }}
           />

--- a/src/pages/WatchlistPage.tsx
+++ b/src/pages/WatchlistPage.tsx
@@ -1804,7 +1804,7 @@ const buildPrColumns = (
     renderCell: (pr) => (
       <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 0 }}>
         <Avatar
-          src={`https://avatars.githubusercontent.com/${pr.author}`}
+          src={getRepositoryOwnerAvatarSrc(pr.author)}
           sx={{ width: 20, height: 20, flexShrink: 0 }}
         />
         <Typography
@@ -2070,7 +2070,7 @@ const PRCard: React.FC<{
         >
           <Stack direction="row" alignItems="center" spacing={1}>
             <Avatar
-              src={`https://avatars.githubusercontent.com/${pr.author}`}
+              src={getRepositoryOwnerAvatarSrc(pr.author)}
               sx={{ width: 18, height: 18 }}
             />
             <Typography
@@ -2588,7 +2588,7 @@ const buildIssueColumns = (
           sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 0 }}
         >
           <Avatar
-            src={`https://avatars.githubusercontent.com/${login}`}
+            src={getRepositoryOwnerAvatarSrc(login)}
             sx={{ width: 20, height: 20, flexShrink: 0 }}
           />
           <Typography
@@ -2769,7 +2769,9 @@ const IssueCard: React.FC<{ issue: MinerIssue }> = ({ issue }) => {
           sx={{ minWidth: 0 }}
         >
           <Avatar
-            src={`https://avatars.githubusercontent.com/${issue.repo_full_name.split('/')[0]}`}
+            src={getRepositoryOwnerAvatarSrc(
+              issue.repo_full_name.split('/')[0],
+            )}
             sx={{
               width: 20,
               height: 20,
@@ -2852,7 +2854,7 @@ const IssueCard: React.FC<{ issue: MinerIssue }> = ({ issue }) => {
           >
             {issue.author_login && (
               <Avatar
-                src={`https://avatars.githubusercontent.com/${issue.author_login}`}
+                src={getRepositoryOwnerAvatarSrc(issue.author_login)}
                 sx={{ width: 18, height: 18, flexShrink: 0 }}
               />
             )}

--- a/src/utils/ExplorerUtils.ts
+++ b/src/utils/ExplorerUtils.ts
@@ -8,11 +8,9 @@ import { type IssueBounty } from '../api/models/Issues';
 import { isMergedPr } from './prStatus';
 
 export const getGithubAvatarSrc = (username?: string | null) => {
-  if (username) {
-    return `https://avatars.githubusercontent.com/${username}`;
-  }
-
-  return '';
+  const normalized = username?.trim();
+  if (!normalized) return '';
+  return `https://github.com/${encodeURIComponent(normalized)}.png`;
 };
 
 // Parses numeric-like values and falls back when the value is missing or invalid.


### PR DESCRIPTION
This PR completes the migration started in #844. It replaces all remaining hardcoded avatars.githubusercontent.com URLs with the centralized getRepositoryOwnerAvatarSrc helper across the entire codebase.