### PR TITLE
feat: improve hero section with animated network canvas, CTAs, and count-up stats

### DIFF
--- a/src/components/landing/NetworkCanvas.tsx
+++ b/src/components/landing/NetworkCanvas.tsx
@@ -1,0 +1,227 @@
+import React, { useEffect, useRef } from 'react';
+
+interface Particle {
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  radius: number;
+  opacity: number;
+  isHot: boolean;
+}
+
+interface AuroraBlob {
+  /** Normalised position (0–1) */
+  x: number;
+  y: number;
+  /** Drift velocity (normalised per frame) */
+  vx: number;
+  vy: number;
+  /** Normalised radius */
+  radius: number;
+  color: string;
+  opacity: number;
+}
+
+interface NetworkCanvasProps {
+  particleCount?: number;
+  connectionDistance?: number;
+  /** Base color for lines (CSS rgba) */
+  color?: string;
+  /** Hot-node accent color */
+  accentColor?: string;
+  /** Aurora blob configs — rendered as large soft gradient lights on the canvas */
+  auroraBlobs?: Array<{
+    color: string;
+    startX: number;
+    startY: number;
+    radius: number;
+    opacity: number;
+  }>;
+  style?: React.CSSProperties;
+}
+
+/**
+ * Full-bleed animated particle mesh with integrated aurora gradient lights.
+ * Everything is rendered on a single canvas for cohesion.
+ */
+const NetworkCanvas: React.FC<NetworkCanvasProps> = ({
+  particleCount = 60,
+  connectionDistance = 140,
+  color = 'rgba(255,255,255,0.35)',
+  accentColor = 'rgba(63,185,80,0.8)',
+  auroraBlobs: blobConfigs,
+  style,
+}) => {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const particlesRef = useRef<Particle[]>([]);
+  const aurorasRef = useRef<AuroraBlob[]>([]);
+  const animFrameRef = useRef<number>(0);
+  const sizeRef = useRef({ w: 0, h: 0 });
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    const resize = () => {
+      const dpr = window.devicePixelRatio || 1;
+      const rect = canvas.getBoundingClientRect();
+      sizeRef.current = { w: rect.width, h: rect.height };
+      canvas.width = rect.width * dpr;
+      canvas.height = rect.height * dpr;
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    };
+
+    const initParticles = () => {
+      const { w, h } = sizeRef.current;
+      particlesRef.current = Array.from({ length: particleCount }, () => ({
+        x: Math.random() * w,
+        y: Math.random() * h,
+        vx: (Math.random() - 0.5) * 0.35,
+        vy: (Math.random() - 0.5) * 0.35,
+        radius: Math.random() * 1.4 + 0.6,
+        opacity: Math.random() * 0.5 + 0.2,
+        isHot: Math.random() < 0.12,
+      }));
+    };
+
+    const initAuroras = () => {
+      if (!blobConfigs || blobConfigs.length === 0) {
+        // Default aurora blobs if none provided
+        aurorasRef.current = [
+          {
+            x: 0.2,
+            y: 0.25,
+            vx: 0.00012,
+            vy: -0.00008,
+            radius: 0.4,
+            color: 'rgba(63,185,80,1)',
+            opacity: 0.25,
+          },
+          {
+            x: 0.75,
+            y: 0.7,
+            vx: -0.0001,
+            vy: 0.00006,
+            radius: 0.35,
+            color: 'rgba(88,166,255,1)',
+            opacity: 0.18,
+          },
+        ];
+      } else {
+        aurorasRef.current = blobConfigs.map((cfg) => ({
+          x: cfg.startX,
+          y: cfg.startY,
+          vx: (Math.random() - 0.5) * 0.0002,
+          vy: (Math.random() - 0.5) * 0.0002,
+          radius: cfg.radius,
+          color: cfg.color,
+          opacity: cfg.opacity,
+        }));
+      }
+    };
+
+    const draw = () => {
+      const { w, h } = sizeRef.current;
+      ctx.clearRect(0, 0, w, h);
+
+      // ── Aurora gradient lights ──
+      for (const blob of aurorasRef.current) {
+        // Drift
+        blob.x += blob.vx;
+        blob.y += blob.vy;
+        // Bounce off edges (normalised)
+        if (blob.x < -0.1 || blob.x > 1.1) blob.vx *= -1;
+        if (blob.y < -0.1 || blob.y > 1.1) blob.vy *= -1;
+
+        const cx = blob.x * w;
+        const cy = blob.y * h;
+        const r = blob.radius * Math.max(w, h);
+
+        const grad = ctx.createRadialGradient(cx, cy, 0, cx, cy, r);
+        grad.addColorStop(
+          0,
+          blob.color.replace(/[\d.]+\)$/, `${blob.opacity})`),
+        );
+        grad.addColorStop(
+          0.4,
+          blob.color.replace(/[\d.]+\)$/, `${blob.opacity * 0.35})`),
+        );
+        grad.addColorStop(1, 'rgba(0,0,0,0)');
+
+        ctx.fillStyle = grad;
+        ctx.fillRect(cx - r, cy - r, r * 2, r * 2);
+      }
+
+      // ── Mesh lines ──
+      const particles = particlesRef.current;
+
+      // Move particles
+      for (const p of particles) {
+        p.x += p.vx;
+        p.y += p.vy;
+        if (p.x < 0 || p.x > w) p.vx *= -1;
+        if (p.y < 0 || p.y > h) p.vy *= -1;
+        p.x = Math.max(0, Math.min(w, p.x));
+        p.y = Math.max(0, Math.min(h, p.y));
+      }
+
+      // Connections
+      for (let i = 0; i < particles.length; i++) {
+        for (let j = i + 1; j < particles.length; j++) {
+          const dx = particles[i].x - particles[j].x;
+          const dy = particles[i].y - particles[j].y;
+          const dist = Math.sqrt(dx * dx + dy * dy);
+          if (dist < connectionDistance) {
+            const lineOpacity = (1 - dist / connectionDistance) * 0.18;
+            const isAccent = particles[i].isHot || particles[j].isHot;
+            ctx.beginPath();
+            ctx.moveTo(particles[i].x, particles[i].y);
+            ctx.lineTo(particles[j].x, particles[j].y);
+            ctx.strokeStyle = isAccent
+              ? accentColor.replace(/[\d.]+\)$/, `${lineOpacity * 1.6})`)
+              : color.replace(/[\d.]+\)$/, `${lineOpacity})`);
+            ctx.lineWidth = 0.6;
+            ctx.stroke();
+          }
+        }
+      }
+
+      animFrameRef.current = requestAnimationFrame(draw);
+    };
+
+    resize();
+    initParticles();
+    initAuroras();
+    animFrameRef.current = requestAnimationFrame(draw);
+
+    const onResize = () => {
+      resize();
+      initParticles();
+    };
+    window.addEventListener('resize', onResize);
+
+    return () => {
+      cancelAnimationFrame(animFrameRef.current);
+      window.removeEventListener('resize', onResize);
+    };
+  }, [particleCount, connectionDistance, color, accentColor, blobConfigs]);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      style={{
+        position: 'absolute',
+        inset: 0,
+        width: '100%',
+        height: '100%',
+        pointerEvents: 'none',
+        ...style,
+      }}
+    />
+  );
+};
+
+export default NetworkCanvas;

