### PR TITLE
fix(avatars): robust avatar resolution for miners using numeric IDs

### DIFF
--- a/src/components/leaderboard/LeaderboardSidebar.tsx
+++ b/src/components/leaderboard/LeaderboardSidebar.tsx
@@ -274,7 +274,7 @@ const LeaderboardRow: React.FC<LeaderboardRowProps> = ({
         }}
       >
         <Avatar
-          src={getGithubAvatarSrc(miner.author || miner.githubId)}
+          src={getGithubAvatarSrc(miner.author, miner.githubId)}
           alt={miner.author || miner.githubId}
           sx={{ width: 20, height: 20 }}
         />

--- a/src/components/leaderboard/MinerCard.tsx
+++ b/src/components/leaderboard/MinerCard.tsx
@@ -68,7 +68,7 @@ export const MinerCard: React.FC<MinerCardProps> = ({
     (!isNumericId(miner.author) ? miner.author : miner.githubId) ||
     miner.githubId ||
     '';
-  const avatarSrc = githubData?.avatarUrl || getGithubAvatarSrc(username);
+  const avatarSrc = githubData?.avatarUrl || getGithubAvatarSrc(miner.author, miner.githubId);
 
   const credibilityPercent = (miner.credibility ?? 0) * 100;
   const issueCredPercent = (miner.issueCredibility ?? 0) * 100;

--- a/src/components/leaderboard/MinersList.tsx
+++ b/src/components/leaderboard/MinersList.tsx
@@ -228,7 +228,7 @@ const MinerIdentityCell: React.FC<MinerIdentityCellProps> = ({ miner }) => {
     (!isNumericId(miner.author) ? miner.author : miner.githubId) ||
     miner.githubId ||
     '';
-  const avatarSrc = githubData?.avatarUrl || getGithubAvatarSrc(username);
+  const avatarSrc = githubData?.avatarUrl || getGithubAvatarSrc(miner.author, miner.githubId);
 
   return (
     <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 0 }}>

--- a/src/utils/ExplorerUtils.ts
+++ b/src/utils/ExplorerUtils.ts
@@ -5,11 +5,10 @@ import {
   type RepositoryPrScoring,
 } from '../api';
 import { type IssueBounty } from '../api/models/Issues';
-import { getRepositoryOwnerAvatarSrc } from './avatar';
+import { getRepositoryOwnerAvatarSrc, getGithubAvatarSrc } from './avatar';
 import { isMergedPr } from './prStatus';
 
-export const getGithubAvatarSrc = (username?: string | null) =>
-  getRepositoryOwnerAvatarSrc(username);
+export { getGithubAvatarSrc };
 
 // Parses numeric-like values and falls back when the value is missing or invalid.
 export const parseNumber = (value: unknown, fallback = 0): number => {

--- a/src/utils/avatar.ts
+++ b/src/utils/avatar.ts
@@ -15,3 +15,30 @@ export const getGithubUserAvatarSrcById = (
     normalizedId,
   )}`;
 };
+
+/**
+ * Robust avatar source resolver.
+ * Handles both usernames (github.com/user.png) and numeric IDs (avatars.githubusercontent.com/u/ID).
+ * If both are provided, it prefers username unless it looks like a numeric ID.
+ */
+export const getGithubAvatarSrc = (
+  username?: string | null,
+  id?: string | number | null,
+): string => {
+  const trimmedUsername = username?.trim();
+  const isNumeric = (val?: string | null) => !!val && /^\d+$/.test(val);
+
+  if (trimmedUsername && !isNumeric(trimmedUsername)) {
+    return getRepositoryOwnerAvatarSrc(trimmedUsername);
+  }
+
+  if (id) {
+    return getGithubUserAvatarSrcById(id);
+  }
+
+  if (isNumeric(trimmedUsername)) {
+    return getGithubUserAvatarSrcById(trimmedUsername);
+  }
+
+  return '';
+};


### PR DESCRIPTION
### Summary

This PR fixes a bug where avatars fail to load in the leaderboard and miner lists when a miner's author name (username) is missing and the system falls back to their numeric `githubId`. 

Previously, the system would attempt to fetch the avatar from `github.com/{id}.png`, which returns a 404 for numeric IDs. I have refactored the avatar utility to automatically detect numeric identifiers and use the correct `avatars.githubusercontent.com/u/{id}` endpoint.

### Changes

- **Utility Refactor (`src/utils/avatar.ts`):** Added `getGithubAvatarSrc`, a robust resolver that handles both usernames and numeric IDs with auto-detection logic.
- **Global Update (`src/utils/ExplorerUtils.ts`):** Re-exported the robust utility to ensure all callers benefit from the fix.
- **Leaderboard Fix (`LeaderboardSidebar.tsx`, `MinerCard.tsx`, `MinersList.tsx`):** Updated call sites to pass both `author` and `githubId`, providing the resolver with the best available data.

### Verification

- Verified that numeric strings (e.g., "240883001") now resolve to `https://avatars.githubusercontent.com/u/240883001` instead of `https://github.com/240883001.png`.
- Verified that alphabetic usernames still resolve to the standard `github.com/{user}.png` URL.
- Ensured no regressions in other components using the shared utility.