### PR TITLE
ci: bake VITE_REACT_APP_MIRROR_BASE_URL into docker image

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -30,7 +30,9 @@ jobs:
           fi
 
       - name: Create .env file
-        run: echo "VITE_REACT_APP_BASE_URL=${{ vars.VITE_REACT_APP_BASE_URL }}" > .env
+        run: |
+          echo "VITE_REACT_APP_BASE_URL=${{ vars.VITE_REACT_APP_BASE_URL }}" > .env
+          echo "VITE_REACT_APP_MIRROR_BASE_URL=${{ vars.VITE_REACT_APP_MIRROR_BASE_URL }}" >> .env
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5


### PR DESCRIPTION
## Summary
- Issue Discovery's miner-issues call (`/miners/:githubId/issues`) was hitting `gittensor.io` instead of `mirror.gittensor.io` because the mirror base URL was never present in the docker build context.
- `docker-publish.yml` only wrote `VITE_REACT_APP_BASE_URL` into `.env` before `npm run build`, so Vite baked an empty `VITE_REACT_APP_MIRROR_BASE_URL` and the mirror call fell back to a relative URL (resolved against the page origin in production).
- This PR appends `VITE_REACT_APP_MIRROR_BASE_URL` to the generated `.env` so it gets inlined into the bundle.

## Required follow-up (manual)
Set `VITE_REACT_APP_MIRROR_BASE_URL` as a variable on the GitHub Environments:
- `test` → `https://mirror.gittensor.io/api/v1` (or the test mirror, if there is one)
- `prod` → `https://mirror.gittensor.io/api/v1`

Without those vars, the line resolves to an empty string and the bug persists.

## Test plan
- [ ] Add `VITE_REACT_APP_MIRROR_BASE_URL` to the `test` GitHub Environment
- [ ] Merge → CI publishes `entrius/gt-ui:test`
- [ ] On test host, confirm Watchtower pulls the new image, then `docker exec gt-ui sh -c 'grep -ho "https://mirror[^\"]*" /app/dist/assets/*.js | sort -u'` shows the mirror URL baked in
- [ ] Visit Issue Discovery for a miner on test and verify the request goes to `mirror.gittensor.io/api/v1/miners/.../issues` (200) instead of the page origin
- [ ] Repeat for `prod` environment before promoting to `main`