### PR TITLE
feat(repo): enhance PR discovery with persistent shareable search filters

### DIFF
--- a/src/components/repositories/RepositoryPRsTable.tsx
+++ b/src/components/repositories/RepositoryPRsTable.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { useSessionStoredState } from '../../hooks/useSessionStoredState';
 import {
   Avatar,
   Box,
@@ -6,7 +7,6 @@ import {
   Chip,
   CircularProgress,
   InputAdornment,
-  Link,
   Stack,
   TextField,
   Typography,
@@ -29,12 +29,7 @@ import {
   useWatchlist,
 } from '../../hooks/useWatchlist';
 import theme, { TEXT_OPACITY, scrollbarSx } from '../../theme';
-import {
-  filterPrs,
-  filterPrsBySearchTerms,
-  getPrStatusCounts,
-  type PrStatusFilter,
-} from '../../utils';
+import { filterPrs, getPrStatusCounts, type PrStatusFilter } from '../../utils';
 import { getRepositoryOwnerAvatarSrc } from '../../utils/avatar';
 import { formatDate } from '../../utils/format';
 import FilterButton from '../FilterButton';
@@ -57,21 +52,8 @@ interface RepositoryPRsTableProps {
   state?: 'open' | 'closed' | 'merged' | 'all';
 }
 
-const PR_STATUS_FILTERS: readonly PrStatusFilter[] = [
-  'all',
-  'open',
-  'merged',
-  'closed',
-];
-
-const isPrStatusFilter = (value: string | null): value is PrStatusFilter =>
-  value !== null && (PR_STATUS_FILTERS as readonly string[]).includes(value);
-
-const chipLabelSx = {
-  maxWidth: 280,
-  overflow: 'hidden',
-  textOverflow: 'ellipsis',
-} as const;
+const isPrStatusFilter = (v: unknown): v is PrStatusFilter =>
+  v === 'all' || v === 'open' || v === 'merged' || v === 'closed';
 
 const PR_PAGE_SIZE = 20;
 
@@ -82,71 +64,16 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const { isWatched } = useWatchlist('prs');
-  const prStatusParam = searchParams.get('prStatus');
-  /** Open / Merged / Closed / All — driven by `prStatus` in the URL so chips and counts stay aligned. */
-  const filter: PrStatusFilter = isPrStatusFilter(prStatusParam)
-    ? prStatusParam
-    : state;
+  const [filter, setFilter] = useSessionStoredState<PrStatusFilter>(
+    'repository:prs:statusFilter',
+    state,
+    isPrStatusFilter,
+  );
   const [sortField, setSortField] = useState<PrSortField>('score');
   const [sortOrder, setSortOrder] = useState<SortOrder>('desc');
   const [page, setPage] = useState(0);
+  const [searchQuery, setSearchQuery] = useState('');
   const authorFilter = searchParams.get('prAuthor') ?? AUTHOR_FILTER_ALL;
-  /** Each Enter appends one `prQ` param (AND semantics). */
-  const committedPrQRaw = useMemo(
-    () => searchParams.getAll('prQ'),
-    [searchParams],
-  );
-  /** Draft text: live AND-preview with committed terms; Enter appends a chip. */
-  const [draftSearch, setDraftSearch] = useState('');
-
-  const appendCommittedTerm = useCallback(
-    (term: string) => {
-      const t = term.trim();
-      if (!t) return;
-      setSearchParams(
-        (prev) => {
-          const next = new URLSearchParams(prev);
-          next.append('prQ', t);
-          return next;
-        },
-        { replace: true },
-      );
-    },
-    [setSearchParams],
-  );
-
-  const removeCommittedTermAt = useCallback(
-    (index: number) => {
-      setSearchParams(
-        (prev) => {
-          const list = prev.getAll('prQ');
-          const next = new URLSearchParams(prev);
-          next.delete('prQ');
-          list.forEach((raw, i) => {
-            if (i !== index) next.append('prQ', raw);
-          });
-          return next;
-        },
-        { replace: true },
-      );
-    },
-    [setSearchParams],
-  );
-
-  const setFilterParam = useCallback(
-    (next: PrStatusFilter) => {
-      setSearchParams(
-        (prev) => {
-          const nextParams = new URLSearchParams(prev);
-          if (next === 'all') nextParams.delete('prStatus');
-          else nextParams.set('prStatus', next);
-          return nextParams;
-        },
-        { replace: true },
-      );
-    },
-    [setSearchParams],
-  );
 
   const setAuthorFilter = useCallback(
     (nextAuthor: string) => {
@@ -163,82 +90,6 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
     [setSearchParams],
   );
 
-  // Fetch ALL PRs at once for instant client-side filtering + accurate counts.
-  const { data: allMinerPRs, isLoading } = useAllPrs();
-
-  const allPRs = useMemo(() => {
-    if (!allMinerPRs) return [];
-    return allMinerPRs.filter(
-      (pr) => pr.repository.toLowerCase() === repositoryFullName.toLowerCase(),
-    );
-  }, [allMinerPRs, repositoryFullName]);
-
-  /**
-   * Tab badges show repo-wide status totals (or totals for the selected author only).
-   * Search terms — draft or pinned (`prQ`) — never change these numbers.
-   */
-  const prsForStatusTabCounts = useMemo(
-    () =>
-      filterPrs(allPRs, {
-        author: authorFilter === AUTHOR_FILTER_ALL ? null : authorFilter,
-      }),
-    [allPRs, authorFilter],
-  );
-
-  const tabCounts = useMemo(
-    () => getPrStatusCounts(prsForStatusTabCounts),
-    [prsForStatusTabCounts],
-  );
-
-  /** Single pipeline: baseline count (status + author) + search-narrowed rows. */
-  const { filteredPRs, baselinePrCount } = useMemo(() => {
-    const byAuthor = filterPrs(allPRs, {
-      statusFilter: filter,
-      author: authorFilter === AUTHOR_FILTER_ALL ? null : authorFilter,
-    });
-    const baselinePrCount = byAuthor.length;
-    const pool = filterPrsBySearchTerms(
-      byAuthor,
-      [...committedPrQRaw, draftSearch],
-      true,
-    );
-    return { filteredPRs: pool, baselinePrCount };
-  }, [allPRs, filter, authorFilter, committedPrQRaw, draftSearch]);
-
-  const hasCommittedSearchFilters = committedPrQRaw.some((t) => t.trim());
-
-  /** Draft or pinned terms — status chips below only show alongside search context. */
-  const hasSearchContext =
-    draftSearch.trim() !== '' || hasCommittedSearchFilters;
-
-  /** Don’t duplicate Open/Merged/Closed as chips unless search is also active. */
-  const showActiveFiltersRow =
-    authorFilter !== AUTHOR_FILTER_ALL ||
-    hasCommittedSearchFilters ||
-    (filter !== 'all' && hasSearchContext);
-
-  /** “N of M” and Clear all — any narrowing from default + draft typing. */
-  const isNarrowed =
-    filter !== 'all' ||
-    authorFilter !== AUTHOR_FILTER_ALL ||
-    draftSearch.trim() !== '' ||
-    hasCommittedSearchFilters;
-
-  /** One atomic URL write — batched `setSearchParams` calls could reuse stale `prev` and leave `prQ` behind. */
-  const clearAllFilters = useCallback(() => {
-    setDraftSearch('');
-    setSearchParams(
-      (prev) => {
-        const next = new URLSearchParams(prev);
-        next.delete('prQ');
-        next.delete('prStatus');
-        next.delete('prAuthor');
-        return next;
-      },
-      { replace: true },
-    );
-  }, [setSearchParams]);
-
   const handleSort = (field: PrSortField) => {
     if (sortField === field) {
       setSortOrder((o) => (o === 'asc' ? 'desc' : 'asc'));
@@ -249,6 +100,37 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
       );
     }
   };
+
+  // Fetch ALL PRs at once for instant client-side filtering + accurate counts.
+  const { data: allMinerPRs, isLoading } = useAllPrs();
+
+  const allPRs = useMemo(() => {
+    if (!allMinerPRs) return [];
+    return allMinerPRs.filter(
+      (pr) => pr.repository.toLowerCase() === repositoryFullName.toLowerCase(),
+    );
+  }, [allMinerPRs, repositoryFullName]);
+
+  const tabCounts = useMemo(
+    () =>
+      getPrStatusCounts(
+        filterPrs(allPRs, {
+          author: authorFilter === AUTHOR_FILTER_ALL ? null : authorFilter,
+        }),
+      ),
+    [allPRs, authorFilter],
+  );
+
+  const filteredPRs = useMemo(
+    () =>
+      filterPrs(allPRs, {
+        statusFilter: filter,
+        author: authorFilter === AUTHOR_FILTER_ALL ? null : authorFilter,
+        searchQuery,
+        includeNumber: true,
+      }),
+    [allPRs, filter, authorFilter, searchQuery],
+  );
 
   const sortedPRs = useMemo(() => {
     const dir = sortOrder === 'asc' ? 1 : -1;
@@ -295,7 +177,7 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
   // Reset to the first page whenever the result set changes underneath us.
   useEffect(() => {
     setPage(0);
-  }, [filter, authorFilter, sortField, sortOrder]);
+  }, [filter, authorFilter, searchQuery, sortField, sortOrder]);
 
   const totalPages = Math.ceil(sortedPRs.length / PR_PAGE_SIZE);
   const pagedPRs = useMemo(
@@ -325,28 +207,28 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
       <FilterButton
         label="All"
         isActive={filter === 'all'}
-        onClick={() => setFilterParam('all')}
+        onClick={() => setFilter('all')}
         count={tabCounts.all}
         color={theme.palette.status.neutral}
       />
       <FilterButton
         label="Open"
         isActive={filter === 'open'}
-        onClick={() => setFilterParam('open')}
+        onClick={() => setFilter('open')}
         count={tabCounts.open}
         color={theme.palette.status.open}
       />
       <FilterButton
         label="Merged"
         isActive={filter === 'merged'}
-        onClick={() => setFilterParam('merged')}
+        onClick={() => setFilter('merged')}
         count={tabCounts.merged}
         color={theme.palette.status.merged}
       />
       <FilterButton
         label="Closed"
         isActive={filter === 'closed'}
-        onClick={() => setFilterParam('closed')}
+        onClick={() => setFilter('closed')}
         count={tabCounts.closed}
         color={theme.palette.status.closed}
       />
@@ -359,6 +241,29 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
       />
     </Stack>
   );
+
+  if (isLoading) {
+    return (
+      <Card
+        sx={{
+          borderRadius: 3,
+          border: `1px solid ${theme.palette.border.light}`,
+          backgroundColor: 'transparent',
+          p: 4,
+          textAlign: 'center',
+        }}
+        elevation={0}
+      >
+        <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 3 }}>
+          <Typography variant="h6" sx={{ color: 'text.primary' }}>
+            Pull Requests
+          </Typography>
+          {filterButtons}
+        </Box>
+        <CircularProgress size={40} sx={{ color: 'primary.main' }} />
+      </Card>
+    );
+  }
 
   const columns: DataTableColumn<CommitLog, PrSortField>[] = [
     {
@@ -522,29 +427,6 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
     },
   ];
 