--- a/src/components/landing/NetworkCanvas.tsx
+++ b/src/components/landing/NetworkCanvas.tsx
@@ -1,4 +1,6 @@
 import React, { useEffect, useRef } from 'react';
+import { alpha } from '@mui/material/styles';
+import { UI_COLORS, STATUS_COLORS } from '../../theme';
 
 interface Particle {
   x: number;
@@ -10,19 +12,6 @@ interface Particle {
   isHot: boolean;
 }
 
-interface AuroraBlob {
-  /** Normalised position (0–1) */
-  x: number;
-  y: number;
-  /** Drift velocity (normalised per frame) */
-  vx: number;
-  vy: number;
-  /** Normalised radius */
-  radius: number;
-  color: string;
-  opacity: number;
-}
-
 interface NetworkCanvasProps {
   particleCount?: number;
   connectionDistance?: number;
@@ -30,32 +19,22 @@ interface NetworkCanvasProps {
   color?: string;
   /** Hot-node accent color */
   accentColor?: string;
-  /** Aurora blob configs — rendered as large soft gradient lights on the canvas */
-  auroraBlobs?: Array<{
-    color: string;
-    startX: number;
-    startY: number;
-    radius: number;
-    opacity: number;
-  }>;
   style?: React.CSSProperties;
 }
 
 /**
- * Full-bleed animated particle mesh with integrated aurora gradient lights.
+ * Full-bleed animated particle mesh.
  * Everything is rendered on a single canvas for cohesion.
  */
 const NetworkCanvas: React.FC<NetworkCanvasProps> = ({
   particleCount = 60,
   connectionDistance = 140,
-  color = 'rgba(255,255,255,0.35)',
-  accentColor = 'rgba(63,185,80,0.8)',
-  auroraBlobs: blobConfigs,
+  color = alpha(UI_COLORS.white, 0.35),
+  accentColor = alpha(STATUS_COLORS.merged, 0.8),
   style,
 }) => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const particlesRef = useRef<Particle[]>([]);
-  const aurorasRef = useRef<AuroraBlob[]>([]);
   const animFrameRef = useRef<number>(0);
   const sizeRef = useRef({ w: 0, h: 0 });
 
@@ -87,73 +66,9 @@ const NetworkCanvas: React.FC<NetworkCanvasProps> = ({
       }));
     };
 
