### PR TITLE
feat: grey out PRs and issues outside the 35-day scoring window

### DIFF
--- a/src/components/issues/IssuesList.tsx
+++ b/src/components/issues/IssuesList.tsx
@@ -39,6 +39,7 @@ import {
 } from '../../utils/format';
 import { getIssueStatusMeta } from '../../utils/issueStatus';
 import { getRepositoryOwnerAvatarSrc } from '../../utils/avatar';
+import { isOutsideScoringWindow } from '../../utils/ExplorerUtils';
 import { STATUS_COLORS, TEXT_OPACITY } from '../../theme';
 import { DataTable, type DataTableColumn } from '../common/DataTable';
 import { WatchlistButton } from '../common/WatchlistButton';
@@ -1048,6 +1049,11 @@ const IssuesList: React.FC<IssuesListProps> = ({
           }
           emptyState={emptyState}
           pagination={pagination}
+          getRowSx={(issue) =>
+            issue.completedAt && isOutsideScoringWindow(issue.completedAt)
+              ? { opacity: 0.4, filter: 'grayscale(0.5)' }
+              : {}
+          }
           sort={{
             field: sortKey,
             order: sortDirection,

--- a/src/components/miners/MinerIssuesTable.tsx
+++ b/src/components/miners/MinerIssuesTable.tsx
@@ -16,7 +16,7 @@ import { Search as SearchIcon } from '@mui/icons-material';
 import { Link as RouterLink, useSearchParams } from 'react-router-dom';
 import { useMinerIssues } from '../../api';
 import { type MinerIssue } from '../../api/models/Dashboard';
-import { getRepositoryOwnerAvatarSrc, paginateItems } from '../../utils';
+import { getRepositoryOwnerAvatarSrc, isOutsideScoringWindow, paginateItems } from '../../utils';
 import { LABEL_COLORS } from '../../theme';
 import {
   DataTable,
@@ -521,6 +521,11 @@ const MinerIssuesTable: React.FC<MinerIssuesTableProps> = ({ githubId }) => {
               {emptyMessage}
             </Typography>
           </Box>
+        }
+        getRowSx={(issue) =>
+          issue.closed_at && isOutsideScoringWindow(issue.closed_at)
+            ? { opacity: 0.4, filter: 'grayscale(0.5)' }
+            : {}
         }
         sort={{
           field: sortField,

--- a/src/components/miners/MinerIssuesTable.tsx
+++ b/src/components/miners/MinerIssuesTable.tsx
@@ -16,7 +16,11 @@ import { Search as SearchIcon } from '@mui/icons-material';
 import { Link as RouterLink, useSearchParams } from 'react-router-dom';
 import { useMinerIssues } from '../../api';
 import { type MinerIssue } from '../../api/models/Dashboard';
-import { getRepositoryOwnerAvatarSrc, isOutsideScoringWindow, paginateItems } from '../../utils';
+import {
+  getRepositoryOwnerAvatarSrc,
+  isOutsideScoringWindow,
+  paginateItems,
+} from '../../utils';
 import { LABEL_COLORS } from '../../theme';
 import {
   DataTable,

--- a/src/components/miners/MinerPRsTable.tsx
+++ b/src/components/miners/MinerPRsTable.tsx
@@ -19,6 +19,7 @@ import {
   filterPrs,
   getRepositoryOwnerAvatarSrc,
   getPrStatusCounts,
+  isOutsideScoringWindow,
   paginateItems,
   type PrStatusFilter,
 } from '../../utils';
@@ -594,6 +595,11 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
           </Box>
         }
         onRowClick={handleRowClick}
+        getRowSx={(pr) =>
+          pr.mergedAt && isOutsideScoringWindow(pr.mergedAt)
+            ? { opacity: 0.4, filter: 'grayscale(0.5)' }
+            : {}
+        }
         sort={{
           field: sortField,
           order: sortDir,

--- a/src/pages/WatchlistPage.tsx
+++ b/src/pages/WatchlistPage.tsx
@@ -74,7 +74,7 @@ import type { IssueBounty } from '../api/models/Issues';
 import { usePrices } from '../hooks/usePrices';
 import { BountyCard } from '../components/issues/BountyCard';
 import { mapAllMinersToStats } from '../utils/minerMapper';
-import { buildRepoDiscoveryRollupFromMiners } from '../utils/ExplorerUtils';
+import { buildRepoDiscoveryRollupFromMiners, isOutsideScoringWindow } from '../utils/ExplorerUtils';
 import {
   useWatchlist,
   useWatchlistCounts,
@@ -2887,6 +2887,7 @@ const PRCard: React.FC<{
 }> = ({ pr, sources = [] }) => {
   const { label, color } = prStatusMeta(pr);
   const key = serializePRKey(pr.repository, pr.pullRequestNumber);
+  const isStale = !!pr.mergedAt && isOutsideScoringWindow(pr.mergedAt);
   return (
     <Card
       elevation={0}
@@ -2896,6 +2897,7 @@ const PRCard: React.FC<{
         backdropFilter: 'blur(12px)',
         border: '1px solid',
         borderColor: alpha(color, 0.3),
+        ...(isStale && { opacity: 0.4, filter: 'grayscale(0.5)' }),
         borderRadius: 2,
         cursor: 'pointer',
         transition: 'all 0.2s cubic-bezier(0.4, 0, 0.2, 1)',
@@ -3246,6 +3248,11 @@ const PRsList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
           stickyHeader
           isLoading={isLoading && items.length === 0}
           emptyLabel="No watched pull requests found."
+          getRowSx={(pr) =>
+            pr.mergedAt && isOutsideScoringWindow(pr.mergedAt)
+              ? { opacity: 0.4, filter: 'grayscale(0.5)' }
+              : {}
+          }
           sort={{
             field: sortField,
             order: sortOrder,
@@ -3636,6 +3643,7 @@ const IssueCard: React.FC<{
 }> = ({ issue, sources = [] }) => {
   const { label, color } = issueStatusMeta(issue);
   const prNumber = issue.solving_pr?.pr_number ?? issue.solved_by_pr ?? null;
+  const isStale = !!issue.closed_at && isOutsideScoringWindow(issue.closed_at);
   return (
     <Card
       elevation={0}
@@ -3645,6 +3653,7 @@ const IssueCard: React.FC<{
         backdropFilter: 'blur(12px)',
         border: '1px solid',
         borderColor: alpha(color, 0.3),
+        ...(isStale && { opacity: 0.4, filter: 'grayscale(0.5)' }),
         borderRadius: 2,
         cursor: 'pointer',
         transition: 'all 0.2s cubic-bezier(0.4, 0, 0.2, 1)',
@@ -3995,6 +4004,11 @@ const IssuesList: React.FC<{ minerIds: string[] }> = ({ minerIds }) => {
           stickyHeader
           isLoading={isLoading && items.length === 0}
           emptyLabel="No issues found for the watched miners."
+          getRowSx={(issue) =>
+            issue.closed_at && isOutsideScoringWindow(issue.closed_at)
+              ? { opacity: 0.4, filter: 'grayscale(0.5)' }
+              : {}
+          }
           sort={{
             field: sortField,
             order: sortOrder,

--- a/src/pages/WatchlistPage.tsx
+++ b/src/pages/WatchlistPage.tsx
@@ -74,7 +74,10 @@ import type { IssueBounty } from '../api/models/Issues';
 import { usePrices } from '../hooks/usePrices';
 import { BountyCard } from '../components/issues/BountyCard';
 import { mapAllMinersToStats } from '../utils/minerMapper';
-import { buildRepoDiscoveryRollupFromMiners, isOutsideScoringWindow } from '../utils/ExplorerUtils';
+import {
+  buildRepoDiscoveryRollupFromMiners,
+  isOutsideScoringWindow,
+} from '../utils/ExplorerUtils';
 import {
   useWatchlist,
   useWatchlistCounts,


### PR DESCRIPTION
## Summary

- Grey out merged PRs and closed issues that fall outside the 35-day scoring window (`opacity: 0.4, filter: grayscale(0.5)`)
- Applies consistently across all affected views: miner PR table, miner issues table, issues list, and watchlist (both table rows and cards)

## Affected Components

- `MinerPRsTable` — greys out merged PRs older than 35 days
- `MinerIssuesTable` — greys out closed issues older than 35 days
- `IssuesList` — greys out completed issues outside the window
- `WatchlistPage` — greys out stale PR/issue rows and cards (PRCard, IssueCard)

## Test plan

- [ ] Open a miner with old merged PRs — rows beyond 35 days should appear dimmed
- [ ] Open a miner's issues tab — closed issues beyond 35 days should appear dimmed
- [ ] Check watchlist PR/issue table rows and cards for the same effect
- [ ] Verify recent items (within 35 days) are unaffected
## Summary

- Grey out merged PRs and closed issues that fall outside the 35-day scoring window (`opacity: 0.4, filter: grayscale(0.5)`)
- Applies consistently across all affected views: miner PR table, miner issues table, issues list, and watchlist (both table rows and cards)

## Affected Components

- `MinerPRsTable` — greys out merged PRs older than 35 days
- `MinerIssuesTable` — greys out closed issues older than 35 days
- `IssuesList` — greys out completed issues outside the window
- `WatchlistPage` — greys out stale PR/issue rows and cards (PRCard, IssueCard)

## Test plan

- [ ] Open a miner with old merged PRs — rows beyond 35 days should appear dimmed
- [ ] Open a miner's issues tab — closed issues beyond 35 days should appear dimmed
- [ ] Check watchlist PR/issue table rows and cards for the same effect
- [ ] Verify recent items (within 35 days) are unaffected
<img width="1912" height="871" alt="Untitled" src="https://github.com/user-attachments/assets/b4016177-1209-4cb9-8555-c7fe9de1b93d" />

Fixes #996 