### PR TITLE
fix: base open-discovery repo warning on unique repos

### DIFF
--- a/src/components/miners/MinerOpenDiscoveryIssuesByRepo.tsx
+++ b/src/components/miners/MinerOpenDiscoveryIssuesByRepo.tsx
@@ -29,7 +29,7 @@ import { DataTable, type DataTableColumn } from '../common/DataTable';
 import ExplorerFilterButton from './ExplorerFilterButton';
 import TablePagination from './TablePagination';
 import {
-  selectMinerIssueScanRepos,
+  selectMinerIssueScanRepoSummary,
   useMinerRepositoriesOpenIssues,
 } from '../../hooks/useMinerRepositoriesOpenIssues';
 import { type RepositoryIssue } from '../../api/models/Miner';
@@ -238,7 +238,11 @@ const MinerOpenDiscoveryIssuesByRepo: React.FC<
   const [otherPage, setOtherPage] = useState(0);
   const [otherExpanded, setOtherExpanded] = useState(false);
 
-  const scanRepos = useMemo(() => selectMinerIssueScanRepos(prs), [prs]);
+  const scanRepoSummary = useMemo(
+    () => selectMinerIssueScanRepoSummary(prs),
+    [prs],
+  );
+  const scanRepos = scanRepoSummary.repos;
   const login = githubProfile?.login ?? '';
 
   const {
@@ -997,10 +1001,10 @@ const MinerOpenDiscoveryIssuesByRepo: React.FC<
         ) : null}
       </Alert>
 
-      {prs.length > repoFetchLimit ? (
+      {scanRepoSummary.totalRepos > repoFetchLimit ? (
         <Typography variant="caption" color="text.secondary">
-          You have PRs in more than {repoFetchLimit} repositories; only the most
-          active {repoFetchLimit} are scanned here to limit load.
+          You have more than {repoFetchLimit} repositories with scored PRs; only
+          the most active {repoFetchLimit} are scanned here to limit load.
         </Typography>
       ) : null}
 

--- a/src/hooks/useMinerRepositoriesOpenIssues.ts
+++ b/src/hooks/useMinerRepositoriesOpenIssues.ts
@@ -23,8 +23,10 @@ const fetchRepositoryIssues = async (
  * Repositories where the miner has scored PR activity, ordered by most recent
  * PR timestamp (merged or created), capped for parallel fetch limits.
  */
-export const selectMinerIssueScanRepos = (prs: CommitLog[] | undefined) => {
-  if (!prs?.length) return [];
+export const selectMinerIssueScanRepoSummary = (
+  prs: CommitLog[] | undefined,
+) => {
+  if (!prs?.length) return { repos: [], totalRepos: 0 };
   const latest = new Map<string, number>();
   prs.forEach((pr) => {
     const raw = pr.mergedAt || pr.prCreatedAt;
@@ -32,11 +34,16 @@ export const selectMinerIssueScanRepos = (prs: CommitLog[] | undefined) => {
     const prev = latest.get(pr.repository) ?? 0;
     if (t >= prev) latest.set(pr.repository, t);
   });
-  return [...latest.entries()]
+  const repos = [...latest.entries()]
     .sort((a, b) => b[1] - a[1])
     .map(([repo]) => repo)
     .slice(0, REPO_FETCH_LIMIT);
+
+  return { repos, totalRepos: latest.size };
 };
+
+export const selectMinerIssueScanRepos = (prs: CommitLog[] | undefined) =>
+  selectMinerIssueScanRepoSummary(prs).repos;
 
 /**
  * Parallel fetch of `/repos/{repo}/issues` for each repository in `repos`.

--- a/src/tests/useMinerRepositoriesOpenIssues.test.ts
+++ b/src/tests/useMinerRepositoriesOpenIssues.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import type { CommitLog } from '../api/models/Dashboard';
+import {
+  selectMinerIssueScanRepoSummary,
+  selectMinerIssueScanRepos,
+} from '../hooks/useMinerRepositoriesOpenIssues';
+
+const pr = (repository: string, index: number): CommitLog =>
+  ({
+    repository,
+    mergedAt: `2026-01-${String((index % 28) + 1).padStart(2, '0')}T00:00:00Z`,
+    prCreatedAt: '',
+  }) as CommitLog;
+
+describe('selectMinerIssueScanRepoSummary', () => {
+  it('does not treat more than 50 PRs in fewer repositories as over the repo limit', () => {
+    const prs = Array.from({ length: 60 }, (_, index) =>
+      pr(index % 2 === 0 ? 'owner/api' : 'owner/web', index),
+    );
+
+    const summary = selectMinerIssueScanRepoSummary(prs);
+
+    expect(summary.totalRepos).toBe(2);
+    expect(summary.repos).toHaveLength(2);
+    expect(summary.totalRepos).toBeLessThanOrEqual(50);
+  });
+
+  it('reports when more than 50 unique repositories are eligible to scan', () => {
+    const prs = Array.from({ length: 55 }, (_, index) =>
+      pr(`owner/repo-${index}`, index),
+    );
+
+    const summary = selectMinerIssueScanRepoSummary(prs);
+
+    expect(summary.totalRepos).toBe(55);
+    expect(summary.repos).toHaveLength(50);
+    expect(summary.totalRepos).toBeGreaterThan(50);
+  });
+});
+
+describe('selectMinerIssueScanRepos', () => {
+  it('preserves the capped repository list API', () => {
+    const prs = Array.from({ length: 55 }, (_, index) =>
+      pr(`owner/repo-${index}`, index),
+    );
+
+    expect(selectMinerIssueScanRepos(prs)).toHaveLength(50);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #972.

Fixes the Miner Details open-discovery repo-limit warning so it is based on the number of unique repositories eligible for scanning, not the raw PR count.

The scan helper already de-duplicates PRs by repository before applying the 50-repository cap. The UI warning now uses that same uncapped unique repository count, so miners with many PRs in a small number of repositories no longer see a false repo-limit warning.

## Changes

- Add `selectMinerIssueScanRepoSummary()` to return both capped scan repos and uncapped unique repository count.
- Keep `selectMinerIssueScanRepos()` as the existing capped-list API.
- Update `MinerOpenDiscoveryIssuesByRepo` to show the repo-limit warning only when unique repositories exceed the fetch limit.
- Add regression tests for many PRs in few repos and more than 50 unique repos.

## Testing

```bash
npm test -- --run src/tests/useMinerRepositoriesOpenIssues.test.ts
npx prettier --check src/hooks/useMinerRepositoriesOpenIssues.ts src/components/miners/MinerOpenDiscoveryIssuesByRepo.tsx src/tests/useMinerRepositoriesOpenIssues.test.ts
npx eslint src/hooks/useMinerRepositoriesOpenIssues.ts src/components/miners/MinerOpenDiscoveryIssuesByRepo.tsx src/tests/useMinerRepositoriesOpenIssues.test.ts --ext ts,tsx --max-warnings 0
npm run build
```
