### PR TITLE
fix(bounties): cap top hunters submissions fan-out and forward query signal

### DIFF
--- a/src/api/IssuesApi.ts
+++ b/src/api/IssuesApi.ts
@@ -63,6 +63,12 @@ export const useIssueDetails = (id: number) =>
     !!id,
   );
 
+// Shared cache key for an issue's submissions. Used by `useIssueSubmissions`
+// and any fan-out consumers (e.g. the bounty-hunters aggregator) so they share
+// the same React Query entry instead of re-fetching the same payload.
+export const getIssueSubmissionsQueryKey = (id: number) =>
+  ['useIssueSubmissions', `/issues/${id}/submissions`, undefined] as const;
+
 /**
  * Fetch PR submissions for an issue.
  */

--- a/src/components/issues/BountySidebar.tsx
+++ b/src/components/issues/BountySidebar.tsx
@@ -16,6 +16,7 @@ import { useQueries } from '@tanstack/react-query';
 import axios from 'axios';
 
 import {
+  getIssueSubmissionsQueryKey,
   type IssueBounty,
   type IssuesStats,
   type IssueSubmission,
@@ -52,15 +53,20 @@ interface HunterRow {
   totalAlpha: number;
 }
 
-const TOP_HUNTERS_FETCH_LIMIT = 50;
+// Sample size for the leaderboard aggregation. Display is capped at `topN`
+// (5) further down, so this only needs to be wide enough for a representative
+// ranking — not the full bounty history. Kept small to avoid fanning out a
+// browser's full per-origin connection budget on first paint.
+const TOP_HUNTERS_FETCH_LIMIT = 15;
 
 const fetchIssueSubmissions = async (
   id: number,
+  signal?: AbortSignal,
 ): Promise<IssueSubmission[]> => {
   const baseUrl = import.meta.env.VITE_REACT_APP_BASE_URL;
   const path = `/issues/${id}/submissions`;
   const url = baseUrl ? `${baseUrl}${path}` : path;
-  const { data } = await axios.get<IssueSubmission[]>(url);
+  const { data } = await axios.get<IssueSubmission[]>(url, { signal });
   return data;
 };
 
@@ -69,8 +75,9 @@ const fetchIssueSubmissions = async (
  *
  * For each completed bounty we fetch its `/issues/{id}/submissions`, find the
  * row with `isWinner: true`, and tally its `authorLogin` plus the bounty's
- * paid `bountyAmount`. Cache key matches `useIssueSubmissions` so the bounty
- * details page re-uses these fetches.
+ * paid `bountyAmount`. Reuses the `useIssueSubmissions` cache key via
+ * `getIssueSubmissionsQueryKey` so the bounty-details page shares these
+ * fetches.
  */
 const useTopBountyHunters = (
   issues: IssueBounty[],
@@ -89,12 +96,8 @@ const useTopBountyHunters = (
 
   const queries = useQueries({
     queries: completedBounties.map((b) => ({
-      queryKey: [
-        'useIssueSubmissions',
-        `/issues/${b.id}/submissions`,
-        undefined,
-      ] as const,
-      queryFn: () => fetchIssueSubmissions(b.id),
+      queryKey: getIssueSubmissionsQueryKey(b.id),
+      queryFn: ({ signal }) => fetchIssueSubmissions(b.id, signal),
       staleTime: 60_000,
       retry: false,
     })),


### PR DESCRIPTION
## Summary

The Top Hunters card in the bounty sidebar fans out one `/issues/{id}/submissions` request per recently completed bounty, capped at 50. On a cold `/bounties` visit that means up to 50 parallel HTTP calls against the same origin, most queued behind the browser per-origin connection limit, and the card sits in its skeleton state until the queue drains. Navigating away mid-load also leaks in-flight requests because the TanStack Query signal is not forwarded to axios.

Three small changes scoped to the bounty sidebar resolve both:

- Lower `TOP_HUNTERS_FETCH_LIMIT` from 50 to 15. The displayed leaderboard is capped at five rows by `topN`, so a sample of 15 keeps the ranking representative without burning a full per-origin connection budget on first paint.
- Forward the TanStack Query `signal` through `fetchIssueSubmissions` to `axios.get`, matching the cancellation pattern already used in `CodeViewer`, `ContributingViewer`, and `ReadmeViewer`. Navigating away from `/bounties` mid-load now cancels the in-flight requests cleanly.
- Extract `getIssueSubmissionsQueryKey` in `src/api/IssuesApi.ts`, mirroring the existing `getIssuesQueryKey` helper, and reuse it from the bounty-hunters fan-out. The shared cache entry with the bounty-details page (`useIssueSubmissions`) is preserved through the helper instead of a duplicated key shape.

A `useMediaQuery` gate was deliberately not added. The bounty sidebar still renders at full width below the issues list under the `xl` breakpoint, so gating the hook would prevent mobile visitors from ever seeing the leaderboard.

## Related Issues

Closes #1003

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

No visual change. Verified via DevTools Network on a cold load of `/bounties`: the request count for `/issues/{id}/submissions` drops from up to 50 down to at most 15, and in-flight requests flip to canceled when navigating away mid-load.

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [ ] Screenshots included for any UI/visual changes
