### PR TITLE
feat: repository registration flow for maintainers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
 # use test api
 VITE_REACT_APP_BASE_URL=https://test-api.gittensor.io
 VITE_REACT_APP_MIRROR_BASE_URL=https://mirror.gittensor.io/api/v1
+
+# Web3Forms — repository registration form delivery
+VITE_WEB3FORMS_ACCESS_KEY=

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -33,6 +33,7 @@ jobs:
         run: |
           echo "VITE_REACT_APP_BASE_URL=${{ vars.VITE_REACT_APP_BASE_URL }}" > .env
           echo "VITE_REACT_APP_MIRROR_BASE_URL=${{ vars.VITE_REACT_APP_MIRROR_BASE_URL }}" >> .env
+          echo "VITE_WEB3FORMS_ACCESS_KEY=${{ secrets.VITE_WEB3FORMS_ACCESS_KEY }}" >> .env
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5

--- a/src/api/MirrorApi.ts
+++ b/src/api/MirrorApi.ts
@@ -1,0 +1,43 @@
+// Mirror API — public health endpoint of das-github-mirror.
+// Used to verify a repository has the Gittensor Mirror GitHub App installed
+// before letting registration submissions through.
+const MIRROR_BASE_URL = import.meta.env.VITE_REACT_APP_MIRROR_BASE_URL;
+
+export interface MirrorHealthRepo {
+  repo_full_name: string;
+  last_event_at: string | null;
+  hours_ago: number | null;
+}
+
+export interface MirrorHealthResponse {
+  status: 'ok' | 'error';
+  repos?: MirrorHealthRepo[];
+}
+
+/**
+ * Fetches the mirror's public /health response. Throws on missing config,
+ * non-2xx responses, or network/parse failure so callers can distinguish
+ * "couldn't check" from a successful empty result.
+ */
+export const fetchMirrorHealth = async (): Promise<MirrorHealthResponse> => {
+  if (!MIRROR_BASE_URL) {
+    throw new Error('Mirror base URL is not configured.');
+  }
+  const response = await fetch(`${MIRROR_BASE_URL}/health`);
+  if (!response.ok) {
+    throw new Error(`Mirror health check failed (${response.status}).`);
+  }
+  return (await response.json()) as MirrorHealthResponse;
+};
+
+/**
+ * Returns true if `repoFullName` ("owner/name") is currently in the mirror's
+ * tracked repos list. Match is case-insensitive. Throws on fetch failure.
+ */
+export const isRepoTracked = async (repoFullName: string): Promise<boolean> => {
+  const data = await fetchMirrorHealth();
+  const tracked = new Set(
+    (data.repos ?? []).map((repo) => repo.repo_full_name.toLowerCase()),
+  );
+  return tracked.has(repoFullName.toLowerCase());
+};

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -3,6 +3,7 @@ export * from './ConfigurationsApi';
 export * from './DashboardApi';
 export * from './IssuesApi';
 export * from './MinerApi';
+export * from './MirrorApi';
 export * from './PrsApi';
 export * from './ReposApi';
 export * from './SearchApi';

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,6 +1,8 @@
 /// <reference types="vite/client" />
 interface ImportMetaEnv {
   readonly VITE_REACT_APP_BASE_URL: string;
+  readonly VITE_REACT_APP_MIRROR_BASE_URL?: string;
+  readonly VITE_WEB3FORMS_ACCESS_KEY?: string;
 }
 
 interface ImportMeta {

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -236,11 +236,24 @@ const HomePage: React.FC = () => {
   const theme = useTheme();
   const monthlyRewards = useMonthlyRewards();
   const [activePanel, setActivePanel] = useState<'feed' | 'miners'>('feed');
+  const [activeBottomCard, setActiveBottomCard] = useState<
+    'maintainer' | 'miner'
+  >('maintainer');
 
   useEffect(() => {
     const interval = setInterval(() => {
       setActivePanel((current) => (current === 'feed' ? 'miners' : 'feed'));
-    }, 8000); // Rotate every 8 seconds
+    }, 5000);
+    return () => clearInterval(interval);
+  }, []);
+
+  useEffect(() => {
+    // Coprime cadence vs the top panel (5s) so flips rarely line up.
+    const interval = setInterval(() => {
+      setActiveBottomCard((current) =>
+        current === 'maintainer' ? 'miner' : 'maintainer',
+      );
+    }, 7000);
     return () => clearInterval(interval);
   }, []);
   const { datasets, isLoading } = useDashboardData('35d');