-  if (isLoading) {
-    return (
-      <Card
-        sx={{
-          borderRadius: 3,
-          border: `1px solid ${theme.palette.border.light}`,
-          backgroundColor: 'transparent',
-          p: 4,
-          textAlign: 'center',
-        }}
-        elevation={0}
-      >
-        <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 3 }}>
-          <Typography variant="h6" sx={{ color: 'text.primary' }}>
-            Pull Requests
-          </Typography>
-          {filterButtons}
-        </Box>
-        <CircularProgress size={40} sx={{ color: 'primary.main' }} />
-      </Card>
-    );
-  }
-
   const headerToolbar = (
     <Box
       sx={{
@@ -564,150 +446,45 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
           gap: 2,
         }}
       >
-        <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 1 }}>
-          <Typography
-            variant="h6"
-            sx={{ color: 'text.primary', fontSize: '1.1rem', fontWeight: 500 }}
-          >
-            Pull Requests
-          </Typography>
-          <Typography
-            sx={{
-              color: 'text.tertiary',
-              fontSize: '0.85rem',
-            }}
-          >
-            (
-            {draftSearch.trim() !== '' || sortedPRs.length !== baselinePrCount
-              ? `${sortedPRs.length} of ${baselinePrCount}`
-              : sortedPRs.length}
-            )
-          </Typography>
-        </Box>
+        <Typography
+          variant="h6"
+          sx={{ color: 'text.primary', fontSize: '1.1rem', fontWeight: 500 }}
+        >
+          Pull Requests ({sortedPRs.length})
+        </Typography>
         {filterButtons}
       </Box>
-
-      <Box
-        sx={{
-          display: 'flex',
-          alignItems: 'center',
-          gap: 2,
-          width: '100%',
-          flexWrap: { xs: 'wrap', sm: 'nowrap' },
+      <TextField
+        size="small"
+        placeholder="Search title, PR #, merged date…"
+        value={searchQuery}
+        onChange={(e) => setSearchQuery(e.target.value)}
+        InputProps={{
+          startAdornment: (
+            <InputAdornment position="start">
+              <SearchIcon sx={{ color: 'text.tertiary', fontSize: '1rem' }} />
+            </InputAdornment>
+          ),
+          endAdornment: (
+            <ClearSearchAdornment
+              visible={Boolean(searchQuery)}
+              onClear={() => setSearchQuery('')}
+            />
+          ),
         }}
-      >
-        <TextField
-          size="small"
-          placeholder="Add a term, press Enter — each term narrows results (AND)"
-          value={draftSearch}
-          onChange={(e) => setDraftSearch(e.target.value)}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter') {
-              e.preventDefault();
-              appendCommittedTerm(draftSearch);
-              setDraftSearch('');
-            }
-          }}
-          InputProps={{
-            startAdornment: (
-              <InputAdornment position="start">
-                <SearchIcon sx={{ color: 'text.tertiary', fontSize: '1rem' }} />
-              </InputAdornment>
-            ),
-            endAdornment: (
-              <ClearSearchAdornment
-                visible={Boolean(draftSearch)}
-                onClear={() => setDraftSearch('')}
-              />
-            ),
-          }}
-          sx={{
-            flex: 1,
-            minWidth: 0,
-            maxWidth: { xs: '100%', sm: 520 },
-            '& .MuiOutlinedInput-root': {
-              fontSize: '0.8rem',
-              color: 'text.primary',
-              backgroundColor: 'surface.subtle',
-              borderRadius: 2,
-              '& fieldset': { borderColor: 'border.light' },
-              '&:hover fieldset': { borderColor: 'border.medium' },
-              '&.Mui-focused fieldset': { borderColor: 'primary.main' },
-            },
-          }}
-        />
-        {isNarrowed && (
-          <Link
-            component="button"
-            type="button"
-            underline="hover"
-            onClick={clearAllFilters}
-            sx={{
-              flexShrink: 0,
-              cursor: 'pointer',
-              fontSize: '0.8rem',
-              fontWeight: 600,
-              whiteSpace: 'nowrap',
-              color: 'primary.main',
-            }}
-          >
-            Clear all
-          </Link>
-        )}
-      </Box>
-
-      {showActiveFiltersRow && (
-        <Box
-          sx={{
-            display: 'flex',
-            flexWrap: 'wrap',
-            alignItems: 'center',
-            gap: 1.5,
-          }}
-        >
-          <Typography
-            component="span"
-            sx={{
-              color: 'text.secondary',
-              fontSize: '0.8rem',
-              flexShrink: 0,
-            }}
-          >
-            Active filters:
-          </Typography>
-          <Stack direction="row" flexWrap="wrap" useFlexGap spacing={1}>
-            {filter !== 'all' && hasSearchContext && (
-              <Chip
-                variant="filter"
-                label={filter}
-                onDelete={() => setFilterParam('all')}
-                sx={{ '& .MuiChip-label': chipLabelSx }}
-              />
-            )}
-            {authorFilter !== AUTHOR_FILTER_ALL && (
-              <Chip
-                variant="filter"
-                label={`author: ${authorFilter}`}
-                onDelete={() => setAuthorFilter(AUTHOR_FILTER_ALL)}
-                sx={{ '& .MuiChip-label': chipLabelSx }}
-              />
-            )}
-            {committedPrQRaw.map((raw, index) => {
-              const label = raw.trim();
-              if (!label) return null;
-              return (
-                <Chip
-                  key={`prq-${index}-${label}`}
-                  variant="filter"
-                  label={label}
-                  onDelete={() => removeCommittedTermAt(index)}
-                  sx={{ '& .MuiChip-label': chipLabelSx }}
-                />
-              );
-            })}
-          </Stack>
-        </Box>
-      )}
+        sx={{
+          maxWidth: { xs: '100%', sm: 520 },
+          '& .MuiOutlinedInput-root': {
+            fontSize: '0.8rem',
+            color: 'text.primary',
+            backgroundColor: 'surface.subtle',
+            borderRadius: 2,
+            '& fieldset': { borderColor: 'border.light' },
+            '&:hover fieldset': { borderColor: 'border.medium' },
+            '&.Mui-focused fieldset': { borderColor: 'primary.main' },
+          },
+        }}
+      />
     </Box>
   );
 

