### PR TITLE
fix(miners): filter open discovery issues to gittensor tracked repos

### DIFF
--- a/src/components/miners/MinerOpenDiscoveryIssuesByRepo.tsx
+++ b/src/components/miners/MinerOpenDiscoveryIssuesByRepo.tsx
@@ -32,6 +32,10 @@ import {
   selectMinerIssueScanRepos,
   useMinerRepositoriesOpenIssues,
 } from '../../hooks/useMinerRepositoriesOpenIssues';
+import {
+  isTrackedRepo,
+  useTrackedRepoSet,
+} from '../../hooks/useTrackedRepoSet';
 import { type RepositoryIssue } from '../../api/models/Miner';
 
 type IssueFilter = 'all' | 'open' | 'solved' | 'closed';
@@ -131,6 +135,7 @@ const fetchLinkedPrNumberForIssue = async (
 
 const fetchGithubIssuesByAuthor = async (
   login: string,
+  trackedRepos: Set<string>,
 ): Promise<RepositoryIssue[]> => {
   const { data } = await axios.get<GithubSearchIssuesResponse>(
     'https://api.github.com/search/issues',
@@ -158,7 +163,9 @@ const fetchGithubIssuesByAuthor = async (
         url: item.html_url,
       } satisfies RepositoryIssue;
     })
-    .filter((issue) => !!issue.repositoryFullName);
+    // Drop issues from repositories outside the gittensor tracked set before
+    // running the per-issue timeline enrichment, which is the expensive part.
+    .filter((issue) => isTrackedRepo(trackedRepos, issue.repositoryFullName));
 
   const enriched = await Promise.all(
     mapped.map(async (issue) => {
@@ -241,6 +248,9 @@ const MinerOpenDiscoveryIssuesByRepo: React.FC<
   const scanRepos = useMemo(() => selectMinerIssueScanRepos(prs), [prs]);
   const login = githubProfile?.login ?? '';
 
+  const { trackedRepos, isLoading: isLoadingTrackedRepos } =
+    useTrackedRepoSet();
+
   const {
     data: githubAuthoredIssues = [],
     isLoading: isLoadingAuthoredIssues,
@@ -248,8 +258,10 @@ const MinerOpenDiscoveryIssuesByRepo: React.FC<
     isError: isAuthorFallbackError,
   } = useQuery({
     queryKey: ['githubAuthorIssues', login],
-    queryFn: () => fetchGithubIssuesByAuthor(login),
-    enabled: !!login,
+    queryFn: () => fetchGithubIssuesByAuthor(login, trackedRepos),
+    // Wait for the tracked-repo allowlist before searching, so the search
+    // result is filtered before the per-issue enrichment fan-out runs.
+    enabled: !!login && !isLoadingTrackedRepos && trackedRepos.size > 0,
     staleTime: 60_000,
     retry: 1,
   });
@@ -943,6 +955,7 @@ const MinerOpenDiscoveryIssuesByRepo: React.FC<
 
   const isDataLoading =
     isLoading ||
+    isLoadingTrackedRepos ||
     isLoadingAuthoredIssues ||
     isFetchingAuthoredIssues ||
     isLoadingAuthoredRepoIssues;

--- a/src/hooks/useTrackedRepoSet.ts
+++ b/src/hooks/useTrackedRepoSet.ts
@@ -1,0 +1,23 @@
+import { useMemo } from 'react';
+import { useReposAndWeights } from '../api';
+
+/**
+ * Lowercase set of full names for every repository tracked by gittensor.
+ *
+ * Source of truth: GET /dash/repos. Use this whenever data fetched from
+ * outside the gittensor API (e.g. the GitHub search endpoint) needs to be
+ * narrowed down to repositories the subnet actually scores.
+ */
+export const useTrackedRepoSet = () => {
+  const { data, isLoading, isError } = useReposAndWeights();
+  const trackedRepos = useMemo(
+    () => new Set((data ?? []).map((r) => r.fullName.toLowerCase())),
+    [data],
+  );
+  return { trackedRepos, isLoading, isError };
+};
+
+export const isTrackedRepo = (
+  trackedRepos: Set<string>,
+  repoFullName: string | null | undefined,
+): boolean => !!repoFullName && trackedRepos.has(repoFullName.toLowerCase());


### PR DESCRIPTION
## Summary

The miner discovery issues page was rendering items from repositories outside the gittensor tracked set, because `fetchGithubIssuesByAuthor` in `MinerOpenDiscoveryIssuesByRepo.tsx` queries `api.github.com/search/issues` directly and the result was never intersected with the allowlist.

This change introduces a small reusable hook, `useTrackedRepoSet`, that returns a memoized lowercase set built from `GET /dash/repos` (the same source the `/repositories` page already uses). The discovery component reads the set, gates the GitHub search query on it, and passes it into the fetcher so the filter runs before the per issue timeline enrichment fan out. Everything downstream (`authoredRepos`, the secondary issues fetch, and the grouping logic) becomes correct without any further changes.

Notable effects:

* Untracked repositories no longer appear in the "Your open discovery issues" or "Other open discovery issues" sections.
* Up to 100 unnecessary GitHub timeline requests per page load are avoided, easing the unauthenticated rate limit pressure.
* The new hook is generic and can be reused anywhere external data needs to be narrowed to gittensor tracked repositories.

## Related Issues

Fixes #965

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

Before: untracked repositories listed in the discovery issues sections.
<img width="1886" height="861" alt="before" src="https://github.com/user-attachments/assets/b9ba1f23-adee-488b-8910-682e8570b7cb" />

After: only repositories present in `GET /dash/repos` are shown.
<img width="1887" height="853" alt="after" src="https://github.com/user-attachments/assets/6d000ba9-f24a-4a49-9eac-48f4b7bcc63e" />

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes