### PR TITLE
fix(top-miners): rename 'Leaderboard' tab to 'OSS Contributions' (#941)

### DIFF
--- a/src/pages/TopMinersPage.tsx
+++ b/src/pages/TopMinersPage.tsx
@@ -21,7 +21,7 @@ type TimelineTab = 'oss' | 'discoveries';
 const TIMELINE_ORDER: readonly TimelineTab[] = ['oss', 'discoveries'] as const;
 
 const TIMELINE_LABELS: Record<TimelineTab, string> = {
-  oss: 'Leaderboard',
+  oss: 'OSS Contributions',
   discoveries: 'Discoveries',
 };
 


### PR DESCRIPTION
## Summary

Renames the first timeline tab on `/top-miners` from **"Leaderboard"** → **"OSS Contributions"** so it's parallel to the sibling **"Discoveries"** tab and accurately describes the tab's content.

```diff
 const TIMELINE_LABELS: Record<TimelineTab, string> = {
-  oss: 'Leaderboard',
+  oss: 'OSS Contributions',
   discoveries: 'Discoveries',
 };
```

That's the entire change — one line in `src/pages/TopMinersPage.tsx`.

## Why

- The page itself **is** the Leaderboard — using "Leaderboard" as one of its sub-tabs is redundant and misleading.
- The sibling tab is **Discoveries** (issue-discovery rankings). Renaming this one to **OSS Contributions** makes the two tabs symmetric and self-describing: _OSS Contributions vs. Discoveries_.
- Internally the variant is already keyed as `'oss'` and the watchlist UI already uses the "OSS" label for the same dimension — this aligns the user-facing tab with that vocabulary.

## Related Issues

Fixes #941

## Type of Change

- [ ] Bug fix
- [x] Refactor (label only — no behavior change)
- [ ] New feature
- [ ] Documentation
- [ ] Other

## Out of scope (per #941)

- **No URL param change** — `?timeline=oss` stays as the default and existing bookmarks keep working.
- **No SEO/page title change** — the page still uses "Leaderboard" as its `<title>`; that describes the page, not the tab.
- **No route or sidebar nav change** — `/top-miners` and the sidebar entry are untouched.

## Screenshots

<img width="1827" height="766" alt="image" src="https://github.com/user-attachments/assets/ab9dede6-63e9-4d2c-9644-11e0d172306a" />

## Test plan

- [ ] Visit `/top-miners` — first tab reads **"OSS Contributions"** and is selected by default.
- [ ] Visit `/top-miners?timeline=discoveries` — second tab reads **"Discoveries"** and is selected.
- [ ] Click between the two tabs — URL updates correctly (`?timeline=discoveries` ↔ no param), table content swaps as before.
- [ ] Existing bookmarks with `?timeline=oss` and `?timeline=discoveries` still resolve to the correct tab.
- [ ] Browser tab title still says "Leaderboard" (page-level SEO unchanged).

## Checklist

- [x] Uses predefined theme tokens (no hardcoded colors)
- [x] Responsive/mobile checked — Tabs component already responsive; only the label string changed
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] `npm test` passes (75/75)
- [ ] Screenshots included for UI/visual changes