@@ -248,6 +261,9 @@ const HomePage: React.FC = () => {
   const onboardLink = useLinkBehavior<HTMLAnchorElement>('/onboard');
   const docsLink = useLinkBehavior<HTMLAnchorElement>(
     'https://docs.gittensor.io',
+  );
+  const registerRepoLink = useLinkBehavior<HTMLAnchorElement>(
+    '/repository-registration',
   );
 
   const minerRows = useMemo(
@@ -483,7 +499,102 @@ const HomePage: React.FC = () => {
             totalIssuesSolved={totalIssuesSolvedEver}
             medianMergeRate={medianMergeRate}
           />
-          <OnboardingCard onboardLink={onboardLink} docsLink={docsLink} />
+          <Box
+            sx={{
+              minWidth: 0,
+              alignSelf: 'stretch',
+              display: 'grid',
+              gridTemplateColumns: '1fr',
+              gridTemplateRows: '1fr',
+              position: 'relative',
+            }}
+          >
+            <Box
+              sx={{
+                gridArea: '1 / 1',
+                display: 'flex',
+                opacity: activeBottomCard === 'maintainer' ? 1 : 0,
+                pointerEvents:
+                  activeBottomCard === 'maintainer' ? 'auto' : 'none',
+                transition: 'opacity 0.6s ease',
+                zIndex: activeBottomCard === 'maintainer' ? 1 : 0,
+              }}
+            >
+              <OnboardingCard
+                content={{
+                  kicker: 'Maintain a repo?',
+                  headline: 'Open issues, get PRs.',
+                  body: 'Install the GitHub App and submit a quick form. The team reviews each repo before listing.',
+                  primaryLabel: 'Register a repo',
+                  primaryLink: registerRepoLink,
+                  secondaryLabel: 'Read docs',
+                  secondaryLink: docsLink,
+                }}
+              />
+            </Box>
+            <Box
+              sx={{
+                gridArea: '1 / 1',
+                display: 'flex',
+                opacity: activeBottomCard === 'miner' ? 1 : 0,
+                pointerEvents: activeBottomCard === 'miner' ? 'auto' : 'none',
+                transition: 'opacity 0.6s ease',
+                zIndex: activeBottomCard === 'miner' ? 1 : 0,
+              }}
+            >
+              <OnboardingCard
+                content={{
+                  kicker: 'Ready to contribute?',
+                  headline: 'Register once, then submit PRs.',
+                  body: 'Read the quickstart guide to get set up. No complex infrastructure or always-on servers required.',
+                  primaryLabel: 'Miner guide',
+                  primaryLink: onboardLink,
+                  secondaryLabel: 'Read docs',
+                  secondaryLink: docsLink,
+                }}
+              />
+            </Box>
+            <Stack
+              direction="row"
+              spacing={1}
+              sx={{
+                position: 'absolute',
+                bottom: -24,
+                left: '50%',
+                transform: 'translateX(-50%)',
+                zIndex: 2,
+              }}
+            >
+              <Box
+                onClick={() => setActiveBottomCard('maintainer')}
+                sx={(theme) => ({
+                  width: 32,
+                  height: 4,
+                  borderRadius: 2,
+                  backgroundColor:
+                    activeBottomCard === 'maintainer'
+                      ? theme.palette.status.merged
+                      : alpha(theme.palette.text.primary, 0.1),
+                  cursor: 'pointer',
+                  transition: 'background-color 0.3s ease',
+                })}
+              />
+              <Box
+                onClick={() => setActiveBottomCard('miner')}
+                sx={(theme) => ({
+                  width: 32,
+                  height: 4,
+                  borderRadius: 2,
+                  backgroundColor:
+                    activeBottomCard === 'miner'
+                      ? theme.palette.status.merged
+                      : alpha(theme.palette.text.primary, 0.1),
+                  cursor: 'pointer',
+                  transition: 'background-color 0.3s ease',
+                })}
+              />
+            </Stack>
+          </Box>
         </Box>
       </Box>
     </Page>
@@ -1372,13 +1483,22 @@ const HowItWorksSection: React.FC<{
   </Box>
 );
 
-const OnboardingCard: React.FC<{
-  onboardLink: ReturnType<typeof useLinkBehavior<HTMLAnchorElement>>;
-  docsLink: ReturnType<typeof useLinkBehavior<HTMLAnchorElement>>;
-}> = ({ onboardLink, docsLink }) => (
+type OnboardingCardContent = {
+  kicker: string;
+  headline: React.ReactNode;
+  body: React.ReactNode;
+  primaryLabel: string;
+  primaryLink: ReturnType<typeof useLinkBehavior<HTMLAnchorElement>>;
+  secondaryLabel: string;
+  secondaryLink: ReturnType<typeof useLinkBehavior<HTMLAnchorElement>>;
+};
+
+const OnboardingCard: React.FC<{ content: OnboardingCardContent }> = ({
+  content,
+}) => (
   <Box
     sx={(theme) => ({
-      alignSelf: 'stretch',
+      width: '100%',
       display: 'flex',
       flexDirection: 'column',
       justifyContent: 'space-between',
@@ -1415,7 +1535,7 @@ const OnboardingCard: React.FC<{
           textTransform: 'uppercase',
         })}
       >
-        Ready to contribute?
+        {content.kicker}
       </Typography>
       <Typography
         sx={{
@@ -1425,7 +1545,7 @@ const OnboardingCard: React.FC<{
           lineHeight: 1,
         }}
       >
-        Register once, then submit PRs.
+        {content.headline}
       </Typography>
       <Typography
         sx={(theme) => ({
@@ -1434,8 +1554,7 @@ const OnboardingCard: React.FC<{
           lineHeight: 1.6,
         })}
       >
-        Read the quickstart guide to get set up. No complex infrastructure or
-        always-on servers required.
+        {content.body}
       </Typography>
     </Stack>
     <Stack
@@ -1445,7 +1564,7 @@ const OnboardingCard: React.FC<{
     >
       <Button
         component="a"
-        {...onboardLink}
+        {...content.primaryLink}
         variant="contained"
         endIcon={<ArrowForwardIcon />}
         sx={(theme) => ({
@@ -1463,11 +1582,11 @@ const OnboardingCard: React.FC<{
           transition: 'all 0.2s ease',
         })}
       >
-        Miner guide
+        {content.primaryLabel}
       </Button>
       <Button
         component="a"
-        {...docsLink}
+        {...content.secondaryLink}
         variant="outlined"
         sx={(theme) => ({
           minHeight: 44,
@@ -1482,7 +1601,7 @@ const OnboardingCard: React.FC<{
           },
         })}
       >
-        Read docs
+        {content.secondaryLabel}
       </Button>
     </Stack>
   </Box>

--- a/src/pages/RepositoriesPage.tsx
+++ b/src/pages/RepositoriesPage.tsx
@@ -1,9 +1,10 @@
 import React, { useMemo } from 'react';
 
-import { Avatar, Box, Card, Tooltip, Typography } from '@mui/material';
+import { Avatar, Box, Button, Card, Tooltip, Typography } from '@mui/material';
 import { alpha, type Theme } from '@mui/material/styles';
+import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
 
-import { LinkBox } from '../components/common/linkBehavior';
+import { LinkBox, useLinkBehavior } from '../components/common/linkBehavior';
 import { Page } from '../components/layout';
 import { TopRepositoriesTable, SEO } from '../components';
 import { useAllPrs, useAllMiners, useReposAndWeights } from '../api';
@@ -123,6 +124,10 @@ const getPrHref = (name: string, number: number) =>
   `/miners/pr?repo=${encodeURIComponent(name)}&number=${number}`;
 
 const RepositoriesPage: React.FC = () => {
+  const registerRepoLink = useLinkBehavior<HTMLAnchorElement>(
+    '/repository-registration',
+  );
+
   const formatRelativeTime = (date: Date) => {
     const now = new Date();
     if (date > now) return 'just now';
@@ -611,6 +616,65 @@ const RepositoriesPage: React.FC = () => {
               </>
             ) : null}
           </Card>
+        </Box>
+
+        {/* ── Register-a-repo CTA ───────────────────────────────────── */}
+        <Box
+          sx={(theme) => ({
+            mb: 3,
+            p: { xs: 2, sm: 2.5 },
+            borderRadius: 2,
+            border: `1px solid ${theme.palette.border.light}`,
+            backgroundColor: theme.palette.surface.transparent,
+            display: 'flex',
+            flexDirection: { xs: 'column', sm: 'row' },
+            alignItems: { xs: 'flex-start', sm: 'center' },
+            justifyContent: 'space-between',
+            gap: 2,
+          })}
+        >
+          <Box sx={{ minWidth: 0 }}>
+            <Typography
+              sx={(theme) => ({
+                fontFamily: FONTS.mono,
+                fontSize: '0.85rem',
+                fontWeight: 600,
+                color: theme.palette.text.primary,
+                mb: 0.5,
+              })}
+            >
+              Don&apos;t see your repository?
+            </Typography>
+            <Typography
+              sx={(theme) => ({
+                fontSize: '0.78rem',
+                color: theme.palette.text.secondary,
+                lineHeight: 1.5,
+              })}
+            >
+              Maintainers can register a repo to be added to the network.
+            </Typography>
+          </Box>
+          <Button
+            component="a"
+            {...registerRepoLink}
+            variant="contained"
+            endIcon={<ArrowForwardIcon />}
+            sx={(theme) => ({
+              flexShrink: 0,
+              minHeight: 40,
+              borderRadius: 1.5,
+              backgroundColor: theme.palette.status.merged,
+              color: theme.palette.common.black,
+              textTransform: 'none',
+              fontWeight: 800,
+              '&:hover': {
+                backgroundColor: alpha(theme.palette.status.merged, 0.9),
+              },
+            })}
+          >
+            Register a repo
+          </Button>
         </Box>
 
         {/* ── Main Table ────────────────────────────────────────────── */}

--- a/src/pages/RepositoryRegistrationPage.tsx
+++ b/src/pages/RepositoryRegistrationPage.tsx
@@ -1,0 +1,579 @@
+import React, { useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  Checkbox,
+  FormControlLabel,
+  Stack,
+  TextField,
+  Typography,
+} from '@mui/material';
+import { alpha } from '@mui/material/styles';
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
+import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
+import { isRepoTracked } from '../api';
+import { useLinkBehavior } from '../components/common/linkBehavior';
+import { Page } from '../components/layout';
+import { SEO } from '../components';
+
+type VerifyResult =
+  | { tracked: true }
+  | { tracked: false; reason: 'not-installed' | 'transient' | 'bad-url' };
+
+const extractRepoFullName = (url: string): string | null => {
+  const match = url
+    .trim()
+    .match(/^https?:\/\/github\.com\/([^/]+)\/([^/]+?)\/?$/i);
+  if (!match) return null;
+  return `${match[1]}/${match[2]}`;
+};
+
+const verifyRepoTracked = async (repoUrl: string): Promise<VerifyResult> => {
+  const fullName = extractRepoFullName(repoUrl);
+  if (!fullName) return { tracked: false, reason: 'bad-url' };
+  try {
+    const tracked = await isRepoTracked(fullName);
+    return tracked
+      ? { tracked: true }
+      : { tracked: false, reason: 'not-installed' };
+  } catch {
+    return { tracked: false, reason: 'transient' };
+  }
+};
+
+type FieldKey =
+  | 'repoUrl'
+  | 'description'
+  | 'githubHandle'
+  | 'otherSocial'
+  | 'email'
+  | 'appInstalled';
+
+type FieldErrors = Partial<Record<FieldKey, string>>;
+
+const validators: Record<
+  FieldKey,
+  (value: string | boolean) => string | undefined
+> = {
+  repoUrl: (value) => {
+    const trimmed = String(value).trim();
+    if (!trimmed) return 'Repository URL is required.';
+    if (!/^https?:\/\/github\.com\/[^/]+\/[^/]+\/?$/.test(trimmed)) {
+      return 'Use the full GitHub URL, e.g. https://github.com/owner/repo';
+    }
+    return undefined;
+  },
+  description: (value) =>
+    String(value).trim() ? undefined : 'Short description is required.',
+  githubHandle: (value) =>
+    String(value).trim() ? undefined : 'GitHub handle is required.',
+  otherSocial: (value) =>
+    String(value).trim() ? undefined : 'Another link or handle is required.',
+  email: (value) => {
+    const trimmed = String(value).trim();
+    if (!trimmed) return 'Contact email is required.';
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(trimmed)) {
+      return 'Enter a valid email address.';
+    }
+    return undefined;
+  },
+  appInstalled: (value) =>
+    value ? undefined : 'Install the GitHub App before submitting.',
+};
+
+const RepositoryRegistrationPage: React.FC = () => {
+  const installAppLink = useLinkBehavior<HTMLAnchorElement>(
+    'https://github.com/apps/gittensor-mirror',
+  );
+  const docsLink = useLinkBehavior<HTMLAnchorElement>(
+    'https://docs.gittensor.io',
+  );
+
+  const [repoUrl, setRepoUrl] = useState('');
+  const [description, setDescription] = useState('');
+  const [githubHandle, setGithubHandle] = useState('');
+  const [otherSocial, setOtherSocial] = useState('');
+  const [email, setEmail] = useState('');
+  const [appInstalled, setAppInstalled] = useState(false);
+
+  const [botcheck, setBotcheck] = useState('');
+  const [errors, setErrors] = useState<FieldErrors>({});
+  const [submitting, setSubmitting] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  const validateField = (key: FieldKey, value: string | boolean) => {
+    const message = validators[key](value);
+    setErrors((prev) => ({ ...prev, [key]: message }));
+  };
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    const next: FieldErrors = {
+      repoUrl: validators.repoUrl(repoUrl),
+      description: validators.description(description),
+      githubHandle: validators.githubHandle(githubHandle),
+      otherSocial: validators.otherSocial(otherSocial),
+      email: validators.email(email),
+      appInstalled: validators.appInstalled(appInstalled),
+    };
+    const filtered: FieldErrors = {};
+    (Object.keys(next) as FieldKey[]).forEach((key) => {
+      const message = next[key];
+      if (message) filtered[key] = message;
+    });
+    setErrors(filtered);
+    if (Object.keys(filtered).length > 0) return;
+
+    const accessKey = import.meta.env.VITE_WEB3FORMS_ACCESS_KEY;
+    if (!accessKey) {
+      setSubmitError(
+        'Form is not configured. Please contact the team directly.',
+      );
+      return;
+    }
+
+    setSubmitting(true);
+    setSubmitError(null);
+
+    const verification = await verifyRepoTracked(repoUrl);
+    if (!verification.tracked) {
+      setSubmitting(false);
+      if (verification.reason === 'transient') {
+        setSubmitError(
+          "We couldn't verify your repository right now. Please try again in a moment.",
+        );
+      } else if (verification.reason === 'bad-url') {
+        setSubmitError(
+          'Could not parse the repository URL. Use the form https://github.com/owner/repo.',
+        );
+      } else {
+        setSubmitError(
+          "We don't see the Gittensor Mirror App installed on this repository. Install the App in Step 1 above and try again.",
+        );
+      }
+      return;
+    }
+
+    try {
+      const response = await fetch('https://api.web3forms.com/submit', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+        },
+        body: JSON.stringify({
+          access_key: accessKey,
+          subject: `Repository registration: ${repoUrl}`,
+          from_name: 'Gittensor Registration Form',
+          repository_url: repoUrl,
+          description,
+          github_handle: githubHandle,
+          other_handle: otherSocial,
+          contact_email: email,
+          app_installed_confirmed: appInstalled,
+          // Honeypot — bots fill this, humans don't see it.
+          botcheck,
+        }),
+      });
+      const data = (await response.json()) as { success?: boolean };
+      if (!data.success) {
+        throw new Error('Submission failed.');
+      }
+      setSubmitted(true);
+    } catch {
+      setSubmitError(
+        'Something went wrong submitting your registration. Please try again, or email the team directly.',
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (submitted) {
+    return (
+      <Page title="Registration submitted">
+        <SEO
+          title="Registration submitted - Gittensor"
+          description="Thanks for registering your repository with Gittensor."
+        />
+        <Box
+          sx={{
+            maxWidth: 640,
+            mx: 'auto',
+            width: '100%',
+            py: { xs: 6, md: 8 },
+            px: { xs: 2, md: 0 },
+            textAlign: 'center',
+          }}
+        >
+          <CheckCircleOutlineIcon
+            sx={(theme) => ({
+              color: theme.palette.status.merged,
+              fontSize: 56,
+              mb: 2,
+            })}
+          />
+          <Typography
+            sx={{
+              fontFamily: 'var(--font-heading)',
+              fontWeight: 900,
+              fontSize: { xs: '1.85rem', md: '2.2rem' },
+              lineHeight: 1.1,
+              mb: 2,
+            }}
+          >
+            Registration received.
+          </Typography>
+          <Typography
+            sx={(theme) => ({
+              color: alpha(theme.palette.text.primary, 0.68),
+              fontSize: '0.95rem',
+              lineHeight: 1.6,
+              mb: 4,
+            })}
+          >
+            We&apos;ll review your submission and reach out at{' '}
+            <Box component="strong">{email}</Box>. In the meantime, the public
+            repositories list shows everything currently scored.
+          </Typography>
+          <Stack
+            direction={{ xs: 'column', sm: 'row' }}
+            spacing={1.5}
+            justifyContent="center"
+          >
+            <Button
+              component="a"
+              href="/"
+              variant="outlined"
+              sx={(theme) => ({
+                minHeight: 44,
+                borderRadius: 1.5,
+                textTransform: 'none',
+                fontWeight: 800,
+                borderColor: theme.palette.border.medium,
+                color: theme.palette.text.primary,
+              })}
+            >
+              Back to home
+            </Button>
+            <Button
+              component="a"
+              href="/repositories"
+              variant="contained"
+              sx={(theme) => ({
+                minHeight: 44,
+                borderRadius: 1.5,
+                backgroundColor: theme.palette.status.merged,
+                color: theme.palette.common.black,
+                textTransform: 'none',
+                fontWeight: 900,
+                '&:hover': {
+                  backgroundColor: alpha(theme.palette.status.merged, 0.9),
+                },
+              })}
+            >
+              View repositories
+            </Button>
+          </Stack>
+        </Box>
+      </Page>
+    );
+  }
+
+  return (
+    <Page title="Register Your Repository">
+      <SEO
+        title="Register Your Repository - Gittensor"
+        description="Submit your repository to be recognized by the Gittensor network."
+      />
+      <Box
+        sx={{
+          maxWidth: 640,
+          mx: 'auto',
+          width: '100%',
+          py: { xs: 3, md: 5 },
+          px: { xs: 2, md: 0 },
+        }}
+      >
+        <Stack spacing={1.5} sx={{ mb: 4 }}>
+          <Typography
+            sx={(theme) => ({
+              color: theme.palette.text.secondary,
+              fontSize: '0.66rem',
+              letterSpacing: '0.16em',
+              textTransform: 'uppercase',
+            })}
+          >
+            For repository maintainers
+          </Typography>
+          <Typography
+            sx={{
+              fontFamily: 'var(--font-heading)',
+              fontWeight: 900,
+              fontSize: { xs: '2rem', md: '2.45rem' },
+              lineHeight: 1.05,
+            }}
+          >
+            Register your repository.
+          </Typography>
+          <Typography
+            sx={(theme) => ({
+              color: alpha(theme.palette.text.primary, 0.68),
+              fontSize: '0.95rem',
+              lineHeight: 1.6,
+            })}
+          >
+            Get your repo recognized so the network&apos;s miners can contribute
+            pull requests against your open issues. Two steps: install the
+            GitHub App, then fill out the form below.
+          </Typography>
+        </Stack>
+
+        <Box
+          sx={(theme) => ({
+            mb: 3,
+            p: { xs: 2, md: 2.5 },
+            borderRadius: 2,
+            border: `1px solid ${theme.palette.border.medium}`,
+            backgroundColor: theme.palette.surface.subtle,
+          })}
+        >
+          <Typography
+            sx={(theme) => ({
+              color: theme.palette.text.secondary,
+              fontSize: '0.66rem',
+              letterSpacing: '0.16em',
+              textTransform: 'uppercase',
+              mb: 1,
+            })}
+          >
+            Step 1 — install the GitHub App
+          </Typography>
+          <Typography sx={{ fontSize: '0.9rem', lineHeight: 1.6, mb: 2 }}>
+            Install the Gittensor Mirror App on the repository (or organization)
+            you want to register. Read-only access only.
+          </Typography>
+          <Button
+            component="a"
+            {...installAppLink}
+            variant="outlined"
+            endIcon={<OpenInNewIcon />}
+            sx={(theme) => ({
+              minHeight: 44,
+              borderRadius: 1.5,
+              borderColor: theme.palette.border.medium,
+              color: theme.palette.text.primary,
+              textTransform: 'none',
+              fontWeight: 800,
+            })}
+          >
+            Install the GitHub App
+          </Button>
+        </Box>
+
+        <Box
+          component="form"
+          onSubmit={handleSubmit}
+          noValidate
+          sx={(theme) => ({
+            p: { xs: 2, md: 2.5 },
+            borderRadius: 2,
+            border: `1px solid ${theme.palette.border.medium}`,
+            backgroundColor: theme.palette.surface.subtle,
+          })}
+        >
+          <Typography
+            sx={(theme) => ({
+              color: theme.palette.text.secondary,
+              fontSize: '0.66rem',
+              letterSpacing: '0.16em',
+              textTransform: 'uppercase',
+              mb: 2,
+            })}
+          >
+            Step 2 — tell us about the repo
+          </Typography>
+
+          {submitError && (
+            <Alert
+              severity="error"
+              role="alert"
+              sx={{ mb: 2 }}
+              onClose={() => setSubmitError(null)}
+            >
+              {submitError}
+            </Alert>
+          )}
+
+          {/* Honeypot — visually hidden, ignored by humans, filled by naive bots. */}
+          <input
+            type="text"
+            name="botcheck"
+            value={botcheck}
+            onChange={(event) => setBotcheck(event.target.value)}
+            tabIndex={-1}
+            autoComplete="off"
+            aria-hidden="true"
+            style={{
+              position: 'absolute',
+              left: '-9999px',
+              width: 1,
+              height: 1,
+              opacity: 0,
+            }}
+          />
+
+          <Stack spacing={2.5}>
+            <TextField
+              label="Repository URL"
+              required
+              fullWidth
+              value={repoUrl}
+              placeholder="https://github.com/owner/repo"
+              onChange={(event) => setRepoUrl(event.target.value)}
+              onBlur={() => validateField('repoUrl', repoUrl)}
+              error={Boolean(errors.repoUrl)}
+              helperText={errors.repoUrl ?? ' '}
+              inputProps={{ inputMode: 'url' }}
+              FormHelperTextProps={
+                errors.repoUrl ? { role: 'alert' } : undefined
+              }
+            />
+            <TextField
+              label="Short description"
+              required
+              fullWidth
+              value={description}
+              placeholder="One sentence about what your project does"
+              onChange={(event) => setDescription(event.target.value)}
+              onBlur={() => validateField('description', description)}
+              error={Boolean(errors.description)}
+              helperText={errors.description ?? ' '}
+              FormHelperTextProps={
+                errors.description ? { role: 'alert' } : undefined
+              }
+            />
+            <TextField
+              label="Your GitHub handle"
+              required
+              fullWidth
+              value={githubHandle}
+              placeholder="yourhandle"
+              onChange={(event) => setGithubHandle(event.target.value)}
+              onBlur={() => validateField('githubHandle', githubHandle)}
+              error={Boolean(errors.githubHandle)}
+              helperText={errors.githubHandle ?? ' '}
+              FormHelperTextProps={
+                errors.githubHandle ? { role: 'alert' } : undefined
+              }
+            />
+            <TextField
+              label="Another link or handle"
+              required
+              fullWidth
+              value={otherSocial}
+              placeholder="Twitter, LinkedIn, personal site, etc."
+              onChange={(event) => setOtherSocial(event.target.value)}
+              onBlur={() => validateField('otherSocial', otherSocial)}
+              error={Boolean(errors.otherSocial)}
+              helperText={errors.otherSocial ?? ' '}
+              FormHelperTextProps={
+                errors.otherSocial ? { role: 'alert' } : undefined
+              }
+            />
+            <TextField
+              label="Contact email"
+              required
+              fullWidth
+              type="email"
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+              onBlur={() => validateField('email', email)}
+              error={Boolean(errors.email)}
+              helperText={errors.email ?? ' '}
+              inputProps={{ inputMode: 'email' }}
+              FormHelperTextProps={errors.email ? { role: 'alert' } : undefined}
+            />
+            <Box>
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    checked={appInstalled}
+                    onChange={(event) => {
+                      setAppInstalled(event.target.checked);
+                      validateField('appInstalled', event.target.checked);
+                    }}
+                  />
+                }
+                label="I have installed the Gittensor Mirror GitHub App on this repository."
+                sx={{ alignItems: 'flex-start' }}
+              />
+              {errors.appInstalled && (
+                <Typography
+                  role="alert"
+                  sx={(theme) => ({
+                    color: theme.palette.error.main,
+                    fontSize: '0.75rem',
+                    mt: 0.5,
+                    ml: 4,
+                  })}
+                >
+                  {errors.appInstalled}
+                </Typography>
+              )}
+            </Box>
+          </Stack>
+
+          <Stack
+            direction={{ xs: 'column', sm: 'row' }}
+            spacing={1}
+            sx={{ mt: 4, justifyContent: 'flex-end' }}
+          >
+            <Button
+              component="a"
+              {...docsLink}
+              variant="outlined"
+              endIcon={<OpenInNewIcon />}
+              sx={(theme) => ({
+                minHeight: 44,
+                borderRadius: 1.5,
+                borderColor: theme.palette.border.medium,
+                color: theme.palette.text.primary,
+                textTransform: 'none',
+                fontWeight: 800,
+              })}
+            >
+              Read the docs
+            </Button>
+            <Button
+              type="submit"
+              variant="contained"
+              disabled={submitting}
+              sx={(theme) => ({
+                minHeight: 44,
+                borderRadius: 1.5,
+                backgroundColor: theme.palette.status.merged,
+                color: theme.palette.common.black,
+                textTransform: 'none',
+                fontWeight: 900,
+                '&:hover': {
+                  backgroundColor: alpha(theme.palette.status.merged, 0.9),
+                },
+                '&.Mui-disabled': {
+                  backgroundColor: alpha(theme.palette.status.merged, 0.5),
+                  color: theme.palette.common.black,
+                },
+              })}
+            >
+              {submitting ? 'Submitting…' : 'Submit registration'}
+            </Button>
+          </Stack>
+        </Box>
+      </Box>
+    </Page>
+  );
+};
+
+export default RepositoryRegistrationPage;

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -26,6 +26,9 @@ const PRDetailsPage = React.lazy(() => import('./pages/PRDetailsPage'));
 
 const OnboardPage = React.lazy(() => import('./pages/OnboardPage'));
 const WatchlistPage = React.lazy(() => import('./pages/WatchlistPage'));
+const RepositoryRegistrationPage = React.lazy(
+  () => import('./pages/RepositoryRegistrationPage'),
+);
 
 // 404 page
 const NotFoundPage = React.lazy(() => import('./pages/NotFoundPage'));
@@ -102,6 +105,11 @@ const routesArray: AppRoute[] = [
     name: 'onboard',
     path: '/onboard',
     element: <OnboardPage />,
+  },
+  {
+    name: 'repository-registration',
+    path: '/repository-registration',
+    element: <RepositoryRegistrationPage />,
   },
 
   // 404 catch-all route (must be last)


### PR DESCRIPTION
## Summary
- New `/repository-registration` form page where maintainers submit their repo to be added to the network
- Submissions are emailed to `x9entrius@gmail.com` via Web3Forms (no backend needed for v1)
- Spam wall: verifies the Gittensor Mirror App is actually installed on the submitted repo before accepting (calls mirror `/health` and checks membership in the tracked repos list). Plus a hidden honeypot field
- Homepage bottom-right card alternates between **maintainer** and **miner** CTAs on a coprime 5s / 7s cadence (so flips don't sync with the live-data panel above)
- "Don't see your repository?" CTA banner between the highlight cards and the main table on `/repositories`

## Companion docs
Already pushed to test on `gittensor-docs-ui`: new "For Maintainers" section, sidebar group, top-nav entry, and home-page hero CTA pointing at `/register-repository`. Also fixed two stale `/onboard?tab=repositories` links.

## Required before merging to main
- [ ] Add `VITE_WEB3FORMS_ACCESS_KEY` as a **Secret** in the GitHub Actions `prod` environment (test environment intentionally left empty so test deploys don't email)

## Test plan
- [ ] On test deploy, visit `/repository-registration` → submit with any data → expect "Form is not configured" (test env has no key, by design)
- [ ] On test deploy, submit with a non-installed repo URL → expect "We don't see the Gittensor Mirror App installed on this repository"
- [ ] Visual: homepage bottom-right card alternates correctly, dot indicator clickable, top panel and bottom card don't flip in lockstep
- [ ] Visual: "Don't see your repository?" banner sits between highlight cards and main table on `/repositories`
- [ ] After merge to main + secret set: end-to-end smoke — submit form on prod with a real installed repo → confirm email lands at `x9entrius@gmail.com`