### PR TITLE
feat(repositories): right sidebar filters align with Watchlist/Leaderboard

### DIFF
--- a/src/components/FilterButton.tsx
+++ b/src/components/FilterButton.tsx
@@ -46,7 +46,11 @@ const FilterButton: React.FC<FilterButtonProps> = ({
         : fullWidth
           ? '1px solid'
           : '1px solid transparent',
-      borderColor: isActive ? undefined : fullWidth ? 'border.light' : undefined,
+      borderColor: isActive
+        ? undefined
+        : fullWidth
+          ? 'border.light'
+          : undefined,
       justifyContent: fullWidth ? 'space-between' : undefined,
       '&:hover': {
         backgroundColor: 'border.light',

--- a/src/components/FilterButton.tsx
+++ b/src/components/FilterButton.tsx
@@ -8,6 +8,8 @@ interface FilterButtonProps {
   count?: number;
   color: string;
   activeTextColor?: string;
+  /** Full-width row (e.g. sidebar Filters); inactive rows get a light outline for even hit-targets. */
+  fullWidth?: boolean;
 }
 
 const FilterButton: React.FC<FilterButtonProps> = ({
@@ -17,19 +19,35 @@ const FilterButton: React.FC<FilterButtonProps> = ({
   count,
   color,
   activeTextColor = 'text.primary',
+  fullWidth = false,
 }) => (
   <Button
     size="small"
+    fullWidth={fullWidth}
     onClick={onClick}
     sx={{
-      color: isActive ? activeTextColor : 'text.tertiary',
-      backgroundColor: isActive ? 'border.subtle' : 'transparent',
+      color: isActive
+        ? activeTextColor
+        : fullWidth
+          ? 'text.secondary'
+          : 'text.tertiary',
+      backgroundColor: isActive
+        ? 'border.subtle'
+        : fullWidth
+          ? 'surface.subtle'
+          : 'transparent',
       borderRadius: '6px',
-      px: 2,
+      px: fullWidth ? 1.5 : 2,
       minWidth: 'auto',
       textTransform: 'none',
       fontSize: '0.8rem',
-      border: isActive ? `1px solid ${color}` : '1px solid transparent',
+      border: isActive
+        ? `1px solid ${color}`
+        : fullWidth
+          ? '1px solid'
+          : '1px solid transparent',
+      borderColor: isActive ? undefined : fullWidth ? 'border.light' : undefined,
+      justifyContent: fullWidth ? 'space-between' : undefined,
       '&:hover': {
         backgroundColor: 'border.light',
       },

--- a/src/components/common/TabsOptionsPortal.tsx
+++ b/src/components/common/TabsOptionsPortal.tsx
@@ -1,0 +1,315 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Box,
+  Collapse,
+  Divider,
+  InputAdornment,
+  Popover,
+  Portal,
+  Stack,
+  TextField,
+  Tooltip,
+  Typography,
+  alpha,
+  useMediaQuery,
+} from '@mui/material';
+import SearchIcon from '@mui/icons-material/Search';
+import TuneOutlinedIcon from '@mui/icons-material/TuneOutlined';
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+import theme from '../../theme';
+
+/** Section header inside tabs-options sidebar / popover. */
+export const TabsOptionsLabel: React.FC<{
+  children: React.ReactNode;
+  /** When false, omits bottom margin (e.g. paired headings on one line). */
+  gutterBottom?: boolean;
+}> = ({ children, gutterBottom = true }) => (
+  <Typography
+    sx={(t) => ({
+      fontFamily: '"JetBrains Mono", monospace',
+      fontSize: '0.72rem',
+      fontWeight: 600,
+      color: alpha(t.palette.text.secondary, 0.95),
+      textTransform: 'uppercase',
+      letterSpacing: '0.06em',
+      mb: gutterBottom ? 1.25 : 0,
+      lineHeight: 1.3,
+    })}
+  >
+    {children}
+  </Typography>
+);
+
+export interface TabsOptionsPortalProps {
+  filterContent: React.ReactNode;
+  extraContent?: React.ReactNode;
+  searchValue: string;
+  searchPlaceholder: string;
+  onSearchChange: (v: string) => void;
+  /** Optional handlers on the search field (e.g. Enter to navigate). */
+  onSearchKeyDown?: React.KeyboardEventHandler<HTMLInputElement>;
+  viewMode: string;
+  onViewModeChange: (v: any) => void;
+  viewModeToggle: React.ReactNode;
+  hasActiveFilter: boolean;
+  /**
+   * When true, skip the built-in “View” heading — pass headings + controls inside `viewModeToggle`
+   * (e.g. View | Chart titles on one line with controls below).
+   */
+  viewSlotIncludesHeading?: boolean;
+}
+
+/** Sidebar panel on xl (`#tabs-options-portal`); compact Options popover otherwise. */
+export const TabsOptionsPortal: React.FC<TabsOptionsPortalProps> = (props) => {
+  const [target, setTarget] = useState<HTMLElement | null>(null);
+  const isLargeScreen = useMediaQuery(theme.breakpoints.up('xl'));
+
+  useEffect(() => {
+    setTarget(document.getElementById('tabs-options-portal'));
+  }, []);
+
+  if (target && isLargeScreen) {
+    return (
+      <Portal container={target}>
+        <TabsOptionsSidebarPanel {...props} />
+      </Portal>
+    );
+  }
+
+  return (
+    <Box
+      sx={{
+        p: 1.5,
+        display: 'flex',
+        justifyContent: 'flex-end',
+        borderBottom: '1px solid',
+        borderColor: 'border.light',
+      }}
+    >
+      <TabsOptionsPopoverButton {...props} />
+    </Box>
+  );
+};
+
+const TabsOptionsSidebarPanel: React.FC<TabsOptionsPortalProps> = (props) => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Box>
+      <Box
+        component="button"
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        sx={(t) => ({
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          width: '100%',
+          border: 0,
+          background: 'none',
+          cursor: 'pointer',
+          p: 0,
+          color: t.palette.text.primary,
+        })}
+      >
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
+          <TuneOutlinedIcon
+            sx={{ fontSize: '1rem', color: 'text.secondary' }}
+          />
+          <Typography
+            sx={{
+              fontFamily: '"JetBrains Mono", monospace',
+              fontSize: '0.8rem',
+              fontWeight: 600,
+            }}
+          >
+            Filters
+          </Typography>
+          {props.hasActiveFilter && (
+            <Box
+              component="span"
+              sx={{
+                width: 6,
+                height: 6,
+                borderRadius: '50%',
+                backgroundColor: 'status.info',
+              }}
+            />
+          )}
+        </Box>
+        <KeyboardArrowDownIcon
+          sx={{
+            fontSize: '1.1rem',
+            color: 'text.secondary',
+            transform: open ? 'rotate(-180deg)' : 'none',
+            transition: 'transform 0.2s ease',
+          }}
+        />
+      </Box>
+      <Collapse in={open}>
+        <Box sx={{ pt: 2 }}>
+          <TabsOptionsSidebarPanelContent {...props} />
+        </Box>
+      </Collapse>
+    </Box>
+  );
+};
+
+const tabsOptionsDivider = (
+  <Divider
+    sx={{
+      borderColor: 'border.subtle',
+      opacity: 1,
+    }}
+  />
+);
+
+const TabsOptionsSidebarPanelContent: React.FC<TabsOptionsPortalProps> = ({
+  filterContent,
+  extraContent,
+  searchValue,
+  searchPlaceholder,
+  onSearchChange,
+  onSearchKeyDown,
+  viewModeToggle,
+  viewSlotIncludesHeading = false,
+}) => (
+  <Stack spacing={2.25} divider={tabsOptionsDivider} sx={{ width: '100%' }}>
+    <Box>
+      <TabsOptionsLabel>Filter</TabsOptionsLabel>
+      {filterContent}
+    </Box>
+
+    <Box>
+      <TabsOptionsLabel>Search</TabsOptionsLabel>
+      <TextField
+        placeholder={searchPlaceholder}
+        size="small"
+        value={searchValue}
+        onChange={(e) => onSearchChange(e.target.value)}
+        onKeyDown={onSearchKeyDown}
+        InputProps={{
+          startAdornment: (
+            <InputAdornment position="start">
+              <SearchIcon sx={{ color: 'text.tertiary', fontSize: '1rem' }} />
+            </InputAdornment>
+          ),
+        }}
+        sx={{
+          width: '100%',
+          '& .MuiOutlinedInput-root': {
+            color: 'text.primary',
+            backgroundColor: 'background.default',
+            fontSize: '0.8rem',
+            height: '34px',
+            borderRadius: 2,
+            '& fieldset': { borderColor: 'border.light' },
+            '&:hover fieldset': { borderColor: 'border.medium' },
+            '&.Mui-focused fieldset': { borderColor: 'primary.main' },
+          },
+        }}
+      />
+    </Box>
+
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0 }}>
+      {!viewSlotIncludesHeading ? (
+        <TabsOptionsLabel>View</TabsOptionsLabel>
+      ) : null}
+      {viewModeToggle}
+    </Box>
+
+    {extraContent != null ? (
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+        {extraContent}
+      </Box>
+    ) : null}
+  </Stack>
+);
+
+const TabsOptionsPopoverButton: React.FC<TabsOptionsPortalProps> = (props) => {
+  const { hasActiveFilter } = props;
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+  const open = Boolean(anchorEl);
+
+  return (
+    <>
+      <Tooltip title="Options" arrow>
+        <Box
+          component="button"
+          type="button"
+          onClick={(e) =>
+            setAnchorEl((prev) => (prev ? null : e.currentTarget))
+          }
+          sx={(t) => ({
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 0.75,
+            px: 1.25,
+            py: 0.5,
+            minHeight: 32,
+            borderRadius: 2,
+            border: `1px solid ${t.palette.border.light}`,
+            backgroundColor: open
+              ? alpha(t.palette.text.primary, 0.06)
+              : 'transparent',
+            cursor: 'pointer',
+            transition: 'all 0.15s',
+            '&:hover': {
+              backgroundColor: alpha(t.palette.text.primary, 0.04),
+              borderColor: t.palette.border.medium,
+            },
+          })}
+        >
+          <TuneOutlinedIcon
+            sx={{ fontSize: '1rem', color: 'text.secondary' }}
+          />
+          <Typography
+            component="span"
+            sx={{
+              fontFamily: '"JetBrains Mono", monospace',
+              fontSize: '0.72rem',
+              fontWeight: 600,
+              color: 'text.secondary',
+            }}
+          >
+            Options
+          </Typography>
+          {hasActiveFilter && (
+            <Box
+              component="span"
+              sx={{
+                width: 6,
+                height: 6,
+                borderRadius: '50%',
+                backgroundColor: 'status.info',
+              }}
+            />
+          )}
+        </Box>
+      </Tooltip>
+
+      <Popover
+        open={open}
+        anchorEl={anchorEl}
+        onClose={() => setAnchorEl(null)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+        transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+        slotProps={{
+          paper: {
+            sx: (t) => ({
+              mt: 1,
+              p: 2.5,
+              minWidth: 300,
+              borderRadius: 3,
+              border: `1px solid ${t.palette.border.light}`,
+              backgroundColor: t.palette.background.default,
+              backgroundImage: 'none',
+            }),
+          },
+        }}
+      >
+        <TabsOptionsSidebarPanelContent {...props} />
+      </Popover>
+    </>
+  );
+};

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -2,3 +2,4 @@ export * from './SearchInput';
 export * from './linkBehavior';
 export * from './WatchlistButton';
 export * from './DataTable';
+export * from './TabsOptionsPortal';

--- a/src/components/leaderboard/ActivitySidebarCards.tsx
+++ b/src/components/leaderboard/ActivitySidebarCards.tsx
@@ -10,13 +10,25 @@ import { useEligibilityFilteredMiners } from './useEligibilityFilteredMiners';
 interface ActivitySidebarCardsProps {
   miners: MinerStats[];
   defaultFilter?: 'eligible' | 'all';
-  /** Content to insert between the Miners Activity card and the rest. */
+  /** When false, omits the "Miners Activity" card (e.g. Repositories sidebar). Portal slot still renders first when set. */
+  showMinersActivity?: boolean;
+  /** When false, omits Total $/day on PR/Issue cards and Avg Credibility on Code Impact. */
+  showUsdPerDayAndCredibility?: boolean;
+  /** When false, omits the entire "Code Impact" card. */
+  showCodeImpact?: boolean;
+  /** When false, omits Merge Rate (PR) and Solve Rate (Issue) rows. */
+  showMergeAndSolveRates?: boolean;
+  /** Content to insert between the Miners Activity card (or sidebar top when Miners omitted) and the rest. */
   insertAfterFirstCard?: React.ReactNode;
 }
 
 export const ActivitySidebarCards: React.FC<ActivitySidebarCardsProps> = ({
   miners: allMiners,
   defaultFilter = 'eligible',
+  showMinersActivity = true,
+  showUsdPerDayAndCredibility = true,
+  showCodeImpact = true,
+  showMergeAndSolveRates = true,
   insertAfterFirstCard,
 }) => {
   const miners = useEligibilityFilteredMiners(allMiners, defaultFilter);
@@ -76,6 +88,14 @@ export const ActivitySidebarCards: React.FC<ActivitySidebarCardsProps> = ({
   }, [miners]);
 
   const codeStats = useMemo(() => {
+    if (!showCodeImpact) {
+      return {
+        linesAdded: 0,
+        linesDeleted: 0,
+        reposTouched: 0,
+        avgCredibility: 0,
+      };
+    }
     const linesAdded = miners.reduce((acc, m) => acc + (m.linesAdded || 0), 0);
     const linesDeleted = miners.reduce(
       (acc, m) => acc + (m.linesDeleted || 0),
@@ -97,7 +117,7 @@ export const ActivitySidebarCards: React.FC<ActivitySidebarCardsProps> = ({
           )
         : 0;
     return { linesAdded, linesDeleted, reposTouched, avgCredibility };
-  }, [miners]);
+  }, [miners, showCodeImpact]);
 
   const solveRateColor =
     issueStats.solveRate >= 80
@@ -113,73 +133,77 @@ export const ActivitySidebarCards: React.FC<ActivitySidebarCardsProps> = ({
         ? CREDIBILITY_COLORS.moderate
         : STATUS_COLORS.closed;
 
+  const showMetricsFooterDivider =
+    showMergeAndSolveRates || showUsdPerDayAndCredibility;
+
   return (
     <>
-      {/* CARD 1: Miners Activity */}
-      <SectionCard title="Miners Activity" sx={{ flexShrink: 0 }}>
-        <Box sx={{ px: 2, pt: 1, pb: 2 }}>
-          <Box
-            sx={(theme) => ({
-              display: 'grid',
-              gridTemplateColumns: '1fr 1fr 1fr',
-              gap: 1,
-              alignItems: 'center',
-              pb: 1.5,
-              borderBottom: `1px solid ${theme.palette.border.light}`,
-              mb: 1.5,
-            })}
-          >
-            <Typography
-              sx={{
-                fontFamily: FONTS.mono,
-                fontSize: '0.7rem',
-                color: STATUS_COLORS.open,
-                textTransform: 'uppercase',
-              }}
+      {showMinersActivity ? (
+        <SectionCard title="Miners Activity" sx={{ flexShrink: 0 }}>
+          <Box sx={{ px: 2, pt: 1, pb: 2 }}>
+            <Box
+              sx={(theme) => ({
+                display: 'grid',
+                gridTemplateColumns: '1fr 1fr 1fr',
+                gap: 1,
+                alignItems: 'center',
+                pb: 1.5,
+                borderBottom: `1px solid ${theme.palette.border.light}`,
+                mb: 1.5,
+              })}
             >
-              &nbsp;
-            </Typography>
-            <Typography
-              sx={{
-                fontFamily: FONTS.mono,
-                fontSize: '0.7rem',
-                color: STATUS_COLORS.open,
-                textTransform: 'uppercase',
-                textAlign: 'center',
-              }}
-            >
-              PR
-            </Typography>
-            <Typography
-              sx={{
-                fontFamily: FONTS.mono,
-                fontSize: '0.7rem',
-                color: STATUS_COLORS.open,
-                textTransform: 'uppercase',
-                textAlign: 'center',
-              }}
-            >
-              Issue
-            </Typography>
-          </Box>
+              <Typography
+                sx={{
+                  fontFamily: FONTS.mono,
+                  fontSize: '0.7rem',
+                  color: STATUS_COLORS.open,
+                  textTransform: 'uppercase',
+                }}
+              >
+                &nbsp;
+              </Typography>
+              <Typography
+                sx={{
+                  fontFamily: FONTS.mono,
+                  fontSize: '0.7rem',
+                  color: STATUS_COLORS.open,
+                  textTransform: 'uppercase',
+                  textAlign: 'center',
+                }}
+              >
+                PR
+              </Typography>
+              <Typography
+                sx={{
+                  fontFamily: FONTS.mono,
+                  fontSize: '0.7rem',
+                  color: STATUS_COLORS.open,
+                  textTransform: 'uppercase',
+                  textAlign: 'center',
+                }}
+              >
+                Issue
+              </Typography>
+            </Box>
 
-          <MinerActivityRow
-            label="All"
-            pr={minerActivityStats.all}
-            issue={minerActivityStats.all}
-          />
-          <MinerActivityRow
-            label="Eligible"
-            pr={minerActivityStats.eligiblePr}
-            issue={minerActivityStats.eligibleIssue}
-          />
-          <MinerActivityRow
-            label="Ineligible"
-            pr={minerActivityStats.ineligiblePr}
-            issue={minerActivityStats.ineligibleIssue}
-          />
-        </Box>
-      </SectionCard>
+            <MinerActivityRow
+              label="All"
+              pr={minerActivityStats.all}
+              issue={minerActivityStats.all}
+            />
+            <MinerActivityRow
+              label="Eligible"
+              pr={minerActivityStats.eligiblePr}
+              issue={minerActivityStats.eligibleIssue}
+            />
+            <MinerActivityRow
+              label="Ineligible"
+              pr={minerActivityStats.ineligiblePr}
+              issue={minerActivityStats.ineligibleIssue}
+            />
+          </Box>
+        </SectionCard>
+      ) : null}
 
       {/* Slot for injected content (e.g. options panel) */}
       {insertAfterFirstCard}
@@ -192,9 +216,13 @@ export const ActivitySidebarCards: React.FC<ActivitySidebarCardsProps> = ({
               display: 'grid',
               gridTemplateColumns: '1fr 1fr 1fr',
               gap: 1,
-              mb: 2,
-              pb: 2,
-              borderBottom: `1px solid ${theme.palette.border.light}`,
+              ...(showMetricsFooterDivider
+                ? {
+                    mb: 2,
+                    pb: 2,
+                    borderBottom: `1px solid ${theme.palette.border.light}`,
+                  }
+                : {}),
             })}
           >
             <PRColumn
@@ -214,44 +242,48 @@ export const ActivitySidebarCards: React.FC<ActivitySidebarCardsProps> = ({
             />
           </Box>
 
-          <Box
-            sx={{
-              display: 'flex',
-              justifyContent: 'space-between',
-              alignItems: 'center',
-            }}
-          >
-            <Typography
+          {showMergeAndSolveRates ? (
+            <Box
               sx={{
-                fontFamily: FONTS.mono,
-                fontSize: '0.85rem',
-                color: STATUS_COLORS.open,
+                display: 'flex',
+                justifyContent: 'space-between',
+                alignItems: 'center',
               }}
             >
-              Merge Rate
-            </Typography>
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
-              <RateBar rate={prStats.mergeRate} color={mergeRateColor} />
               <Typography
                 sx={{
                   fontFamily: FONTS.mono,
-                  fontWeight: 600,
-                  fontSize: '1.1rem',
-                  color: mergeRateColor,
-                  minWidth: 40,
-                  textAlign: 'right',
+                  fontSize: '0.85rem',
+                  color: STATUS_COLORS.open,
                 }}
               >
-                {prStats.mergeRate}%
+                Merge Rate
               </Typography>
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
+                <RateBar rate={prStats.mergeRate} color={mergeRateColor} />
+                <Typography
+                  sx={{
+                    fontFamily: FONTS.mono,
+                    fontWeight: 600,
+                    fontSize: '1.1rem',
+                    color: mergeRateColor,
+                    minWidth: 40,
+                    textAlign: 'right',
+                  }}
+                >
+                  {prStats.mergeRate}%
+                </Typography>
+              </Box>
             </Box>
-          </Box>
+          ) : null}
 
-          <StatRow
-            label="Total $/day"
-            value={`$${Math.round(ossUsdPerDay).toLocaleString()}`}
-            valueColor={STATUS_COLORS.merged}
-          />
+          {showUsdPerDayAndCredibility ? (
+            <StatRow
+              label="Total $/day"
+              value={`$${Math.round(ossUsdPerDay).toLocaleString()}`}
+              valueColor={STATUS_COLORS.merged}
+            />
+          ) : null}
         </Box>
       </SectionCard>
 
@@ -263,9 +295,13 @@ export const ActivitySidebarCards: React.FC<ActivitySidebarCardsProps> = ({
               display: 'grid',
               gridTemplateColumns: '1fr 1fr 1fr',
               gap: 1,
-              mb: 2,
-              pb: 2,
-              borderBottom: `1px solid ${theme.palette.border.light}`,
+              ...(showMetricsFooterDivider
+                ? {
+                    mb: 2,
+                    pb: 2,
+                    borderBottom: `1px solid ${theme.palette.border.light}`,
+                  }
+                : {}),
             })}
           >
             <PRColumn
@@ -285,110 +321,117 @@ export const ActivitySidebarCards: React.FC<ActivitySidebarCardsProps> = ({
             />
           </Box>
 
-          <Box
-            sx={{
-              display: 'flex',
-              justifyContent: 'space-between',
-              alignItems: 'center',
-            }}
-          >
-            <Typography
+          {showMergeAndSolveRates ? (
+            <Box
               sx={{
-                fontFamily: FONTS.mono,
-                fontSize: '0.85rem',
-                color: STATUS_COLORS.open,
+                display: 'flex',
+                justifyContent: 'space-between',
+                alignItems: 'center',
               }}
             >
-              Solve Rate
-            </Typography>
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
-              <RateBar rate={issueStats.solveRate} color={solveRateColor} />
               <Typography
                 sx={{
                   fontFamily: FONTS.mono,
-                  fontWeight: 600,
-                  fontSize: '1.1rem',
-                  color: solveRateColor,
-                  minWidth: 40,
-                  textAlign: 'right',
+                  fontSize: '0.85rem',
+                  color: STATUS_COLORS.open,
                 }}
               >
-                {issueStats.solveRate}%
+                Solve Rate
               </Typography>
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
+                <RateBar rate={issueStats.solveRate} color={solveRateColor} />
+                <Typography
+                  sx={{
+                    fontFamily: FONTS.mono,
+                    fontWeight: 600,
+                    fontSize: '1.1rem',
+                    color: solveRateColor,
+                    minWidth: 40,
+                    textAlign: 'right',
+                  }}
+                >
+                  {issueStats.solveRate}%
+                </Typography>
+              </Box>
             </Box>
-          </Box>
+          ) : null}
 
-          <StatRow
-            label="Total $/day"
-            value={`$${Math.round(issueUsdPerDay).toLocaleString()}`}
-            valueColor={STATUS_COLORS.merged}
-          />
+          {showUsdPerDayAndCredibility ? (
+            <StatRow
+              label="Total $/day"
+              value={`$${Math.round(issueUsdPerDay).toLocaleString()}`}
+              valueColor={STATUS_COLORS.merged}
+            />
+          ) : null}
         </Box>
       </SectionCard>
 
-      {/* CARD 4: Code Impact */}
-      <SectionCard title="Code Impact" sx={{ flexShrink: 0 }}>
-        <Box
-          sx={{
-            px: 2,
-            pt: 1,
-            pb: 2,
-            display: 'flex',
-            flexDirection: 'column',
-            gap: 2,
-          }}
-        >
-          <StatRow
-            label="Lines Added"
-            value={`+${codeStats.linesAdded.toLocaleString()}`}
-            valueColor={DIFF_COLORS.additions}
-          />
-          <StatRow
-            label="Lines Deleted"
-            value={`-${codeStats.linesDeleted.toLocaleString()}`}
-            valueColor={DIFF_COLORS.deletions}
-          />
-          <StatRow
-            label="Repos Touched"
-            value={codeStats.reposTouched.toLocaleString()}
-          />
+      {showCodeImpact ? (
+        <SectionCard title="Code Impact" sx={{ flexShrink: 0 }}>
           <Box
             sx={{
+              px: 2,
+              pt: 1,
+              pb: 2,
               display: 'flex',
-              justifyContent: 'space-between',
-              alignItems: 'center',
+              flexDirection: 'column',
+              gap: 2,
             }}
           >
-            <Typography
-              sx={{
-                fontFamily: FONTS.mono,
-                fontSize: '0.85rem',
-                color: STATUS_COLORS.open,
-              }}
-            >
-              Avg Credibility
-            </Typography>
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
-              <RateBar
-                rate={codeStats.avgCredibility}
-                color={credibilityColor(codeStats.avgCredibility / 100)}
-              />
-              <Typography
+            <StatRow
+              label="Lines Added"
+              value={`+${codeStats.linesAdded.toLocaleString()}`}
+              valueColor={DIFF_COLORS.additions}
+            />
+            <StatRow
+              label="Lines Deleted"
+              value={`-${codeStats.linesDeleted.toLocaleString()}`}
+              valueColor={DIFF_COLORS.deletions}
+            />
+            <StatRow
+              label="Repos Touched"
+              value={codeStats.reposTouched.toLocaleString()}
+            />
+            {showUsdPerDayAndCredibility ? (
+              <Box
                 sx={{
-                  fontFamily: FONTS.mono,
-                  fontWeight: 600,
-                  fontSize: '1.1rem',
-                  color: credibilityColor(codeStats.avgCredibility / 100),
-                  minWidth: 40,
-                  textAlign: 'right',
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  alignItems: 'center',
                 }}
               >
-                {codeStats.avgCredibility}%
-              </Typography>
-            </Box>
+                <Typography
+                  sx={{
+                    fontFamily: FONTS.mono,
+                    fontSize: '0.85rem',
+                    color: STATUS_COLORS.open,
+                  }}
+                >
+                  Avg Credibility
+                </Typography>
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
+                  <RateBar
+                    rate={codeStats.avgCredibility}
+                    color={credibilityColor(codeStats.avgCredibility / 100)}
+                  />
+                  <Typography
+                    sx={{
+                      fontFamily: FONTS.mono,
+                      fontWeight: 600,
+                      fontSize: '1.1rem',
+                      color: credibilityColor(codeStats.avgCredibility / 100),
+                      minWidth: 40,
+                      textAlign: 'right',
+                    }}
+                  >
+                    {codeStats.avgCredibility}%
+                  </Typography>
+                </Box>
+              </Box>
+            ) : null}
           </Box>
-        </Box>
-      </SectionCard>
+        </SectionCard>
+      ) : null}
     </>
   );
 };

--- a/src/components/leaderboard/RepositoryCard.tsx
+++ b/src/components/leaderboard/RepositoryCard.tsx
@@ -239,12 +239,12 @@ export const RepositoryCard: React.FC<RepositoryCardProps> = ({
           }}
         >
           <MetricCell
-            label="OSS Score"
+            label="OSS score"
             value={formatMetric(repo.totalScore, 2)}
           />
           <MetricCell label="PRs" value={formatMetric(repo.totalPRs)} />
           <MetricCell
-            label="Contributors"
+            label="OSS contributors"
             value={formatMetric(repo.uniqueMiners?.size ?? 0)}
           />
         </Box>
@@ -267,7 +267,7 @@ export const RepositoryCard: React.FC<RepositoryCardProps> = ({
             value={formatMetric(repo.discoveryIssues)}
           />
           <MetricCell
-            label="Contributors"
+            label="Issue contributors"
             value={formatMetric(repo.discoveryContributors?.size ?? 0)}
           />
         </Box>

--- a/src/components/leaderboard/TopRepositoriesTable.tsx
+++ b/src/components/leaderboard/TopRepositoriesTable.tsx
@@ -80,6 +80,10 @@ import {
   echartsStrongAxisLabelColor,
   echartsTransparentBackground,
 } from '../../utils/echarts/gittensorChartTheme';
+import {
+  repoLeaderboardHasDiscoveryActivity,
+  repoLeaderboardHasOssActivity,
+} from '../../utils/ExplorerUtils';
 
 type SortColumn =
   | 'rank'
@@ -209,16 +213,6 @@ const VALID_SORT_COLUMNS: SortColumn[] = [
   'discoveryContributors',
   'watch',
 ];
-
-/** List view: show numeric zeros when the row has OSS activity (avoids PRs > 0 with OSS score "-"). */
-const repoHasOssActivity = (repo: RepoStats) =>
-  (repo.totalPRs ?? 0) > 0 || (repo.totalScore ?? 0) > 0;
-
-/** List view: show discovery numbers when any discovery dimension is non-zero. */
-const repoHasDiscoveryActivity = (repo: RepoStats) =>
-  (repo.discoveryIssues ?? 0) !== 0 ||
-  (repo.discoveryScore ?? 0) !== 0 ||
-  (repo.discoveryContributors?.size ?? 0) > 0;
 
 const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
   repositories,
@@ -864,7 +858,7 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
       align: 'right',
       headerSx: sortableHeaderSx,
       renderCell: (repo) => {
-        const active = repoHasOssActivity(repo);
+        const active = repoLeaderboardHasOssActivity(repo);
         const v = repo.totalScore ?? 0;
         return (
           <Typography
@@ -886,7 +880,7 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
       align: 'right',
       headerSx: sortableHeaderSx,
       renderCell: (repo) => {
-        const active = repoHasOssActivity(repo);
+        const active = repoLeaderboardHasOssActivity(repo);
         const n = repo.totalPRs ?? 0;
         return (
           <Typography
@@ -907,7 +901,7 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
       align: 'right',
       headerSx: sortableHeaderSx,
       renderCell: (repo) => {
-        const active = repoHasDiscoveryActivity(repo);
+        const active = repoLeaderboardHasDiscoveryActivity(repo);
         const v = repo.discoveryScore ?? 0;
         return (
           <Typography
@@ -929,7 +923,7 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
       align: 'right',
       headerSx: sortableHeaderSx,
       renderCell: (repo) => {
-        const active = repoHasDiscoveryActivity(repo);
+        const active = repoLeaderboardHasDiscoveryActivity(repo);
         const n = repo.discoveryIssues ?? 0;
         return (
           <Typography
@@ -950,7 +944,7 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
       align: 'right',
       headerSx: sortableHeaderSx,
       renderCell: (repo) => {
-        const active = repoHasOssActivity(repo);
+        const active = repoLeaderboardHasOssActivity(repo);
         const n = repo.uniqueMiners?.size ?? 0;
         return (
           <Typography
@@ -975,7 +969,7 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
       align: 'right',
       headerSx: sortableHeaderSx,
       renderCell: (repo) => {
-        const active = repoHasDiscoveryActivity(repo);
+        const active = repoLeaderboardHasDiscoveryActivity(repo);
         const n = repo.discoveryContributors?.size ?? 0;
         return (
           <Typography

--- a/src/components/leaderboard/TopRepositoriesTable.tsx
+++ b/src/components/leaderboard/TopRepositoriesTable.tsx
@@ -1061,9 +1061,7 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
             />
             <FilterButton
               label="Active"
-              count={
-                rankedRepositories.filter((r) => !r.inactiveAt).length
-              }
+              count={rankedRepositories.filter((r) => !r.inactiveAt).length}
               color={STATUS_COLORS.success}
               isActive={statusFilter === 'active'}
               fullWidth
@@ -1075,9 +1073,7 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
             />
             <FilterButton
               label="Inactive"
-              count={
-                rankedRepositories.filter((r) => !!r.inactiveAt).length
-              }
+              count={rankedRepositories.filter((r) => !!r.inactiveAt).length}
               color={STATUS_COLORS.closed}
               isActive={statusFilter === 'inactive'}
               fullWidth
@@ -1239,9 +1235,7 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
             </Box>
           </>
         }
-        hasActiveFilter={
-          statusFilter !== 'all' || trimmedSearch.length > 0
-        }
+        hasActiveFilter={statusFilter !== 'all' || trimmedSearch.length > 0}
       />
 
       <Collapse in={showChart}>

--- a/src/components/leaderboard/TopRepositoriesTable.tsx
+++ b/src/components/leaderboard/TopRepositoriesTable.tsx
@@ -12,31 +12,28 @@ import {
   Skeleton,
   Typography,
   Avatar,
-  TextField,
-  InputAdornment,
   Tooltip,
   IconButton,
   Collapse,
   TablePagination,
   Select,
   MenuItem,
-  FormControl,
   Button,
   Switch,
   FormControlLabel,
   CircularProgress,
   alpha,
-  useMediaQuery,
   useTheme,
 } from '@mui/material';
-import SearchIcon from '@mui/icons-material/Search';
 import BarChartIcon from '@mui/icons-material/BarChart';
 import TableChartIcon from '@mui/icons-material/TableChart';
 import ViewModuleIcon from '@mui/icons-material/ViewModule';
 import ViewListIcon from '@mui/icons-material/ViewList';
-import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
-import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
 import FilterButton from '../FilterButton';
+import {
+  TabsOptionsPortal,
+  TabsOptionsLabel,
+} from '../common/TabsOptionsPortal';
 import { RepositoryCard } from './RepositoryCard';
 import {
   REPOSITORIES_CARD_ROWS,
@@ -63,7 +60,11 @@ import {
 } from '../../utils';
 import { useWatchlist } from '../../hooks/useWatchlist';
 import { RankIcon } from './RankIcon';
-import { getRepositoryOwnerAvatarBackground, type RepoStats } from './types';
+import {
+  getRepositoryOwnerAvatarBackground,
+  type RepoStats,
+  FONTS,
+} from './types';
 import {
   CHART_COLORS,
   STATUS_COLORS,
@@ -94,15 +95,100 @@ type SortColumn =
 type SortDirection = 'asc' | 'desc';
 type ViewMode = RepositoriesViewMode;
 
-/** Card sort: classic metrics + Issues; issue score/contrib. sort via list headers / URL. */
-const CARD_SORT_OPTIONS: Array<{ value: SortColumn; label: string }> = [
+/** Card-view sort pills; list column titles are set on `listColumns` below. */
+const CARD_SORT_PILL_OPTIONS: Array<{ value: SortColumn; label: string }> = [
   { value: 'weight', label: 'Weight' },
   { value: 'totalScore', label: 'OSS score' },
   { value: 'totalPRs', label: 'PRs' },
-  { value: 'contributors', label: 'Contributors' },
+  { value: 'contributors', label: 'OSS contributors' },
+  { value: 'discoveryScore', label: 'Issue score' },
   { value: 'discoveryIssues', label: 'Issues' },
-  { value: 'repository', label: 'Repository' },
+  { value: 'discoveryContributors', label: 'Issue contributors' },
 ];
+
+const repositoriesCardSortSidebarLabelSx = {
+  fontFamily: FONTS.mono,
+  fontSize: '0.65rem',
+  fontWeight: 600,
+  color: 'text.secondary',
+  textTransform: 'uppercase',
+  letterSpacing: '0.08em',
+  mb: 1,
+} as const;
+
+interface RepositoriesCardSortButtonsProps {
+  sortColumn: SortColumn;
+  sortDirection: SortDirection;
+  onSortChange: (column: SortColumn) => void;
+}
+
+const RepositoriesCardSortButtons: React.FC<
+  RepositoriesCardSortButtonsProps
+> = ({ sortColumn, sortDirection, onSortChange }) => (
+  <Box
+    sx={{
+      display: 'flex',
+      gap: 0.5,
+      flexWrap: 'wrap',
+      justifyContent: 'flex-start',
+    }}
+  >
+    {CARD_SORT_PILL_OPTIONS.map((option) => {
+      const isActive = sortColumn === option.value;
+      return (
+        <Box
+          key={option.value}
+          component="button"
+          type="button"
+          onClick={() => onSortChange(option.value)}
+          sx={(t) => ({
+            px: 1.5,
+            minHeight: 32,
+            display: 'flex',
+            alignItems: 'center',
+            gap: 0.5,
+            borderRadius: 2,
+            cursor: 'pointer',
+            font: 'inherit',
+            backgroundColor: isActive
+              ? alpha(t.palette.text.primary, 0.1)
+              : 'transparent',
+            color: isActive ? t.palette.text.primary : STATUS_COLORS.open,
+            border: '1px solid',
+            borderColor: isActive ? t.palette.border.medium : 'transparent',
+            transition: 'all 0.2s',
+            '&:hover': {
+              backgroundColor: t.palette.surface.light,
+              color: t.palette.text.primary,
+            },
+            '&:focus-visible': {
+              outline: `2px solid ${t.palette.status.info}`,
+              outlineOffset: 2,
+            },
+          })}
+        >
+          <Typography
+            sx={{
+              fontFamily: FONTS.mono,
+              fontSize: '0.75rem',
+              fontWeight: 600,
+            }}
+          >
+            {option.label}
+          </Typography>
+          {isActive && (
+            <Typography
+              component="span"
+              sx={{ fontSize: '0.7rem', opacity: 0.7 }}
+            >
+              {sortDirection === 'asc' ? '▲' : '▼'}
+            </Typography>
+          )}
+        </Box>
+      );
+    })}
+  </Box>
+);
 
 interface TopRepositoriesTableProps {
   repositories: RepoStats[];
@@ -183,7 +269,6 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
     urlDir === 'asc' || urlDir === 'desc' ? urlDir : 'desc',
   );
   const [useLogScale, setUseLogScale] = useState(true);
-  const [isMobileSearchOpen, setIsMobileSearchOpen] = useState(false);
   const [storedViewMode, setStoredViewMode] = useState<ViewMode>(
     readStoredRepositoriesViewMode,
   );
@@ -198,31 +283,8 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
   const isInitialMount = useRef(true);
   const { isWatched } = useWatchlist('repos');
   const theme = useTheme();
-  const isMobile = useMediaQuery(theme.breakpoints.down('md'));
   const trimmedSearch = searchQuery.trim();
-  const isMobileSearchVisible =
-    isMobile && (isMobileSearchOpen || !!trimmedSearch);
   const isDirectRepoInput = /^[^/\s]+\/[^/\s]+$/.test(trimmedSearch);
-
-  const cardSortSelectOptions = useMemo(() => {
-    const opts = [...CARD_SORT_OPTIONS];
-    const inCardList = opts.some((o) => o.value === sortColumn);
-    if (
-      !inCardList &&
-      (sortColumn === 'discoveryScore' ||
-        sortColumn === 'discoveryContributors')
-    ) {
-      opts.push(
-        sortColumn === 'discoveryScore'
-          ? { value: 'discoveryScore' as const, label: 'Issue score' }
-          : {
-              value: 'discoveryContributors' as const,
-              label: 'Issue contributors',
-            },
-      );
-    }
-    return opts;
-  }, [sortColumn]);
 
   // Sync filter state to URL params (replace, don't push)
   const syncToUrl = useCallback(
@@ -395,7 +457,7 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
       },
       contributors: {
         title: 'OSS contributors by repository',
-        yAxis: 'Contributors',
+        yAxis: 'OSS contributors',
         value: (r) => r.uniqueMiners?.size || 0,
       },
       discoveryScore: {
@@ -410,7 +472,7 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
       },
       discoveryContributors: {
         title: 'Issue contributors by repository',
-        yAxis: 'Contributors',
+        yAxis: 'Issue contributors',
         value: (r) => r.discoveryContributors?.size || 0,
       },
       rank: {
@@ -664,65 +726,7 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
         state: linkState,
       });
     }
-    if (e.key === 'Escape' && !trimmedSearch) {
-      setIsMobileSearchOpen(false);
-    }
   };
-
-  const searchAdornment = (
-    <InputAdornment position="start">
-      <SearchIcon
-        sx={{
-          color: 'text.tertiary',
-          fontSize: '1rem',
-        }}
-      />
-    </InputAdornment>
-  );
-
-  const searchFieldBaseSx = {
-    '& .MuiOutlinedInput-root': {
-      color: 'text.primary',
-      backgroundColor: 'background.default',
-      fontSize: '0.8rem',
-      height: '36px',
-      borderRadius: 2,
-      '& fieldset': { borderColor: 'border.light' },
-      '&:hover fieldset': {
-        borderColor: 'border.medium',
-      },
-      '&.Mui-focused fieldset': { borderColor: 'primary.main' },
-    },
-  } as const;
-
-  const searchInput = (
-    <TextField
-      placeholder="Search or enter owner/repo..."
-      size="small"
-      value={searchQuery}
-      onChange={(e) => setSearchQuery(e.target.value)}
-      onKeyDown={handleSearchKeyDown}
-      onBlur={() => {
-        if (isMobile && !trimmedSearch) {
-          setIsMobileSearchOpen(false);
-        }
-      }}
-      autoFocus={isMobileSearchOpen}
-      InputProps={{
-        startAdornment: searchAdornment,
-      }}
-      sx={{
-        width: '200px',
-        ...(isMobileSearchVisible
-          ? {
-              flexBasis: { xs: '100%', sm: 'auto' },
-              order: { xs: 10, sm: 'initial' },
-            }
-          : {}),
-        ...searchFieldBaseSx,
-      }}
-    />
-  );
 
   // Custom sort header to preserve the original unicode arrow look and
   // cell-wide click + hover (MUI's TableSortLabel differs visually). The
@@ -1012,12 +1016,6 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
     syncToUrl({ search: searchQuery, page: '0' });
   }, [searchQuery]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  useEffect(() => {
-    if (!isMobile) {
-      setIsMobileSearchOpen(false);
-    }
-  }, [isMobile]);
-
   if (isLoading) {
     return (
       <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
@@ -1039,29 +1037,14 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
       }}
       elevation={0}
     >
-      <Box
-        sx={{
-          borderBottom: '1px solid',
-          borderColor: 'border.light',
-        }}
-      >
-        {/* Row 1: All Controls */}
-        <Box
-          sx={{
-            p: { xs: 1.5, md: 2 },
-            display: 'flex',
-            flexDirection: { xs: 'column', md: 'row' },
-            alignItems: { xs: 'stretch', md: 'center' },
-            gap: { xs: 1.25, md: 2 },
-          }}
-        >
+      <TabsOptionsPortal
+        filterContent={
           <Box
             sx={{
-              display: 'flex',
-              gap: 0.5,
-              alignItems: 'center',
-              flexWrap: 'wrap',
-              width: { xs: '100%', md: 'auto' },
+              display: 'grid',
+              gridTemplateColumns: 'repeat(3, minmax(0, 1fr))',
+              gap: 1,
+              width: '100%',
             }}
           >
             <FilterButton
@@ -1069,6 +1052,7 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
               count={rankedRepositories.length}
               color={STATUS_COLORS.neutral}
               isActive={statusFilter === 'all'}
+              fullWidth
               onClick={() => {
                 setStatusFilter('all');
                 setPage(0);
@@ -1077,9 +1061,12 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
             />
             <FilterButton
               label="Active"
-              count={rankedRepositories.filter((r) => !r.inactiveAt).length}
+              count={
+                rankedRepositories.filter((r) => !r.inactiveAt).length
+              }
               color={STATUS_COLORS.success}
               isActive={statusFilter === 'active'}
+              fullWidth
               onClick={() => {
                 setStatusFilter('active');
                 setPage(0);
@@ -1088,9 +1075,12 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
             />
             <FilterButton
               label="Inactive"
-              count={rankedRepositories.filter((r) => !!r.inactiveAt).length}
+              count={
+                rankedRepositories.filter((r) => !!r.inactiveAt).length
+              }
               color={STATUS_COLORS.closed}
               isActive={statusFilter === 'inactive'}
+              fullWidth
               onClick={() => {
                 setStatusFilter('inactive');
                 setPage(0);
@@ -1098,224 +1088,161 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
               }}
             />
           </Box>
-
-          <Box
-            sx={{
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: { xs: 'space-between', md: 'flex-end' },
-              gap: 1,
-              flexWrap: 'wrap',
-              width: { xs: '100%', md: 'auto' },
-            }}
-          >
-            <Tooltip title={showChart ? 'Hide Chart' : 'Show Chart'}>
-              <IconButton
-                onClick={() => setShowChart(!showChart)}
+        }
+        extraContent={
+          <>
+            <Box>
+              <TabsOptionsLabel>Rows</TabsOptionsLabel>
+              <Select
                 size="small"
+                fullWidth
+                value={rowsPerPage}
+                onChange={(e) => {
+                  const newRows = e.target.value as number;
+                  setRowsPerPage(newRows);
+                  setPage(0);
+                  syncToUrl({ rows: String(newRows), page: '0' });
+                }}
                 sx={{
-                  color: showChart ? 'text.primary' : 'text.tertiary',
-                  border: '1px solid',
-                  borderColor: 'border.light',
+                  color: 'text.primary',
+                  backgroundColor: 'background.default',
+                  fontSize: '0.8rem',
+                  height: '34px',
                   borderRadius: 2,
-                  padding: '6px',
-                  '&:hover': {
-                    backgroundColor: 'surface.light',
+                  '& fieldset': { borderColor: 'border.light' },
+                  '&:hover fieldset': {
                     borderColor: 'border.medium',
                   },
+                  '&.Mui-focused fieldset': { borderColor: 'primary.main' },
+                  '& .MuiSelect-select': { py: 0.65 },
                 }}
               >
-                {showChart ? (
-                  <TableChartIcon fontSize="small" />
-                ) : (
-                  <BarChartIcon fontSize="small" />
-                )}
-              </IconButton>
-            </Tooltip>
+                {(viewMode === 'cards'
+                  ? REPOSITORIES_CARD_ROWS
+                  : REPOSITORIES_LIST_ROWS
+                ).map((n) => (
+                  <MenuItem key={n} value={n}>
+                    {n}
+                  </MenuItem>
+                ))}
+              </Select>
+            </Box>
 
             {showChart && (
-              <FormControlLabel
-                control={
-                  <Switch
-                    checked={useLogScale}
-                    onChange={(e) => setUseLogScale(e.target.checked)}
-                    size="small"
-                    sx={{
-                      '& .MuiSwitch-switchBase.Mui-checked': {
-                        color: 'primary.main',
-                      },
-                      '& .MuiSwitch-track': {
-                        backgroundColor: 'border.medium',
-                      },
-                    }}
-                  />
-                }
-                label={
-                  <Typography
-                    variant="body2"
-                    sx={{
-                      fontSize: '0.8rem',
-                      color: 'text.secondary',
-                    }}
-                  >
-                    Log Scale
-                  </Typography>
-                }
-              />
-            )}
-
-            <FormControl size="small">
-              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                <Typography
-                  variant="body2"
-                  sx={{
-                    color: 'text.secondary',
-                    fontSize: '0.8rem',
-                  }}
-                >
-                  Rows:
-                </Typography>
-                <Select
-                  value={rowsPerPage}
-                  onChange={(e) => {
-                    const newRows = e.target.value as number;
-                    setRowsPerPage(newRows);
-                    setPage(0);
-                    syncToUrl({ rows: String(newRows), page: '0' });
-                  }}
-                  sx={{
-                    color: 'text.primary',
-                    backgroundColor: 'background.default',
-                    fontSize: '0.8rem',
-                    height: '36px',
-                    borderRadius: 2,
-                    minWidth: '80px',
-                    '& fieldset': { borderColor: 'border.light' },
-                    '&:hover fieldset': {
-                      borderColor: 'border.medium',
-                    },
-                    '&.Mui-focused fieldset': { borderColor: 'primary.main' },
-                    '& .MuiSelect-select': { py: 0.75 },
-                  }}
-                >
-                  {(viewMode === 'cards'
-                    ? REPOSITORIES_CARD_ROWS
-                    : REPOSITORIES_LIST_ROWS
-                  ).map((n) => (
-                    <MenuItem key={n} value={n}>
-                      {n}
-                    </MenuItem>
-                  ))}
-                </Select>
+              <Box>
+                <TabsOptionsLabel>Chart scale</TabsOptionsLabel>
+                <FormControlLabel
+                  control={
+                    <Switch
+                      checked={useLogScale}
+                      onChange={(e) => setUseLogScale(e.target.checked)}
+                      size="small"
+                      sx={{
+                        '& .MuiSwitch-switchBase.Mui-checked': {
+                          color: 'primary.main',
+                        },
+                        '& .MuiSwitch-track': {
+                          backgroundColor: 'border.medium',
+                        },
+                      }}
+                    />
+                  }
+                  label={
+                    <Typography
+                      variant="body2"
+                      sx={{
+                        fontSize: '0.8rem',
+                        color: 'text.secondary',
+                      }}
+                    >
+                      Log scale
+                    </Typography>
+                  }
+                />
               </Box>
-            </FormControl>
-
-            {isMobileSearchVisible ? (
-              searchInput
-            ) : isMobile ? (
-              <IconButton
-                size="small"
-                onClick={() => setIsMobileSearchOpen(true)}
-                sx={{
-                  color: 'text.tertiary',
-                  border: '1px solid',
-                  borderColor: 'border.light',
-                  borderRadius: 2,
-                  width: 36,
-                  height: 36,
-                  '&:hover': {
-                    backgroundColor: 'surface.light',
-                    borderColor: 'border.medium',
-                  },
-                }}
-              >
-                <SearchIcon sx={{ fontSize: '1rem' }} />
-              </IconButton>
-            ) : (
-              searchInput
             )}
 
-            <Box sx={{ ml: { xs: 0, md: 'auto' } }}>
+            {viewMode === 'cards' && (
+              <Box>
+                <Typography sx={repositoriesCardSortSidebarLabelSx}>
+                  Sort by
+                </Typography>
+                <RepositoriesCardSortButtons
+                  sortColumn={sortColumn}
+                  sortDirection={sortDirection}
+                  onSortChange={handleSort}
+                />
+              </Box>
+            )}
+          </>
+        }
+        searchValue={searchQuery}
+        searchPlaceholder="Search or enter owner/repo..."
+        onSearchChange={setSearchQuery}
+        onSearchKeyDown={handleSearchKeyDown}
+        viewMode={viewMode}
+        onViewModeChange={handleViewModeChange}
+        viewSlotIncludesHeading
+        viewModeToggle={
+          <>
+            <Box
+              sx={{
+                display: 'flex',
+                justifyContent: 'space-between',
+                alignItems: 'baseline',
+                width: '100%',
+                mb: 1.25,
+              }}
+            >
+              <TabsOptionsLabel gutterBottom={false}>View</TabsOptionsLabel>
+              <TabsOptionsLabel gutterBottom={false}>Chart</TabsOptionsLabel>
+            </Box>
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                gap: 1,
+                width: '100%',
+              }}
+            >
               <ViewModeToggle
                 viewMode={viewMode}
                 onChange={handleViewModeChange}
               />
+              <Tooltip title={showChart ? 'Hide chart' : 'Show chart'}>
+                <IconButton
+                  onClick={() => setShowChart(!showChart)}
+                  size="small"
+                  aria-label={showChart ? 'Hide chart' : 'Show chart'}
+                  sx={{
+                    flexShrink: 0,
+                    color: showChart
+                      ? theme.palette.text.primary
+                      : alpha(theme.palette.common.white, TEXT_OPACITY.muted),
+                    border: `1px solid ${theme.palette.border.light}`,
+                    borderRadius: 2,
+                    padding: '6px',
+                    '&:hover': {
+                      backgroundColor: theme.palette.surface.subtle,
+                      borderColor: theme.palette.border.medium,
+                    },
+                  }}
+                >
+                  {showChart ? (
+                    <TableChartIcon fontSize="small" />
+                  ) : (
+                    <BarChartIcon fontSize="small" />
+                  )}
+                </IconButton>
+              </Tooltip>
             </Box>
-          </Box>
-        </Box>
-
-        {/* Row 2: Sort controls (card view only) */}
-        {viewMode === 'cards' && (
-          <Box
-            sx={{
-              px: 2,
-              pb: 2,
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'flex-end',
-              gap: 1,
-            }}
-          >
-            <Typography
-              variant="body2"
-              sx={{ color: 'text.secondary', fontSize: '0.8rem' }}
-            >
-              Sort:
-            </Typography>
-            <Select
-              size="small"
-              value={sortColumn}
-              onChange={(e) => handleSort(e.target.value as SortColumn)}
-              sx={{
-                color: 'text.primary',
-                backgroundColor: 'background.default',
-                fontSize: '0.8rem',
-                height: '36px',
-                borderRadius: 2,
-                minWidth: '140px',
-                '& fieldset': { borderColor: 'border.light' },
-                '&:hover fieldset': { borderColor: 'border.medium' },
-                '&.Mui-focused fieldset': { borderColor: 'primary.main' },
-                '& .MuiSelect-select': { py: 0.75 },
-              }}
-            >
-              {cardSortSelectOptions.map((opt) => (
-                <MenuItem key={opt.value} value={opt.value}>
-                  {opt.label}
-                </MenuItem>
-              ))}
-            </Select>
-            <Tooltip
-              title={sortDirection === 'asc' ? 'Ascending' : 'Descending'}
-            >
-              <IconButton
-                onClick={() => handleSort(sortColumn)}
-                size="small"
-                aria-label={
-                  sortDirection === 'asc' ? 'Sort descending' : 'Sort ascending'
-                }
-                sx={{
-                  color: 'text.primary',
-                  border: '1px solid',
-                  borderColor: 'border.light',
-                  borderRadius: 2,
-                  padding: '6px',
-                  '&:hover': {
-                    backgroundColor: 'surface.light',
-                    borderColor: 'border.medium',
-                  },
-                }}
-              >
-                {sortDirection === 'asc' ? (
-                  <ArrowUpwardIcon fontSize="small" />
-                ) : (
-                  <ArrowDownwardIcon fontSize="small" />
-                )}
-              </IconButton>
-            </Tooltip>
-          </Box>
-        )}
-      </Box>
+          </>
+        }
+        hasActiveFilter={
+          statusFilter !== 'all' || trimmedSearch.length > 0
+        }
+      />
 
       <Collapse in={showChart}>
         <Box

--- a/src/pages/RepositoriesPage.tsx
+++ b/src/pages/RepositoriesPage.tsx
@@ -423,275 +423,275 @@ const RepositoriesPage: React.FC = () => {
             minHeight: isLargeScreen ? 'calc(100vh - 88px)' : 'auto',
           }}
         >
-        {/* ── Highlight Sections ─────────────────────────────────────── */}
-        <Box
-          sx={{
-            display: 'grid',
-            gridTemplateColumns: { xs: '1fr', lg: '1fr 1fr 1fr' },
-            gap: 2,
-            mb: 3,
-            alignItems: 'stretch',
-          }}
-        >
-          {/* Trending This Week */}
-          <Card sx={cardSx}>
-            {isLoading || trendingRepos.length > 0 ? (
-              <>
-                <SectionHeader>Trending This Week</SectionHeader>
-                <Box sx={{ display: 'flex', flexDirection: 'column' }}>
-                  {trendingRepos.length === 0 && !isLoading ? (
-                    <Typography
-                      sx={(theme) => ({
-                        color: alpha(theme.palette.text.primary, 0.3),
-                        fontSize: '0.8rem',
-                        fontStyle: 'italic',
-                        p: 1,
-                      })}
-                    >
-                      No data available
-                    </Typography>
-                  ) : (
-                    trendingRepos.map((repo) => (
-                      <HighlightRow
-                        key={repo.name}
-                        href={getRepoHref(repo.name)}
-                        linkState={REPO_LINK_STATE}
-                        avatar={getRepositoryOwnerAvatarSrc(
-                          repo.name.split('/')[0],
-                        )}
-                        avatarBg={getAvatarBg(repo.name)}
-                        label={
-                          <Tooltip title={repo.name} arrow placement="top">
-                            <Typography
-                              sx={{
-                                fontFamily: FONTS.mono,
-                                fontSize: '0.82rem',
-                                color: 'text.primary',
-                                overflow: 'hidden',
-                                textOverflow: 'ellipsis',
-                                whiteSpace: 'nowrap',
-                              }}
-                            >
-                              {repo.name}
-                            </Typography>
-                          </Tooltip>
-                        }
-                        right={
-                          <Typography
-                            sx={(theme) => ({
-                              fontFamily: FONTS.mono,
-                              fontSize: '0.75rem',
-                              fontWeight: 600,
-                              color: theme.palette.status.success,
-                              flexShrink: 0,
-                              backgroundColor: alpha(
-                                theme.palette.status.success,
-                                0.1,
-                              ),
-                              px: 0.75,
-                              py: 0.25,
-                              borderRadius: '4px',
-                            })}
-                          >
-                            +{repo.pctIncrease.toFixed(0)}%
-                          </Typography>
-                        }
-                      />
-                    ))
-                  )}
-                </Box>
-              </>
-            ) : null}
-          </Card>
-
-          {/* Most Collateral Staked */}
-          <Card sx={cardSx}>
-            {isLoading || topCollateralRepos.length > 0 ? (
-              <>
-                <SectionHeader>Most Collateral Staked</SectionHeader>
-                <Box sx={{ display: 'flex', flexDirection: 'column' }}>
-                  {topCollateralRepos.length === 0 && !isLoading ? (
-                    <Typography
-                      sx={(theme) => ({
-                        color: alpha(theme.palette.text.primary, 0.3),
-                        fontSize: '0.8rem',
-                        fontStyle: 'italic',
-                        p: 1,
-                      })}
-                    >
-                      No collateral data available
-                    </Typography>
-                  ) : (
-                    topCollateralRepos.map((repo) => (
-                      <HighlightRow
-                        key={repo.name}
-                        href={getRepoHref(repo.name)}
-                        linkState={REPO_LINK_STATE}
-                        avatar={getRepositoryOwnerAvatarSrc(
-                          repo.name.split('/')[0],
-                        )}
-                        avatarBg={getAvatarBg(repo.name)}
-                        label={
-                          <Tooltip title={repo.name} arrow placement="top">
-                            <Typography
-                              sx={{
-                                fontFamily: FONTS.mono,
-                                fontSize: '0.82rem',
-                                color: 'text.primary',
-                                overflow: 'hidden',
-                                textOverflow: 'ellipsis',
-                                whiteSpace: 'nowrap',
-                              }}
-                            >
-                              {repo.name}
-                            </Typography>
-                          </Tooltip>
-                        }
-                        right={
-                          <Typography
-                            sx={{
-                              fontFamily: FONTS.mono,
-                              fontSize: '0.72rem',
-                              color: 'text.secondary',
-                              flexShrink: 0,
-                              whiteSpace: 'nowrap',
-                            }}
-                          >
-                            {repo.collateral.toFixed(1)} ({repo.openPRs} PR
-                            {repo.openPRs !== 1 ? 's' : ''})
-                          </Typography>
-                        }
-                      />
-                    ))
-                  )}
-                </Box>
-              </>
-            ) : null}
-          </Card>
-
-          {/* Recent PRs */}
-          <Card sx={cardSx}>
-            {isLoading || recentPrs.length > 0 ? (
-              <>
-                <SectionHeader>Recent Pull Requests</SectionHeader>
-                <Box sx={{ display: 'flex', flexDirection: 'column' }}>
-                  {recentPrs.length === 0 && !isLoading ? (
-                    <Typography
-                      sx={(theme) => ({
-                        color: alpha(theme.palette.text.primary, 0.3),
-                        fontSize: '0.8rem',
-                        fontStyle: 'italic',
-                        p: 1,
-                      })}
-                    >
-                      No data available
-                    </Typography>
-                  ) : (
-                    recentPrs.map((pr) => (
-                      <HighlightRow
-                        key={`${pr.name}-${pr.number}`}
-                        href={getPrHref(pr.name, pr.number)}
-                        linkState={REPO_LINK_STATE}
-                        avatar={getRepositoryOwnerAvatarSrc(
-                          pr.name.split('/')[0],
-                        )}
-                        avatarBg={getAvatarBg(pr.name)}
-                        label={
-                          <Box
-                            sx={{
-                              minWidth: 0,
-                              display: 'flex',
-                              flexDirection: 'column',
-                              justifyContent: 'center',
-                            }}
-                          >
-                            <Tooltip title={pr.name} arrow placement="top">
+          {/* ── Highlight Sections ─────────────────────────────────────── */}
+          <Box
+            sx={{
+              display: 'grid',
+              gridTemplateColumns: { xs: '1fr', lg: '1fr 1fr 1fr' },
+              gap: 2,
+              mb: 3,
+              alignItems: 'stretch',
+            }}
+          >
+            {/* Trending This Week */}
+            <Card sx={cardSx}>
+              {isLoading || trendingRepos.length > 0 ? (
+                <>
+                  <SectionHeader>Trending This Week</SectionHeader>
+                  <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+                    {trendingRepos.length === 0 && !isLoading ? (
+                      <Typography
+                        sx={(theme) => ({
+                          color: alpha(theme.palette.text.primary, 0.3),
+                          fontSize: '0.8rem',
+                          fontStyle: 'italic',
+                          p: 1,
+                        })}
+                      >
+                        No data available
+                      </Typography>
+                    ) : (
+                      trendingRepos.map((repo) => (
+                        <HighlightRow
+                          key={repo.name}
+                          href={getRepoHref(repo.name)}
+                          linkState={REPO_LINK_STATE}
+                          avatar={getRepositoryOwnerAvatarSrc(
+                            repo.name.split('/')[0],
+                          )}
+                          avatarBg={getAvatarBg(repo.name)}
+                          label={
+                            <Tooltip title={repo.name} arrow placement="top">
                               <Typography
                                 sx={{
                                   fontFamily: FONTS.mono,
-                                  fontSize: '0.68rem',
-                                  color: 'text.tertiary',
-                                  overflow: 'hidden',
-                                  textOverflow: 'ellipsis',
-                                  whiteSpace: 'nowrap',
-                                  lineHeight: 1.2,
-                                }}
-                              >
-                                {pr.name}
-                              </Typography>
-                            </Tooltip>
-                            <Tooltip title={pr.title} arrow placement="top">
-                              <Typography
-                                sx={{
-                                  fontFamily: FONTS.mono,
-                                  fontSize: '0.78rem',
+                                  fontSize: '0.82rem',
                                   color: 'text.primary',
                                   overflow: 'hidden',
                                   textOverflow: 'ellipsis',
                                   whiteSpace: 'nowrap',
-                                  lineHeight: 1.3,
                                 }}
                               >
-                                {pr.title}
+                                {repo.name}
                               </Typography>
                             </Tooltip>
-                          </Box>
-                        }
-                        right={
-                          <Typography
-                            sx={(theme) => ({
-                              fontFamily: FONTS.mono,
-                              fontSize: '0.68rem',
-                              color: alpha(theme.palette.text.primary, 0.35),
-                              flexShrink: 0,
-                              whiteSpace: 'nowrap',
-                              ml: 1,
-                            })}
-                          >
-                            {formatRelativeTime(pr.createdAt)}
-                          </Typography>
-                        }
-                      />
-                    ))
-                  )}
-                </Box>
-              </>
-            ) : null}
-            {!isLoading && recentPrs.length === 0 ? (
-              <>
-                <SectionHeader>Recent Pull Requests</SectionHeader>
-                <Box
-                  sx={{
-                    flex: 1,
-                    minHeight: ROW_HEIGHT * 5,
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                  }}
-                >
-                  <Typography
-                    sx={(theme) => ({
-                      color: alpha(theme.palette.text.primary, 0.3),
-                      fontSize: '0.8rem',
-                      p: 1,
-                      textAlign: 'center',
-                    })}
-                  >
-                    No merged PRs today
-                  </Typography>
-                </Box>
-              </>
-            ) : null}
-          </Card>
-        </Box>
+                          }
+                          right={
+                            <Typography
+                              sx={(theme) => ({
+                                fontFamily: FONTS.mono,
+                                fontSize: '0.75rem',
+                                fontWeight: 600,
+                                color: theme.palette.status.success,
+                                flexShrink: 0,
+                                backgroundColor: alpha(
+                                  theme.palette.status.success,
+                                  0.1,
+                                ),
+                                px: 0.75,
+                                py: 0.25,
+                                borderRadius: '4px',
+                              })}
+                            >
+                              +{repo.pctIncrease.toFixed(0)}%
+                            </Typography>
+                          }
+                        />
+                      ))
+                    )}
+                  </Box>
+                </>
+              ) : null}
+            </Card>
 
-        {/* ── Main Table ────────────────────────────────────────────── */}
-        <TopRepositoriesTable
-          repositories={repoStats}
-          isLoading={isLoading}
-          getRepositoryHref={getRepoHref}
-          linkState={REPO_LINK_STATE}
-        />
+            {/* Most Collateral Staked */}
+            <Card sx={cardSx}>
+              {isLoading || topCollateralRepos.length > 0 ? (
+                <>
+                  <SectionHeader>Most Collateral Staked</SectionHeader>
+                  <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+                    {topCollateralRepos.length === 0 && !isLoading ? (
+                      <Typography
+                        sx={(theme) => ({
+                          color: alpha(theme.palette.text.primary, 0.3),
+                          fontSize: '0.8rem',
+                          fontStyle: 'italic',
+                          p: 1,
+                        })}
+                      >
+                        No collateral data available
+                      </Typography>
+                    ) : (
+                      topCollateralRepos.map((repo) => (
+                        <HighlightRow
+                          key={repo.name}
+                          href={getRepoHref(repo.name)}
+                          linkState={REPO_LINK_STATE}
+                          avatar={getRepositoryOwnerAvatarSrc(
+                            repo.name.split('/')[0],
+                          )}
+                          avatarBg={getAvatarBg(repo.name)}
+                          label={
+                            <Tooltip title={repo.name} arrow placement="top">
+                              <Typography
+                                sx={{
+                                  fontFamily: FONTS.mono,
+                                  fontSize: '0.82rem',
+                                  color: 'text.primary',
+                                  overflow: 'hidden',
+                                  textOverflow: 'ellipsis',
+                                  whiteSpace: 'nowrap',
+                                }}
+                              >
+                                {repo.name}
+                              </Typography>
+                            </Tooltip>
+                          }
+                          right={
+                            <Typography
+                              sx={{
+                                fontFamily: FONTS.mono,
+                                fontSize: '0.72rem',
+                                color: 'text.secondary',
+                                flexShrink: 0,
+                                whiteSpace: 'nowrap',
+                              }}
+                            >
+                              {repo.collateral.toFixed(1)} ({repo.openPRs} PR
+                              {repo.openPRs !== 1 ? 's' : ''})
+                            </Typography>
+                          }
+                        />
+                      ))
+                    )}
+                  </Box>
+                </>
+              ) : null}
+            </Card>
+
+            {/* Recent PRs */}
+            <Card sx={cardSx}>
+              {isLoading || recentPrs.length > 0 ? (
+                <>
+                  <SectionHeader>Recent Pull Requests</SectionHeader>
+                  <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+                    {recentPrs.length === 0 && !isLoading ? (
+                      <Typography
+                        sx={(theme) => ({
+                          color: alpha(theme.palette.text.primary, 0.3),
+                          fontSize: '0.8rem',
+                          fontStyle: 'italic',
+                          p: 1,
+                        })}
+                      >
+                        No data available
+                      </Typography>
+                    ) : (
+                      recentPrs.map((pr) => (
+                        <HighlightRow
+                          key={`${pr.name}-${pr.number}`}
+                          href={getPrHref(pr.name, pr.number)}
+                          linkState={REPO_LINK_STATE}
+                          avatar={getRepositoryOwnerAvatarSrc(
+                            pr.name.split('/')[0],
+                          )}
+                          avatarBg={getAvatarBg(pr.name)}
+                          label={
+                            <Box
+                              sx={{
+                                minWidth: 0,
+                                display: 'flex',
+                                flexDirection: 'column',
+                                justifyContent: 'center',
+                              }}
+                            >
+                              <Tooltip title={pr.name} arrow placement="top">
+                                <Typography
+                                  sx={{
+                                    fontFamily: FONTS.mono,
+                                    fontSize: '0.68rem',
+                                    color: 'text.tertiary',
+                                    overflow: 'hidden',
+                                    textOverflow: 'ellipsis',
+                                    whiteSpace: 'nowrap',
+                                    lineHeight: 1.2,
+                                  }}
+                                >
+                                  {pr.name}
+                                </Typography>
+                              </Tooltip>
+                              <Tooltip title={pr.title} arrow placement="top">
+                                <Typography
+                                  sx={{
+                                    fontFamily: FONTS.mono,
+                                    fontSize: '0.78rem',
+                                    color: 'text.primary',
+                                    overflow: 'hidden',
+                                    textOverflow: 'ellipsis',
+                                    whiteSpace: 'nowrap',
+                                    lineHeight: 1.3,
+                                  }}
+                                >
+                                  {pr.title}
+                                </Typography>
+                              </Tooltip>
+                            </Box>
+                          }
+                          right={
+                            <Typography
+                              sx={(theme) => ({
+                                fontFamily: FONTS.mono,
+                                fontSize: '0.68rem',
+                                color: alpha(theme.palette.text.primary, 0.35),
+                                flexShrink: 0,
+                                whiteSpace: 'nowrap',
+                                ml: 1,
+                              })}
+                            >
+                              {formatRelativeTime(pr.createdAt)}
+                            </Typography>
+                          }
+                        />
+                      ))
+                    )}
+                  </Box>
+                </>
+              ) : null}
+              {!isLoading && recentPrs.length === 0 ? (
+                <>
+                  <SectionHeader>Recent Pull Requests</SectionHeader>
+                  <Box
+                    sx={{
+                      flex: 1,
+                      minHeight: ROW_HEIGHT * 5,
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                    }}
+                  >
+                    <Typography
+                      sx={(theme) => ({
+                        color: alpha(theme.palette.text.primary, 0.3),
+                        fontSize: '0.8rem',
+                        p: 1,
+                        textAlign: 'center',
+                      })}
+                    >
+                      No merged PRs today
+                    </Typography>
+                  </Box>
+                </>
+              ) : null}
+            </Card>
+          </Box>
+
+          {/* ── Main Table ────────────────────────────────────────────── */}
+          <TopRepositoriesTable
+            repositories={repoStats}
+            isLoading={isLoading}
+            getRepositoryHref={getRepoHref}
+            linkState={REPO_LINK_STATE}
+          />
         </Box>
 
         <Box

--- a/src/pages/RepositoriesPage.tsx
+++ b/src/pages/RepositoriesPage.tsx
@@ -13,15 +13,8 @@ import { alpha, type Theme } from '@mui/material/styles';
 
 import { LinkBox } from '../components/common/linkBehavior';
 import { Page } from '../components/layout';
-import {
-  TopRepositoriesTable,
-  SEO,
-  ActivitySidebarCards,
-  StatRow,
-  SectionCard,
-} from '../components';
+import { TopRepositoriesTable, SEO, StatRow, SectionCard } from '../components';
 import { useTwitterStickySidebar } from '../hooks/useTwitterStickySidebar';
-import { mapAllMinersToStats } from '../utils/minerMapper';
 import theme, { STATUS_COLORS, scrollbarSx } from '../theme';
 import { useAllPrs, useAllMiners, useReposAndWeights } from '../api';
 import { type CommitLog } from '../api/models/Dashboard';
@@ -241,11 +234,6 @@ const RepositoriesPage: React.FC = () => {
       })
       .sort((a, b) => b.totalScore - a.totalScore);
   }, [allPRs, allMiners, reposWithWeights]);
-
-  const minerStatsForSidebar = useMemo(
-    () => (Array.isArray(allMiners) ? mapAllMinersToStats(allMiners) : []),
-    [allMiners],
-  );
 
   const repoSidebarOverview = useMemo(() => {
     const total = repoStats.length;
@@ -738,11 +726,7 @@ const RepositoriesPage: React.FC = () => {
               </Box>
             </SectionCard>
 
-            <ActivitySidebarCards
-              miners={minerStatsForSidebar}
-              defaultFilter="all"
-              insertAfterFirstCard={optionsPortalTarget}
-            />
+            {optionsPortalTarget}
           </Stack>
         </Box>
       </Box>

--- a/src/pages/RepositoriesPage.tsx
+++ b/src/pages/RepositoriesPage.tsx
@@ -1,11 +1,28 @@
 import React, { useMemo } from 'react';
 
-import { Avatar, Box, Card, Tooltip, Typography } from '@mui/material';
+import {
+  Avatar,
+  Box,
+  Card,
+  Stack,
+  Tooltip,
+  Typography,
+  useMediaQuery,
+} from '@mui/material';
 import { alpha, type Theme } from '@mui/material/styles';
 
 import { LinkBox } from '../components/common/linkBehavior';
 import { Page } from '../components/layout';
-import { TopRepositoriesTable, SEO } from '../components';
+import {
+  TopRepositoriesTable,
+  SEO,
+  ActivitySidebarCards,
+  StatRow,
+  SectionCard,
+} from '../components';
+import { useTwitterStickySidebar } from '../hooks/useTwitterStickySidebar';
+import { mapAllMinersToStats } from '../utils/minerMapper';
+import theme, { STATUS_COLORS, scrollbarSx } from '../theme';
 import { useAllPrs, useAllMiners, useReposAndWeights } from '../api';
 import { type CommitLog } from '../api/models/Dashboard';
 import { getRepositoryOwnerAvatarSrc } from '../utils/avatar';
@@ -123,6 +140,34 @@ const getPrHref = (name: string, number: number) =>
   `/miners/pr?repo=${encodeURIComponent(name)}&number=${number}`;
 
 const RepositoriesPage: React.FC = () => {
+  const isLargeScreen = useMediaQuery(theme.breakpoints.up('xl'));
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+  const isTablet = useMediaQuery(theme.breakpoints.between('sm', 'md'));
+  const sidebarWidth =
+    isMobile || isTablet ? '100%' : isLargeScreen ? '340px' : '300px';
+  const stickySidebarRef = useTwitterStickySidebar();
+
+  const optionsPortalTarget = useMemo(
+    () => (
+      <Box
+        id="tabs-options-portal"
+        sx={{
+          display: 'none',
+          '@media (min-width: 1536px)': {
+            display: 'flex',
+            flexDirection: 'column',
+            p: 2,
+            borderRadius: 3,
+            border: '1px solid',
+            borderColor: 'border.light',
+            backgroundColor: 'background.default',
+          },
+        }}
+      />
+    ),
+    [],
+  );
+
   const formatRelativeTime = (date: Date) => {
     const now = new Date();
     if (date > now) return 'just now';
@@ -196,6 +241,24 @@ const RepositoriesPage: React.FC = () => {
       })
       .sort((a, b) => b.totalScore - a.totalScore);
   }, [allPRs, allMiners, reposWithWeights]);
+
+  const minerStatsForSidebar = useMemo(
+    () => (Array.isArray(allMiners) ? mapAllMinersToStats(allMiners) : []),
+    [allMiners],
+  );
+
+  const repoSidebarOverview = useMemo(() => {
+    const total = repoStats.length;
+    if (!total) {
+      return { total: 0, active: 0, inactive: 0 };
+    }
+    const active = repoStats.filter((r) => !r.inactiveAt).length;
+    return {
+      total,
+      active,
+      inactive: total - active,
+    };
+  }, [repoStats]);
 
   // ── Trending: repos with biggest % score increase in the last 7 days ──
   // Excludes brand-new repos (no prior score) so only genuine growth shows
@@ -341,12 +404,25 @@ const RepositoriesPage: React.FC = () => {
       <Box
         sx={{
           width: '100%',
-          maxWidth: 1200,
-          mx: 'auto',
-          py: { xs: 2, sm: 3 },
-          px: { xs: 2, sm: 3 },
+          display: 'flex',
+          flexDirection: isLargeScreen ? 'row' : 'column',
+          alignItems: isLargeScreen ? 'flex-start' : 'stretch',
+          gap: { xs: 2, sm: 2, md: 2.5, lg: 3 },
+          py: { xs: 2, sm: 2, md: 2.5, lg: 3 },
+          px: { xs: 2, sm: 2, md: 2.5, lg: 3 },
         }}
       >
+        <Box
+          sx={{
+            flex: 1,
+            display: 'flex',
+            flexDirection: 'column',
+            gap: { xs: 2, sm: 1.5 },
+            minWidth: 0,
+            pr: isLargeScreen ? 1 : 0,
+            minHeight: isLargeScreen ? 'calc(100vh - 88px)' : 'auto',
+          }}
+        >
         {/* ── Highlight Sections ─────────────────────────────────────── */}
         <Box
           sx={{
@@ -610,23 +686,65 @@ const RepositoriesPage: React.FC = () => {
         </Box>
 
         {/* ── Main Table ────────────────────────────────────────────── */}
-        <Card
-          sx={(theme) => ({
-            borderRadius: 3,
-            border: '1px solid',
-            borderColor: theme.palette.border.light,
-            backgroundColor: theme.palette.surface.transparent,
-            overflow: 'hidden',
-          })}
-          elevation={0}
+        <TopRepositoriesTable
+          repositories={repoStats}
+          isLoading={isLoading}
+          getRepositoryHref={getRepoHref}
+          linkState={REPO_LINK_STATE}
+        />
+        </Box>
+
+        <Box
+          ref={isLargeScreen ? stickySidebarRef : undefined}
+          sx={{
+            width: isLargeScreen ? sidebarWidth : '100%',
+            flexShrink: 0,
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 2,
+            position: isLargeScreen ? 'sticky' : 'static',
+            top: isLargeScreen ? 88 : 'auto',
+            ...(isLargeScreen && {
+              maxHeight: 'calc(100vh - 88px)',
+              overflowY: 'auto',
+              scrollbarWidth: 'none',
+              '&::-webkit-scrollbar': { display: 'none' },
+            }),
+          }}
         >
-          <TopRepositoriesTable
-            repositories={repoStats}
-            isLoading={isLoading}
-            getRepositoryHref={getRepoHref}
-            linkState={REPO_LINK_STATE}
-          />
-        </Card>
+          <Stack spacing={2} sx={{ ...scrollbarSx, width: '100%', pr: 0.5 }}>
+            <SectionCard title="Tracked repositories">
+              <Box
+                sx={{
+                  px: 2,
+                  pt: 1,
+                  pb: 2,
+                  display: 'flex',
+                  flexDirection: 'column',
+                  gap: 2,
+                }}
+              >
+                <StatRow label="Total" value={repoSidebarOverview.total} />
+                <StatRow
+                  label="Active"
+                  value={repoSidebarOverview.active}
+                  valueColor={STATUS_COLORS.success}
+                />
+                <StatRow
+                  label="Inactive"
+                  value={repoSidebarOverview.inactive}
+                  valueColor={STATUS_COLORS.closed}
+                />
+              </Box>
+            </SectionCard>
+
+            <ActivitySidebarCards
+              miners={minerStatsForSidebar}
+              defaultFilter="all"
+              insertAfterFirstCard={optionsPortalTarget}
+            />
+          </Stack>
+        </Box>
       </Box>
     </Page>
   );

--- a/src/utils/ExplorerUtils.ts
+++ b/src/utils/ExplorerUtils.ts
@@ -574,6 +574,29 @@ export const buildRepoDiscoveryRollupFromMiners = (
   return out;
 };
 
+/**
+ * Matches repository leaderboard OSS column gating (`repoHasOssActivity`).
+ */
+export const repoLeaderboardHasOssActivity = (repo: {
+  totalPRs?: number;
+  totalScore?: number;
+}): boolean => (repo.totalPRs ?? 0) > 0 || (repo.totalScore ?? 0) > 0;
+
+/**
+ * Matches repository leaderboard issue-discovery gating (`repoHasDiscoveryActivity`).
+ * Do not treat `discoveryIssues > 0` alone as “has discovery”: miner pro-rating can
+ * round fractional issues to 0 while discovery score or contributors are still
+ * non-zero, which `TopRepositoriesTable` surfaces as activity.
+ */
+export const repoLeaderboardHasDiscoveryActivity = (repo: {
+  discoveryIssues?: number;
+  discoveryScore?: number;
+  discoveryContributors?: Set<string>;
+}): boolean =>
+  (repo.discoveryIssues ?? 0) !== 0 ||
+  (repo.discoveryScore ?? 0) !== 0 ||
+  (repo.discoveryContributors?.size ?? 0) > 0;
+
 export type IssueBountyRepoRollup = {
   bountyIssuesTotal: number;
   bountyIssuesActive: number;


### PR DESCRIPTION
## Summary

- Add **`TabsOptionsPortal`** (`#tabs-options-portal` on **xl**, **Options** popover below **xl**) and export it from **`components/common`**.
- **`RepositoriesPage`**: **xl** two-column layout with sticky sidebar (`useTwitterStickySidebar`), **`ActivitySidebarCards`**, **Tracked repositories** overview (total / active / inactive), and portal slot **after** the first activity card (Watchlist/Leaderboard pattern).
- **`TopRepositoriesTable`**: move filters, search, rows, chart toggle/scale, and **card-view Sort by** pills into the portal; **leaderboard-style** sort chips (not a dropdown); status filters layout (**All / Active / Inactive** on one row); remove **Repository** from sort pills only (list headers unchanged).
- **`FilterButton`**: optional **`fullWidth`** for sidebar filter styling.

## Related Issues

Fixes #947

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- **`/repositories`**: **xl** — sidebar scroll/sticky, **Filters** collapse, portal content; **< xl** — **Options** popover.
- Card vs list view, URL params (**sort**, **status**, **rows**, **view**, search), chart + log scale.
- **`npm run build`** passes locally.

## Screenshots

-Before fix
<img width="1889" height="778" alt="image" src="https://github.com/user-attachments/assets/c436e8ef-7015-4f5a-952c-b4ea243a5823" />

-After fix
<img width="1629" height="845" alt="image" src="https://github.com/user-attachments/assets/f62c0bf8-79ae-40e3-bc9e-6730b3c0eae9" />

## Checklist

- [ ] New components are modularized/separated where sensible
- [ ] Uses predefined theme (e.g. no hardcoded colors)
- [ ] Responsive/mobile checked
- [ ] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes

---

Per **[CONTRIBUTING.md](CONTRIBUTING.md)**: branch from **`test`**, PR targets **`test`**; assign **`anderdc`** and **`landyndev`** for review; use labels such as **`enhancement`** as appropriate.