### PR TITLE
fix mobile layout of repos page

### DIFF
--- a/src/components/repositories/RepositoryContributorsTable.tsx
+++ b/src/components/repositories/RepositoryContributorsTable.tsx
@@ -424,8 +424,6 @@ const RepositoryContributorsTable: React.FC<
               sx={{
                 px: { xs: 0.6, sm: 1 },
                 py: { xs: 0.6, sm: 0.65 },
-                px: 0.5,
-                py: 0.65,
                 border: 0,
                 borderRadius: 1.5,
                 cursor: 'pointer',

--- a/src/components/repositories/RepositoryContributorsTable.tsx
+++ b/src/components/repositories/RepositoryContributorsTable.tsx
@@ -436,10 +436,16 @@ const RepositoryContributorsTable: React.FC<
                   lineHeight: 1.2,
                 }}
               >
-                <Box component="span" sx={{ display: { xs: 'inline', lg: 'none' } }}>
+                <Box
+                  component="span"
+                  sx={{ display: { xs: 'inline', lg: 'none' } }}
+                >
                   {option.mobileLabel}
                 </Box>
-                <Box component="span" sx={{ display: { xs: 'none', lg: 'inline' } }}>
+                <Box
+                  component="span"
+                  sx={{ display: { xs: 'none', lg: 'inline' } }}
+                >
                   {option.label}
                 </Box>
               </Typography>

--- a/src/components/repositories/RepositoryContributorsTable.tsx
+++ b/src/components/repositories/RepositoryContributorsTable.tsx
@@ -384,8 +384,16 @@ const RepositoryContributorsTable: React.FC<
       >
         {(
           [
-            { label: 'OSS Contributions', value: 'oss' as const },
-            { label: 'Issue Discovery', value: 'issues' as const },
+            {
+              label: 'OSS Contributions',
+              mobileLabel: 'OSS',
+              value: 'oss' as const,
+            },
+            {
+              label: 'Issue Discovery',
+              mobileLabel: 'Discovery',
+              value: 'issues' as const,
+            },
           ] as const
         ).map((option) => {
           const isActive = programTab === option.value;
@@ -397,13 +405,16 @@ const RepositoryContributorsTable: React.FC<
               aria-pressed={isActive}
               onClick={() => setProgramTab(option.value)}
               sx={{
-                px: 1,
-                py: 0.65,
+                px: { xs: 0.6, sm: 1 },
+                py: { xs: 0.6, sm: 0.65 },
                 border: 0,
                 borderRadius: 1.5,
                 cursor: 'pointer',
                 minWidth: 0,
                 flex: 1,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
                 fontFamily: 'inherit',
                 backgroundColor: isActive ? 'surface.elevated' : 'transparent',
                 color: isActive
@@ -418,14 +429,19 @@ const RepositoryContributorsTable: React.FC<
             >
               <Typography
                 sx={{
-                  fontSize: '0.72rem',
+                  fontSize: { xs: '0.66rem', sm: '0.68rem', lg: '0.72rem' },
                   fontWeight: 600,
                   textAlign: 'center',
                   whiteSpace: 'nowrap',
                   lineHeight: 1.2,
                 }}
               >
-                {option.label}
+                <Box component="span" sx={{ display: { xs: 'inline', lg: 'none' } }}>
+                  {option.mobileLabel}
+                </Box>
+                <Box component="span" sx={{ display: { xs: 'none', lg: 'inline' } }}>
+                  {option.label}
+                </Box>
               </Typography>
             </Box>
           );

--- a/src/pages/RepositoryDetailsPage.tsx
+++ b/src/pages/RepositoryDetailsPage.tsx
@@ -414,7 +414,9 @@ const RepositoryDetailsPage: React.FC = () => {
 
           {/* Sidebar */}
           <Grid item xs={12} lg={3}>
-            <Box sx={{ position: { xs: 'static', lg: 'sticky' }, top: { lg: 24 } }}>
+            <Box
+              sx={{ position: { xs: 'static', lg: 'sticky' }, top: { lg: 24 } }}
+            >
               <Box sx={{ pt: 0 }}>
                 {/* Repository Stats */}
                 <RepositoryStats repositoryFullName={repo} />

--- a/src/pages/RepositoryDetailsPage.tsx
+++ b/src/pages/RepositoryDetailsPage.tsx
@@ -376,7 +376,7 @@ const RepositoryDetailsPage: React.FC = () => {
       {/* Main Content */}
       <Container maxWidth="xl" sx={{ pb: 8, pt: 1 }}>
         <Grid container spacing={4}>
-          <Grid item xs={12} md={9}>
+          <Grid item xs={12} lg={9}>
             {/* Readme Tab */}
             <CustomTabPanel value={tabValue} index={0}>
               <ReadmeViewer repositoryFullName={repo} />
@@ -413,8 +413,8 @@ const RepositoryDetailsPage: React.FC = () => {
           </Grid>
 
           {/* Sidebar */}
-          <Grid item xs={12} md={3}>
-            <Box sx={{ position: 'sticky', top: 24 }}>
+          <Grid item xs={12} lg={3}>
+            <Box sx={{ position: { xs: 'static', lg: 'sticky' }, top: { lg: 24 } }}>
               <Box sx={{ pt: 0 }}>
                 {/* Repository Stats */}
                 <RepositoryStats repositoryFullName={repo} />


### PR DESCRIPTION
## Summary

Fixes responsive layout issues in the repository details sidebar and Top Miner Contributors segmented toggle.

- Updated `RepositoryDetailsPage` grid breakpoints so `1024px` uses the same stacked layout behavior as tablet/mobile (`lg` breakpoint now controls two-column layout).
- Limited sidebar sticky behavior to `lg+` to avoid narrow-width rendering conflicts.
- Updated the segmented toggle in `RepositoryContributorsTable` with responsive label behavior and sizing so labels do not overlap/clamp at smaller and mid-width screens.
- Preserved desktop behavior for wider viewports while improving usability on `<=1024px`.

## Related Issues

Fixes #953 .

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

- before
<br/>
<img width="1252" height="669" alt="repo" src="https://github.com/user-attachments/assets/d37716e2-2a73-439d-87dd-dab6b349bb45" />
<br/>

- after
<br/>
<img width="1245" height="670" alt="repo_fix" src="https://github.com/user-attachments/assets/9d0818f7-4253-45ab-9a97-0b75bec85451" />
<br/>

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [ ] Tested against the test API
- [ ] `npm run format` and `npm run lint:fix` have been run
- [ ] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
