### PR TITLE
fix(repository): show short toggle labels on mobile contributors card

### DIFF
--- a/src/components/repositories/RepositoryContributorsTable.tsx
+++ b/src/components/repositories/RepositoryContributorsTable.tsx
@@ -6,6 +6,7 @@ import {
   CircularProgress,
   alpha,
   useTheme,
+  useMediaQuery,
   Tooltip,
 } from '@mui/material';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
@@ -57,6 +58,7 @@ const RepositoryContributorsTable: React.FC<
   RepositoryContributorsTableProps
 > = ({ repositoryFullName }) => {
   const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
   const { data: allPRs, isLoading: isPrsLoading } = useAllPrs();
   const { data: allMinersStats, isLoading: isMinersLoading } = useAllMiners();
 
@@ -401,8 +403,14 @@ const RepositoryContributorsTable: React.FC<
       >
         {(
           [
-            { label: 'OSS Contributions', value: 'oss' as const },
-            { label: 'Issue Discovery', value: 'issues' as const },
+            {
+              label: isMobile ? 'OSS' : 'OSS Contributions',
+              value: 'oss' as const,
+            },
+            {
+              label: isMobile ? 'Discovery' : 'Issue Discovery',
+              value: 'issues' as const,
+            },
           ] as const
         ).map((option) => {
           const isActive = programTab === option.value;


### PR DESCRIPTION
## Summary

The `OSS Contributions` / `Issue Discovery` segmented toggle inside the
**Top Miner Contributors** card on the repository details page renders
broken on viewports below the `sm` breakpoint. The labels keep
`whiteSpace: 'nowrap'`, so the two `flex: 1` pills overflow inside the
`xs={12}` sidebar column and the active-pill highlight loses alignment
with its segment.

This PR shortens the labels to **OSS** and **Discovery** below the `sm`
breakpoint so each pill fits cleanly inside the narrow card header. On
`sm` and wider the labels stay as **OSS Contributions** and
**Issue Discovery** — no desktop change.

## Related Issues

Closes #953

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

<!-- Replace with before/after screenshots from the repository details page
on a ≤600 px viewport (DevTools mobile preset is fine). -->

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [ ] Screenshots included for any UI/visual changes