### PR TITLE
fix(miners): use ScrollAwareTooltip in MinersList to close tooltips on scroll

### DIFF
--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -2,3 +2,4 @@ export * from './SearchInput';
 export * from './linkBehavior';
 export * from './WatchlistButton';
 export * from './DataTable';
+export * from './ScrollAwareTooltip';

--- a/src/components/leaderboard/MinersList.tsx
+++ b/src/components/leaderboard/MinersList.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import { Avatar, Box, Card, Tooltip, Typography } from '@mui/material';
+import { Avatar, Box, Card, Typography } from '@mui/material';
 import { useMinerGithubData, useMinerPRs } from '../../api';
 import { CHART_COLORS, scrollbarSx } from '../../theme';
 import { getGithubAvatarSrc, type SortOrder } from '../../utils/ExplorerUtils';
-import { DataTable, type DataTableColumn, WatchlistButton } from '../common';
+import { DataTable, type DataTableColumn, ScrollAwareTooltip, WatchlistButton } from '../common';
 import { RankIcon } from './RankIcon';
 import {
   type LeaderboardVariant,
@@ -249,7 +249,7 @@ const MinerIdentityCell: React.FC<MinerIdentityCellProps> = ({ miner }) => {
           borderColor: 'border.medium',
         }}
       />
-      <Tooltip title={username} placement="top">
+      <ScrollAwareTooltip title={username} placement="top">
         <Typography
           component="span"
           sx={{
@@ -265,7 +265,7 @@ const MinerIdentityCell: React.FC<MinerIdentityCellProps> = ({ miner }) => {
         >
           {username}
         </Typography>
-      </Tooltip>
+      </ScrollAwareTooltip>
     </Box>
   );
 };
@@ -302,7 +302,7 @@ const MinerActivitySegments: React.FC<MinerActivitySegmentsProps> = ({
       }}
     >
       {segments.map((segment, i) => (
-        <Tooltip
+        <ScrollAwareTooltip
           key={segment.label}
           title={segment.label}
           arrow
@@ -324,7 +324,7 @@ const MinerActivitySegments: React.FC<MinerActivitySegmentsProps> = ({
               {segment.value}
             </Typography>
           </Box>
-        </Tooltip>
+        </ScrollAwareTooltip>
       ))}
     </Box>
   );


### PR DESCRIPTION
## Summary

On the OSS contributions miners list, username and activity-dot tooltips stayed open when the table was scrolled, causing them to float over the sticky header outside the table.

## Fix

Swap the in-table `Tooltip` components in `MinersList.tsx` for the existing `ScrollAwareTooltip` helper (introduced in #876), which auto-closes any open tooltip on scroll. Also export `ScrollAwareTooltip` from the common barrel file.

Sticky-header tooltips (view-mode toggle, eligibility filter) are unchanged — they do not scroll, so the regular `Tooltip` is fine.

Fixes #920