### PR TITLE
refactor: replace infinite scroll with pagination on tablet screens

### DIFF
--- a/src/components/leaderboard/MinersList.tsx
+++ b/src/components/leaderboard/MinersList.tsx
@@ -32,6 +32,7 @@ interface MinersListProps {
   onSort: (option: SortOption) => void;
   getHref: (miner: MinerStats) => string;
   linkState?: Record<string, unknown>;
+  pagination?: React.ReactNode;
 }
 
 export const MinersList: React.FC<MinersListProps> = ({
@@ -42,6 +43,7 @@ export const MinersList: React.FC<MinersListProps> = ({
   onSort,
   getHref,
   linkState,
+  pagination,
 }) => {
   const isWatchlist = variant === 'watchlist';
   const isDiscoveries = variant === 'discoveries';
@@ -207,6 +209,7 @@ export const MinersList: React.FC<MinersListProps> = ({
           order: sortDirection,
           onChange: onSort,
         }}
+        pagination={pagination}
       />
     </Card>
   );

--- a/src/components/leaderboard/TopMinersTable.tsx
+++ b/src/components/leaderboard/TopMinersTable.tsx
@@ -15,6 +15,7 @@ import {
   Popover,
   Portal,
   useMediaQuery,
+  TablePagination,
 } from '@mui/material';
 import { alpha } from '@mui/material/styles';
 import TuneOutlinedIcon from '@mui/icons-material/TuneOutlined';
@@ -361,26 +362,78 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
     setVisibleCount(0);
   }, [filteredMiners.length, visibleCount, setVisibleCount]);
 
-  const visibleMiners = useMemo(
-    () => filteredMiners.slice(0, visibleCount),
-    [filteredMiners, visibleCount],
-  );
-
-  const remainingMiners = Math.max(
-    0,
-    filteredMiners.length - visibleMiners.length,
-  );
-
   const isLargeScreen = useMediaQuery(theme.breakpoints.up('xl'));
   const [portalTarget, setPortalTarget] = useState<HTMLElement | null>(null);
   const observerTarget = useRef<HTMLDivElement>(null);