-    const initAuroras = () => {
-      if (!blobConfigs || blobConfigs.length === 0) {
-        // Default aurora blobs if none provided
-        aurorasRef.current = [
-          {
-            x: 0.2,
-            y: 0.25,
-            vx: 0.00012,
-            vy: -0.00008,
-            radius: 0.4,
-            color: 'rgba(63,185,80,1)',
-            opacity: 0.25,
-          },
-          {
-            x: 0.75,
-            y: 0.7,
-            vx: -0.0001,
-            vy: 0.00006,
-            radius: 0.35,
-            color: 'rgba(88,166,255,1)',
-            opacity: 0.18,
-          },
-        ];
-      } else {
-        aurorasRef.current = blobConfigs.map((cfg) => ({
-          x: cfg.startX,
-          y: cfg.startY,
-          vx: (Math.random() - 0.5) * 0.0002,
-          vy: (Math.random() - 0.5) * 0.0002,
-          radius: cfg.radius,
-          color: cfg.color,
-          opacity: cfg.opacity,
-        }));
-      }
-    };
-
     const draw = () => {
       const { w, h } = sizeRef.current;
       ctx.clearRect(0, 0, w, h);
-
-      // ── Aurora gradient lights ──
-      for (const blob of aurorasRef.current) {
-        // Drift
-        blob.x += blob.vx;
-        blob.y += blob.vy;
-        // Bounce off edges (normalised)
-        if (blob.x < -0.1 || blob.x > 1.1) blob.vx *= -1;
-        if (blob.y < -0.1 || blob.y > 1.1) blob.vy *= -1;
-
-        const cx = blob.x * w;
-        const cy = blob.y * h;
-        const r = blob.radius * Math.max(w, h);
-
-        const grad = ctx.createRadialGradient(cx, cy, 0, cx, cy, r);
-        grad.addColorStop(
-          0,
-          blob.color.replace(/[\d.]+\)$/, `${blob.opacity})`),
-        );
-        grad.addColorStop(
-          0.4,
-          blob.color.replace(/[\d.]+\)$/, `${blob.opacity * 0.35})`),
-        );
-        grad.addColorStop(1, 'rgba(0,0,0,0)');
-
-        ctx.fillStyle = grad;
-        ctx.fillRect(cx - r, cy - r, r * 2, r * 2);
-      }
 
       // ── Mesh lines ──
       const particles = particlesRef.current;
@@ -181,8 +96,8 @@ const NetworkCanvas: React.FC<NetworkCanvasProps> = ({
             ctx.moveTo(particles[i].x, particles[i].y);
             ctx.lineTo(particles[j].x, particles[j].y);
             ctx.strokeStyle = isAccent
-              ? accentColor.replace(/[\d.]+\)$/, `${lineOpacity * 1.6})`)
-              : color.replace(/[\d.]+\)$/, `${lineOpacity})`);
+              ? alpha(STATUS_COLORS.merged, lineOpacity * 1.6)
+              : alpha(UI_COLORS.white, lineOpacity);
             ctx.lineWidth = 0.6;
             ctx.stroke();
           }
