### PR TITLE
fix(readme): respect ?s=N size hint on avatar images (#954)

### DIFF
--- a/src/components/repositories/ContributingViewer.tsx
+++ b/src/components/repositories/ContributingViewer.tsx
@@ -11,7 +11,7 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import rehypeRaw from 'rehype-raw';
 import axios from 'axios';
-import { resolveRelativeUrl } from './MarkdownRenderers';
+import { resolveRelativeUrl, getImageSizeHint } from './MarkdownRenderers';
 import { markdownDocumentPaperSx } from '../../theme';
 
 interface ContributingViewerProps {
@@ -120,24 +120,36 @@ const ContributingViewer: React.FC<ContributingViewerProps> = ({
             src,
             alt,
             ...rest
-          }: React.ImgHTMLAttributes<HTMLImageElement>) => (
-            <img
-              src={resolveRelativeUrl(
-                src,
-                repositoryFullName,
-                defaultBranch,
-                'cdn',
-              )}
-              alt={alt}
-              style={{
-                maxWidth: '100%',
-                height: 'auto',
-                borderRadius: '6px',
-                margin: '16px 0',
-              }}
-              {...rest}
-            />
-          ),
+          }: React.ImgHTMLAttributes<HTMLImageElement>) => {
+            const sizeHint = getImageSizeHint(src);
+            return (
+              <img
+                src={resolveRelativeUrl(
+                  src,
+                  repositoryFullName,
+                  defaultBranch,
+                  'cdn',
+                )}
+                alt={alt}
+                {...(sizeHint ? { width: sizeHint, height: sizeHint } : {})}
+                style={
+                  sizeHint
+                    ? {
+                        width: sizeHint,
+                        height: sizeHint,
+                        borderRadius: '6px',
+                      }
+                    : {
+                        maxWidth: '100%',
+                        height: 'auto',
+                        borderRadius: '6px',
+                        margin: '16px 0',
+                      }
+                }
+                {...rest}
+              />
+            );
+          },
         }}
       >
         {content || ''}

--- a/src/components/repositories/MarkdownRenderers.tsx
+++ b/src/components/repositories/MarkdownRenderers.tsx
@@ -1,4 +1,16 @@
 /**
+ * Extract a square pixel size from an image URL's `s` query param
+ * (e.g. GitHub avatars: `https://avatars.githubusercontent.com/u/58493?s=48`).
+ */
+export const getImageSizeHint = (url: string | undefined): number | null => {
+  if (!url) return null;
+  const match = url.match(/[?&]s=(\d+)/);
+  if (!match) return null;
+  const size = parseInt(match[1], 10);
+  return Number.isFinite(size) && size > 0 ? size : null;
+};
+
+/**
  * Resolve a relative URL to an absolute GitHub URL.
  * Returns the original URL if it's already absolute.
  */

--- a/src/components/repositories/ReadmeViewer.tsx
+++ b/src/components/repositories/ReadmeViewer.tsx
@@ -11,7 +11,7 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import rehypeRaw from 'rehype-raw';
 import axios from 'axios';
-import { resolveRelativeUrl } from './MarkdownRenderers';
+import { resolveRelativeUrl, getImageSizeHint } from './MarkdownRenderers';
 import { markdownDocumentPaperSx } from '../../theme';
 
 interface ReadmeViewerProps {
@@ -111,24 +111,36 @@ const ReadmeViewer: React.FC<ReadmeViewerProps> = ({ repositoryFullName }) => {
             src,
             alt,
             ...rest
-          }: React.ImgHTMLAttributes<HTMLImageElement>) => (
-            <img
-              src={resolveRelativeUrl(
-                src,
-                repositoryFullName,
-                defaultBranch,
-                'cdn',
-              )}
-              alt={alt}
-              style={{
-                maxWidth: '100%',
-                height: 'auto',
-                borderRadius: '6px',
-                margin: '16px 0',
-              }}
-              {...rest}
-            />
-          ),
+          }: React.ImgHTMLAttributes<HTMLImageElement>) => {
+            const sizeHint = getImageSizeHint(src);
+            return (
+              <img
+                src={resolveRelativeUrl(
+                  src,
+                  repositoryFullName,
+                  defaultBranch,
+                  'cdn',
+                )}
+                alt={alt}
+                {...(sizeHint ? { width: sizeHint, height: sizeHint } : {})}
+                style={
+                  sizeHint
+                    ? {
+                        width: sizeHint,
+                        height: sizeHint,
+                        borderRadius: '6px',
+                      }
+                    : {
+                        maxWidth: '100%',
+                        height: 'auto',
+                        borderRadius: '6px',
+                        margin: '16px 0',
+                      }
+                }
+                {...rest}
+              />
+            );
+          },
         }}
       >
         {content || ''}


### PR DESCRIPTION
Closes entrius/gittensor-ui#954

## Summary

- Add `getImageSizeHint(url)` in `MarkdownRenderers.tsx` that pulls a numeric `s=N` from any image URL.
- In `ReadmeViewer` and `ContributingViewer`, when the hint is present, render the `<img>` at exactly `N × N` (explicit `width`/`height` attributes + matching inline style, no vertical margin so it can sit inline with surrounding text).
- Images without an `s=N` hint keep the existing responsive `maxWidth: 100%; height: auto` behavior unchanged.

## Why

GitHub avatar URLs (e.g. `https://avatars.githubusercontent.com/u/58493?v=4&s=48`) carry the requested render size in the `s` query param. We were ignoring it and applying a generic block style, which let avatars stretch large and forced a vertical layout — bad for the inline contributor lists those READMEs use.

## Test plan

- [ ] Open a repo whose README contains an avatar URL with `?s=48` (e.g. a contributors section) — avatar renders at 48×48 and sits inline.
- [ ] Open a repo whose README contains a regular screenshot/diagram image (no `s=` param) — image still scales responsively up to container width.
- [ ] Same checks against `CONTRIBUTING.md` via `ContributingViewer`.
- [ ] Verify on mobile width that non-hinted images still respect `maxWidth: 100%`.
Before
<img width="1008" height="879" alt="image" src="https://github.com/user-attachments/assets/e1e219a4-dfa4-44fe-bdeb-e8be75290611" />

After
<img width="1476" height="766" alt="image" src="https://github.com/user-attachments/assets/da876b74-65d0-49d7-b6a7-c157a904bbe9" />