+  const [stackedLayoutPage, setStackedLayoutPage] = useState(0);
+
+  useEffect(() => {
+    setStackedLayoutPage(0);
+  }, [
+    sortOption,
+    sortDirection,
+    viewMode,
+    searchQuery,
+    eligibleOssFilter,
+    eligibleDiscoveryFilter,
+  ]);
+
+  useEffect(() => {
+    setStackedLayoutPage(0);
+  }, [isLargeScreen]);
+
+  const stackedLayoutTotalPages = Math.max(
+    1,
+    Math.ceil(filteredMiners.length / MINERS_PAGE_SIZE),
+  );
+
+  useEffect(() => {
+    setStackedLayoutPage((p) => Math.min(p, stackedLayoutTotalPages - 1));
+  }, [stackedLayoutTotalPages]);
+
+  const visibleMiners = useMemo(() => {
+    if (isLargeScreen) {
+      return filteredMiners.slice(0, visibleCount);
+    }
+    const start = stackedLayoutPage * MINERS_PAGE_SIZE;
+    return filteredMiners.slice(start, start + MINERS_PAGE_SIZE);
+  }, [filteredMiners, isLargeScreen, visibleCount, stackedLayoutPage]);
+
+  const remainingMiners = isLargeScreen
+    ? Math.max(0, filteredMiners.length - visibleMiners.length)
+    : 0;
+
+  /** Same MUI `TablePagination` pattern as `TopRepositoriesTable` for stacked (< xl) layouts. */
+  const stackedPaginationControls = !isLargeScreen ? (
+    <TablePagination
+      rowsPerPageOptions={[]}
+      component="div"
+      count={filteredMiners.length}
+      rowsPerPage={MINERS_PAGE_SIZE}
+      page={stackedLayoutPage}
+      onPageChange={(_event, newPage) => setStackedLayoutPage(newPage)}
+      onRowsPerPageChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+        void e;
+      }}
+      showFirstButton
+      showLastButton
+      sx={{
+        borderTop: '1px solid',
+        borderColor: 'border.light',
+        color: 'text.secondary',
+        '.MuiTablePagination-displayedRows': {},
+      }}
+    />
+  ) : null;
 
   useEffect(() => {
     setPortalTarget(document.getElementById('tabs-options-portal'));
   }, []);
 
   useEffect(() => {
-    if (!observerTarget.current || remainingMiners <= 0) return;
+    if (!isLargeScreen || !observerTarget.current || remainingMiners <= 0) {
+      return;
+    }
 
     const observer = new IntersectionObserver(
       (entries) => {
@@ -399,7 +452,13 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
 
     observer.observe(observerTarget.current);
     return () => observer.disconnect();
-  }, [remainingMiners, visibleCount, filteredMiners.length, setVisibleCount]);
+  }, [
+    isLargeScreen,
+    remainingMiners,
+    visibleCount,
+    filteredMiners.length,
+    setVisibleCount,
+  ]);
 
   if (isLoading) {
     return (
@@ -455,19 +514,22 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
 
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
         {filteredMiners.length > 0 && viewMode === 'cards' && (
-          <Grid container spacing={2}>
-            {visibleMiners.map((miner) => (
-              <Grid item xs={12} sm={12} md={6} lg={4} xl={4} key={miner.id}>
-                <MinerCard
-                  miner={miner}
-                  variant={variant}
-                  href={getMinerHref(miner)}
-                  linkState={linkState}
-                  showDualEligibilityBadges={showDualEligibilityBadges}
-                />
-              </Grid>
-            ))}
-          </Grid>
+          <>
+            <Grid container spacing={2}>
+              {visibleMiners.map((miner) => (
+                <Grid item xs={12} sm={12} md={6} lg={4} xl={4} key={miner.id}>
+                  <MinerCard
+                    miner={miner}
+                    variant={variant}
+                    href={getMinerHref(miner)}
+                    linkState={linkState}
+                    showDualEligibilityBadges={showDualEligibilityBadges}
+                  />
+                </Grid>
+              ))}
+            </Grid>
+            {stackedPaginationControls}
+          </>
         )}
 
         {filteredMiners.length > 0 && viewMode === 'list' && (
@@ -479,6 +541,7 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
             onSort={handleSortChange}
             getHref={getMinerHref}
             linkState={linkState}
+            pagination={stackedPaginationControls ?? undefined}
           />
         )}
 

--- a/src/pages/WatchlistPage.tsx
+++ b/src/pages/WatchlistPage.tsx
@@ -32,6 +32,7 @@ import {
   Badge,
   useMediaQuery,
   Portal,
+  TablePagination,
 } from '@mui/material';
 import SearchIcon from '@mui/icons-material/Search';
 import ViewModuleIcon from '@mui/icons-material/ViewModule';
@@ -1558,12 +1559,43 @@ const RepoCard: React.FC<{ repo: WatchedRepoStats; maxWeight: number }> = ({
   );
 };
 
-const ROWS_PER_PAGE = 50;
+const ROWS_PER_PAGE = 60; // If we set this to 50, tile mode displays 2 cards with an empty slot in the last row.
+
+const WatchlistStackedPagination: React.FC<{
+  count: number;
+  page: number;
+  onPageChange: (nextPage: number) => void;
+}> = ({ count, page, onPageChange }) => (
+  <TablePagination
+    rowsPerPageOptions={[]}
+    component="div"
+    count={count}
+    rowsPerPage={ROWS_PER_PAGE}
+    page={page}
+    onPageChange={(_event, newPage) => onPageChange(newPage)}
+    onRowsPerPageChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+      void e;
+    }}
+    showFirstButton
+    showLastButton
+    sx={{
+      borderTop: '1px solid',
+      borderColor: 'border.light',
+      color: 'text.secondary',
+      '.MuiTablePagination-displayedRows': {},
+    }}
+  />
+);
+
+/** Sidebar is beside main content only at `xl+`; below that, paginate tables so stacked sidebars stay reachable. */
+const useWatchlistSidebarFixedRight = () =>
+  useMediaQuery(theme.breakpoints.up('xl'));
 
 const ReposList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
   const { data: repos } = useReposAndWeights();
   const { data: allPrs } = useAllPrs();
   const { data: allMiners } = useAllMiners();
+  const sidebarFixedRight = useWatchlistSidebarFixedRight();
   const [searchQuery, setSearchQuery] = useState('');
   const [statusFilter, setStatusFilter] = useState<RepoStatusFilter>('all');
   const [viewMode, setViewMode] = useWatchlistViewMode();