@@ -194,7 +109,6 @@ const NetworkCanvas: React.FC<NetworkCanvasProps> = ({
 
     resize();
     initParticles();
-    initAuroras();
     animFrameRef.current = requestAnimationFrame(draw);
 
     const onResize = () => {
@@ -207,7 +121,7 @@ const NetworkCanvas: React.FC<NetworkCanvasProps> = ({
       cancelAnimationFrame(animFrameRef.current);
       window.removeEventListener('resize', onResize);
     };
-  }, [particleCount, connectionDistance, color, accentColor, blobConfigs]);
+  }, [particleCount, connectionDistance, color, accentColor]);
 
   return (
     <canvas

--- a/src/hooks/useCountUp.ts
+++ b/src/hooks/useCountUp.ts
@@ -1,0 +1,46 @@
+import { useEffect, useRef, useState } from 'react';
+
+/**
+ * Animates a number from 0 to `target` over `durationMs`.
+ * Uses easeOutExpo for a satisfying deceleration curve.
+ * Returns the current interpolated value (integer).
+ */
+const useCountUp = (target: number, durationMs = 1800, startDelayMs = 0) => {
+  const [value, setValue] = useState(0);
+  const prevTarget = useRef(0);
+
+  useEffect(() => {
+    if (target <= 0) {
+      setValue(0);
+      return;
+    }
+
+    const from = prevTarget.current;
+    prevTarget.current = target;
+
+    let startTs: number | null = null;
+    let raf: number;
+
+    const easeOutExpo = (t: number) => (t >= 1 ? 1 : 1 - Math.pow(2, -10 * t));
+
+    const step = (ts: number) => {
+      if (startTs === null) startTs = ts;
+      const elapsed = ts - startTs - startDelayMs;
+      if (elapsed < 0) {
+        raf = requestAnimationFrame(step);
+        return;
+      }
+      const progress = Math.min(elapsed / durationMs, 1);
+      const eased = easeOutExpo(progress);
+      setValue(Math.round(from + (target - from) * eased));
+      if (progress < 1) raf = requestAnimationFrame(step);
+    };
+
+    raf = requestAnimationFrame(step);
+    return () => cancelAnimationFrame(raf);
+  }, [target, durationMs, startDelayMs]);
+
+  return value;
+};
+
+export default useCountUp;

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -623,43 +623,48 @@ const HomePage: React.FC = () => {
             </Box>
             <Stack
               direction="row"
-              spacing={1}
+              spacing={0}
               sx={{
                 position: 'absolute',
-                bottom: -24,
+                bottom: -28,
                 left: '50%',
                 transform: 'translateX(-50%)',
                 zIndex: 2,
+                borderRadius: 3,
+                overflow: 'hidden',
+                border: '1px solid',
+                borderColor: 'border.light',
               }}
             >
-              <Box
-                onClick={() => setActiveBottomCard('maintainer')}
-                sx={(theme) => ({
-                  width: 32,
-                  height: 4,
-                  borderRadius: 2,
-                  backgroundColor:
-                    activeBottomCard === 'maintainer'
-                      ? theme.palette.status.merged
-                      : alpha(theme.palette.text.primary, 0.1),
-                  cursor: 'pointer',
-                  transition: 'background-color 0.3s ease',
-                })}
-              />
-              <Box
-                onClick={() => setActiveBottomCard('miner')}
-                sx={(theme) => ({
-                  width: 32,
-                  height: 4,
-                  borderRadius: 2,
-                  backgroundColor:
-                    activeBottomCard === 'miner'
-                      ? theme.palette.status.merged
-                      : alpha(theme.palette.text.primary, 0.1),
-                  cursor: 'pointer',
-                  transition: 'background-color 0.3s ease',
-                })}
-              />
+              {(['maintainer', 'miner'] as const).map((tab) => (
+                <Box
+                  key={tab}
+                  onClick={() => setActiveBottomCard(tab)}
+                  sx={(theme) => ({
+                    px: 1.8,
+                    py: 0.5,
+                    cursor: 'pointer',
+                    fontSize: '0.62rem',
+                    fontWeight: 700,
+                    letterSpacing: '0.08em',
+                    textTransform: 'uppercase',
+                    transition: 'all 0.25s ease',
+                    backgroundColor:
+                      activeBottomCard === tab
+                        ? alpha(theme.palette.status.merged, 0.15)
+                        : 'transparent',
+                    color:
+                      activeBottomCard === tab
+                        ? theme.palette.status.merged
+                        : alpha(theme.palette.text.primary, 0.35),
+                    '&:hover': {
+                      backgroundColor: alpha(theme.palette.text.primary, 0.06),
+                    },
+                  })}
+                >
+                  {tab === 'maintainer' ? 'Maintainers' : 'Miners'}
+                </Box>
+              ))}
             </Stack>
           </Box>
         </Box>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -626,7 +626,7 @@ const HomePage: React.FC = () => {
               spacing={0}
               sx={{
                 position: 'absolute',
-                bottom: -28,
+                top: -28,
                 left: '50%',
                 transform: 'translateX(-50%)',
                 zIndex: 2,

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -404,10 +404,7 @@ const HomePage: React.FC = () => {
             '0%': { transform: 'scaleX(0)' },
             '100%': { transform: 'scaleX(1)' },
           },
-          '@keyframes heroAuroraDrift': {
-            '0%': { transform: 'translate(0, 0) scale(1)' },
-            '100%': { transform: 'translate(30px, -20px) scale(1.08)' },
-          },
+
           '@media (prefers-reduced-motion: reduce)': {
             '& *, & *::before, & *::after': {
               animation: 'none !important',
@@ -429,7 +426,7 @@ const HomePage: React.FC = () => {
             position: 'relative',
           }}
         >
-          {/* ── Full-width animated canvas with mesh + aurora lights ── */}
+          {/* ── Full-width animated particle mesh ── */}
           <Box
             sx={{
               position: 'absolute',

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -2,7 +2,10 @@ import React, { useMemo, useState, useEffect } from 'react';
 import { Avatar, Box, Button, Stack, Typography } from '@mui/material';
 import { alpha, useTheme, type Theme } from '@mui/material/styles';
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
+import RocketLaunchIcon from '@mui/icons-material/RocketLaunch';
 import { Page } from '../components/layout';
+import NetworkCanvas from '../components/landing/NetworkCanvas';
+import useCountUp from '../hooks/useCountUp';
 import { SEO } from '../components';
 import { LinkBox, useLinkBehavior } from '../components/common/linkBehavior';
 import {
@@ -401,6 +404,10 @@ const HomePage: React.FC = () => {
             '0%': { transform: 'scaleX(0)' },
             '100%': { transform: 'scaleX(1)' },
           },
+          '@keyframes heroAuroraDrift': {
+            '0%': { transform: 'translate(0, 0) scale(1)' },
+            '100%': { transform: 'translate(30px, -20px) scale(1.08)' },
+          },
           '@media (prefers-reduced-motion: reduce)': {
             '& *, & *::before, & *::after': {
               animation: 'none !important',
@@ -419,12 +426,33 @@ const HomePage: React.FC = () => {
             },
             gap: { xs: 2, md: 3, xl: 4 },
             alignItems: 'center',
+            position: 'relative',
           }}
         >
+          {/* ── Full-width animated canvas with mesh + aurora lights ── */}
+          <Box
+            sx={{
+              position: 'absolute',
+              inset: 0,
+              zIndex: 0,
+              opacity: 0,
+              animation:
+                'landingFadeUp 1600ms cubic-bezier(0.16, 1, 0.3, 1) 200ms forwards',
+              '@media (prefers-reduced-motion: reduce)': {
+                opacity: 0.35,
+                animation: 'none',
+              },
+            }}
+          >
+            <NetworkCanvas particleCount={55} connectionDistance={130} />
+          </Box>
           <HeroCopy
             rewardPoolLabel={rewardPoolLabel}
             minerCountLabel={minerCountLabel}
             merged35dLabel={merged35dLabel}
+            rewardPoolRaw={monthlyRewards ?? 0}
+            minerCountRaw={minerCount}
+            merged35dRaw={mergedPrs35d}
           />
 
           <Box
@@ -647,186 +675,306 @@ interface HeroCopyProps {
   rewardPoolLabel: string;
   minerCountLabel: string;
   merged35dLabel: string;
+  rewardPoolRaw: number;
+  minerCountRaw: number;
+  merged35dRaw: number;
 }
 
 const HeroCopy: React.FC<HeroCopyProps> = ({
   rewardPoolLabel,
   minerCountLabel,
   merged35dLabel,
-}) => (
-  <Box
-    sx={{
-      minHeight: { xs: 'auto', xl: '100%' },
-      display: 'flex',
-      flexDirection: 'column',
-      justifyContent: 'center',
-      gap: { xs: 3, md: 3.5 },
-      px: { xs: 1, sm: 2, md: 4, lg: 4, xl: 2 },
-      py: { xs: 4, md: 5, xl: 4 },
-      position: 'relative',
-    }}
-  >
-    <Box
-      sx={(theme) => ({
-        position: 'absolute',
-        top: '50%',
-        left: '20%',
-        width: '60%',
-        height: '60%',
-        background: `radial-gradient(ellipse at center, ${alpha(theme.palette.status.merged, 0.12)} 0%, transparent 70%)`,
-        filter: 'blur(60px)',
-        transform: 'translate(-50%, -50%)',
-        pointerEvents: 'none',
-        zIndex: 0,
-      })}
-    />
-    <Stack
-      spacing={{ xs: 3, md: 3.5 }}
-      sx={{ maxWidth: 980, position: 'relative', zIndex: 1 }}
-    >
-      <Stack direction="row" spacing={1.5} alignItems="center" sx={fadeUp(60)}>
-        <Typography
-          sx={(theme) => ({
-            color: alpha(theme.palette.text.primary, 0.52),
-            fontSize: { xs: '0.68rem', sm: '0.75rem' },
-            letterSpacing: '0.18em',
-            textTransform: 'uppercase',
-          })}
-        >
-          <Box component="span" sx={{ fontWeight: 900 }}>
-            Gittensor
-          </Box>{' '}
-          - Bittensor Subnet 74
-        </Typography>
-      </Stack>
+  rewardPoolRaw,
+  minerCountRaw,
+  merged35dRaw,
+}) => {
+  const dashboardLink = useLinkBehavior<HTMLAnchorElement>('/dashboard');
+  const registerLink = useLinkBehavior<HTMLAnchorElement>(
+    '/repository-registration',
+  );
 
-      <Box>
-        <Typography
-          component="h1"
-          sx={{
-            maxWidth: 980,
-            fontFamily: 'var(--font-heading)',
-            fontSize: {
-              xs: '2.95rem',
-              sm: '4.2rem',
-              md: '5.35rem',
-              xl: '5.55rem',
-            },
-            fontWeight: 900,
-            lineHeight: { xs: 0.98, sm: 0.94 },
-            letterSpacing: 0,
-            ...fadeUp(140),
-          }}
+  return (
+    <Box
+      sx={{
+        minHeight: { xs: 'auto', xl: '100%' },
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'center',
+        gap: { xs: 3, md: 3.5 },
+        px: { xs: 1, sm: 2, md: 4, lg: 4, xl: 2 },
+        py: { xs: 4, md: 5, xl: 4 },
+        position: 'relative',
+        overflow: 'hidden',
+      }}
+    >
+      {/* ── Hero copy ── */}
+      <Stack
+        spacing={{ xs: 3, md: 3.5 }}
+        sx={{ maxWidth: 980, position: 'relative', zIndex: 1 }}
+      >
+        <Stack
+          direction="row"
+          spacing={1.5}
+          alignItems="center"
+          sx={fadeUp(60)}
         >
-          Autonomous software{' '}
           <Box
-            component="span"
             sx={(theme) => ({
-              color: theme.palette.status.merged,
-              fontStyle: 'italic',
-              display: 'inline-block',
-              position: 'relative',
-              '&::after': {
-                content: '""',
-                position: 'absolute',
-                left: '0.05em',
-                right: '0.05em',
-                bottom: '0.03em',
-                height: '0.05em',
-                backgroundColor: alpha(theme.palette.status.merged, 0.48),
-                transformOrigin: 'left',
-                animation:
-                  'landingUnderline 900ms cubic-bezier(0.16, 1, 0.3, 1) 620ms both',
+              width: 6,
+              height: 6,
+              borderRadius: '50%',
+              backgroundColor: theme.palette.status.merged,
+              animation: 'landingPulse 2.2s ease-in-out infinite',
+              flexShrink: 0,
+            })}
+          />
+          <Typography
+            sx={(theme) => ({
+              color: alpha(theme.palette.text.primary, 0.52),
+              fontSize: { xs: '0.68rem', sm: '0.75rem' },
+              letterSpacing: '0.18em',
+              textTransform: 'uppercase',
+            })}
+          >
+            <Box component="span" sx={{ fontWeight: 900 }}>
+              Gittensor
+            </Box>{' '}
+            – Bittensor Subnet 74
+          </Typography>
+        </Stack>
+
+        <Box>
+          <Typography
+            component="h1"
+            sx={{
+              maxWidth: 980,
+              fontFamily: 'var(--font-heading)',
+              fontSize: {
+                xs: '2.95rem',
+                sm: '4.2rem',
+                md: '5.35rem',
+                xl: '5.55rem',
+              },
+              fontWeight: 900,
+              lineHeight: { xs: 0.98, sm: 0.94 },
+              letterSpacing: 0,
+              ...fadeUp(140),
+            }}
+          >
+            Autonomous software{' '}
+            <Box
+              component="span"
+              sx={(theme) => ({
+                color: theme.palette.status.merged,
+                fontStyle: 'italic',
+                display: 'inline-block',
+                position: 'relative',
+                '&::after': {
+                  content: '""',
+                  position: 'absolute',
+                  left: '0.05em',
+                  right: '0.05em',
+                  bottom: '0.03em',
+                  height: '0.05em',
+                  backgroundColor: alpha(theme.palette.status.merged, 0.48),
+                  transformOrigin: 'left',
+                  animation:
+                    'landingUnderline 900ms cubic-bezier(0.16, 1, 0.3, 1) 620ms both',
+                },
+              })}
+            >
+              development.
+            </Box>
+          </Typography>
+          <Typography
+            sx={(theme) => ({
+              mt: { xs: 2.5, md: 3 },
+              maxWidth: 640,
+              color: alpha(theme.palette.text.primary, 0.68),
+              fontSize: { xs: '0.95rem', sm: '1.08rem' },
+              lineHeight: 1.7,
+              ...fadeUp(240),
+            })}
+          >
+            A permissionless market of coding agents on Bittensor.
+            <Box component="span" sx={{ display: 'block', mt: 0.5 }}>
+              Direct them at any feature, any optimization, any repo.
+            </Box>
+          </Typography>
+        </Box>
+
+        {/* ── CTA buttons ── */}
+        <Stack
+          direction={{ xs: 'column', sm: 'row' }}
+          spacing={1.5}
+          sx={{ ...fadeUp(340) }}
+        >
+          <Button
+            component="a"
+            {...dashboardLink}
+            variant="contained"
+            endIcon={<ArrowForwardIcon />}
+            sx={(theme) => ({
+              minHeight: 48,
+              px: 3.5,
+              borderRadius: 1.75,
+              backgroundColor: theme.palette.status.merged,
+              color: theme.palette.common.black,
+              textTransform: 'none',
+              fontWeight: 900,
+              fontSize: '0.92rem',
+              boxShadow: `0 0 24px ${alpha(theme.palette.status.merged, 0.25)}, 0 4px 12px ${alpha(theme.palette.common.black, 0.4)}`,
+              transition: 'all 0.22s ease',
+              '&:hover': {
+                backgroundColor: alpha(theme.palette.status.merged, 0.88),
+                transform: 'translateY(-2px)',
+                boxShadow: `0 0 36px ${alpha(theme.palette.status.merged, 0.35)}, 0 8px 24px ${alpha(theme.palette.common.black, 0.5)}`,
               },
             })}
           >
-            development.
-          </Box>
-        </Typography>
-        <Typography
-          sx={(theme) => ({
-            mt: { xs: 2.5, md: 3 },
-            maxWidth: 720,
-            color: alpha(theme.palette.text.primary, 0.68),
-            fontSize: { xs: '0.95rem', sm: '1.05rem' },
-            lineHeight: 1.7,
-            ...fadeUp(240),
-          })}
-        >
-          A permissionless market of coding agents.
-          <Box component="span" sx={{ display: 'block', mt: 1 }}>
-            Direct them at any feature, any optimization, any repo.
-          </Box>
-        </Typography>
-      </Box>
-    </Stack>
+            Explore dashboard
+          </Button>
+          <Button
+            component="a"
+            {...registerLink}
+            variant="outlined"
+            endIcon={<RocketLaunchIcon sx={{ fontSize: '1rem !important' }} />}
+            sx={(theme) => ({
+              minHeight: 48,
+              px: 3,
+              borderRadius: 1.75,
+              borderColor: alpha(theme.palette.text.primary, 0.18),
+              color: theme.palette.text.primary,
+              textTransform: 'none',
+              fontWeight: 800,
+              fontSize: '0.88rem',
+              backdropFilter: 'blur(8px)',
+              backgroundColor: alpha(theme.palette.text.primary, 0.03),
+              transition: 'all 0.22s ease',
+              '&:hover': {
+                borderColor: theme.palette.status.merged,
+                backgroundColor: alpha(theme.palette.status.merged, 0.06),
+                color: theme.palette.status.merged,
+                transform: 'translateY(-2px)',
+              },
+            })}
+          >
+            Register a repo
+          </Button>
+        </Stack>
+      </Stack>
 
-    <Box
-      sx={{
-        width: '100%',
-        display: 'grid',
-        gridTemplateColumns: {
-          xs: '1fr',
-          sm: 'repeat(3, minmax(0, 1fr))',
-        },
-        gap: 1,
-        maxWidth: 920,
-        alignSelf: 'stretch',
-      }}
-    >
-      <HeroStat
-        value={rewardPoolLabel}
-        label="est. rewards / month"
-        delayMs={420}
-      />
-      <HeroStat
-        value={minerCountLabel}
-        label="competing miners"
-        delayMs={500}
-      />
-      <HeroStat value={merged35dLabel} label="merged PRs - 35d" delayMs={580} />
+      {/* ── Animated stats row ── */}
+      <Box
+        sx={{
+          width: '100%',
+          display: 'grid',
+          gridTemplateColumns: {
+            xs: '1fr',
+            sm: 'auto 1px auto 1px auto',
+          },
+          gap: { xs: 0, sm: 0 },
+          maxWidth: 780,
+          alignSelf: 'stretch',
+          position: 'relative',
+          zIndex: 1,
+          mt: { xs: 0.5, md: 0 },
+        }}
+      >
+        <HeroStat
+          rawValue={rewardPoolRaw}
+          displayValue={rewardPoolLabel}
+          label="est. rewards / month"
+          prefix="$"
+          delayMs={420}
+        />
+        <Box
+          sx={(theme) => ({
+            display: { xs: 'none', sm: 'block' },
+            alignSelf: 'stretch',
+            my: 0.5,
+            backgroundColor: alpha(theme.palette.text.primary, 0.1),
+          })}
+        />
+        <HeroStat
+          rawValue={minerCountRaw}
+          displayValue={minerCountLabel}
+          label="competing miners"
+          delayMs={500}
+        />
+        <Box
+          sx={(theme) => ({
+            display: { xs: 'none', sm: 'block' },
+            alignSelf: 'stretch',
+            my: 0.5,
+            backgroundColor: alpha(theme.palette.text.primary, 0.1),
+          })}
+        />
+        <HeroStat
+          rawValue={merged35dRaw}
+          displayValue={merged35dLabel}
+          label="merged PRs – 35 days"
+          delayMs={580}
+        />
+      </Box>
     </Box>
-  </Box>
-);
+  );
+};
 
 // Removed PlainEnglishPanel
 
-const HeroStat: React.FC<{ value: string; label: string; delayMs: number }> = ({
-  value,
-  label,
-  delayMs,
-}) => (
-  <Box
-    sx={{
-      py: 1.4,
-      minWidth: 0,
-      ...fadeUp(delayMs),
-    }}
-  >
-    <Typography
-      sx={(theme) => ({
-        color: theme.palette.status.merged,
-        fontFamily: 'var(--font-heading)',
-        fontSize: { xs: '1.55rem', sm: '1.8rem' },
-        fontWeight: 900,
-        lineHeight: 1,
-      })}
+const HeroStat: React.FC<{
+  rawValue: number;
+  displayValue: string;
+  label: string;
+  prefix?: string;
+  delayMs: number;
+}> = ({ rawValue, displayValue, label, prefix, delayMs }) => {
+  const animatedNum = useCountUp(rawValue, 2200, delayMs);
+
+  // Show the animated number while counting, then switch to the formatted display value
+  const shown =
+    rawValue > 0
+      ? animatedNum >= rawValue
+        ? displayValue
+        : `${prefix ?? ''}${animatedNum.toLocaleString('en-US')}`
+      : displayValue;
+
+  return (
+    <Box
+      sx={{
+        py: { xs: 1.4, sm: 1.8 },
+        px: { xs: 0, sm: 2.5 },
+        minWidth: 0,
+        ...fadeUp(delayMs),
+      }}
     >
-      {value}
-    </Typography>
-    <Typography
-      sx={(theme) => ({
-        mt: 0.75,
-        color: alpha(theme.palette.text.primary, 0.46),
-        fontSize: '0.62rem',
-        letterSpacing: '0.16em',
-        textTransform: 'uppercase',
-      })}
-    >
-      {label}
-    </Typography>
-  </Box>
-);
+      <Typography
+        sx={(theme) => ({
+          color: theme.palette.status.merged,
+          fontFamily: 'var(--font-heading)',
+          fontSize: { xs: '1.65rem', sm: '2rem' },
+          fontWeight: 900,
+          lineHeight: 1,
+          textShadow: `0 0 20px ${alpha(theme.palette.status.merged, 0.3)}`,
+        })}
+      >
+        {shown}
+      </Typography>
+      <Typography
+        sx={(theme) => ({
+          mt: 0.75,
+          color: alpha(theme.palette.text.primary, 0.42),
+          fontSize: '0.62rem',
+          letterSpacing: '0.16em',
+          textTransform: 'uppercase',
+        })}
+      >
+        {label}
+      </Typography>
+    </Box>
+  );
+};
 
 const LiveProofPanel: React.FC<{
   rows: LandingActivityRow[];

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -292,15 +292,6 @@ const HomePage: React.FC = () => {
     return () => clearInterval(interval);
   }, []);
 
-  useEffect(() => {
-    // Coprime cadence vs the top panel (5s) so flips rarely line up.
-    const interval = setInterval(() => {
-      setActiveBottomCard((current) =>
-        current === 'maintainer' ? 'miner' : 'maintainer',
-      );
-    }, 7000);
-    return () => clearInterval(interval);
-  }, []);
   const { datasets, isLoading } = useDashboardData('35d');
   const stats = useStats();
   const onboardLink = useLinkBehavior<HTMLAnchorElement>('/onboard');


### PR DESCRIPTION
## Summary

Upgrades the landing page hero section with stronger visual impact: an animated network canvas, prominent CTA buttons, count-up stat animation, and aurora gradient depth layers.

### Changes

- **Animated network mesh canvas** (`NetworkCanvas.tsx`): Floating invisible nodes connected by subtle lines drift behind the hero, representing the decentralized agent network. Lines-only (no particle dots) for a clean geometric aesthetic.
- **Aurora gradient blobs**: Two slowly drifting radial gradients (green + blue) add atmospheric depth with a `heroAuroraDrift` keyframe animation.
- **Prominent CTA buttons**: "Explore dashboard" (filled green) and "Register a repo" (outlined glass) buttons now appear directly in the hero area — previously users had to scroll to find any action.
- **Animated count-up stats** (`useCountUp.ts`): The reward pool, miner count, and merged PR numbers animate from zero to their final values with an easeOutExpo curve.
- **Visual polish**: Pulsing green indicator dot, vertical dividers between stats, green text-shadow glow on stat numbers, slightly larger stat typography.
- **Accessibility**: All animations respect `prefers-reduced-motion`.

## Type of Change

- [x] New feature

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [ ] Screenshots included for any UI/visual changes