### PR TITLE
fix(bounty-sidebar): restrict completion rate denominator to terminal bounties

### DIFF
--- a/src/components/issues/BountySidebar.tsx
+++ b/src/components/issues/BountySidebar.tsx
@@ -400,7 +400,8 @@ const CompletionDonut: React.FC<{
       else if (i.status === 'cancelled') cancelled += 1;
     }
     const total = registered + active + completed + cancelled;
-    const rate = total > 0 ? Math.round((completed / total) * 100) : 0;
+    const finished = completed + cancelled;
+    const rate = finished > 0 ? Math.round((completed / finished) * 100) : null;
     return { registered, active, completed, cancelled, total, rate };
   }, [issues]);
 
@@ -503,11 +504,14 @@ const CompletionDonut: React.FC<{
                     fontFamily: FONTS.mono,
                     fontSize: '1rem',
                     fontWeight: 700,
-                    color: rateColor(breakdown.rate),
+                    color:
+                      breakdown.rate == null
+                        ? STATUS_COLORS.open
+                        : rateColor(breakdown.rate),
                     lineHeight: 1,
                   }}
                 >
-                  {breakdown.rate}%
+                  {breakdown.rate == null ? '—' : `${breakdown.rate}%`}
                 </Typography>
                 <Typography
                   sx={{


### PR DESCRIPTION
## Summary

The Completion Rate donut on `/bounties` was computing its center percentage as `completed / (registered + active + completed + cancelled)`. Counting queued and in-progress bounties in the denominator pulled the displayed rate down whenever the network had a healthy backlog, even when nearly every finished bounty had completed successfully.

This change restricts the denominator to terminal states (`completed + cancelled`), so the headline number now reflects the share of resolved bounties that completed rather than the share of all bounties that have already completed. When no bounty has resolved yet, the center renders a neutral placeholder instead of a misleading `0%`. The donut wedges and the Total Bounties row still show all four status buckets, so backlog visibility is unchanged. The existing `rateColor` thresholds (50 and 80) stay meaningful since they were calibrated against a true success rate.

## Related Issues

Fixes #1006

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

<img width="1878" height="853" alt="after" src="https://github.com/user-attachments/assets/1ef6681f-7de7-4b49-93b0-38259532beba" />


## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