@@ -1575,6 +1607,10 @@ const ReposList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
 
   const [sortField, setSortField] = useState<RepoSortKey>('weight');
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc');
+
+  useEffect(() => {
+    setPage(0);
+  }, [sidebarFixedRight]);
 
   useEffect(() => {
     setPage(0);
@@ -1694,12 +1730,25 @@ const ReposList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
     });
   }, [filtered, sortField, sortOrder]);
 
-  const paged = useMemo(
-    () => sorted.slice(0, (page + 1) * ROWS_PER_PAGE),
-    [sorted, page],
+  const totalRepoPages = Math.max(
+    1,
+    Math.ceil(filtered.length / ROWS_PER_PAGE),
   );
 
   useEffect(() => {
+    setPage((p) => Math.min(p, totalRepoPages - 1));
+  }, [totalRepoPages]);
+
+  const paged = useMemo(() => {
+    if (sidebarFixedRight) {
+      return sorted.slice(0, (page + 1) * ROWS_PER_PAGE);
+    }
+    const start = page * ROWS_PER_PAGE;
+    return sorted.slice(start, start + ROWS_PER_PAGE);
+  }, [sorted, page, sidebarFixedRight]);
+
+  useEffect(() => {
+    if (!sidebarFixedRight) return;
     const target = observerTarget.current;
     if (!target) return;
     const observer = new IntersectionObserver(
@@ -1716,7 +1765,7 @@ const ReposList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
     );
     observer.observe(target);
     return () => observer.disconnect();
-  }, [page, filtered.length]);
+  }, [sidebarFixedRight, page, filtered.length]);
 
   const maxWeight = useMemo(
     () =>
@@ -2015,6 +2064,15 @@ const ReposList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
             order: sortOrder,
             onChange: handleSort,
           }}
+          pagination={
+            !sidebarFixedRight ? (
+              <WatchlistStackedPagination
+                count={filtered.length}
+                page={page}
+                onPageChange={setPage}
+              />
+            ) : undefined
+          }
         />
       ) : (
         <Box
@@ -2055,7 +2113,7 @@ const ReposList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
           )}
         </Box>
       )}
-      {filtered.length > (page + 1) * ROWS_PER_PAGE && (
+      {sidebarFixedRight && filtered.length > (page + 1) * ROWS_PER_PAGE && (
         <Box
           ref={observerTarget}
           sx={{
@@ -2083,6 +2141,13 @@ const ReposList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
           )}
         </Box>
       )}
+      {!sidebarFixedRight && viewMode !== 'list' ? (
+        <WatchlistStackedPagination
+          count={filtered.length}
+          page={page}
+          onPageChange={setPage}
+        />
+      ) : null}
     </Card>
   );
 };
@@ -2300,6 +2365,7 @@ const buildBountyColumns = (): DataTableColumn<
 const BountiesList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
   const { data: allIssues, isLoading } = useIssues();
   const { taoPrice, alphaPrice } = usePrices();
+  const sidebarFixedRight = useWatchlistSidebarFixedRight();
   const bountyColumns = useMemo(() => buildBountyColumns(), []);
 
   const items = useMemo<IssueBounty[]>(() => {
@@ -2319,6 +2385,10 @@ const BountiesList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
 
   const [sortField, setSortField] = useState<BountySortKey>('date');
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc');
+
+  useEffect(() => {
+    setPage(0);
+  }, [sidebarFixedRight]);
 
   useEffect(() => {
     setPage(0);
@@ -2366,12 +2436,25 @@ const BountiesList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
     });
   }, [filtered, sortField, sortOrder]);
 
-  const paged = useMemo(
-    () => sorted.slice(0, (page + 1) * ROWS_PER_PAGE),
-    [sorted, page],
+  const totalBountyPages = Math.max(
+    1,
+    Math.ceil(filtered.length / ROWS_PER_PAGE),
   );
 
   useEffect(() => {
+    setPage((p) => Math.min(p, totalBountyPages - 1));
+  }, [totalBountyPages]);
+
+  const paged = useMemo(() => {
+    if (sidebarFixedRight) {
+      return sorted.slice(0, (page + 1) * ROWS_PER_PAGE);
+    }
+    const start = page * ROWS_PER_PAGE;
+    return sorted.slice(start, start + ROWS_PER_PAGE);
+  }, [sorted, page, sidebarFixedRight]);
+
+  useEffect(() => {
+    if (!sidebarFixedRight) return;
     const target = observerTarget.current;
     if (!target) return;
     const observer = new IntersectionObserver(
@@ -2388,7 +2471,7 @@ const BountiesList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
     );
     observer.observe(target);
     return () => observer.disconnect();
-  }, [page, filtered.length]);
+  }, [sidebarFixedRight, page, filtered.length]);
 
   return (
     <Card
@@ -2460,6 +2543,15 @@ const BountiesList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
             order: sortOrder,
             onChange: handleSort,
           }}
