### PR TITLE
Miner repositories: status/recency filters

### DIFF
--- a/src/components/miners/MinerRepositoriesTable.tsx
+++ b/src/components/miners/MinerRepositoriesTable.tsx
@@ -8,6 +8,7 @@ import {
   TextField,
   Typography,
   alpha,
+  useTheme,
 } from '@mui/material';
 import { Search as SearchIcon } from '@mui/icons-material';
 import { useMinerPRs, useReposAndWeights, useIssues } from '../../api';
@@ -19,6 +20,7 @@ import {
 import RankBadge from './RankBadge';
 import EmptyStateMessage from './EmptyStateMessage';
 import TablePagination from './TablePagination';
+import ExplorerFilterButton from './ExplorerFilterButton';
 import { searchFieldSx } from './MinerRepositoriesTable.styles';
 import {
   type RepoSortField,
@@ -38,8 +40,11 @@ import {
 } from '../../utils/ExplorerUtils';
 import { formatTokenAmount } from '../../utils/format';
 import { getRepositoryOwnerAvatarSrc } from '../../utils/avatar';
+import { scrollbarSx } from '../../theme';
 
 type ViewMode = 'prs' | 'issues';
+
+type RepoStatusFilter = 'all' | 'active' | 'inactive' | 'recent' | 'stale';
 
 interface MinerRepositoriesTableProps {
   githubId: string;
@@ -48,10 +53,25 @@ interface MinerRepositoriesTableProps {
 
 const PAGE_SIZE = 20;
 
+/** Active on subnet + latest merged PR within the rolling scoring window. */
+const isRecentRepoStats = (r: RepoStats): boolean =>
+  !r.inactiveAt && !isOutsideScoringWindow(r.latestPrDate);
+
+/** Latest merged PR is older than the rolling scoring window. */
+const isStaleRepoStats = (r: RepoStats): boolean =>
+  isOutsideScoringWindow(r.latestPrDate);
+
+const isRecentIssueRepoStats = (r: IssueRepoStats): boolean =>
+  !r.inactiveAt && !isOutsideScoringWindow(r.latestActivityDate);
+
+const isStaleIssueRepoStats = (r: IssueRepoStats): boolean =>
+  isOutsideScoringWindow(r.latestActivityDate);
+
 const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
   githubId,
   viewMode = 'prs',
 }) => {
+  const theme = useTheme();
   const isIssueMode = viewMode === 'issues';
   const { data: prs, isLoading: isLoadingPRs } = useMinerPRs(githubId);
   const { data: issues, isLoading: isLoadingIssues } = useIssues();
@@ -62,32 +82,109 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
     useState<IssueRepoSortField>('issueTokenScore');
   const [issueSortOrder, setIssueSortOrder] = useState<SortOrder>('desc');
   const [searchQuery, setSearchQuery] = useState('');
+  const [statusFilter, setStatusFilter] = useState<RepoStatusFilter>('all');
   const [page, setPage] = useState(0);
 
   useEffect(() => {
     setPage(0);
-  }, [viewMode]);
+  }, [viewMode, statusFilter]);
+
+  const inactiveAtByRepo = useMemo(() => {
+    const m = new Map<string, string | null>();
+    for (const r of repos || []) {
+      if (r?.fullName) {
+        m.set(r.fullName.toLowerCase(), r.inactiveAt ?? null);
+      }
+    }
+    return m;
+  }, [repos]);
 
   const repoWeights = useMemo(() => buildRepoWeightsMap(repos), [repos]);
 
-  const repoStats = useMemo(
-    () => aggregatePRsByRepository(prs || [], repoWeights),
-    [prs, repoWeights],
+  const repoStats = useMemo(() => {
+    const base = aggregatePRsByRepository(prs || [], repoWeights);
+    return base.map((row) => ({
+      ...row,
+      inactiveAt: inactiveAtByRepo.get(row.repository.toLowerCase()) ?? null,
+    }));
+  }, [prs, repoWeights, inactiveAtByRepo]);
+
+  const issueRepoStats = useMemo(() => {
+    const base = aggregateIssueDiscoveryByRepository(
+      prs || [],
+      issues,
+      repoWeights,
+    );
+    return base.map((row) => ({
+      ...row,
+      inactiveAt: inactiveAtByRepo.get(row.repository.toLowerCase()) ?? null,
+    }));
+  }, [prs, issues, repoWeights, inactiveAtByRepo]);
+
+  const statusFilteredRepoStats = useMemo(() => {
+    switch (statusFilter) {
+      case 'all':
+        return repoStats;
+      case 'active':
+        return repoStats.filter((r) => !r.inactiveAt);
+      case 'inactive':
+        return repoStats.filter((r) => !!r.inactiveAt);
+      case 'recent':
+        return repoStats.filter(isRecentRepoStats);
+      case 'stale':
+        return repoStats.filter(isStaleRepoStats);
+      default:
+        return repoStats;
+    }
+  }, [repoStats, statusFilter]);
+
+  const statusFilteredIssueRepoStats = useMemo(() => {
+    switch (statusFilter) {
+      case 'all':
+        return issueRepoStats;
+      case 'active':
+        return issueRepoStats.filter((r) => !r.inactiveAt);
+      case 'inactive':
+        return issueRepoStats.filter((r) => !!r.inactiveAt);
+      case 'recent':
+        return issueRepoStats.filter(isRecentIssueRepoStats);
+      case 'stale':
+        return issueRepoStats.filter(isStaleIssueRepoStats);
+      default:
+        return issueRepoStats;
+    }
+  }, [issueRepoStats, statusFilter]);
+
+  const repoStatusCounts = useMemo(
+    () => ({
+      all: repoStats.length,
+      active: repoStats.filter((r) => !r.inactiveAt).length,
+      inactive: repoStats.filter((r) => !!r.inactiveAt).length,
+      recent: repoStats.filter(isRecentRepoStats).length,
+      stale: repoStats.filter(isStaleRepoStats).length,
+    }),
+    [repoStats],
   );
 
-  const issueRepoStats = useMemo(
-    () => aggregateIssueDiscoveryByRepository(prs || [], issues, repoWeights),
-    [prs, issues, repoWeights],
+  const issueRepoStatusCounts = useMemo(
+    () => ({
+      all: issueRepoStats.length,
+      active: issueRepoStats.filter((r) => !r.inactiveAt).length,
+      inactive: issueRepoStats.filter((r) => !!r.inactiveAt).length,
+      recent: issueRepoStats.filter(isRecentIssueRepoStats).length,
+      stale: issueRepoStats.filter(isStaleIssueRepoStats).length,
+    }),
+    [issueRepoStats],
   );
 
   const filteredRepoStats = useMemo(
-    () => filterBySearch(repoStats, searchQuery),
-    [repoStats, searchQuery],
+    () => filterBySearch(statusFilteredRepoStats, searchQuery),
+    [statusFilteredRepoStats, searchQuery],
   );
 
   const filteredIssueRepoStats = useMemo(
-    () => filterBySearch(issueRepoStats, searchQuery),
-    [issueRepoStats, searchQuery],
+    () => filterBySearch(statusFilteredIssueRepoStats, searchQuery),
+    [statusFilteredIssueRepoStats, searchQuery],
   );
 
   const sortedRepoStats = useMemo(
@@ -141,12 +238,14 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
     setPage(0);
   };
 
-  const isFiltered = hasActiveFilters(searchQuery);
+  const isFiltered = hasActiveFilters(searchQuery) || statusFilter !== 'all';
   const displayCount = getDisplayCount(
     activeSortedCount,
     isIssueMode ? issueRepoStats.length : repoStats.length,
     isFiltered,
   );
+
+  const statusCounts = isIssueMode ? issueRepoStatusCounts : repoStatusCounts;
 
   const isLoading =
     isLoadingPRs || isLoadingRepos || (isIssueMode && isLoadingIssues);
@@ -399,6 +498,64 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
             ({displayCount})
           </Typography>
         </Box>
+
+        <Box
+          sx={{
+            width: { xs: '100%', sm: '100%', md: 'auto' },
+            minWidth: 0,
+            maxWidth: '100%',
+            overflowX: { xs: 'auto', sm: 'auto', md: 'visible' },
+            WebkitOverflowScrolling: 'touch',
+            pb: { xs: 0.5, sm: 0.5, md: 0 },
+            ...scrollbarSx,
+          }}
+        >
+          <Box
+            sx={{
+              display: 'flex',
+              gap: 0.5,
+              flexWrap: { xs: 'nowrap', sm: 'nowrap', md: 'wrap' },
+              width: { xs: 'max-content', sm: 'max-content', md: 'auto' },
+              '& > *': { flexShrink: 0 },
+            }}
+          >
+            <ExplorerFilterButton
+              label="All"
+              count={statusCounts.all}
+              color={theme.palette.status.neutral}
+              selected={statusFilter === 'all'}
+              onClick={() => setStatusFilter('all')}
+            />
+            <ExplorerFilterButton
+              label="Active"
+              count={statusCounts.active}
+              color={theme.palette.status.success}
+              selected={statusFilter === 'active'}
+              onClick={() => setStatusFilter('active')}
+            />
+            <ExplorerFilterButton
+              label="Inactive"
+              count={statusCounts.inactive}
+              color={theme.palette.status.closed}
+              selected={statusFilter === 'inactive'}
+              onClick={() => setStatusFilter('inactive')}
+            />
+            <ExplorerFilterButton
+              label="Recent"
+              count={statusCounts.recent}
+              color={theme.palette.status.merged}
+              selected={statusFilter === 'recent'}
+              onClick={() => setStatusFilter('recent')}
+            />
+            <ExplorerFilterButton
+              label="Stale"
+              count={statusCounts.stale}
+              color={theme.palette.status.warning}
+              selected={statusFilter === 'stale'}
+              onClick={() => setStatusFilter('stale')}
+            />
+          </Box>
+        </Box>
       </Box>
 
       <TextField
@@ -468,7 +625,11 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
             onChange: handleIssueSort,
           }}
           getRowSx={(repo) => ({
-            opacity: isOutsideScoringWindow(repo.latestActivityDate) ? 0.4 : 1,
+            opacity: repo.inactiveAt
+              ? 0.5
+              : isOutsideScoringWindow(repo.latestActivityDate)
+                ? 0.4
+                : 1,
             transition: 'opacity 0.2s',
           })}
           pagination={
@@ -497,7 +658,11 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
             onChange: handlePrSort,
           }}
           getRowSx={(repo) => ({
-            opacity: isOutsideScoringWindow(repo.latestPrDate) ? 0.4 : 1,
+            opacity: repo.inactiveAt
+              ? 0.5
+              : isOutsideScoringWindow(repo.latestPrDate)
+                ? 0.4
+                : 1,
             transition: 'opacity 0.2s',
           })}
           pagination={

--- a/src/utils/ExplorerUtils.ts
+++ b/src/utils/ExplorerUtils.ts
@@ -127,6 +127,8 @@ export interface RepoStats {
   tokenScore: number;
   weight: number;
   latestPrDate?: string | null;
+  /** Set when subnet repo list marks the repository inactive (miners / enrich layer). */
+  inactiveAt?: string | null;
 }
 
 /** Per-repository stats for Issue Discovery (miner solved bounties via winning PRs). */
@@ -138,6 +140,7 @@ export interface IssueRepoStats {
   bountyEarned: number;
   weight: number;
   latestActivityDate: string | null;
+  inactiveAt?: string | null;
 }
 
 export type RepoSortField =


### PR DESCRIPTION
## Summary

 Miner → Repositories: Adds All, Active, Inactive, Recent, and Stale filter chips. Counts come from the subnet repo list (inactiveAt) and the same ~35-day scoring window as the rest of the explorer (Recent = active + in window; Stale = last activity outside the window). Rows use theme opacity tokens for inactive vs stale vs normal.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

### Before

<img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/2e221857-22c4-4cbc-8a8e-9fe1c156dccd" />

---------------------------------------------

### After

<img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/1ed51868-f7d5-47fe-b4f9-99ee5fd4b35d" />

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
