### PR TITLE
fix(watchlist): align Issues and Bounties tabs with PRs/Repos style

### DIFF
--- a/src/components/issues/BountyCard.tsx
+++ b/src/components/issues/BountyCard.tsx
@@ -31,6 +31,12 @@ interface BountyCardProps {
   linkState?: Record<string, unknown>;
   taoPrice?: number;
   alphaPrice?: number;
+  /**
+   * Compact variant: smaller avatar, no forced 2-line title minHeight, and
+   * the GitHub link row is hidden so card height matches PRCard / RepoCard
+   * in the Watchlist tabs.
+   */
+  compact?: boolean;
 }
 
 export const BountyCard: React.FC<BountyCardProps> = ({
@@ -39,6 +45,7 @@ export const BountyCard: React.FC<BountyCardProps> = ({
   linkState,
   taoPrice,
   alphaPrice,
+  compact = false,
 }) => {
   const owner = issue.repositoryFullName.split('/')[0] || '';
   const statusMeta = getIssueStatusMeta(issue.status);
@@ -99,8 +106,8 @@ export const BountyCard: React.FC<BountyCardProps> = ({
           src={getRepositoryOwnerAvatarSrc(owner)}
           alt={owner}
           sx={(theme) => ({
-            width: 36,
-            height: 36,
+            width: compact ? 28 : 36,
+            height: compact ? 28 : 36,
             flexShrink: 0,
             border: '1px solid',
             borderColor: theme.palette.border.medium,
@@ -162,44 +169,46 @@ export const BountyCard: React.FC<BountyCardProps> = ({
               WebkitLineClamp: 2,
               WebkitBoxOrient: 'vertical',
               lineHeight: 1.4,
-              minHeight: 'calc(2 * 1.4em)',
+              ...(compact ? {} : { minHeight: 'calc(2 * 1.4em)' }),
             }}
           >
             {issue.title}
           </Typography>
         </Tooltip>
-        <Link
-          href={issue.githubUrl}
-          target="_blank"
-          rel="noopener noreferrer"
-          onClick={(e) => e.stopPropagation()}
-          sx={(theme) => ({
-            display: 'inline-flex',
-            alignItems: 'center',
-            gap: 0.6,
-            width: 'fit-content',
-            fontSize: '0.78rem',
-            fontWeight: 500,
-            color: alpha(theme.palette.common.white, TEXT_OPACITY.secondary),
-            textDecoration: 'none',
-            px: 1,
-            py: 0.5,
-            borderRadius: 1.5,
-            border: `1px solid ${alpha(theme.palette.common.white, 0.12)}`,
-            backgroundColor: alpha(theme.palette.common.white, 0.05),
-            transition: 'all 0.15s',
-            '&:hover': {
-              color: theme.palette.common.white,
-              borderColor: alpha(theme.palette.common.white, 0.28),
-              backgroundColor: alpha(theme.palette.common.white, 0.1),
+        {!compact && (
+          <Link
+            href={issue.githubUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={(e) => e.stopPropagation()}
+            sx={(theme) => ({
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 0.6,
+              width: 'fit-content',
+              fontSize: '0.78rem',
+              fontWeight: 500,
+              color: alpha(theme.palette.common.white, TEXT_OPACITY.secondary),
               textDecoration: 'none',
-            },
-          })}
-        >
-          <GitHubIcon sx={{ fontSize: 13 }} />#{issue.issueNumber} Open on
-          GitHub
-          <OpenInNewIcon sx={{ fontSize: 11, opacity: 0.6 }} />
-        </Link>
+              px: 1,
+              py: 0.5,
+              borderRadius: 1.5,
+              border: `1px solid ${alpha(theme.palette.common.white, 0.12)}`,
+              backgroundColor: alpha(theme.palette.common.white, 0.05),
+              transition: 'all 0.15s',
+              '&:hover': {
+                color: theme.palette.common.white,
+                borderColor: alpha(theme.palette.common.white, 0.28),
+                backgroundColor: alpha(theme.palette.common.white, 0.1),
+                textDecoration: 'none',
+              },
+            })}
+          >
+            <GitHubIcon sx={{ fontSize: 13 }} />#{issue.issueNumber} Open on
+            GitHub
+            <OpenInNewIcon sx={{ fontSize: 11, opacity: 0.6 }} />
+          </Link>
+        )}
       </Box>
 
       <Divider sx={{ borderColor: 'border.light', opacity: 0.6 }} />

--- a/src/pages/WatchlistPage.tsx
+++ b/src/pages/WatchlistPage.tsx
@@ -70,6 +70,9 @@ import type {
   MinerIssue,
   Repository,
 } from '../api/models/Dashboard';
+import type { IssueBounty } from '../api/models/Issues';
+import { usePrices } from '../hooks/usePrices';
+import { BountyCard } from '../components/issues/BountyCard';
 import { mapAllMinersToStats } from '../utils/minerMapper';
 import {
   useWatchlist,
@@ -85,7 +88,7 @@ import {
 } from '../utils/prStatus';
 import { filterPrs, type PrStatusFilter } from '../utils/prTable';
 import { getIssueStatusMeta } from '../utils/issueStatus';
-import { formatTokenAmount } from '../utils/format';
+import { formatDate, formatTokenAmount } from '../utils/format';
 import { compareByWatchlist } from '../utils/watchlistSort';
 import { getRepositoryOwnerAvatarSrc } from '../utils/avatar';
 import theme, {
@@ -515,91 +518,6 @@ const WatchlistPage: React.FC = () => {
     </Page>
   );
 };
-
-const rowSx = {
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'space-between',
-  gap: 2,
-  px: 1.5,
-  py: 1.25,
-  borderRadius: 1,
-  transition: 'background 0.15s',
-  '&:hover': { backgroundColor: 'surface.light' },
-};
-
-const primaryTextSx = {
-  fontSize: '0.85rem',
-  color: 'text.primary',
-  overflow: 'hidden',
-  textOverflow: 'ellipsis',
-  whiteSpace: 'nowrap',
-};
-
-const secondaryTextSx = {
-  fontSize: '0.7rem',
-  color: 'text.secondary',
-  mt: 0.25,
-};
-
-interface WatchedItemRowProps {
-  href: string;
-  primary: React.ReactNode;
-  secondary?: React.ReactNode;
-  actions: React.ReactNode;
-}
-
-// LinkBox wraps only the navigable text area (not the whole row) so the
-// star button — a real <button> — is a sibling of the <a>, not a descendant.
-// Keeps middle-click / Cmd-click / "Open in new tab" working natively while
-// avoiding invalid interactive-inside-anchor HTML.
-const WatchedItemRow: React.FC<WatchedItemRowProps> = ({
-  href,
-  primary,
-  secondary,
-  actions,
-}) => (
-  <Box sx={rowSx}>
-    <LinkBox
-      href={href}
-      linkState={{ backLabel: 'Back to Watchlist' }}
-      sx={{ display: 'block', minWidth: 0, flex: 1 }}
-    >
-      <Typography sx={primaryTextSx}>{primary}</Typography>
-      {secondary !== undefined && (
-        <Typography sx={secondaryTextSx}>{secondary}</Typography>
-      )}
-    </LinkBox>
-    <Stack direction="row" spacing={2} alignItems="center">
-      {actions}
-    </Stack>
-  </Box>
-);
-
-interface StatusPillProps {
-  label: string;
-  color: string;
-  background: string;
-}
-
-const StatusPill: React.FC<StatusPillProps> = ({
-  label,
-  color,
-  background,
-}) => (
-  <Typography
-    sx={{
-      fontSize: '0.72rem',
-      color,
-      backgroundColor: background,
-      px: 1,
-      py: 0.25,
-      borderRadius: 0.75,
-    }}
-  >
-    {label}
-  </Typography>
-);
 
 /* ─── OptionsLabel: section header inside popovers ─── */
 const OptionsLabel: React.FC<{ children: React.ReactNode }> = ({
@@ -1906,9 +1824,222 @@ const ReposList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
   );
 };
 
+// ---------------------------------------------------------------------------
+// BountiesList — mirrors PRsList shell (toolbar + DataTable + card grid +
+// load-more sentinel) for watched bounties. Reuses the shared `BountyCard`
+// for card view so the watchlist matches the standalone /bounties page.
+// ---------------------------------------------------------------------------
+
+type BountyStatusFilter = 'all' | 'available' | 'pending' | 'history';
+type BountySortKey = 'issue' | 'repo' | 'bounty' | 'status' | 'date';
+
+const BOUNTY_STATUS_FILTERS: readonly BountyStatusFilter[] = [
+  'all',
+  'available',
+  'pending',
+  'history',
+];
+
+const bountyKey = (issue: IssueBounty) => String(issue.id);
+
+const getBountyHref = (issue: IssueBounty) =>
+  `/bounties/details?id=${issue.id}`;
+
+const bountyDate = (issue: IssueBounty): string =>
+  issue.completedAt ||
+  issue.closedAt ||
+  issue.updatedAt ||
+  issue.createdAt ||
+  '';
+
+// Group raw API status into the filter buckets used on the standalone
+// /bounties page so this tab reads consistently across the app.
+const bountyStatusGroup = (
+  issue: IssueBounty,
+): Exclude<BountyStatusFilter, 'all'> => {
+  if (issue.status === 'active') return 'available';
+  if (issue.status === 'registered') return 'pending';
+  return 'history';
+};
+
+const bountyStatusColor = (s: BountyStatusFilter): string => {
+  switch (s) {
+    case 'all':
+      return STATUS_COLORS.neutral;
+    case 'available':
+      return STATUS_COLORS.success;
+    case 'pending':
+      return STATUS_COLORS.warning;
+    case 'history':
+      return STATUS_COLORS.merged;
+  }
+};
+
+const filterBounties = (
+  items: IssueBounty[],
+  opts: { statusFilter: BountyStatusFilter; searchQuery: string },
+): IssueBounty[] => {
+  const q = opts.searchQuery.trim().toLowerCase();
+  return items.filter((i) => {
+    if (
+      opts.statusFilter !== 'all' &&
+      bountyStatusGroup(i) !== opts.statusFilter
+    )
+      return false;
+    if (!q) return true;
+    return (
+      i.repositoryFullName.toLowerCase().includes(q) ||
+      (i.title || '').toLowerCase().includes(q) ||
+      String(i.issueNumber).includes(q)
+    );
+  });
+};
+
+const getBountyCounts = (items: IssueBounty[]) => {
+  const c: Record<BountyStatusFilter, number> = {
+    all: items.length,
+    available: 0,
+    pending: 0,
+    history: 0,
+  };
+  items.forEach((i) => (c[bountyStatusGroup(i)] += 1));
+  return c;
+};
+
+const bountyCellSx = { py: 1.5 } as const;
+
+const buildBountyColumns = (): DataTableColumn<
+  IssueBounty,
+  BountySortKey
+>[] => [
+  {
+    key: 'issue',
+    header: 'Issue',
+    width: '90px',
+    sortKey: 'issue',
+    cellSx: bountyCellSx,
+    renderCell: (i) => (
+      <Typography sx={{ fontSize: '0.75rem', fontWeight: 600 }}>
+        #{i.issueNumber}
+      </Typography>
+    ),
+  },
+  {
+    key: 'title',
+    header: 'Title',
+    width: '32%',
+    cellSx: bountyCellSx,
+    renderCell: (i) => (
+      <Typography
+        sx={{
+          fontSize: '0.75rem',
+          fontWeight: 500,
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {i.title || '—'}
+      </Typography>
+    ),
+  },
+  {
+    key: 'repo',
+    header: 'Repository',
+    width: '24%',
+    sortKey: 'repo',
+    cellSx: bountyCellSx,
+    renderCell: (i) => (
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 0 }}>
+        <Avatar
+          src={getRepositoryOwnerAvatarSrc(i.repositoryFullName.split('/')[0])}
+          sx={{ width: 20, height: 20, flexShrink: 0 }}
+        />
+        <Typography
+          sx={{
+            fontSize: '0.75rem',
+            color: 'text.secondary',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {i.repositoryFullName}
+        </Typography>
+      </Box>
+    ),
+  },
+  {
+    key: 'bounty',
+    header: 'Bounty',
+    width: '130px',
+    align: 'right',
+    sortKey: 'bounty',
+    cellSx: bountyCellSx,
+    renderCell: (i) => (
+      <Typography
+        sx={{
+          fontSize: '0.75rem',
+          fontWeight: 600,
+          color: 'status.success',
+        }}
+      >
+        {formatTokenAmount(i.targetBounty || i.bountyAmount)} ل
+      </Typography>
+    ),
+  },
+  {
+    key: 'status',
+    header: 'Status',
+    width: '110px',
+    align: 'center',
+    sortKey: 'status',
+    cellSx: bountyCellSx,
+    renderCell: (i) => {
+      const meta = getIssueStatusMeta(i.status);
+      return (
+        <Chip
+          variant="status"
+          label={meta.text}
+          sx={{ color: meta.color, borderColor: meta.color }}
+        />
+      );
+    },
+  },
+  {
+    key: 'date',
+    header: 'Updated',
+    width: '120px',
+    sortKey: 'date',
+    cellSx: bountyCellSx,
+    renderCell: (i) => (
+      <Typography sx={{ fontSize: '0.75rem', color: 'text.secondary' }}>
+        {formatDate(bountyDate(i))}
+      </Typography>
+    ),
+  },
+  {
+    key: 'watch',
+    header: '★',
+    width: '52px',
+    align: 'center',
+    cellSx: { p: 0 },
+    renderCell: (i) => (
+      <WatchlistButton
+        category="bounties"
+        itemKey={bountyKey(i)}
+        size="small"
+      />
+    ),
+  },
+];
+
 const BountiesList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
-  const { data: allIssues } = useIssues();
-  const items = useMemo(() => {
+  const { data: allIssues, isLoading } = useIssues();
+  const { taoPrice, alphaPrice } = usePrices();
+  const bountyColumns = useMemo(() => buildBountyColumns(), []);
+
+  const items = useMemo<IssueBounty[]>(() => {
     if (!allIssues) return [];
     // Stored keys and issue ids are compared as strings to avoid any
     // numeric coercion drift if issue ids ever become composite.
@@ -1916,40 +2047,238 @@ const BountiesList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
     return allIssues.filter((issue) => set.has(String(issue.id)));
   }, [allIssues, itemKeys]);
 
+  const [searchQuery, setSearchQuery] = useState('');
+  const [statusFilter, setStatusFilter] = useState<BountyStatusFilter>('all');
+  const [viewMode, setViewMode] = useWatchlistViewMode();
+  const [page, setPage] = useState(0);
+  const observerTarget = useRef<HTMLDivElement>(null);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+
+  const [sortField, setSortField] = useState<BountySortKey>('date');
+  const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc');
+
+  useEffect(() => {
+    setPage(0);
+  }, [statusFilter, searchQuery, sortField, sortOrder, viewMode]);
+
+  const handleSort = (field: BountySortKey) => {
+    if (sortField === field) {
+      setSortOrder((o) => (o === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setSortField(field);
+      setSortOrder(field === 'repo' ? 'asc' : 'desc');
+    }
+    setPage(0);
+  };
+
+  const counts = useMemo(() => getBountyCounts(items), [items]);
+
+  const filtered = useMemo(
+    () => filterBounties(items, { statusFilter, searchQuery }),
+    [items, statusFilter, searchQuery],
+  );
+
+  const sorted = useMemo(() => {
+    const dir = sortOrder === 'asc' ? 1 : -1;
+    const cmpStr = (a = '', b = '') => a.localeCompare(b) * dir;
+    const cmpNum = (a = 0, b = 0) => (a - b) * dir;
+    return [...filtered].sort((a, b) => {
+      switch (sortField) {
+        case 'issue':
+          return cmpNum(a.issueNumber, b.issueNumber);
+        case 'repo':
+          return cmpStr(a.repositoryFullName, b.repositoryFullName);
+        case 'bounty':
+          return cmpNum(
+            parseFloat(a.targetBounty || a.bountyAmount || '0'),
+            parseFloat(b.targetBounty || b.bountyAmount || '0'),
+          );
+        case 'status':
+          return cmpStr(a.status, b.status);
+        case 'date':
+          return cmpStr(bountyDate(a), bountyDate(b));
+        default:
+          return 0;
+      }
+    });
+  }, [filtered, sortField, sortOrder]);
+
+  const paged = useMemo(
+    () => sorted.slice(0, (page + 1) * ROWS_PER_PAGE),
+    [sorted, page],
+  );
+
+  useEffect(() => {
+    const target = observerTarget.current;
+    if (!target) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting) {
+          setIsLoadingMore(true);
+          setTimeout(() => {
+            setPage((p) => p + 1);
+            setIsLoadingMore(false);
+          }, 400);
+        }
+      },
+      { root: null, rootMargin: '0px 0px 400px 0px', threshold: 0 },
+    );
+    observer.observe(target);
+    return () => observer.disconnect();
+  }, [page, filtered.length]);
+
   return (
-    <Stack spacing={0.5} sx={{ width: '100%' }}>
-      {items.map((issue) => {
-        const meta = getIssueStatusMeta(issue.status);
-        return (
-          <WatchedItemRow
-            key={issue.id}
-            href={`/bounties/details?id=${issue.id}`}
-            primary={
-              issue.title || `${issue.repositoryFullName} #${issue.issueNumber}`
-            }
-            secondary={`${issue.repositoryFullName} #${issue.issueNumber}`}
-            actions={
-              <>
-                <StatusPill
-                  label={meta.text}
-                  color={meta.color}
-                  background={meta.bgColor}
-                />
-                <Typography
-                  sx={{ fontSize: '0.75rem', color: 'status.success' }}
-                >
-                  {formatTokenAmount(issue.bountyAmount)} ل
-                </Typography>
-                <WatchlistButton
-                  category="bounties"
-                  itemKey={String(issue.id)}
-                />
-              </>
-            }
+    <Card
+      elevation={0}
+      sx={{
+        borderRadius: 3,
+        border: '1px solid',
+        borderColor: 'border.light',
+        backgroundColor: 'transparent',
+        display: 'flex',
+        flexDirection: 'column',
+      }}
+    >
+      <WatchlistPortal
+        filterContent={
+          <Box
+            sx={{
+              display: 'flex',
+              gap: 0.5,
+              alignItems: 'center',
+              flexWrap: 'wrap',
+            }}
+          >
+            {BOUNTY_STATUS_FILTERS.map((s) => (
+              <FilterButton
+                key={s}
+                label={s[0].toUpperCase() + s.slice(1)}
+                count={counts[s]}
+                color={bountyStatusColor(s)}
+                isActive={statusFilter === s}
+                onClick={() => setStatusFilter(s)}
+              />
+            ))}
+          </Box>
+        }
+        searchValue={searchQuery}
+        searchPlaceholder="Search bounties..."
+        onSearchChange={setSearchQuery}
+        viewMode={viewMode}
+        onViewModeChange={(next) => {
+          setViewMode(next);
+          setPage(0);
+        }}
+        viewModeToggle={
+          <PRsViewModeToggle
+            viewMode={viewMode}
+            onChange={(next) => {
+              setViewMode(next);
+              setPage(0);
+            }}
           />
-        );
-      })}
-    </Stack>
+        }
+        hasActiveFilter={statusFilter !== 'all'}
+      />
+
+      {viewMode === 'list' ? (
+        <DataTable<IssueBounty, BountySortKey>
+          columns={bountyColumns}
+          rows={paged}
+          getRowKey={bountyKey}
+          getRowHref={getBountyHref}
+          linkState={{ backLabel: 'Back to Watchlist' }}
+          minWidth="900px"
+          stickyHeader
+          isLoading={isLoading && items.length === 0}
+          emptyLabel="No watched bounties found."
+          sort={{
+            field: sortField,
+            order: sortOrder,
+            onChange: handleSort,
+          }}
+        />
+      ) : (
+        <Box
+          sx={{
+            p: 2,
+            flex: 1,
+            minHeight: 0,
+            overflowY: 'auto',
+            ...scrollbarSx,
+          }}
+        >
+          {isLoading && paged.length === 0 ? (
+            <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+              <CircularProgress size={24} />
+            </Box>
+          ) : paged.length === 0 ? (
+            <Typography
+              sx={{
+                color: 'text.secondary',
+                textAlign: 'center',
+                py: 4,
+                fontSize: '0.85rem',
+              }}
+            >
+              No watched bounties found.
+            </Typography>
+          ) : (
+            <Grid container spacing={2} alignItems="stretch">
+              {paged.map((issue) => (
+                <Grid
+                  item
+                  xs={12}
+                  sm={6}
+                  md={4}
+                  key={bountyKey(issue)}
+                  sx={{ display: 'flex' }}
+                >
+                  <Box sx={{ width: '100%' }}>
+                    <BountyCard
+                      issue={issue}
+                      href={getBountyHref(issue)}
+                      linkState={{ backLabel: 'Back to Watchlist' }}
+                      taoPrice={taoPrice}
+                      alphaPrice={alphaPrice}
+                      compact
+                    />
+                  </Box>
+                </Grid>
+              ))}
+            </Grid>
+          )}
+        </Box>
+      )}
+      {filtered.length > (page + 1) * ROWS_PER_PAGE && (
+        <Box
+          ref={observerTarget}
+          sx={{
+            height: 60,
+            width: '100%',
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center',
+          }}
+        >
+          {isLoadingMore && (
+            <>
+              <CircularProgress size={20} sx={{ color: 'text.secondary' }} />
+              <Typography
+                sx={{
+                  color: 'text.secondary',
+                  fontSize: '0.85rem',
+                  fontFamily: '"JetBrains Mono", monospace',
+                  ml: 1.5,
+                }}
+              >
+                Loading more...
+              </Typography>
+            </>
+          )}
+        </Box>
+      )}
+    </Card>
   );
 };
 
@@ -3032,7 +3361,10 @@ const buildIssueColumns = (
 const getIssueHref = (issue: MinerIssue): string =>
   `https://github.com/${issue.repo_full_name}/issues/${issue.issue_number}`;
 
-const IssueCard: React.FC<{ issue: MinerIssue }> = ({ issue }) => {
+const IssueCard: React.FC<{
+  issue: MinerIssue;
+  sources?: WatchedPRSource[];
+}> = ({ issue, sources = [] }) => {
   const { label, color } = issueStatusMeta(issue);
   const prNumber = issue.solving_pr?.pr_number ?? issue.solved_by_pr ?? null;
   return (
@@ -3074,7 +3406,9 @@ const IssueCard: React.FC<{ issue: MinerIssue }> = ({ issue }) => {
           sx={{ minWidth: 0 }}
         >
           <Avatar
-            src={`https://avatars.githubusercontent.com/${issue.repo_full_name.split('/')[0]}`}
+            src={getRepositoryOwnerAvatarSrc(
+              issue.repo_full_name.split('/')[0],
+            )}
             sx={{
               width: 20,
               height: 20,
@@ -3111,6 +3445,7 @@ const IssueCard: React.FC<{ issue: MinerIssue }> = ({ issue }) => {
               backgroundColor: alpha(color, 0.08),
             }}
           />
+          <WatchedSourceBadges sources={sources} />
           <WatchlistButton
             category="issues"
             itemKey={issueKey(issue)}
@@ -3398,7 +3733,15 @@ const IssuesList: React.FC<{ minerIds: string[] }> = ({ minerIds }) => {
           }}
         />
       ) : (
-        <Box sx={{ p: 2, overflowY: 'auto', ...scrollbarSx }}>
+        <Box
+          sx={{
+            p: 2,
+            flex: 1,
+            minHeight: 0,
+            overflowY: 'auto',
+            ...scrollbarSx,
+          }}
+        >
           {isLoading && paged.length === 0 ? (
             <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
               <CircularProgress size={24} />
@@ -3426,7 +3769,10 @@ const IssuesList: React.FC<{ minerIds: string[] }> = ({ minerIds }) => {
                   sx={{ display: 'flex' }}
                 >
                   <Box sx={{ width: '100%' }}>
-                    <IssueCard issue={i} />
+                    <IssueCard
+                      issue={i}
+                      sources={sourcesByKey.get(issueKey(i))}
+                    />
                   </Box>
                 </Grid>
               ))}


### PR DESCRIPTION
Close #936
Close #949 

## Summary

The **Issues** and **Bounties** tabs in the Watchlist didn't match the layout/behavior of the **Pull Requests** and **Repositories** tabs (right-sidebar `WatchlistPortal` toolbar + list/card view toggle + infinite scroll + shared card components). Two fixes bring them in line.

### 1. Issues tab — visual parity with PRsList (`44684da`)

**What was wrong:**
- Card-view grid expanded to its full content height instead of scrolling, pushing the load-more sentinel off-screen.
- `IssueCard` didn't render the watched-source badges (starred / miner / repo) even though `IssuesList` was already computing `sourcesByKey`.
- `IssueCard` used a raw `https://avatars.githubusercontent.com/${owner}` URL instead of the centralized `getRepositoryOwnerAvatarSrc` helper from #844.

**Changes (`IssuesList` / `IssueCard`):**
- Added `flex: 1, minHeight: 0` to the card-grid Box so it scrolls inside the Card with pagination pinned, matching `PRsList`.
- Added a `sources?: WatchedPRSource[]` prop on `IssueCard` and rendered `<WatchedSourceBadges>` next to the status chip; wired `sourcesByKey.get(issueKey(i))` from `IssuesList`.
- Switched the repo avatar to `getRepositoryOwnerAvatarSrc(...)`.

### 2. Bounties tab — full rewrite to match PRs/Repos shell (`98b32f9`)

**What was wrong:**
The old `BountiesList` was a flat `<Stack>` of bare rows — no toolbar, no filters, no search, no sort, no view-mode toggle, no infinite scroll. Looked like a different feature from every other tab.

**Changes (`BountiesList`):**
- Mirror the `PRsList` shell: `<Card>` + `<WatchlistPortal>` toolbar + list/card view + load-more sentinel + same `IntersectionObserver` pagination (50 per batch).
- **Filter buttons:** All · Available · Pending · History — same grouping as the standalone `/bounties` page (`active` → available, `registered` → pending, `completed | cancelled` → history).
- **Search:** by repo full name, title, or issue number.
- **List view:** `<DataTable>` with sortable columns (Issue · Title · Repository · Bounty · Status · Updated · Star), repo avatar via `getRepositoryOwnerAvatarSrc`.
- **Card view:** reuses the existing shared `<BountyCard>` from `src/components/issues/BountyCard.tsx` — same component the standalone `/bounties` page renders. USD display wired via `usePrices()` (`taoPrice` / `alphaPrice`).

**Dead code removed** (only used by the old `BountiesList`):
- `WatchedItemRow` component + `WatchedItemRowProps` interface
- `StatusPill` component + `StatusPillProps` interface
- `rowSx`, `primaryTextSx`, `secondaryTextSx` style objects

## Test plan

**Issues tab**
- [ ] Watchlist → Issues → card view: grid scrolls inside the Card; load-more sentinel pinned at the bottom.
- [ ] Each `IssueCard` shows the same starred / miner / repo badges as `PRCard`.
- [ ] Repo avatar renders via `github.com/{owner}.png` (centralized helper).
- [ ] List view continues to show source badges in its column (unchanged).

**Bounties tab**
- [ ] Watchlist → Bounties: right-sidebar `WatchlistPortal` shows All / Available / Pending / History filter buttons with correct counts.
- [ ] Search field filters by repo / title / issue number.
- [ ] List view: sortable columns (Issue / Repository / Bounty / Status / Updated); row click navigates to `/bounties/details?id={id}`.
- [ ] Card view: `<BountyCard>` grid renders; USD display populates when prices are available.
- [ ] Infinite scroll loads 50 more rows when the sentinel is reached.
- [ ] Star button on a card removes the bounty from the watchlist (item disappears from the tab).
- [ ] No regression in Pull Requests / Repositories card views.


## Before

Issue Tab
<img width="1457" height="765" alt="Screenshot 2026-05-04 202205" src="https://github.com/user-attachments/assets/af60d686-7844-4dab-9cb1-7cc28696a71a" />

Bounty Tab
<img width="1906" height="912" alt="image" src="https://github.com/user-attachments/assets/dccf99e9-f3b9-43f9-a49d-1e2f81ceb80f" />

## After

Issue Tab
<img width="1699" height="854" alt="Screenshot 2026-05-04 201620" src="https://github.com/user-attachments/assets/f160ad78-853e-40c4-960d-750c686e8a91" />


Bounty Tab
<img width="1693" height="840" alt="image" src="https://github.com/user-attachments/assets/228472aa-b004-4d3b-bd54-1e7beff0454e" />