+          pagination={
+            !sidebarFixedRight ? (
+              <WatchlistStackedPagination
+                count={filtered.length}
+                page={page}
+                onPageChange={setPage}
+              />
+            ) : undefined
+          }
         />
       ) : (
         <Box
@@ -2513,7 +2605,7 @@ const BountiesList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
           )}
         </Box>
       )}
-      {filtered.length > (page + 1) * ROWS_PER_PAGE && (
+      {sidebarFixedRight && filtered.length > (page + 1) * ROWS_PER_PAGE && (
         <Box
           ref={observerTarget}
           sx={{
@@ -2541,6 +2633,13 @@ const BountiesList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
           )}
         </Box>
       )}
+      {!sidebarFixedRight && viewMode !== 'list' ? (
+        <WatchlistStackedPagination
+          count={filtered.length}
+          page={page}
+          onPageChange={setPage}
+        />
+      ) : null}
     </Card>
   );
 };
@@ -3059,6 +3158,7 @@ const PRsList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
   const { items, sourcesByKey, isLoading } = useWatchedPRs(itemKeys);
   const prColumns = useMemo(() => buildPrColumns(sourcesByKey), [sourcesByKey]);
   const { isWatched } = useWatchlist('prs');
+  const sidebarFixedRight = useWatchlistSidebarFixedRight();
   const [searchQuery, setSearchQuery] = useState('');
   const [statusFilter, setStatusFilter] = useState<PrStatusFilter>('all');
   const [viewMode, setViewMode] = useWatchlistViewMode();
@@ -3068,6 +3168,10 @@ const PRsList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
 
   const [sortField, setSortField] = useState<PrSortKey>('date');
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc');
+
+  useEffect(() => {
+    setPage(0);
+  }, [sidebarFixedRight]);
 
   useEffect(() => {
     setPage(0);
@@ -3129,12 +3233,22 @@ const PRsList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
     });
   }, [filtered, sortField, sortOrder, isWatched]);
 
-  const paged = useMemo(
-    () => sorted.slice(0, (page + 1) * ROWS_PER_PAGE),
-    [sorted, page],
-  );
+  const totalPrPages = Math.max(1, Math.ceil(filtered.length / ROWS_PER_PAGE));
 
   useEffect(() => {
+    setPage((p) => Math.min(p, totalPrPages - 1));
+  }, [totalPrPages]);
+
+  const paged = useMemo(() => {
+    if (sidebarFixedRight) {
+      return sorted.slice(0, (page + 1) * ROWS_PER_PAGE);
+    }
+    const start = page * ROWS_PER_PAGE;
+    return sorted.slice(start, start + ROWS_PER_PAGE);
+  }, [sorted, page, sidebarFixedRight]);
+
+  useEffect(() => {
+    if (!sidebarFixedRight) return;
     const target = observerTarget.current;
     if (!target) return;
     const observer = new IntersectionObserver(
@@ -3151,7 +3265,7 @@ const PRsList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
     );
     observer.observe(target);
     return () => observer.disconnect();
-  }, [page, filtered.length]);
+  }, [sidebarFixedRight, page, filtered.length]);
 
   return (
     <Card
@@ -3245,6 +3359,15 @@ const PRsList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
             order: sortOrder,
             onChange: handleSort,
           }}
+          pagination={
+            !sidebarFixedRight ? (
+              <WatchlistStackedPagination
+                count={filtered.length}
+                page={page}
+                onPageChange={setPage}
+              />
+            ) : undefined
+          }
         />
       ) : (
         <Box
@@ -3296,7 +3419,7 @@ const PRsList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
           )}
         </Box>
       )}
-      {filtered.length > (page + 1) * ROWS_PER_PAGE && (
+      {sidebarFixedRight && filtered.length > (page + 1) * ROWS_PER_PAGE && (
         <Box
           ref={observerTarget}
           sx={{
@@ -3324,6 +3447,13 @@ const PRsList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
           )}
         </Box>
       )}
+      {!sidebarFixedRight && viewMode !== 'list' ? (
+        <WatchlistStackedPagination
+          count={filtered.length}
+          page={page}
+          onPageChange={setPage}
+        />
+      ) : null}
     </Card>
   );
 };
