### PR TITLE
fix(dashboard): use mirror data for issues trend

### DIFF
--- a/src/api/MinerApi.ts
+++ b/src/api/MinerApi.ts
@@ -96,12 +96,24 @@ export const useMinerIssues = (githubId: string, enabled?: boolean) =>
   );
 
 /**
- * Fan-out variant: one mirror-API call per miner, useful for the watchlist.
+ * Fan-out variant: one mirror-API call per miner, useful for the watchlist
+ * and the dashboard issues-trend aggregation.
+ *
+ * `since` (ISO timestamp) is forwarded to the mirror as a query param. Omit
+ * for the mirror's default 35-day window — this also keeps the cache key
+ * stable across callers that don't need a custom range.
  */
-export const useMinersIssues = (githubIds: string[], enabled?: boolean) =>
+export const useMinersIssues = (
+  githubIds: string[],
+  enabled?: boolean,
+  since?: string,
+) =>
   useMirrorApiQueries<MinerIssuesResponse, MinerIssue[]>(
     'useMinerIssues',
-    githubIds.map((id) => `/miners/${id}/issues`),
+    githubIds.map((id) => {
+      const path = `/miners/${id}/issues`;
+      return since ? `${path}?since=${encodeURIComponent(since)}` : path;
+    }),
     {
       enabled,
       select: (data) => data?.issues ?? [],

--- a/src/pages/dashboard/dashboardData.ts
+++ b/src/pages/dashboard/dashboardData.ts
@@ -10,9 +10,9 @@
 import {
   type CommitLog,
   type MinerEvaluation,
+  type MinerIssue,
   type Repository,
 } from '../../api';
-import { type IssueBounty } from '../../api/models/Issues';
 import {
   getPrStatusLabel,
   isIssueDiscoveryContributionPr,
@@ -170,6 +170,40 @@ export const getPreviousWindowBounds = (
   };
 };
 
+// Omitting `since` uses the mirror's default 35-day window and keeps the
+// cache key stable across 1d/7d/35d ranges.
+export const getMirrorSinceParam = (
+  range: TrendTimeRange,
+): string | undefined =>
+  range === 'all' ? new Date(GITTENSOR_START_MS).toISOString() : undefined;
+
+// Dedupe by (repo, number) so an issue surfaced under multiple miners is counted once.
+export const flattenMinerIssues = (
+  responses: ReadonlyArray<ReadonlyArray<MinerIssue>>,
+): MinerIssue[] => {
+  const seen = new Set<string>();
+  const flattened: MinerIssue[] = [];
+  responses.forEach((batch) => {
+    batch.forEach((issue) => {
+      const key = `${issue.repo_full_name}#${issue.issue_number}`;
+      if (seen.has(key)) return;
+      seen.add(key);
+      flattened.push(issue);
+    });
+  });
+  return flattened;
+};
+
+export const isResolvedMinerIssue = (issue: MinerIssue): boolean =>
+  issue.state === 'CLOSED' && issue.state_reason === 'COMPLETED';
+
+export const isResolvedInWindow = (
+  issue: MinerIssue,
+  window: WindowBounds,
+): boolean =>
+  isResolvedMinerIssue(issue) &&
+  isWithinWindow(toTimestamp(issue.closed_at), window);
+
 const getUtcWeekStart = (timestamp: number) => {
   const date = new Date(timestamp);
   const dayOfWeek = date.getUTCDay();
@@ -278,18 +312,18 @@ const formatDelta = (
 
 export const buildDashboardTrendData = (
   prs: CommitLog[],
-  issues: IssueBounty[],
+  issues: MinerIssue[],
   range: TrendTimeRange,
   now = new Date(),
 ): { labels: string[]; series: DashboardTrendSeries[] } => {
   const mergedPrTimestamps = prs.map((pr) => toTimestamp(pr.mergedAt));
   const openedPrTimestamps = prs.map((pr) => toTimestamp(pr.prCreatedAt));
   const openedIssueTimestamps = issues.map((issue) =>
-    toTimestamp(issue.createdAt),
+    toTimestamp(issue.created_at),
   );
   const resolvedIssueTimestamps = issues
-    .filter((issue) => issue.status === 'completed')
-    .map((issue) => toTimestamp(issue.completedAt));
+    .filter(isResolvedMinerIssue)
+    .map((issue) => toTimestamp(issue.closed_at));
   const buckets = buildTrendBuckets(
     [
       ...mergedPrTimestamps,
@@ -618,7 +652,7 @@ export const buildDashboardOverview = (
 
 export const buildDashboardKpis = (
   prs: CommitLog[],
-  issues: IssueBounty[],
+  issues: MinerIssue[],
   range: TrendTimeRange,
   now = new Date(),
 ): DashboardKpi[] => {
@@ -626,10 +660,8 @@ export const buildDashboardKpis = (
   const mergedWindowPrs = prs.filter((pr) =>
     isWithinWindow(toTimestamp(pr.mergedAt), window),
   );
-  const solvedIssues = issues.filter(
-    (issue) =>
-      issue.status === 'completed' &&
-      isWithinWindow(toTimestamp(issue.completedAt), window),
+  const solvedIssues = issues.filter((issue) =>
+    isResolvedInWindow(issue, window),
   );
 
   const totalCommits = mergedWindowPrs.reduce(

--- a/src/pages/dashboard/useDashboardData.ts
+++ b/src/pages/dashboard/useDashboardData.ts
@@ -12,6 +12,7 @@ import {
   useAllMiners,
   useAllPrs,
   useIssues,
+  useMinersIssues,
   useReposAndWeights,
 } from '../../api';
 import {
@@ -19,6 +20,7 @@ import {
   type DatasetState,
   type IssueBounty,
   type MinerEvaluation,
+  type MinerIssue,
   type Repository,
 } from '../../api/models';
 import {
@@ -28,6 +30,8 @@ import {
   buildFeaturedContributors,
   buildFeaturedWork,
   buildFeaturedDiscoveryContributors,
+  flattenMinerIssues,
+  getMirrorSinceParam,
   type TrendTimeRange,
 } from './dashboardData';
 
@@ -36,13 +40,46 @@ type DashboardDatasets = {
   miners: DatasetState<MinerEvaluation>;
   issues: DatasetState<IssueBounty>;
   repos: DatasetState<Repository>;
+  minerIssues: DatasetState<MinerIssue>;
 };
 
-const useDashboardData = (range: TrendTimeRange) => {
+const hasIssueActivity = (miner: MinerEvaluation): boolean =>
+  (miner.totalSolvedIssues ?? 0) +
+    (miner.totalOpenIssues ?? 0) +
+    (miner.totalClosedIssues ?? 0) >
+  0;
+
+export const useDashboardData = (range: TrendTimeRange) => {
   const prsQuery = useAllPrs();
   const minersQuery = useAllMiners();
   const issuesQuery = useIssues();
   const reposQuery = useReposAndWeights();
+
+  // Fan-out per-miner mirror calls; gate on issue activity to bound parallel requests.
+  const activeMinerGithubIds = useMemo(
+    () =>
+      (minersQuery.data ?? [])
+        .filter(hasIssueActivity)
+        .map((m) => m.githubId)
+        .filter((id): id is string => Boolean(id)),
+    [minersQuery.data],
+  );
+
+  const minerIssuesSince = getMirrorSinceParam(range);
+  const minerIssuesQueries = useMinersIssues(
+    activeMinerGithubIds,
+    activeMinerGithubIds.length > 0,
+    minerIssuesSince,
+  );
+
+  const minerIssuesData = useMemo<MinerIssue[]>(
+    () => flattenMinerIssues(minerIssuesQueries.map((q) => q.data ?? [])),
+    [minerIssuesQueries],
+  );
+  const isMinerIssuesLoading =
+    activeMinerGithubIds.length > 0 &&
+    minerIssuesQueries.some((q) => q.isLoading);
+  const isMinerIssuesError = minerIssuesQueries.some((q) => q.isError);
 
   const datasets: DashboardDatasets = {
     prs: {
@@ -65,6 +102,11 @@ const useDashboardData = (range: TrendTimeRange) => {
       isLoading: reposQuery.isLoading,
       isError: reposQuery.isError,
     },
+    minerIssues: {
+      data: minerIssuesData,
+      isLoading: isMinerIssuesLoading,
+      isError: isMinerIssuesError,
+    },
   };
 
   const overview = useMemo(
@@ -75,8 +117,12 @@ const useDashboardData = (range: TrendTimeRange) => {
 
   const trendData = useMemo(
     () =>
-      buildDashboardTrendData(datasets.prs.data, datasets.issues.data, range),
-    [datasets.issues.data, datasets.prs.data, range],
+      buildDashboardTrendData(
+        datasets.prs.data,
+        datasets.minerIssues.data,
+        range,
+      ),
+    [datasets.minerIssues.data, datasets.prs.data, range],
   );
 
   const featuredContributors = useMemo(
@@ -99,8 +145,9 @@ const useDashboardData = (range: TrendTimeRange) => {
   );
 
   const kpis = useMemo(
-    () => buildDashboardKpis(datasets.prs.data, datasets.issues.data, range),
-    [datasets.issues.data, datasets.prs.data, range],
+    () =>
+      buildDashboardKpis(datasets.prs.data, datasets.minerIssues.data, range),
+    [datasets.minerIssues.data, datasets.prs.data, range],
   );
 
   const isFeaturedWorkLoading =
@@ -119,11 +166,13 @@ const useDashboardData = (range: TrendTimeRange) => {
     isLoading:
       datasets.prs.isLoading ||
       datasets.miners.isLoading ||
-      datasets.issues.isLoading,
+      datasets.issues.isLoading ||
+      datasets.minerIssues.isLoading,
     isError:
       datasets.prs.isError ||
       datasets.miners.isError ||
-      datasets.issues.isError,
+      datasets.issues.isError ||
+      datasets.minerIssues.isError,
   };
 };
 


### PR DESCRIPTION
## Summary

The dashboard's "Issues Opened / Resolved" trend graph and the "Issues Solved" KPI were sourced from `/issues`, which only returns bounty-backed issues. The overview cards right above the trend use miner aggregates instead, so the two halves of the page disagreed loudly — 33 issues in the chart vs. ~1,000 in the cards.

This PR repoints both the trend graph and the KPI tile at the same population the cards use: a per-miner fan-out to the mirror's `/api/v1/miners/:id/issues` via the existing `useMinersIssues` helper, flattened and deduped client-side.
No backend changes.

## Changes

- **`src/api/MinerApi.ts`** — `useMinersIssues` accepts an optional `since` ISO timestamp, forwarded to the mirror as a query param.
- **`src/pages/dashboard/dashboardData.ts`** — `buildDashboardTrendData` and `buildDashboardKpis` now consume `MinerIssue[]`. Small helpers added:
  - `flattenMinerIssues` — dedupes responses by `(repo, number)` so an issue surfaced under multiple miners is counted once.
  - `isResolvedMinerIssue` — `state === 'CLOSED' && state_reason === 'COMPLETED'` (NOT_PLANNED / TRANSFERRED are excluded, matching GitHub's "completed" semantic). Used by the trend chart's resolved filter.
  - `isResolvedInWindow` — combines `isResolvedMinerIssue` with the active window check; used by the KPI "Issues Solved" filter.
  - `getMirrorSinceParam` — emits `since` only for the `all` range so the cache key stays stable across 1d/7d/35d.
- **`src/pages/dashboard/useDashboardData.ts`** — fans out only to miners with any issue activity to bound the parallel-request count, flattens through `flattenMinerIssues`, then feeds the result into both the trend builder and the KPI memo.

## Known caveat

Aggregates and mirror fan-out won't agree to the last digit. The aggregate counters include issues a miner *solved* (authored by someone else); the mirror endpoint returns issues a miner *authored*. The trend graph and KPI want the latter, so this is the right source — but the overview-card totals will still read higher.

## Related Issues

Fixes #1000

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

<!-- Before / after of the dashboard trend graph. -->

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors) — no styling changes
- [x] Responsive/mobile checked — data-layer change only, no layout impact
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [ ] Screenshots included for any UI/visual changes
