### PR TITLE
fix: Use shared helpers for all GitHub avatar URLs

### DIFF
--- a/src/components/issues/IssuesList.tsx
+++ b/src/components/issues/IssuesList.tsx
@@ -568,6 +568,7 @@ const IssuesList: React.FC<IssuesListProps> = ({
               src={getRepositoryOwnerAvatarSrc(
                 issue.repositoryFullName.split('/')[0],
               )}
+              alt={issue.repositoryFullName}
               sx={{ width: 24, height: 24, borderRadius: 1, flexShrink: 0 }}
             />
             <Typography

--- a/src/components/leaderboard/LeaderboardSidebar.tsx
+++ b/src/components/leaderboard/LeaderboardSidebar.tsx
@@ -275,6 +275,7 @@ const LeaderboardRow: React.FC<LeaderboardRowProps> = ({
       >
         <Avatar
           src={getGithubAvatarSrc(miner.author || miner.githubId)}
+          alt={miner.author || miner.githubId}
           sx={{ width: 20, height: 20 }}
         />
         <Typography

--- a/src/components/leaderboard/MinerCard.tsx
+++ b/src/components/leaderboard/MinerCard.tsx
@@ -146,6 +146,7 @@ export const MinerCard: React.FC<MinerCardProps> = ({
         >
           <Avatar
             src={avatarSrc}
+            alt={username}
             sx={(theme) => ({
               width: 36,
               height: 36,

--- a/src/components/leaderboard/MinersList.tsx
+++ b/src/components/leaderboard/MinersList.tsx
@@ -234,6 +234,7 @@ const MinerIdentityCell: React.FC<MinerIdentityCellProps> = ({ miner }) => {
     <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 0 }}>
       <Avatar
         src={avatarSrc}
+        alt={username}
         sx={{
           width: 24,
           height: 24,

--- a/src/components/miners/MinerScoreCard.tsx
+++ b/src/components/miners/MinerScoreCard.tsx
@@ -41,6 +41,7 @@ import {
   calculateOpenIssueThreshold,
   parseNumber,
 } from '../../utils/ExplorerUtils';
+import { getRepositoryOwnerAvatarSrc } from '../../utils/avatar';
 import { credibilityColor } from '../../utils/format';
 
 const formatTimeAgo = (date: Date): string => {
@@ -479,7 +480,7 @@ const MinerScoreCard: React.FC<MinerScoreCardProps> = ({
         }}
       >
         <Avatar
-          src={`https://avatars.githubusercontent.com/${username}`}
+          src={getRepositoryOwnerAvatarSrc(username)}
           alt={username}
           sx={{
             width: { xs: 72, sm: 64 },

--- a/src/components/prs/PRHeader.tsx
+++ b/src/components/prs/PRHeader.tsx
@@ -344,7 +344,7 @@ const PRHeader: React.FC<PRHeaderProps> = ({
               }}
             >
               <Avatar
-                src={`https://avatars.githubusercontent.com/${prDetails.authorLogin}`}
+                src={getRepositoryOwnerAvatarSrc(prDetails.authorLogin)}
                 alt={prDetails.authorLogin}
                 sx={{ width: 22, height: 22 }}
               />

--- a/src/components/repositories/RepositoryCodeBrowser.tsx
+++ b/src/components/repositories/RepositoryCodeBrowser.tsx
@@ -374,6 +374,7 @@ const RepositoryCodeBrowser: React.FC<RepositoryCodeBrowserProps> = ({
               >
                 <Avatar
                   src={currentCommit.avatarUrl}
+                  alt={currentCommit.committerLogin}
                   sx={{ width: 20, height: 20 }}
                 />
                 <Typography

--- a/src/components/repositories/RepositoryContributorsTable.tsx
+++ b/src/components/repositories/RepositoryContributorsTable.tsx
@@ -15,6 +15,7 @@ import { LinkBox } from '../common/linkBehavior';
 import { STATUS_COLORS } from '../../theme';
 import { isMergedPr } from '../../utils/prStatus';
 import { parseNumber } from '../../utils/ExplorerUtils';
+import { getRepositoryOwnerAvatarSrc } from '../../utils/avatar';
 import { DataTable, type DataTableColumn } from '../common/DataTable';
 
 interface RepositoryContributorsTableProps {
@@ -252,7 +253,8 @@ const RepositoryContributorsTable: React.FC<
               }}
             >
               <Avatar
-                src={`https://avatars.githubusercontent.com/${c.author}`}
+                src={getRepositoryOwnerAvatarSrc(c.author)}
+                alt={c.author}
                 sx={{
                   width: 18,
                   height: 18,

--- a/src/components/repositories/RepositoryPRsTable.tsx
+++ b/src/components/repositories/RepositoryPRsTable.tsx
@@ -20,6 +20,7 @@ import { ScrollAwareTooltip } from '../../components/common/ScrollAwareTooltip';
 import { serializePRKey } from '../../hooks/useWatchlist';
 import theme, { TEXT_OPACITY, scrollbarSx } from '../../theme';
 import { filterPrs, getPrStatusCounts, type PrStatusFilter } from '../../utils';
+import { getRepositoryOwnerAvatarSrc } from '../../utils/avatar';
 import FilterButton from '../FilterButton';
 import { AUTHOR_FILTER_ALL, AuthorFilter } from './AuthorFilter';
 
@@ -269,7 +270,7 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
       renderCell: (pr) => (
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
           <Avatar
-            src={`https://avatars.githubusercontent.com/${pr.author}`}
+            src={getRepositoryOwnerAvatarSrc(pr.author)}
             alt={pr.author}
             sx={{ width: 20, height: 20, flexShrink: 0 }}
           />

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -7,7 +7,12 @@ import { SEO } from '../components';
 import { LinkBox, useLinkBehavior } from '../components/common/linkBehavior';
 import { type CommitLog, type MinerEvaluation, useStats } from '../api';
 import { useMonthlyRewards } from '../hooks/useMonthlyRewards';
-import { getGithubAvatarSrc, getPrStatusLabel, parseNumber } from '../utils';
+import {
+  getGithubAvatarSrc,
+  getGithubUserAvatarSrcById,
+  getPrStatusLabel,
+  parseNumber,
+} from '../utils';
 import useDashboardData from './dashboard/useDashboardData';
 
 const fadeUp = (delayMs = 0) => ({
@@ -228,7 +233,7 @@ const buildActivityRows = (prs: CommitLog[]): LandingActivityRow[] =>
 const getAvatarSrc = (miner: LandingMinerRow) => {
   if (miner.username) return getGithubAvatarSrc(miner.username);
   return /^\d+$/.test(miner.githubId)
-    ? `https://avatars.githubusercontent.com/u/${miner.githubId}`
+    ? getGithubUserAvatarSrcById(miner.githubId)
     : '';
 };
 

--- a/src/pages/RepositoriesPage.tsx
+++ b/src/pages/RepositoriesPage.tsx
@@ -22,10 +22,19 @@ const HighlightRow: React.FC<{
   href: string;
   linkState?: Record<string, unknown>;
   avatar: string;
+  avatarAlt: string;
   avatarBg?: (theme: Theme) => string;
   label: React.ReactNode;
   right: React.ReactNode;
-}> = ({ href, linkState, avatar, avatarBg = 'transparent', label, right }) => {
+}> = ({
+  href,
+  linkState,
+  avatar,
+  avatarAlt,
+  avatarBg = 'transparent',
+  label,
+  right,
+}) => {
   return (
     <LinkBox
       href={href}
@@ -56,6 +65,7 @@ const HighlightRow: React.FC<{
       >
         <Avatar
           src={avatar}
+          alt={avatarAlt}
           sx={{
             width: 24,
             height: 24,
@@ -393,6 +403,7 @@ const RepositoriesPage: React.FC = () => {
                         avatar={getRepositoryOwnerAvatarSrc(
                           repo.name.split('/')[0],
                         )}
+                        avatarAlt={repo.name}
                         avatarBg={getAvatarBg(repo.name)}
                         label={
                           <Tooltip title={repo.name} arrow placement="top">
@@ -464,6 +475,7 @@ const RepositoriesPage: React.FC = () => {
                         avatar={getRepositoryOwnerAvatarSrc(
                           repo.name.split('/')[0],
                         )}
+                        avatarAlt={repo.name}
                         avatarBg={getAvatarBg(repo.name)}
                         label={
                           <Tooltip title={repo.name} arrow placement="top">
@@ -529,6 +541,7 @@ const RepositoriesPage: React.FC = () => {
                         avatar={getRepositoryOwnerAvatarSrc(
                           pr.name.split('/')[0],
                         )}
+                        avatarAlt={pr.name}
                         avatarBg={getAvatarBg(pr.name)}
                         label={
                           <Box

--- a/src/pages/RepositoryDetailsPage.tsx
+++ b/src/pages/RepositoryDetailsPage.tsx
@@ -412,7 +412,7 @@ const RepositoryDetailsPage: React.FC = () => {
                     >
                       <Avatar
                         src={getRepositoryOwnerAvatarSrc(owner)}
-                        alt=""
+                        alt={owner}
                         variant="rounded"
                         imgProps={{ loading: 'lazy', decoding: 'async' }}
                         sx={(theme) => ({
@@ -483,6 +483,7 @@ const RepositoryDetailsPage: React.FC = () => {
                   <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
                     <Avatar
                       src={getRepositoryOwnerAvatarSrc(owner)}
+                      alt={owner}
                       variant="rounded"
                       sx={(theme) => ({
                         width: 32,

--- a/src/pages/WatchlistPage.tsx
+++ b/src/pages/WatchlistPage.tsx
@@ -1065,6 +1065,7 @@ const repoColumns: DataTableColumn<WatchedRepoStats, RepoSortKey>[] = [
       <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 0 }}>
         <Avatar
           src={getRepositoryOwnerAvatarSrc(repo.fullName.split('/')[0])}
+          alt={repo.fullName}
           sx={{
             width: 20,
             height: 20,
@@ -2225,6 +2226,7 @@ const buildBountyColumns = (): DataTableColumn<
       <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 0 }}>
         <Avatar
           src={getRepositoryOwnerAvatarSrc(i.repositoryFullName.split('/')[0])}
+          alt={i.repositoryFullName}
           sx={{ width: 20, height: 20, flexShrink: 0 }}
         />
         <Typography
@@ -2713,7 +2715,8 @@ const buildPrColumns = (
     renderCell: (pr) => (
       <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 0 }}>
         <Avatar
-          src={`https://avatars.githubusercontent.com/${pr.author}`}
+          src={getRepositoryOwnerAvatarSrc(pr.author)}
+          alt={pr.author}
           sx={{ width: 20, height: 20, flexShrink: 0 }}
         />
         <Typography
@@ -2931,6 +2934,7 @@ const PRCard: React.FC<{
         >
           <Avatar
             src={getRepositoryOwnerAvatarSrc(pr.repository.split('/')[0])}
+            alt={pr.repository}
             sx={{
               width: 20,
               height: 20,
@@ -3007,7 +3011,8 @@ const PRCard: React.FC<{
         >
           <Stack direction="row" alignItems="center" spacing={1}>
             <Avatar
-              src={`https://avatars.githubusercontent.com/${pr.author}`}
+              src={getRepositoryOwnerAvatarSrc(pr.author)}
+              alt={pr.author}
               sx={{ width: 18, height: 18 }}
             />
             <Typography
@@ -3494,7 +3499,8 @@ const buildIssueColumns = (
           sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 0 }}
         >
           <Avatar
-            src={`https://avatars.githubusercontent.com/${login}`}
+            src={getRepositoryOwnerAvatarSrc(login)}
+            alt={login}
             sx={{ width: 20, height: 20, flexShrink: 0 }}
           />
           <Typography
@@ -3681,6 +3687,7 @@ const IssueCard: React.FC<{
             src={getRepositoryOwnerAvatarSrc(
               issue.repo_full_name.split('/')[0],
             )}
+            alt={issue.repo_full_name}
             sx={{
               width: 20,
               height: 20,
@@ -3764,7 +3771,8 @@ const IssueCard: React.FC<{
           >
             {issue.author_login && (
               <Avatar
-                src={`https://avatars.githubusercontent.com/${issue.author_login}`}
+                src={getRepositoryOwnerAvatarSrc(issue.author_login)}
+                alt={issue.author_login}
                 sx={{ width: 18, height: 18, flexShrink: 0 }}
               />
             )}

--- a/src/pages/dashboard/views/LiveCommitLog.tsx
+++ b/src/pages/dashboard/views/LiveCommitLog.tsx
@@ -199,6 +199,7 @@ const CommitLogItem: React.FC<{
           <Stack direction="row" alignItems="center" spacing={1}>
             <Avatar
               src={getRepositoryOwnerAvatarSrc(entry.repository.split('/')[0])}
+              alt={entry.repository}
               sx={{
                 width: 16,
                 height: 16,

--- a/src/utils/ExplorerUtils.ts
+++ b/src/utils/ExplorerUtils.ts
@@ -5,15 +5,11 @@ import {
   type RepositoryPrScoring,
 } from '../api';
 import { type IssueBounty } from '../api/models/Issues';
+import { getRepositoryOwnerAvatarSrc } from './avatar';
 import { isMergedPr } from './prStatus';
 
-export const getGithubAvatarSrc = (username?: string | null) => {
-  if (username) {
-    return `https://avatars.githubusercontent.com/${username}`;
-  }
-
-  return '';
-};
+export const getGithubAvatarSrc = (username?: string | null) =>
+  getRepositoryOwnerAvatarSrc(username);
 
 // Parses numeric-like values and falls back when the value is missing or invalid.
 export const parseNumber = (value: unknown, fallback = 0): number => {

--- a/src/utils/avatar.ts
+++ b/src/utils/avatar.ts
@@ -5,3 +5,13 @@ export const getRepositoryOwnerAvatarSrc = (
   if (!normalizedOwner) return '';
   return `https://github.com/${encodeURIComponent(normalizedOwner)}.png`;
 };
+
+export const getGithubUserAvatarSrcById = (
+  githubId: string | number | null | undefined,
+): string => {
+  const normalizedId = String(githubId ?? '').trim();
+  if (!normalizedId) return '';
+  return `https://avatars.githubusercontent.com/u/${encodeURIComponent(
+    normalizedId,
+  )}`;
+};


### PR DESCRIPTION
## Summary

Refactor GitHub avatar URL generation to use shared helper functions and add accessible alt text to avatar images across the app.

Closes #963

## Changes

- Added a shared helper for GitHub ID-based avatar URLs.
- Replaced hardcoded GitHub avatar URL construction in issue, PR, repository, miner, watchlist, and homepage views.
- Updated existing avatar utility usage to keep username/org-based avatar URLs centralized.
- Added `alt` text to GitHub avatar images using the relevant login, repository, owner, or committer identifier.

## Testing

- `npm run format:check`
- `npm run lint`
- `npm test`
- `npm run build`