@@ -3800,6 +3930,7 @@ const IssueCard: React.FC<{
 const IssuesList: React.FC<{ minerIds: string[] }> = ({ minerIds }) => {
   const issueQueries = useMinersIssues(minerIds, minerIds.length > 0);
   const isLoading = issueQueries.some((q) => q.isLoading);
+  const sidebarFixedRight = useWatchlistSidebarFixedRight();
 
   const { ids: starredIssueIds } = useWatchlist('issues');
   const { ids: watchedRepoIds } = useWatchlist('repos');
@@ -3868,6 +3999,10 @@ const IssuesList: React.FC<{ minerIds: string[] }> = ({ minerIds }) => {
 
   useEffect(() => {
     setPage(0);
+  }, [sidebarFixedRight]);
+
+  useEffect(() => {
+    setPage(0);
   }, [statusFilter, searchQuery, sortField, sortOrder, viewMode]);
 
   const handleSort = (field: IssueSortKey) => {
@@ -3909,12 +4044,25 @@ const IssuesList: React.FC<{ minerIds: string[] }> = ({ minerIds }) => {
     });
   }, [filtered, sortField, sortOrder]);
 
-  const paged = useMemo(
-    () => sorted.slice(0, (page + 1) * ROWS_PER_PAGE),
-    [sorted, page],
+  const totalIssuePages = Math.max(
+    1,
+    Math.ceil(filtered.length / ROWS_PER_PAGE),
   );
 
   useEffect(() => {
+    setPage((p) => Math.min(p, totalIssuePages - 1));
+  }, [totalIssuePages]);
+
+  const paged = useMemo(() => {
+    if (sidebarFixedRight) {
+      return sorted.slice(0, (page + 1) * ROWS_PER_PAGE);
+    }
+    const start = page * ROWS_PER_PAGE;
+    return sorted.slice(start, start + ROWS_PER_PAGE);
+  }, [sorted, page, sidebarFixedRight]);
+
+  useEffect(() => {
+    if (!sidebarFixedRight) return;
     const target = observerTarget.current;
     if (!target) return;
     const observer = new IntersectionObserver(
@@ -3931,7 +4079,7 @@ const IssuesList: React.FC<{ minerIds: string[] }> = ({ minerIds }) => {
     );
     observer.observe(target);
     return () => observer.disconnect();
-  }, [page, filtered.length]);
+  }, [sidebarFixedRight, page, filtered.length]);
 
   return (
     <Card
@@ -3994,6 +4142,15 @@ const IssuesList: React.FC<{ minerIds: string[] }> = ({ minerIds }) => {
             order: sortOrder,
             onChange: handleSort,
           }}
+          pagination={
+            !sidebarFixedRight ? (
+              <WatchlistStackedPagination
+                count={filtered.length}
+                page={page}
+                onPageChange={setPage}
+              />
+            ) : undefined
+          }
         />
       ) : (
         <Box
@@ -4043,7 +4200,7 @@ const IssuesList: React.FC<{ minerIds: string[] }> = ({ minerIds }) => {
           )}
         </Box>
       )}
-      {filtered.length > (page + 1) * ROWS_PER_PAGE && (
+      {sidebarFixedRight && filtered.length > (page + 1) * ROWS_PER_PAGE && (
         <Box
           ref={observerTarget}
           sx={{
@@ -4071,6 +4228,13 @@ const IssuesList: React.FC<{ minerIds: string[] }> = ({ minerIds }) => {
           )}
         </Box>
       )}
+      {!sidebarFixedRight && viewMode !== 'list' ? (
+        <WatchlistStackedPagination
+          count={filtered.length}
+          page={page}
+          onPageChange={setPage}
+        />
+      ) : null}
     </Card>
   );
 };


### PR DESCRIPTION
## Summary

- Apply pagination only for tablet breakpoints
- Keep existing infinite scroll behavior on desktop
- Improve tablet usability by preventing excessive page growth
- Ensure sidebar content remains easily accessible on tablet layouts

## Related Issues

closes #991 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Other (describe below)


## Checklist

- [ ] New components are modularized/separated where sensible
- [ ] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [ ] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [ ] Screenshots included for any UI/visual changes
