### PR TITLE
fix: persist filter and tab state on back-navigation (#871)

### DIFF
--- a/src/components/miners/MinerOpenDiscoveryIssuesByRepo.tsx
+++ b/src/components/miners/MinerOpenDiscoveryIssuesByRepo.tsx
@@ -32,9 +32,14 @@ import {
   selectMinerIssueScanRepos,
   useMinerRepositoriesOpenIssues,
 } from '../../hooks/useMinerRepositoriesOpenIssues';
+import {
+  useSessionStoredState,
+  oneOf,
+} from '../../hooks/useSessionStoredState';
 import { type RepositoryIssue } from '../../api/models/Miner';
 
 type IssueFilter = 'all' | 'open' | 'solved' | 'closed';
+const isIssueFilter = oneOf(['all', 'open', 'solved', 'closed'] as const);
 type IssueSortField = 'number' | 'repository' | 'opened';
 type SortDir = 'asc' | 'desc';
 
@@ -223,14 +228,22 @@ const MinerOpenDiscoveryIssuesByRepo: React.FC<
     useMinerGithubData(githubId);
 
   // Mine section state
-  const [mineFilter, setMineFilter] = useState<IssueFilter>('all');
+  const [mineFilter, setMineFilter] = useSessionStoredState<IssueFilter>(
+    'miner:openIssues:mineFilter',
+    'all',
+    isIssueFilter,
+  );
   const [mineSearch, setMineSearch] = useState('');
   const [mineSortField, setMineSortField] = useState<IssueSortField>('opened');
   const [mineSortDir, setMineSortDir] = useState<SortDir>('desc');
   const [minePage, setMinePage] = useState(0);
 
   // Other section state
-  const [otherFilter, setOtherFilter] = useState<IssueFilter>('all');
+  const [otherFilter, setOtherFilter] = useSessionStoredState<IssueFilter>(
+    'miner:openIssues:otherFilter',
+    'all',
+    isIssueFilter,
+  );
   const [otherSearch, setOtherSearch] = useState('');
   const [otherSortField, setOtherSortField] =
     useState<IssueSortField>('opened');

--- a/src/components/repositories/RepositoryContributorsTable.tsx
+++ b/src/components/repositories/RepositoryContributorsTable.tsx
@@ -16,12 +16,17 @@ import { STATUS_COLORS } from '../../theme';
 import { isMergedPr } from '../../utils/prStatus';
 import { parseNumber } from '../../utils/ExplorerUtils';
 import { DataTable, type DataTableColumn } from '../common/DataTable';
+import {
+  useSessionStoredState,
+  oneOf,
+} from '../../hooks/useSessionStoredState';
 
 interface RepositoryContributorsTableProps {
   repositoryFullName: string;
 }
 
 type ContributorsProgramTab = 'oss' | 'issues';
+const isContributorsProgramTab = oneOf(['oss', 'issues'] as const);
 
 interface ContributorRow {
   rank: number;
@@ -50,7 +55,12 @@ const RepositoryContributorsTable: React.FC<
   const { data: allMinersStats, isLoading: isMinersLoading } = useAllMiners();
 
   const [visibleCount, setVisibleCount] = useState(7);
-  const [programTab, setProgramTab] = useState<ContributorsProgramTab>('oss');
+  const [programTab, setProgramTab] =
+    useSessionStoredState<ContributorsProgramTab>(
+      'repository:contributors:programTab',
+      'oss',
+      isContributorsProgramTab,
+    );
 
   useEffect(() => {
     setVisibleCount(7);

--- a/src/components/repositories/RepositoryIssuesTable.tsx
+++ b/src/components/repositories/RepositoryIssuesTable.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import {
   Box,
   Card,
@@ -30,10 +30,17 @@ import {
 } from '../../utils/issueStatus';
 import { STATUS_COLORS, TEXT_OPACITY, scrollbarSx } from '../../theme';
 import FilterButton from '../FilterButton';
+import {
+  useSessionStoredState,
+  oneOf,
+} from '../../hooks/useSessionStoredState';
 
 interface RepositoryIssuesTableProps {
   repositoryFullName: string;
 }
+
+type RepoIssueFilter = 'all' | 'open' | 'closed';
+const isRepoIssueFilter = oneOf(['all', 'open', 'closed'] as const);
 
 const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
   repositoryFullName,
@@ -41,7 +48,11 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
   const theme = useTheme();
   const { data: issues, isLoading } = useRepositoryIssues(repositoryFullName);
   const { data: bounties } = useRepoIssues(repositoryFullName);
-  const [filter, setFilter] = useState<'all' | 'open' | 'closed'>('all');
+  const [filter, setFilter] = useSessionStoredState<RepoIssueFilter>(
+    'repository:issues:filter',
+    'all',
+    isRepoIssueFilter,
+  );
 
   const counts = useMemo(() => {
     if (!issues) return { total: 0, open: 0, closed: 0 };

--- a/src/hooks/useSessionStoredState.ts
+++ b/src/hooks/useSessionStoredState.ts
@@ -1,0 +1,54 @@
+import {
+  useCallback,
+  useState,
+  type Dispatch,
+  type SetStateAction,
+} from 'react';
+
+// Builds a type guard from a readonly tuple of allowed string literals.
+// Pair with `useSessionStoredState` so a stale value from an older build
+// (e.g. a removed filter option) falls back to the default cleanly.
+export const oneOf =
+  <T extends string>(values: readonly T[]) =>
+  (v: unknown): v is T =>
+    typeof v === 'string' && (values as readonly string[]).includes(v);
+
+// useState backed by sessionStorage. Persists across in-tab navigation
+// (detail page → browser Back) without surviving a tab close. The type guard
+// runs against parsed JSON so stale values from older builds fall back to
+// `fallback` instead of corrupting typed state.
+export function useSessionStoredState<T>(
+  key: string,
+  fallback: T,
+  isValid: (value: unknown) => value is T,
+): [T, Dispatch<SetStateAction<T>>] {
+  const [value, setValue] = useState<T>(() => {
+    try {
+      const raw = window.sessionStorage.getItem(key);
+      if (raw === null) return fallback;
+      const parsed: unknown = JSON.parse(raw);
+      return isValid(parsed) ? parsed : fallback;
+    } catch {
+      return fallback;
+    }
+  });
+
+  const set = useCallback<Dispatch<SetStateAction<T>>>(
+    (next) => {
+      setValue((prev) => {
+        const resolved =
+          typeof next === 'function' ? (next as (p: T) => T)(prev) : next;
+        try {
+          window.sessionStorage.setItem(key, JSON.stringify(resolved));
+        } catch {
+          // sessionStorage unavailable (private mode, quota, etc.) — keep
+          // in-memory state and continue without persistence.
+        }
+        return resolved;
+      });
+    },
+    [key],
+  );
+
+  return [value, set];
+}

--- a/src/pages/IssueDetailsPage.tsx
+++ b/src/pages/IssueDetailsPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { useSearchParams, useNavigate } from 'react-router-dom';
 import {
   Box,
@@ -16,6 +16,7 @@ import {
   IssueConversation,
 } from '../components/issues';
 import { useIssueDetails, useIssueSubmissions } from '../api';
+import { useSessionStoredState } from '../hooks/useSessionStoredState';
 import { STATUS_COLORS } from '../theme';
 import ChatBubbleOutlineIcon from '@mui/icons-material/ChatBubbleOutline';
 import ListAltIcon from '@mui/icons-material/ListAlt';
@@ -25,7 +26,11 @@ const IssueDetailsPage: React.FC = () => {
   const navigate = useNavigate();
   const idParam = searchParams.get('id');
   const id = idParam ? parseInt(idParam, 10) : 0;
-  const [tabValue, setTabValue] = useState(0);
+  const [tabValue, setTabValue] = useSessionStoredState<number>(
+    'issue:detailsTab',
+    0,
+    (v): v is number => v === 0 || v === 1,
+  );
 
   const { data: issue, isLoading: isLoadingDetails } = useIssueDetails(id);
   const { data: submissions, isLoading: isLoadingSubmissions } =

--- a/src/pages/PRDetailsPage.tsx
+++ b/src/pages/PRDetailsPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { useSearchParams, useNavigate } from 'react-router-dom';
 import { Box, Tabs, Tab, CircularProgress, Typography } from '@mui/material';
 import { Page } from '../components/layout';
@@ -13,6 +13,7 @@ import {
 } from '../components';
 import { usePullRequestDetails } from '../api';
 import { serializePRKey } from '../hooks/useWatchlist';
+import { useSessionStoredState } from '../hooks/useSessionStoredState';
 import { STATUS_COLORS } from '../theme';
 import VisibilityIcon from '@mui/icons-material/Visibility';
 import CodeIcon from '@mui/icons-material/Code';
@@ -23,7 +24,11 @@ const PRDetailsPage: React.FC = () => {
   const navigate = useNavigate();
   const repository = searchParams.get('repo');
   const pullRequestNumber = searchParams.get('number');
-  const [tabValue, setTabValue] = useState(0);
+  const [tabValue, setTabValue] = useSessionStoredState<number>(
+    'pr:detailsTab',
+    0,
+    (v): v is number => v === 0 || v === 1 || v === 2,
+  );
 
   // Call hook unconditionally (React rules of hooks)
   const { data: prDetails, isLoading } = usePullRequestDetails(

--- a/src/pages/WatchlistPage.tsx
+++ b/src/pages/WatchlistPage.tsx
@@ -78,6 +78,7 @@ import {
   type WatchlistCategory,
 } from '../hooks/useWatchlist';
 import { useWatchedPRs, type WatchedPRSource } from '../hooks/useWatchedPRs';
+import { useSessionStoredState, oneOf } from '../hooks/useSessionStoredState';
 import {
   isMergedPr,
   isClosedUnmergedPr,
@@ -1418,7 +1419,12 @@ const ReposList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
   const { data: repos } = useReposAndWeights();
   const { data: allPrs } = useAllPrs();
   const [searchQuery, setSearchQuery] = useState('');
-  const [statusFilter, setStatusFilter] = useState<RepoStatusFilter>('all');
+  const [statusFilter, setStatusFilter] =
+    useSessionStoredState<RepoStatusFilter>(
+      'watchlist:repos:statusFilter',
+      'all',
+      oneOf(['all', 'active', 'inactive'] as const),
+    );
   const [viewMode, setViewMode] = useWatchlistViewMode();
   const [showChart, setShowChart] = useState(false);
   const [useLogScale, setUseLogScale] = useState(false);
@@ -2468,7 +2474,11 @@ const PRsList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
   const prColumns = useMemo(() => buildPrColumns(sourcesByKey), [sourcesByKey]);
   const { isWatched } = useWatchlist('prs');
   const [searchQuery, setSearchQuery] = useState('');
-  const [statusFilter, setStatusFilter] = useState<PrStatusFilter>('all');
+  const [statusFilter, setStatusFilter] = useSessionStoredState<PrStatusFilter>(
+    'watchlist:prs:statusFilter',
+    'all',
+    oneOf(['all', 'open', 'merged', 'closed'] as const),
+  );
   const [viewMode, setViewMode] = useWatchlistViewMode();
   const [page, setPage] = useState(0);
   const observerTarget = useRef<HTMLDivElement>(null);
@@ -3259,7 +3269,12 @@ const IssuesList: React.FC<{ minerIds: string[] }> = ({ minerIds }) => {
   }, [issueQueries]);
 
   const [searchQuery, setSearchQuery] = useState('');
-  const [statusFilter, setStatusFilter] = useState<IssueStatusFilter>('all');
+  const [statusFilter, setStatusFilter] =
+    useSessionStoredState<IssueStatusFilter>(
+      'watchlist:issues:statusFilter',
+      'all',
+      oneOf(ISSUE_STATUS_FILTERS),
+    );
   const [viewMode, setViewMode] = useWatchlistViewMode();
   const [page, setPage] = useState(0);
   const observerTarget = useRef<HTMLDivElement>(null);


### PR DESCRIPTION
## Summary

Closes #871. Filter and inner-tab selections across several pages were stored in local `useState`, so navigating to a detail page and pressing browser **Back** silently reset them to the default. This swaps those call sites onto a shared `sessionStorage`-backed hook so selections survive the unmount/remount cycle but still reset when the tab is closed.

- New shared hook: `src/hooks/useSessionStoredState.ts` — `useState`-shaped API backed by `sessionStorage`, with a type-guard parameter so stale values from older builds fall back to the default safely.
- Replaced `useState` with `useSessionStoredState` at every call site listed in the issue, using the existing `feature:field` storage-key convention.

## Call sites converted

| Location | Storage key |
|---|---|
| Watchlist → Repos status filter | `watchlist:repos:statusFilter` |
| Watchlist → PRs status filter | `watchlist:prs:statusFilter` |
| Miner profile → Open Issues "Mine" filter | `miner:openIssues:mineFilter` |
| Miner profile → Open Issues "Others" filter | `miner:openIssues:otherFilter` |
| Repository → Contributors program toggle | `repository:contributors:programTab` |
| Repository → Issues filter | `repository:issues:filter` |
| PR details inner tab | `pr:detailsTab` |
| Issue details inner tab | `issue:detailsTab` |

`MinerIssuesTable.tsx` was intentionally left alone — it already persists via URL search params.

## Test plan

For each row above: set a non-default filter/tab → click an item → press browser **Back** → confirm the selection is retained.

- [ ] Watchlist → Repos: select **Active** → open a repo → Back → still **Active**
- [ ] Watchlist → PRs: select **Merged** → open a PR → Back → still **Merged**
- [ ] Miner profile → Open Issues: change **Mine** + **Others** filters → open an issue → Back → both retained
- [ ] Repository → Contributors: switch to **Issue Discovery** → open a miner → Back → still on **Issue Discovery**
- [ ] Repository → Issues: select **Closed** → open an issue → Back → still **Closed**
- [ ] PR details: switch to **Files** or **Conversation** tab → open another PR → Back → tab retained
- [ ] Issue details: switch to **Submissions** tab → open another issue → Back → tab retained
- [ ] Close the tab and reopen the app → all selections reset to defaults (sessionStorage scope)
- [ ] `npm run build` and `npm run lint` pass