--- a/src/components/repositories/RepositoryPRsTable.tsx
+++ b/src/components/repositories/RepositoryPRsTable.tsx
@@ -364,10 +364,7 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
     {
       key: 'pullRequestNumber',
       header: 'PR #',
-<<<<<<< HEAD
       width: 88,
-=======
->>>>>>> 23aa500 (refactor(pr-table): streamline filtering logic and improve readability in RepositoryPRsTable component)
       sortKey: 'pullRequestNumber',
       renderCell: (pr) => (
         // Native <a> to GitHub — `onRowClick` (no row-as-anchor) keeps this valid HTML.
@@ -389,10 +386,7 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
     {
       key: 'pullRequestTitle',
       header: 'Title',
-<<<<<<< HEAD
       width: 320,
-=======
->>>>>>> 23aa500 (refactor(pr-table): streamline filtering logic and improve readability in RepositoryPRsTable component)
       sortKey: 'pullRequestTitle',
       renderCell: (pr) => (
         <ScrollAwareTooltip
@@ -403,11 +397,7 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
         >
           <Box
             sx={{
-<<<<<<< HEAD
               maxWidth: '100%',
-=======
-              maxWidth: 300,
->>>>>>> 23aa500 (refactor(pr-table): streamline filtering logic and improve readability in RepositoryPRsTable component)
               overflow: 'hidden',
               textOverflow: 'ellipsis',
               whiteSpace: 'nowrap',
@@ -421,18 +411,12 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
     {
       key: 'author',
       header: 'Author',
-<<<<<<< HEAD
       width: 180,
       sortKey: 'author',
       renderCell: (pr) => (
         <Box
           sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 0 }}
         >
-=======
-      sortKey: 'author',
-      renderCell: (pr) => (
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
->>>>>>> 23aa500 (refactor(pr-table): streamline filtering logic and improve readability in RepositoryPRsTable component)
           <Avatar
             src={getRepositoryOwnerAvatarSrc(pr.author)}
             alt={pr.author}
@@ -440,7 +424,6 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
           />
           <Box
             component="span"
-<<<<<<< HEAD
             sx={{
               minWidth: 0,
               overflow: 'hidden',
@@ -448,9 +431,6 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
               whiteSpace: 'nowrap',
               wordBreak: 'keep-all',
             }}
-=======
-            sx={{ whiteSpace: 'nowrap', wordBreak: 'keep-all' }}
->>>>>>> 23aa500 (refactor(pr-table): streamline filtering logic and improve readability in RepositoryPRsTable component)
           >
             {pr.author}
           </Box>
@@ -460,10 +440,7 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
     {
       key: 'commitCount',
       header: 'Commits',
-<<<<<<< HEAD
       width: 104,
-=======
->>>>>>> 23aa500 (refactor(pr-table): streamline filtering logic and improve readability in RepositoryPRsTable component)
       align: 'right',
       sortKey: 'commitCount',
       renderCell: (pr) => pr.commitCount,
@@ -471,18 +448,11 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
     {
       key: 'lines',
       header: '+/-',
-<<<<<<< HEAD
       width: 120,
       align: 'right',
       sortKey: 'lines',
       renderCell: (pr) => (
         <Box component="span" sx={{ whiteSpace: 'nowrap' }}>
-=======
-      align: 'right',
-      sortKey: 'lines',
-      renderCell: (pr) => (
-        <>
->>>>>>> 23aa500 (refactor(pr-table): streamline filtering logic and improve readability in RepositoryPRsTable component)
           <Box
             component="span"
             sx={{ color: theme.palette.diff.additions, mr: 1 }}
@@ -492,20 +462,13 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
           <Box component="span" sx={{ color: theme.palette.diff.deletions }}>
             -{pr.deletions}
           </Box>
-<<<<<<< HEAD
         </Box>
-=======
-        </>
->>>>>>> 23aa500 (refactor(pr-table): streamline filtering logic and improve readability in RepositoryPRsTable component)
       ),
     },
     {
       key: 'score',
       header: 'Score',
-<<<<<<< HEAD
       width: 112,
-=======
->>>>>>> 23aa500 (refactor(pr-table): streamline filtering logic and improve readability in RepositoryPRsTable component)
       align: 'right',
       sortKey: 'score',
       renderCell: (pr) => (
@@ -517,10 +480,7 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
     {
       key: 'status',
       header: 'Status',
-<<<<<<< HEAD
       width: 112,
-=======
->>>>>>> 23aa500 (refactor(pr-table): streamline filtering logic and improve readability in RepositoryPRsTable component)
       sortKey: 'status',
       renderCell: (pr) => {
         const state =
@@ -541,25 +501,15 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
     {
       key: 'mergedAt',
       header: 'Merged',
-<<<<<<< HEAD
       width: 120,
       align: 'right',
       sortKey: 'mergedAt',
       renderCell: (pr) => formatDate(pr.mergedAt),
-=======
-      align: 'right',
-      sortKey: 'mergedAt',
-      renderCell: (pr) =>
-        pr.mergedAt ? new Date(pr.mergedAt).toLocaleDateString() : '-',
->>>>>>> 23aa500 (refactor(pr-table): streamline filtering logic and improve readability in RepositoryPRsTable component)
     },
     {
       key: 'watch',
       header: '★',
-<<<<<<< HEAD
       width: 64,
-=======
->>>>>>> 23aa500 (refactor(pr-table): streamline filtering logic and improve readability in RepositoryPRsTable component)
       align: 'center',
       sortKey: 'watch',
       renderCell: (pr) => (
@@ -771,40 +721,6 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
         display: 'flex',
         flexDirection: 'column',
         overflow: 'hidden',
-<<<<<<< HEAD
-=======
-        // Restructure so only the body scrolls — the header sits above the
-        // scroll area, so the scrollbar never appears next to the header row.
-        '& .MuiTableContainer-root': {
-          overflow: 'visible',
-        },
-        '& .MuiTable-root': {
-          display: 'block',
-        },
-        '& .MuiTableHead-root': {
-          display: 'block',
-          // Reserve space matching the body's scrollbar gutter so columns line up.
-          paddingRight: theme.spacing(1),
-          backgroundColor: theme.palette.surface.tooltip,
-        },
-        '& .MuiTableHead-root .MuiTableRow-root': {
-          display: 'table',
-          tableLayout: 'fixed',
-          width: '100%',
-        },
-        '& .MuiTableBody-root': {
-          display: 'block',
-          maxHeight: 500,
-          overflowY: 'auto',
-          scrollbarGutter: 'stable',
-          ...scrollbarSx,
-        },
-        '& .MuiTableBody-root .MuiTableRow-root': {
-          display: 'table',
-          tableLayout: 'fixed',
-          width: '100%',
-        },
->>>>>>> 23aa500 (refactor(pr-table): streamline filtering logic and improve readability in RepositoryPRsTable component)
       }}
       elevation={0}
     >

--- a/src/components/repositories/RepositoryPRsTable.tsx
+++ b/src/components/repositories/RepositoryPRsTable.tsx
@@ -364,7 +364,10 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
     {
       key: 'pullRequestNumber',
       header: 'PR #',
+<<<<<<< HEAD
       width: 88,
+=======
+>>>>>>> 23aa500 (refactor(pr-table): streamline filtering logic and improve readability in RepositoryPRsTable component)
       sortKey: 'pullRequestNumber',
       renderCell: (pr) => (
         // Native <a> to GitHub — `onRowClick` (no row-as-anchor) keeps this valid HTML.
@@ -386,7 +389,10 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
     {
       key: 'pullRequestTitle',
       header: 'Title',
+<<<<<<< HEAD
       width: 320,
+=======
+>>>>>>> 23aa500 (refactor(pr-table): streamline filtering logic and improve readability in RepositoryPRsTable component)
       sortKey: 'pullRequestTitle',
       renderCell: (pr) => (
         <ScrollAwareTooltip
@@ -397,7 +403,11 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
         >
           <Box
             sx={{
+<<<<<<< HEAD
               maxWidth: '100%',
+=======
+              maxWidth: 300,
+>>>>>>> 23aa500 (refactor(pr-table): streamline filtering logic and improve readability in RepositoryPRsTable component)
               overflow: 'hidden',
               textOverflow: 'ellipsis',
               whiteSpace: 'nowrap',
@@ -411,12 +421,18 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
     {
       key: 'author',
       header: 'Author',
+<<<<<<< HEAD
       width: 180,
       sortKey: 'author',
       renderCell: (pr) => (
         <Box
           sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 0 }}
         >
+=======
+      sortKey: 'author',
+      renderCell: (pr) => (
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+>>>>>>> 23aa500 (refactor(pr-table): streamline filtering logic and improve readability in RepositoryPRsTable component)
           <Avatar
             src={getRepositoryOwnerAvatarSrc(pr.author)}
             alt={pr.author}
@@ -424,6 +440,7 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
           />
           <Box
             component="span"
+<<<<<<< HEAD
             sx={{
               minWidth: 0,
               overflow: 'hidden',
@@ -431,6 +448,9 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
               whiteSpace: 'nowrap',
               wordBreak: 'keep-all',
             }}
+=======
+            sx={{ whiteSpace: 'nowrap', wordBreak: 'keep-all' }}
+>>>>>>> 23aa500 (refactor(pr-table): streamline filtering logic and improve readability in RepositoryPRsTable component)
           >
             {pr.author}
           </Box>
@@ -440,7 +460,10 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
     {
       key: 'commitCount',
       header: 'Commits',
+<<<<<<< HEAD
       width: 104,
+=======
+>>>>>>> 23aa500 (refactor(pr-table): streamline filtering logic and improve readability in RepositoryPRsTable component)
       align: 'right',
       sortKey: 'commitCount',
       renderCell: (pr) => pr.commitCount,
@@ -448,11 +471,18 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
     {
       key: 'lines',
       header: '+/-',
+<<<<<<< HEAD
       width: 120,
       align: 'right',
       sortKey: 'lines',
       renderCell: (pr) => (
         <Box component="span" sx={{ whiteSpace: 'nowrap' }}>
+=======
+      align: 'right',
+      sortKey: 'lines',
+      renderCell: (pr) => (
+        <>
+>>>>>>> 23aa500 (refactor(pr-table): streamline filtering logic and improve readability in RepositoryPRsTable component)
           <Box
             component="span"
             sx={{ color: theme.palette.diff.additions, mr: 1 }}
@@ -462,13 +492,20 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
           <Box component="span" sx={{ color: theme.palette.diff.deletions }}>
             -{pr.deletions}
           </Box>
+<<<<<<< HEAD
         </Box>
+=======
+        </>
+>>>>>>> 23aa500 (refactor(pr-table): streamline filtering logic and improve readability in RepositoryPRsTable component)
       ),
     },
     {
       key: 'score',
       header: 'Score',
+<<<<<<< HEAD
       width: 112,
+=======
+>>>>>>> 23aa500 (refactor(pr-table): streamline filtering logic and improve readability in RepositoryPRsTable component)
       align: 'right',
       sortKey: 'score',
       renderCell: (pr) => (
@@ -480,7 +517,10 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
     {
       key: 'status',
       header: 'Status',
+<<<<<<< HEAD
       width: 112,
+=======
+>>>>>>> 23aa500 (refactor(pr-table): streamline filtering logic and improve readability in RepositoryPRsTable component)
       sortKey: 'status',
       renderCell: (pr) => {
         const state =
@@ -501,15 +541,25 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
     {
       key: 'mergedAt',
       header: 'Merged',
+<<<<<<< HEAD
       width: 120,
       align: 'right',
       sortKey: 'mergedAt',
       renderCell: (pr) => formatDate(pr.mergedAt),
+=======
+      align: 'right',
+      sortKey: 'mergedAt',
+      renderCell: (pr) =>
+        pr.mergedAt ? new Date(pr.mergedAt).toLocaleDateString() : '-',
+>>>>>>> 23aa500 (refactor(pr-table): streamline filtering logic and improve readability in RepositoryPRsTable component)
     },
     {
       key: 'watch',
       header: '★',
+<<<<<<< HEAD
       width: 64,
+=======
+>>>>>>> 23aa500 (refactor(pr-table): streamline filtering logic and improve readability in RepositoryPRsTable component)
       align: 'center',
       sortKey: 'watch',
       renderCell: (pr) => (
@@ -721,6 +771,40 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
         display: 'flex',
         flexDirection: 'column',
         overflow: 'hidden',
+<<<<<<< HEAD
+=======
+        // Restructure so only the body scrolls — the header sits above the
+        // scroll area, so the scrollbar never appears next to the header row.
+        '& .MuiTableContainer-root': {
+          overflow: 'visible',
+        },
+        '& .MuiTable-root': {
+          display: 'block',
+        },
+        '& .MuiTableHead-root': {
+          display: 'block',
+          // Reserve space matching the body's scrollbar gutter so columns line up.
+          paddingRight: theme.spacing(1),
+          backgroundColor: theme.palette.surface.tooltip,
+        },
+        '& .MuiTableHead-root .MuiTableRow-root': {
+          display: 'table',
+          tableLayout: 'fixed',
+          width: '100%',
+        },
+        '& .MuiTableBody-root': {
+          display: 'block',
+          maxHeight: 500,
+          overflowY: 'auto',
+          scrollbarGutter: 'stable',
+          ...scrollbarSx,
+        },
+        '& .MuiTableBody-root .MuiTableRow-root': {
+          display: 'table',
+          tableLayout: 'fixed',
+          width: '100%',
+        },
+>>>>>>> 23aa500 (refactor(pr-table): streamline filtering logic and improve readability in RepositoryPRsTable component)
       }}
       elevation={0}
     >

--- a/src/components/repositories/RepositoryPRsTable.tsx
+++ b/src/components/repositories/RepositoryPRsTable.tsx
@@ -1,15 +1,18 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { useSessionStoredState } from '../../hooks/useSessionStoredState';
 import {
   Avatar,
   Box,
   Card,
   Chip,
   CircularProgress,
+  InputAdornment,
+  Link,
   Stack,
+  TextField,
   Typography,
   alpha,
 } from '@mui/material';
+import { Search as SearchIcon } from '@mui/icons-material';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useAllPrs, type CommitLog } from '../../api';
 import {
@@ -18,6 +21,7 @@ import {
 } from '../../components/common/DataTable';
 import { WatchlistButton } from '../../components/common';
 import TablePagination from '../../components/common/TablePagination';
+import { ClearSearchAdornment } from '../common/ClearSearchAdornment';
 import { ScrollAwareTooltip } from '../../components/common/ScrollAwareTooltip';
 import {
   comparePRsByWatchlist,
@@ -25,7 +29,12 @@ import {
   useWatchlist,
 } from '../../hooks/useWatchlist';
 import theme, { TEXT_OPACITY, scrollbarSx } from '../../theme';
-import { filterPrs, getPrStatusCounts, type PrStatusFilter } from '../../utils';
+import {
+  filterPrs,
+  filterPrsBySearchTerms,
+  getPrStatusCounts,
+  type PrStatusFilter,
+} from '../../utils';
 import { getRepositoryOwnerAvatarSrc } from '../../utils/avatar';
 import { formatDate } from '../../utils/format';
 import FilterButton from '../FilterButton';
@@ -48,8 +57,21 @@ interface RepositoryPRsTableProps {
   state?: 'open' | 'closed' | 'merged' | 'all';
 }
 
-const isPrStatusFilter = (v: unknown): v is PrStatusFilter =>
-  v === 'all' || v === 'open' || v === 'merged' || v === 'closed';
+const PR_STATUS_FILTERS: readonly PrStatusFilter[] = [
+  'all',
+  'open',
+  'merged',
+  'closed',
+];
+
+const isPrStatusFilter = (value: string | null): value is PrStatusFilter =>
+  value !== null && (PR_STATUS_FILTERS as readonly string[]).includes(value);
+
+const chipLabelSx = {
+  maxWidth: 280,
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+} as const;
 
 const PR_PAGE_SIZE = 20;
 
@@ -60,15 +82,71 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const { isWatched } = useWatchlist('prs');
-  const [filter, setFilter] = useSessionStoredState<PrStatusFilter>(
-    'repository:prs:statusFilter',
-    state,
-    isPrStatusFilter,
-  );
+  const prStatusParam = searchParams.get('prStatus');
+  /** Open / Merged / Closed / All — driven by `prStatus` in the URL so chips and counts stay aligned. */
+  const filter: PrStatusFilter = isPrStatusFilter(prStatusParam)
+    ? prStatusParam
+    : state;
   const [sortField, setSortField] = useState<PrSortField>('score');
   const [sortOrder, setSortOrder] = useState<SortOrder>('desc');
   const [page, setPage] = useState(0);
   const authorFilter = searchParams.get('prAuthor') ?? AUTHOR_FILTER_ALL;
+  /** Each Enter appends one `prQ` param (AND semantics). */
+  const committedPrQRaw = useMemo(
+    () => searchParams.getAll('prQ'),
+    [searchParams],
+  );
+  /** Draft text: live AND-preview with committed terms; Enter appends a chip. */
+  const [draftSearch, setDraftSearch] = useState('');
+
+  const appendCommittedTerm = useCallback(
+    (term: string) => {
+      const t = term.trim();
+      if (!t) return;
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          next.append('prQ', t);
+          return next;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
+  );
+
+  const removeCommittedTermAt = useCallback(
+    (index: number) => {
+      setSearchParams(
+        (prev) => {
+          const list = prev.getAll('prQ');
+          const next = new URLSearchParams(prev);
+          next.delete('prQ');
+          list.forEach((raw, i) => {
+            if (i !== index) next.append('prQ', raw);
+          });
+          return next;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
+  );
+
+  const setFilterParam = useCallback(
+    (next: PrStatusFilter) => {
+      setSearchParams(
+        (prev) => {
+          const nextParams = new URLSearchParams(prev);
+          if (next === 'all') nextParams.delete('prStatus');
+          else nextParams.set('prStatus', next);
+          return nextParams;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
+  );
 
   const setAuthorFilter = useCallback(
     (nextAuthor: string) => {
@@ -85,17 +163,6 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
     [setSearchParams],
   );
 
-  const handleSort = (field: PrSortField) => {
-    if (sortField === field) {
-      setSortOrder((o) => (o === 'asc' ? 'desc' : 'asc'));
-    } else {
-      setSortField(field);
-      setSortOrder(
-        field === 'pullRequestTitle' || field === 'author' ? 'asc' : 'desc',
-      );
-    }
-  };
-
   // Fetch ALL PRs at once for instant client-side filtering + accurate counts.
   const { data: allMinerPRs, isLoading } = useAllPrs();
 
@@ -106,16 +173,82 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
     );
   }, [allMinerPRs, repositoryFullName]);
 
-  const counts = useMemo(() => {
-    if (!allPRs) return { all: 0, open: 0, merged: 0, closed: 0 };
-    return getPrStatusCounts(allPRs);
-  }, [allPRs]);
+  /**
+   * Tab badges show repo-wide status totals (or totals for the selected author only).
+   * Search terms — draft or pinned (`prQ`) — never change these numbers.
+   */
+  const prsForStatusTabCounts = useMemo(
+    () =>
+      filterPrs(allPRs, {
+        author: authorFilter === AUTHOR_FILTER_ALL ? null : authorFilter,
+      }),
+    [allPRs, authorFilter],
+  );
 
-  const filteredPRs = useMemo(() => {
-    const byStatus = filterPrs(allPRs ?? [], { statusFilter: filter });
-    if (authorFilter === AUTHOR_FILTER_ALL) return byStatus;
-    return byStatus.filter((pr) => pr.author === authorFilter);
-  }, [allPRs, filter, authorFilter]);
+  const tabCounts = useMemo(
+    () => getPrStatusCounts(prsForStatusTabCounts),
+    [prsForStatusTabCounts],
+  );
+
+  /** Single pipeline: baseline count (status + author) + search-narrowed rows. */
+  const { filteredPRs, baselinePrCount } = useMemo(() => {
+    const byAuthor = filterPrs(allPRs, {
+      statusFilter: filter,
+      author: authorFilter === AUTHOR_FILTER_ALL ? null : authorFilter,
+    });
+    const baselinePrCount = byAuthor.length;
+    const pool = filterPrsBySearchTerms(
+      byAuthor,
+      [...committedPrQRaw, draftSearch],
+      true,
+    );
+    return { filteredPRs: pool, baselinePrCount };
+  }, [allPRs, filter, authorFilter, committedPrQRaw, draftSearch]);
+
+  const hasCommittedSearchFilters = committedPrQRaw.some((t) => t.trim());
+
+  /** Draft or pinned terms — status chips below only show alongside search context. */
+  const hasSearchContext =
+    draftSearch.trim() !== '' || hasCommittedSearchFilters;
+
+  /** Don’t duplicate Open/Merged/Closed as chips unless search is also active. */
+  const showActiveFiltersRow =
+    authorFilter !== AUTHOR_FILTER_ALL ||
+    hasCommittedSearchFilters ||
+    (filter !== 'all' && hasSearchContext);
+
+  /** “N of M” and Clear all — any narrowing from default + draft typing. */
+  const isNarrowed =
+    filter !== 'all' ||
+    authorFilter !== AUTHOR_FILTER_ALL ||
+    draftSearch.trim() !== '' ||
+    hasCommittedSearchFilters;
+
+  /** One atomic URL write — batched `setSearchParams` calls could reuse stale `prev` and leave `prQ` behind. */
+  const clearAllFilters = useCallback(() => {
+    setDraftSearch('');
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        next.delete('prQ');
+        next.delete('prStatus');
+        next.delete('prAuthor');
+        return next;
+      },
+      { replace: true },
+    );
+  }, [setSearchParams]);
+
+  const handleSort = (field: PrSortField) => {
+    if (sortField === field) {
+      setSortOrder((o) => (o === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setSortField(field);
+      setSortOrder(
+        field === 'pullRequestTitle' || field === 'author' ? 'asc' : 'desc',
+      );
+    }
+  };
 
   const sortedPRs = useMemo(() => {
     const dir = sortOrder === 'asc' ? 1 : -1;
@@ -192,29 +325,29 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
       <FilterButton
         label="All"
         isActive={filter === 'all'}
-        onClick={() => setFilter('all')}
-        count={counts.all}
+        onClick={() => setFilterParam('all')}
+        count={tabCounts.all}
         color={theme.palette.status.neutral}
       />
       <FilterButton
         label="Open"
         isActive={filter === 'open'}
-        onClick={() => setFilter('open')}
-        count={counts.open}
+        onClick={() => setFilterParam('open')}
+        count={tabCounts.open}
         color={theme.palette.status.open}
       />
       <FilterButton
         label="Merged"
         isActive={filter === 'merged'}
-        onClick={() => setFilter('merged')}
-        count={counts.merged}
+        onClick={() => setFilterParam('merged')}
+        count={tabCounts.merged}
         color={theme.palette.status.merged}
       />
       <FilterButton
         label="Closed"
         isActive={filter === 'closed'}
-        onClick={() => setFilter('closed')}
-        count={counts.closed}
+        onClick={() => setFilterParam('closed')}
+        count={tabCounts.closed}
         color={theme.palette.status.closed}
       />
       <AuthorFilter
@@ -226,29 +359,6 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
       />
     </Stack>
   );
-
-  if (isLoading) {
-    return (
-      <Card
-        sx={{
-          borderRadius: 3,
-          border: `1px solid ${theme.palette.border.light}`,
-          backgroundColor: 'transparent',
-          p: 4,
-          textAlign: 'center',
-        }}
-        elevation={0}
-      >
-        <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 3 }}>
-          <Typography variant="h6" sx={{ color: 'text.primary' }}>
-            Pull Requests
-          </Typography>
-          {filterButtons}
-        </Box>
-        <CircularProgress size={40} sx={{ color: 'primary.main' }} />
-      </Card>
-    );
-  }
 
   const columns: DataTableColumn<CommitLog, PrSortField>[] = [
     {
@@ -412,25 +522,192 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
     },
   ];
 
+  if (isLoading) {
+    return (
+      <Card
+        sx={{
+          borderRadius: 3,
+          border: `1px solid ${theme.palette.border.light}`,
+          backgroundColor: 'transparent',
+          p: 4,
+          textAlign: 'center',
+        }}
+        elevation={0}
+      >
+        <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 3 }}>
+          <Typography variant="h6" sx={{ color: 'text.primary' }}>
+            Pull Requests
+          </Typography>
+          {filterButtons}
+        </Box>
+        <CircularProgress size={40} sx={{ color: 'primary.main' }} />
+      </Card>
+    );
+  }
+
   const headerToolbar = (
     <Box
       sx={{
         p: 3,
         borderBottom: `1px solid ${theme.palette.border.light}`,
         display: 'flex',
-        justifyContent: 'space-between',
-        alignItems: 'center',
-        flexWrap: 'wrap',
+        flexDirection: 'column',
         gap: 2,
       }}
     >
-      <Typography
-        variant="h6"
-        sx={{ color: 'text.primary', fontSize: '1.1rem', fontWeight: 500 }}
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          flexWrap: 'wrap',
+          gap: 2,
+        }}
       >
-        Pull Requests ({sortedPRs.length})
-      </Typography>
-      {filterButtons}
+        <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 1 }}>
+          <Typography
+            variant="h6"
+            sx={{ color: 'text.primary', fontSize: '1.1rem', fontWeight: 500 }}
+          >
+            Pull Requests
+          </Typography>
+          <Typography
+            sx={{
+              color: 'text.tertiary',
+              fontSize: '0.85rem',
+            }}
+          >
+            (
+            {draftSearch.trim() !== '' || sortedPRs.length !== baselinePrCount
+              ? `${sortedPRs.length} of ${baselinePrCount}`
+              : sortedPRs.length}
+            )
+          </Typography>
+        </Box>
+        {filterButtons}
+      </Box>
+
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 2,
+          width: '100%',
+          flexWrap: { xs: 'wrap', sm: 'nowrap' },
+        }}
+      >
+        <TextField
+          size="small"
+          placeholder="Add a term, press Enter — each term narrows results (AND)"
+          value={draftSearch}
+          onChange={(e) => setDraftSearch(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault();
+              appendCommittedTerm(draftSearch);
+              setDraftSearch('');
+            }
+          }}
+          InputProps={{
+            startAdornment: (
+              <InputAdornment position="start">
+                <SearchIcon sx={{ color: 'text.tertiary', fontSize: '1rem' }} />
+              </InputAdornment>
+            ),
+            endAdornment: (
+              <ClearSearchAdornment
+                visible={Boolean(draftSearch)}
+                onClear={() => setDraftSearch('')}
+              />
+            ),
+          }}
+          sx={{
+            flex: 1,
+            minWidth: 0,
+            maxWidth: { xs: '100%', sm: 520 },
+            '& .MuiOutlinedInput-root': {
+              fontSize: '0.8rem',
+              color: 'text.primary',
+              backgroundColor: 'surface.subtle',
+              borderRadius: 2,
+              '& fieldset': { borderColor: 'border.light' },
+              '&:hover fieldset': { borderColor: 'border.medium' },
+              '&.Mui-focused fieldset': { borderColor: 'primary.main' },
+            },
+          }}
+        />
+        {isNarrowed && (
+          <Link
+            component="button"
+            type="button"
+            underline="hover"
+            onClick={clearAllFilters}
+            sx={{
+              flexShrink: 0,
+              cursor: 'pointer',
+              fontSize: '0.8rem',
+              fontWeight: 600,
+              whiteSpace: 'nowrap',
+              color: 'primary.main',
+            }}
+          >
+            Clear all
+          </Link>
+        )}
+      </Box>
+
+      {showActiveFiltersRow && (
+        <Box
+          sx={{
+            display: 'flex',
+            flexWrap: 'wrap',
+            alignItems: 'center',
+            gap: 1.5,
+          }}
+        >
+          <Typography
+            component="span"
+            sx={{
+              color: 'text.secondary',
+              fontSize: '0.8rem',
+              flexShrink: 0,
+            }}
+          >
+            Active filters:
+          </Typography>
+          <Stack direction="row" flexWrap="wrap" useFlexGap spacing={1}>
+            {filter !== 'all' && hasSearchContext && (
+              <Chip
+                variant="filter"
+                label={filter}
+                onDelete={() => setFilterParam('all')}
+                sx={{ '& .MuiChip-label': chipLabelSx }}
+              />
+            )}
+            {authorFilter !== AUTHOR_FILTER_ALL && (
+              <Chip
+                variant="filter"
+                label={`author: ${authorFilter}`}
+                onDelete={() => setAuthorFilter(AUTHOR_FILTER_ALL)}
+                sx={{ '& .MuiChip-label': chipLabelSx }}
+              />
+            )}
+            {committedPrQRaw.map((raw, index) => {
+              const label = raw.trim();
+              if (!label) return null;
+              return (
+                <Chip
+                  key={`prq-${index}-${label}`}
+                  variant="filter"
+                  label={label}
+                  onDelete={() => removeCommittedTermAt(index)}
+                  sx={{ '& .MuiChip-label': chipLabelSx }}
+                />
+              );
+            })}
+          </Stack>
+        </Box>
+      )}
     </Box>
   );
 

--- a/src/utils/prTable.ts
+++ b/src/utils/prTable.ts
@@ -68,8 +68,12 @@ export type ScorePredicate = {
   value: number;
 };
 
+<<<<<<< HEAD
 const SCORE_TOKEN_RE =
   /\bscore\s*((?:>=|<=|>|<|=))\s*([0-9]+(?:\.[0-9]+)?)/i;
+=======
+const SCORE_TOKEN_RE = /\bscore\s*((?:>=|<=|>|<|=))\s*([0-9]+(?:\.[0-9]+)?)/i;
+>>>>>>> 23aa500 (refactor(pr-table): streamline filtering logic and improve readability in RepositoryPRsTable component)
 
 export const parsePrSearchQuery = (
   raw: string,

--- a/src/utils/prTable.ts
+++ b/src/utils/prTable.ts
@@ -1,6 +1,21 @@
 import { type CommitLog } from '../api';
 import { isClosedUnmergedPr, isMergedPr, isOpenPr } from './prStatus';
 
+/** Substring match against merged timestamp (ISO, locale date/time, year). */
+export const mergedAtMatchesSearch = (
+  mergedAt: string | null | undefined,
+  qLower: string,
+): boolean => {
+  if (!mergedAt || !qLower) return false;
+  if (String(mergedAt).toLowerCase().includes(qLower)) return true;
+  const d = new Date(mergedAt);
+  if (Number.isNaN(d.getTime())) return false;
+  if (d.toLocaleDateString().toLowerCase().includes(qLower)) return true;
+  if (d.toLocaleString().toLowerCase().includes(qLower)) return true;
+  if (String(d.getFullYear()).includes(qLower)) return true;
+  return false;
+};
+
 export type PrStatusFilter = 'all' | 'open' | 'merged' | 'closed';
 
 interface FilterPrsOptions {
@@ -33,18 +48,129 @@ export const filterPrs = <T extends CommitLog>(
   const normalizedQuery = searchQuery.trim().toLowerCase();
   if (!normalizedQuery) return filtered;
 
-  return filtered.filter((pr) => {
-    if (pr.pullRequestTitle?.toLowerCase().includes(normalizedQuery))
-      return true;
-    if (pr.repository.toLowerCase().includes(normalizedQuery)) return true;
-    if (includeNumber) {
-      const num = String(pr.pullRequestNumber);
-      if (num.includes(normalizedQuery)) return true;
-      if (`#${num}`.includes(normalizedQuery)) return true;
-    }
-    return false;
-  });
+  return filtered.filter(
+    (pr) =>
+      pr.pullRequestTitle?.toLowerCase().includes(normalizedQuery) ||
+      pr.repository.toLowerCase().includes(normalizedQuery) ||
+      (includeNumber &&
+        (String(pr.pullRequestNumber).includes(normalizedQuery) ||
+          `#${pr.pullRequestNumber}`.includes(normalizedQuery))) ||
+      mergedAtMatchesSearch(pr.mergedAt, normalizedQuery),
+  );
 };
 
 export const paginateItems = <T>(items: T[], page: number, pageSize: number) =>
   items.slice(page * pageSize, page * pageSize + pageSize);
+
+/** Parsed `score` comparison from the PR search box, e.g. `score > 20`. */
+export type ScorePredicate = {
+  op: '>' | '>=' | '<' | '<=' | '=';
+  value: number;
+};
+
+const SCORE_TOKEN_RE =
+  /\bscore\s*((?:>=|<=|>|<|=))\s*([0-9]+(?:\.[0-9]+)?)/i;
+
+export const parsePrSearchQuery = (
+  raw: string,
+): {
+  textSearch: string;
+  scorePredicate: ScorePredicate | null;
+  /** Exact matched substring from `raw` (remove this when dropping the score chip). */
+  scoreMatch: string | null;
+} => {
+  const trimmed = raw.trim();
+  const m = SCORE_TOKEN_RE.exec(trimmed);
+  if (!m) {
+    return { textSearch: trimmed, scorePredicate: null, scoreMatch: null };
+  }
+  const op = m[1] as ScorePredicate['op'];
+  const value = parseFloat(m[2] ?? '');
+  if (Number.isNaN(value)) {
+    return { textSearch: trimmed, scorePredicate: null, scoreMatch: null };
+  }
+  const scoreMatch = m[0];
+  const textSearch =
+    `${trimmed.slice(0, m.index)} ${trimmed.slice(m.index + m[0].length)}`
+      .replace(/\s+/g, ' ')
+      .trim();
+  return {
+    textSearch,
+    scorePredicate: { op, value },
+    scoreMatch,
+  };
+};
+
+export const matchesScorePredicate = (
+  scoreStr: string | undefined,
+  pred: ScorePredicate,
+): boolean => {
+  const n = parseFloat(scoreStr || '0');
+  if (Number.isNaN(n)) return false;
+  switch (pred.op) {
+    case '>':
+      return n > pred.value;
+    case '>=':
+      return n >= pred.value;
+    case '<':
+      return n < pred.value;
+    case '<=':
+      return n <= pred.value;
+    case '=':
+      return n === pred.value;
+    default:
+      return false;
+  }
+};
+
+export const formatScorePredicateLabel = (pred: ScorePredicate): string =>
+  `score ${pred.op} ${pred.value}`;
+
+/**
+ * One search token (e.g. `se`, or `score > 20`, or `fix score > 10`) matched against a PR.
+ * Text matches title, repo name, optionally PR number, and merged time string; score clause applies when parsed.
+ */
+export const matchesPrSearchTerm = (
+  pr: CommitLog,
+  rawTerm: string,
+  includeNumber: boolean,
+): boolean => {
+  const trimmed = rawTerm.trim();
+  if (!trimmed) return false;
+  const { textSearch, scorePredicate } = parsePrSearchQuery(trimmed);
+  const q = textSearch.trim().toLowerCase();
+  const hasText = q.length > 0;
+  const hasScore = scorePredicate !== null;
+
+  if (!hasText && !hasScore) return false;
+
+  if (
+    hasScore &&
+    scorePredicate &&
+    !matchesScorePredicate(pr.score, scorePredicate)
+  )
+    return false;
+
+  if (hasText) {
+    return (
+      Boolean(pr.pullRequestTitle?.toLowerCase().includes(q)) ||
+      pr.repository.toLowerCase().includes(q) ||
+      (includeNumber && String(pr.pullRequestNumber).includes(q)) ||
+      mergedAtMatchesSearch(pr.mergedAt, q)
+    );
+  }
+
+  return true;
+};
+
+/** Apply multiple tokens with AND semantics (every term must match). */
+export const filterPrsBySearchTerms = <T extends CommitLog>(
+  prs: T[],
+  rawTerms: readonly string[],
+  includeNumber: boolean,
+): T[] =>
+  rawTerms.reduce<T[]>((acc, raw) => {
+    const t = raw.trim();
+    if (!t) return acc;
+    return acc.filter((pr) => matchesPrSearchTerm(pr, t, includeNumber));
+  }, prs);

--- a/src/utils/prTable.ts
+++ b/src/utils/prTable.ts
@@ -68,12 +68,7 @@ export type ScorePredicate = {
   value: number;
 };
 
-<<<<<<< HEAD
-const SCORE_TOKEN_RE =
-  /\bscore\s*((?:>=|<=|>|<|=))\s*([0-9]+(?:\.[0-9]+)?)/i;
-=======
 const SCORE_TOKEN_RE = /\bscore\s*((?:>=|<=|>|<|=))\s*([0-9]+(?:\.[0-9]+)?)/i;
->>>>>>> 23aa500 (refactor(pr-table): streamline filtering logic and improve readability in RepositoryPRsTable component)
 
 export const parsePrSearchQuery = (
   raw: string,

--- a/src/utils/prTable.ts
+++ b/src/utils/prTable.ts
@@ -2,7 +2,7 @@ import { type CommitLog } from '../api';
 import { isClosedUnmergedPr, isMergedPr, isOpenPr } from './prStatus';
 
 /** Substring match against merged timestamp (ISO, locale date/time, year). */
-export const mergedAtMatchesSearch = (
+const mergedAtMatchesSearch = (
   mergedAt: string | null | undefined,
   qLower: string,
 ): boolean => {
@@ -30,7 +30,7 @@ export const filterPrs = <T extends CommitLog>(
   {
     author,
     includeNumber = false,
-    searchQuery = '',
+    searchQuery,
     statusFilter = 'all',
   }: FilterPrsOptions = {},
 ) => {
@@ -45,7 +45,7 @@ export const filterPrs = <T extends CommitLog>(
   else if (statusFilter === 'closed')
     filtered = filtered.filter(isClosedUnmergedPr);
 
-  const normalizedQuery = searchQuery.trim().toLowerCase();
+  const normalizedQuery = searchQuery?.trim().toLowerCase() ?? '';
   if (!normalizedQuery) return filtered;
 
   return filtered.filter(
@@ -61,115 +61,3 @@ export const filterPrs = <T extends CommitLog>(
 
 export const paginateItems = <T>(items: T[], page: number, pageSize: number) =>
   items.slice(page * pageSize, page * pageSize + pageSize);
-
-/** Parsed `score` comparison from the PR search box, e.g. `score > 20`. */
-export type ScorePredicate = {
-  op: '>' | '>=' | '<' | '<=' | '=';
-  value: number;
-};
-
-const SCORE_TOKEN_RE = /\bscore\s*((?:>=|<=|>|<|=))\s*([0-9]+(?:\.[0-9]+)?)/i;
-
-export const parsePrSearchQuery = (
-  raw: string,
-): {
-  textSearch: string;
-  scorePredicate: ScorePredicate | null;
-  /** Exact matched substring from `raw` (remove this when dropping the score chip). */
-  scoreMatch: string | null;
-} => {
-  const trimmed = raw.trim();
-  const m = SCORE_TOKEN_RE.exec(trimmed);
-  if (!m) {
-    return { textSearch: trimmed, scorePredicate: null, scoreMatch: null };
-  }
-  const op = m[1] as ScorePredicate['op'];
-  const value = parseFloat(m[2] ?? '');
-  if (Number.isNaN(value)) {
-    return { textSearch: trimmed, scorePredicate: null, scoreMatch: null };
-  }
-  const scoreMatch = m[0];
-  const textSearch =
-    `${trimmed.slice(0, m.index)} ${trimmed.slice(m.index + m[0].length)}`
-      .replace(/\s+/g, ' ')
-      .trim();
-  return {
-    textSearch,
-    scorePredicate: { op, value },
-    scoreMatch,
-  };
-};
-
-export const matchesScorePredicate = (
-  scoreStr: string | undefined,
-  pred: ScorePredicate,
-): boolean => {
-  const n = parseFloat(scoreStr || '0');
-  if (Number.isNaN(n)) return false;
-  switch (pred.op) {
-    case '>':
-      return n > pred.value;
-    case '>=':
-      return n >= pred.value;
-    case '<':
-      return n < pred.value;
-    case '<=':
-      return n <= pred.value;
-    case '=':
-      return n === pred.value;
-    default:
-      return false;
-  }
-};
-
-export const formatScorePredicateLabel = (pred: ScorePredicate): string =>
-  `score ${pred.op} ${pred.value}`;
-
-/**
- * One search token (e.g. `se`, or `score > 20`, or `fix score > 10`) matched against a PR.
- * Text matches title, repo name, optionally PR number, and merged time string; score clause applies when parsed.
- */
-export const matchesPrSearchTerm = (
-  pr: CommitLog,
-  rawTerm: string,
-  includeNumber: boolean,
-): boolean => {
-  const trimmed = rawTerm.trim();
-  if (!trimmed) return false;
-  const { textSearch, scorePredicate } = parsePrSearchQuery(trimmed);
-  const q = textSearch.trim().toLowerCase();
-  const hasText = q.length > 0;
-  const hasScore = scorePredicate !== null;
-
-  if (!hasText && !hasScore) return false;
-
-  if (
-    hasScore &&
-    scorePredicate &&
-    !matchesScorePredicate(pr.score, scorePredicate)
-  )
-    return false;
-
-  if (hasText) {
-    return (
-      Boolean(pr.pullRequestTitle?.toLowerCase().includes(q)) ||
-      pr.repository.toLowerCase().includes(q) ||
-      (includeNumber && String(pr.pullRequestNumber).includes(q)) ||
-      mergedAtMatchesSearch(pr.mergedAt, q)
-    );
-  }
-
-  return true;
-};
-
-/** Apply multiple tokens with AND semantics (every term must match). */
-export const filterPrsBySearchTerms = <T extends CommitLog>(
-  prs: T[],
-  rawTerms: readonly string[],
-  includeNumber: boolean,
-): T[] =>
-  rawTerms.reduce<T[]>((acc, raw) => {
-    const t = raw.trim();
-    if (!t) return acc;
-    return acc.filter((pr) => matchesPrSearchTerm(pr, t, includeNumber));
-  }, prs);


### PR DESCRIPTION
## Summary

Adds URL-backed search to the repository PR table with multi-term AND filtering and persistent, shareable query state.

**Users**

* Search by PR title, PR number, merged date, and optional score-style clauses
* Press Enter to pin multiple terms with AND matching
* Share or reopen the URL to restore the exact filtered view

**Product**

* Search state persists across refreshes and direct links
* Improves reproducibility and collaboration with shareable filtered views

**Engineering**

* Centralized filtering/search helpers in `src/utils/prTable.ts`
* Integrated searchable table UI in `RepositoryPRsTable.tsx`

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

### Before

<img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/a9a849bd-ba86-4889-9161-53c3c01d9506" />

---------------------------------------------------------------
### After

[gorec-2026-05-11-05-51-53.webm](https://github.com/user-attachments/assets/bef397df-14e6-4f7b-b6cf-eb410875b9b0)

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
