### PR TITLE
fix: IssueDetailsPage mobile responsive layout

### DIFF
--- a/src/components/issues/IssueConversation.tsx
+++ b/src/components/issues/IssueConversation.tsx
@@ -92,15 +92,15 @@ const IssueConversation: React.FC<IssueConversationProps> = ({ issue }) => {
           key={item.id}
           sx={{
             display: 'flex',
-            gap: 2,
+            gap: { xs: 1.5, sm: 2 },    // tighter on mobile
             position: 'relative',
             zIndex: 1,
             '&::before': {
               content: index !== allItems.length - 1 ? '""' : 'none',
               position: 'absolute',
-              top: '40px',
+              top: { xs: '36px', sm: '40px' },
               bottom: '-24px',
-              left: '20px',
+              left: { xs: '16px', sm: '20px' },
               width: '2px',
               backgroundColor: colors.timeline.line,
               zIndex: 0,
@@ -118,10 +118,10 @@ const IssueConversation: React.FC<IssueConversationProps> = ({ issue }) => {
                 src={item.user.avatarUrl}
                 alt={item.user.login ?? undefined}
                 sx={{
-                  width: 40,
-                  height: 40,
+                  width: { xs: 32, sm: 40 },    // smaller on mobile
+                  height: { xs: 32, sm: 40 },
                   border: `1px solid ${theme.palette.border.light}`,
-                  backgroundColor: theme.palette.background.paper, // Avoid transparency issues over the line
+                  backgroundColor: theme.palette.background.paper,
                 }}
               />
             </Link>
@@ -155,8 +155,8 @@ const IssueConversation: React.FC<IssueConversationProps> = ({ issue }) => {
             {/* Header */}
             <Box
               sx={{
-                px: 2,
-                py: 1.5, // Slightly more vertical padding
+                px: { xs: 1.5, sm: 2 },
+                py: { xs: 1, sm: 1.5 },
                 backgroundColor: colors.canvas.subtle,
                 borderBottom: `1px solid ${colors.border.default}`,
                 borderTopLeftRadius: '6px',
@@ -165,9 +165,9 @@ const IssueConversation: React.FC<IssueConversationProps> = ({ issue }) => {
                 alignItems: 'center',
                 justifyContent: 'space-between',
                 color: colors.fg.muted,
-                fontSize: '14px',
+                fontSize: { xs: '12px', sm: '14px' },
                 position: 'relative',
-                zIndex: 1, // Ensure above the arrow pseudo-element's main body
+                zIndex: 1,
               }}
             >
               <Box

--- a/src/components/issues/IssueHeaderCard.tsx
+++ b/src/components/issues/IssueHeaderCard.tsx
@@ -38,7 +38,7 @@ const IssueHeaderCard: React.FC<IssueHeaderCardProps> = ({ issue }) => {
         backgroundColor: 'background.default',
         border: `1px solid ${theme.palette.border.light}`,
         borderRadius: 3,
-        p: 3,
+        p: { xs: 2, sm: 3 },    // responsive padding
       }}
       elevation={0}
     >
@@ -90,9 +90,10 @@ const IssueHeaderCard: React.FC<IssueHeaderCardProps> = ({ issue }) => {
             sx={{
               fontFamily:
                 '-apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif',
-              fontSize: '1.5rem',
+              fontSize: { xs: '1.15rem', sm: '1.5rem' },  // smaller on mobile
               fontWeight: 600,
               color: 'text.primary',
+              wordBreak: 'break-word',
             }}
           >
             {issue.title}
@@ -102,10 +103,10 @@ const IssueHeaderCard: React.FC<IssueHeaderCardProps> = ({ issue }) => {
         {/* Bounty and metadata row */}
         <Box
           sx={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: 3,
-            flexWrap: 'wrap',
+            display: 'grid',
+            gridTemplateColumns: { xs: 'repeat(2, 1fr)', sm: 'auto' },
+            gap: { xs: 2, sm: 3 },
+            alignItems: 'start',
           }}
         >
           <Box>

--- a/src/components/issues/IssueSubmissionsTable.tsx
+++ b/src/components/issues/IssueSubmissionsTable.tsx
@@ -173,6 +173,7 @@ const IssueSubmissionsTable: React.FC<IssueSubmissionsTableProps> = ({
         <DataTable
           columns={columns}
           rows={submissions ?? []}
+          minWidth={600}
           getRowKey={(submission) =>
             `${submission.repositoryFullName}-${submission.number}`
           }

--- a/src/pages/IssueDetailsPage.tsx
+++ b/src/pages/IssueDetailsPage.tsx
@@ -106,12 +106,18 @@ const IssueDetailsPage: React.FC = () => {
               sx={(theme) => ({
                 borderBottom: 1,
                 borderColor: theme.palette.border.light,
+                overflowX: 'auto',       // allow horizontal scroll on narrow viewports
+                WebkitOverflowScrolling: 'touch',
+                '&::-webkit-scrollbar': { display: 'none' },
+                scrollbarWidth: 'none',
               })}
             >
               <Tabs
                 value={tabValue}
                 onChange={handleTabChange}
                 aria-label="issue details tabs"
+                variant="scrollable"     // MUI built-in scrollable tabs
+                scrollButtons="auto"
                 sx={(theme) => ({
                   '& .MuiTab-root': {
                     color: STATUS_COLORS.open,


### PR DESCRIPTION
Fixes #939

## Summary
Multiple layout and readability fixes for the Issue Details page on mobile viewports.

## Changes

### Tabs (IssueDetailsPage.tsx)
- Added `variant='scrollable'` + `scrollButtons='auto'` to MUI Tabs so all tabs remain reachable on narrow viewports
- Added overflowX:auto with hidden scrollbar for smooth swipe

### Header Card (IssueHeaderCard.tsx)
- Responsive padding: `p: { xs: 2, sm: 3 }`
- Smaller title on mobile: `fontSize: { xs: '1.15rem', sm: '1.5rem' }` with `wordBreak: 'break-word'`
- Metadata row changed from flex to CSS grid: 2-column on mobile, auto on sm+

### Conversation (IssueConversation.tsx)
- Avatar scales down: `32px` on xs, `40px` on sm
- Tighter gap and header padding on mobile
- Font size adapts: `12px` xs, `14px` sm
- Timeline line position adjusts for smaller avatar

### Submissions Table (IssueSubmissionsTable.tsx)
- Set `minWidth=600` so columns don't compress to unreadable widths