### PR TITLE
fix(ui): repository watchlist action on miner details Repositories table

### DIFF
--- a/src/components/miners/MinerRepositoriesTable.tsx
+++ b/src/components/miners/MinerRepositoriesTable.tsx
@@ -15,8 +15,9 @@ import { useMinerPRs, useReposAndWeights, useIssues } from '../../api';
 import { LinkBox } from '../common/linkBehavior';
 import {
   DataTable,
+  WatchlistButton,
   type DataTableColumn,
-} from '../../components/common/DataTable';
+} from '../../components/common';
 import { ClearSearchAdornment } from '../common/ClearSearchAdornment';
 import RankBadge from './RankBadge';
 import EmptyStateMessage from './EmptyStateMessage';
@@ -364,6 +365,21 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
       sortKey: 'weight',
       renderCell: (repo) => repo.weight.toFixed(4),
     },
+    {
+      key: 'watch',
+      header: '★',
+      width: '52px',
+      align: 'center',
+      cellSx: { p: 0 },
+      renderCell: (repo) =>
+        repo.repository ? (
+          <WatchlistButton
+            category="repos"
+            itemKey={repo.repository}
+            size="small"
+          />
+        ) : null,
+    },
   ];
 
   const issueColumns: DataTableColumn<IssueRepoStats, IssueRepoSortField>[] = [
@@ -437,6 +453,21 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
       align: 'right',
       sortKey: 'weight',
       renderCell: (repo) => repo.weight.toFixed(4),
+    },
+    {
+      key: 'watch',
+      header: '★',
+      width: '52px',
+      align: 'center',
+      cellSx: { p: 0 },
+      renderCell: (repo) =>
+        repo.repository ? (
+          <WatchlistButton
+            category="repos"
+            itemKey={repo.repository}
+            size="small"
+          />
+        ) : null,
     },
   ];
 


### PR DESCRIPTION
## Summary

Adds a per-row repository watchlist control to Miner Details → Repositories, for OSS Contributions and Issue Discovery, so users can star/unstar repos from this table instead of navigating away.

## Related Issues

Fixes #1010 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

<img width="1891" height="946" alt="2026-05-09_23h17_07" src="https://github.com/user-attachments/assets/4bfcc7a2-aa5a-49ab-ae11-050f8a54b171" />

<img width="1899" height="877" alt="2026-05-09_23h17_33" src="https://github.com/user-attachments/assets/93947615-38f8-466a-89ff-a02329fff02f" />


## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
