### PR TITLE
fix: rename 'Leaderboard' tab to 'OSS Contributions' on TopMiners page

### DIFF
--- a/src/pages/TopMinersPage.tsx
+++ b/src/pages/TopMinersPage.tsx
@@ -21,7 +21,7 @@ type TimelineTab = 'oss' | 'discoveries';
 const TIMELINE_ORDER: readonly TimelineTab[] = ['oss', 'discoveries'] as const;
 
 const TIMELINE_LABELS: Record<TimelineTab, string> = {
-  oss: 'Leaderboard',
+  oss: 'OSS Contributions',
   discoveries: 'Discoveries',
 };
 
@@ -32,7 +32,7 @@ const parseTimeline = (raw: string | null): TimelineTab =>
 
 /* ─── Miner href helpers ──────────────────────────────────────── */
 
-const OSS_LINK_STATE = { backLabel: 'Back to Leaderboard' } as const;
+const OSS_LINK_STATE = { backLabel: 'Back to OSS Contributions' } as const;
 const DISC_LINK_STATE = { backLabel: 'Back to Discoveries' } as const;
 
 const getOssMinerHref = (miner: MinerStats) =>


### PR DESCRIPTION
Fixes #941

## Summary
- Renamed the timeline tab label from **'Leaderboard'** to **'OSS Contributions'** on the `/top-miners` page
- Updated the back-navigation label from `'Back to Leaderboard'` to `'Back to OSS Contributions'`

## Why
- The page itself is the leaderboard — using 'Leaderboard' as one of its sub-tabs is redundant
- 'OSS Contributions' accurately describes the content (OSS contribution rankings) and is parallel to the existing 'Discoveries' tab

## Changes
- `src/pages/TopMinersPage.tsx`:
  - `TIMELINE_LABELS.oss`: 'Leaderboard' → 'OSS Contributions'
  - `OSS_LINK_STATE.backLabel`: 'Back to Leaderboard' → 'Back to OSS Contributions'