### PR TITLE
feat(repo): add tab-aware PR/issue activity sidebar with interactive chart controls

### DIFF
--- a/src/components/repositories/RepositoryPRsTable.tsx
+++ b/src/components/repositories/RepositoryPRsTable.tsx
@@ -4,15 +4,11 @@ import {
   Box,
   Card,
   Chip,
-  Collapse,
   CircularProgress,
-  IconButton,
   Stack,
-  Tooltip,
   Typography,
   alpha,
 } from '@mui/material';
-import BarChartIcon from '@mui/icons-material/BarChart';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useAllPrs, type CommitLog } from '../../api';
 import {
@@ -27,7 +23,6 @@ import { filterPrs, getPrStatusCounts, type PrStatusFilter } from '../../utils';
 import { getRepositoryOwnerAvatarSrc } from '../../utils/avatar';
 import FilterButton from '../FilterButton';
 import { AUTHOR_FILTER_ALL, AuthorFilter } from './AuthorFilter';
-import RepositoryPrActivityChart from './RepositoryPrActivityChart';
 
 type PrSortField =
   | 'pullRequestNumber'
@@ -43,15 +38,11 @@ type SortOrder = 'asc' | 'desc';
 interface RepositoryPRsTableProps {
   repositoryFullName: string;
   state?: 'open' | 'closed' | 'merged' | 'all';
-  showActivity?: boolean;
-  onToggleActivity?: () => void;
 }
 
 const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
   repositoryFullName,
   state = 'all',
-  showActivity = false,
-  onToggleActivity,
 }) => {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
@@ -393,46 +384,8 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
         >
           Pull Requests ({sortedPRs.length})
         </Typography>
-        <Stack direction="row" spacing={1} alignItems="center">
-          <Tooltip
-            title={showActivity ? 'Hide PR Activity' : 'Show PR Activity'}
-          >
-            <IconButton
-              aria-label="Toggle PR activity graph"
-              size="small"
-              onClick={onToggleActivity}
-              sx={{
-                border: '1px solid',
-                borderColor: alpha(
-                  showActivity
-                    ? theme.palette.primary.main
-                    : theme.palette.text.primary,
-                  showActivity ? 0.48 : 0.2,
-                ),
-                color: showActivity
-                  ? theme.palette.primary.main
-                  : alpha(theme.palette.text.primary, 0.76),
-                backgroundColor: showActivity
-                  ? alpha(theme.palette.primary.main, 0.14)
-                  : 'transparent',
-                '&:hover': {
-                  backgroundColor: showActivity
-                    ? alpha(theme.palette.primary.main, 0.2)
-                    : alpha(theme.palette.text.primary, 0.08),
-                },
-              }}
-            >
-              <BarChartIcon fontSize="small" />
-            </IconButton>
-          </Tooltip>
-          {filterButtons}
-        </Stack>
+        {filterButtons}
       </Box>
-      <Collapse in={showActivity} timeout={320} unmountOnExit>
-        <Box sx={{ mt: 1.5 }}>
-          <RepositoryPrActivityChart repositoryFullName={repositoryFullName} />
-        </Box>
-      </Collapse>
     </Box>
   );
 

--- a/src/components/repositories/RepositoryPRsTable.tsx
+++ b/src/components/repositories/RepositoryPRsTable.tsx
@@ -367,25 +367,20 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
       sx={{
         p: 3,
         borderBottom: `1px solid ${theme.palette.border.light}`,
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        flexWrap: 'wrap',
+        gap: 2,
       }}
     >
-      <Box
-        sx={{
-          display: 'flex',
-          justifyContent: 'space-between',
-          alignItems: 'center',
-          flexWrap: 'wrap',
-          gap: 2,
-        }}
+      <Typography
+        variant="h6"
+        sx={{ color: 'text.primary', fontSize: '1.1rem', fontWeight: 500 }}
       >
-        <Typography
-          variant="h6"
-          sx={{ color: 'text.primary', fontSize: '1.1rem', fontWeight: 500 }}
-        >
-          Pull Requests ({sortedPRs.length})
-        </Typography>
-        {filterButtons}
-      </Box>
+        Pull Requests ({sortedPRs.length})
+      </Typography>
+      {filterButtons}
     </Box>
   );
 

--- a/src/components/repositories/RepositoryPRsTable.tsx
+++ b/src/components/repositories/RepositoryPRsTable.tsx
@@ -4,11 +4,15 @@ import {
   Box,
   Card,
   Chip,
+  Collapse,
   CircularProgress,
+  IconButton,
   Stack,
+  Tooltip,
   Typography,
   alpha,
 } from '@mui/material';
+import BarChartIcon from '@mui/icons-material/BarChart';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useAllPrs, type CommitLog } from '../../api';
 import {
@@ -23,6 +27,7 @@ import { filterPrs, getPrStatusCounts, type PrStatusFilter } from '../../utils';
 import { getRepositoryOwnerAvatarSrc } from '../../utils/avatar';
 import FilterButton from '../FilterButton';
 import { AUTHOR_FILTER_ALL, AuthorFilter } from './AuthorFilter';
+import RepositoryPrActivityChart from './RepositoryPrActivityChart';
 
 type PrSortField =
   | 'pullRequestNumber'
@@ -38,11 +43,15 @@ type SortOrder = 'asc' | 'desc';
 interface RepositoryPRsTableProps {
   repositoryFullName: string;
   state?: 'open' | 'closed' | 'merged' | 'all';
+  showActivity?: boolean;
+  onToggleActivity?: () => void;
 }
 
 const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
   repositoryFullName,
   state = 'all',
+  showActivity = false,
+  onToggleActivity,
 }) => {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
@@ -367,20 +376,63 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
       sx={{
         p: 3,
         borderBottom: `1px solid ${theme.palette.border.light}`,
-        display: 'flex',
-        justifyContent: 'space-between',
-        alignItems: 'center',
-        flexWrap: 'wrap',
-        gap: 2,
       }}
     >
-      <Typography
-        variant="h6"
-        sx={{ color: 'text.primary', fontSize: '1.1rem', fontWeight: 500 }}
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          flexWrap: 'wrap',
+          gap: 2,
+        }}
       >
-        Pull Requests ({sortedPRs.length})
-      </Typography>
-      {filterButtons}
+        <Typography
+          variant="h6"
+          sx={{ color: 'text.primary', fontSize: '1.1rem', fontWeight: 500 }}
+        >
+          Pull Requests ({sortedPRs.length})
+        </Typography>
+        <Stack direction="row" spacing={1} alignItems="center">
+          <Tooltip
+            title={showActivity ? 'Hide PR Activity' : 'Show PR Activity'}
+          >
+            <IconButton
+              aria-label="Toggle PR activity graph"
+              size="small"
+              onClick={onToggleActivity}
+              sx={{
+                border: '1px solid',
+                borderColor: alpha(
+                  showActivity
+                    ? theme.palette.primary.main
+                    : theme.palette.text.primary,
+                  showActivity ? 0.48 : 0.2,
+                ),
+                color: showActivity
+                  ? theme.palette.primary.main
+                  : alpha(theme.palette.text.primary, 0.76),
+                backgroundColor: showActivity
+                  ? alpha(theme.palette.primary.main, 0.14)
+                  : 'transparent',
+                '&:hover': {
+                  backgroundColor: showActivity
+                    ? alpha(theme.palette.primary.main, 0.2)
+                    : alpha(theme.palette.text.primary, 0.08),
+                },
+              }}
+            >
+              <BarChartIcon fontSize="small" />
+            </IconButton>
+          </Tooltip>
+          {filterButtons}
+        </Stack>
+      </Box>
+      <Collapse in={showActivity} timeout={320} unmountOnExit>
+        <Box sx={{ mt: 1.5 }}>
+          <RepositoryPrActivityChart repositoryFullName={repositoryFullName} />
+        </Box>
+      </Collapse>
     </Box>
   );
 

--- a/src/components/repositories/RepositoryPrActivityChart.tsx
+++ b/src/components/repositories/RepositoryPrActivityChart.tsx
@@ -1,0 +1,393 @@
+import React, { useMemo, useState } from 'react';
+import {
+  Box,
+  FormControl,
+  MenuItem,
+  Select,
+  Skeleton,
+  Stack,
+  Typography,
+} from '@mui/material';
+import { alpha, useTheme, type Theme } from '@mui/material/styles';
+import ReactECharts from 'echarts-for-react';
+import {
+  eachDayOfInterval,
+  eachMonthOfInterval,
+  format,
+  isValid,
+  max,
+  min,
+  parseISO,
+  startOfDay,
+  startOfMonth,
+  subDays,
+} from 'date-fns';
+import { useAllPrs, type CommitLog } from '../../api';
+import { STATUS_COLORS } from '../../theme';
+import {
+  echartsAxisTooltipChrome,
+  echartsFontFamily,
+  echartsMutedCartesianAxisColors,
+  echartsTransparentBackground,
+} from '../../utils/echarts/gittensorChartTheme';
+
+type ActivityRange = '7d' | '35d' | 'all';
+
+const RANGE_OPTIONS: { value: ActivityRange; label: string }[] = [
+  { value: '7d', label: '7D' },
+  { value: '35d', label: '35D' },
+  { value: 'all', label: 'All' },
+];
+
+const AREA_GRADIENT_STOPS = [
+  { offset: 0, opacity: 0.28 },
+  { offset: 1, opacity: 0 },
+] as const;
+
+function bucketMonthKey(d: Date): string {
+  return format(startOfMonth(d), 'yyyy-MM');
+}
+
+function bucketDayKey(d: Date): string {
+  return format(startOfDay(d), 'yyyy-MM-dd');
+}
+
+function countByKey(
+  prs: CommitLog[],
+  axisKeys: string[],
+  pickDate: (pr: CommitLog) => string | null,
+  bucketKey: (d: Date) => string,
+): number[] {
+  const counts = new Map<string, number>();
+  axisKeys.forEach((k) => counts.set(k, 0));
+
+  for (const pr of prs) {
+    const raw = pickDate(pr);
+    if (!raw) continue;
+    const d = parseISO(raw);
+    if (!isValid(d)) continue;
+    const key = bucketKey(d);
+    if (!counts.has(key)) continue;
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+
+  return axisKeys.map((k) => counts.get(k) ?? 0);
+}
+
+function buildAxis(
+  prs: CommitLog[],
+  range: ActivityRange,
+): { key: string; label: string; bucket: (d: Date) => string }[] {
+  const today = new Date();
+
+  if (range === '7d' || range === '35d') {
+    const days = range === '7d' ? 7 : 35;
+    const end = startOfDay(today);
+    const start = startOfDay(subDays(end, days - 1));
+    return eachDayOfInterval({ start, end }).map((d) => ({
+      key: format(d, 'yyyy-MM-dd'),
+      label: format(d, 'MMM d'),
+      bucket: bucketDayKey,
+    }));
+  }
+
+  const dates = prs.flatMap((pr) => {
+    const rawDates = [pr.prCreatedAt, pr.mergedAt, pr.closedAt].filter(
+      (raw): raw is string => !!raw,
+    );
+    return rawDates.map((raw) => parseISO(raw)).filter((d) => isValid(d));
+  });
+
+  const earliest = dates.length > 0 ? min(dates) : today;
+  const latest = dates.length > 0 ? max(dates) : today;
+  const start = startOfMonth(earliest);
+  const end = startOfMonth(latest > today ? latest : today);
+
+  return eachMonthOfInterval({ start, end }).map((d) => ({
+    key: format(d, 'yyyy-MM'),
+    label: format(d, 'MMM yy'),
+    bucket: bucketMonthKey,
+  }));
+}
+
+function areaFill(theme: Theme, color: string) {
+  return {
+    type: 'linear' as const,
+    x: 0,
+    y: 0,
+    x2: 0,
+    y2: 1,
+    colorStops: AREA_GRADIENT_STOPS.map((stop) => ({
+      offset: stop.offset,
+      color: alpha(color, stop.opacity),
+    })),
+  };
+}
+
+function buildChartOption(
+  theme: Theme,
+  labels: string[],
+  opened: number[],
+  merged: number[],
+) {
+  const openedColor = alpha(theme.palette.primary.main, 0.92);
+  const mergedColor = alpha(STATUS_COLORS.merged, 0.95);
+  const chartFont = echartsFontFamily(theme);
+  const { labelColor, axisLineColor, splitLineColor } =
+    echartsMutedCartesianAxisColors(theme);
+
+  return {
+    ...echartsTransparentBackground(),
+    animationDuration: 380,
+    color: [openedColor, mergedColor],
+    legend: {
+      data: ['Opened', 'Merged'],
+      top: 0,
+      left: 'center',
+      itemGap: 16,
+      textStyle: {
+        color: labelColor,
+        fontSize: 10,
+        fontFamily: chartFont,
+      },
+      icon: 'circle',
+      itemWidth: 8,
+      itemHeight: 8,
+    },
+    grid: {
+      left: '2%',
+      right: '2%',
+      top: 36,
+      bottom: 6,
+      containLabel: true,
+    },
+    tooltip: {
+      trigger: 'axis',
+      confine: true,
+      appendTo: () => document.body,
+      axisPointer: {
+        type: 'line',
+        lineStyle: {
+          color: alpha(theme.palette.text.primary, 0.18),
+          width: 1,
+        },
+      },
+      ...echartsAxisTooltipChrome(theme),
+      padding: [10, 12],
+      textStyle: {
+        color: theme.palette.text.primary,
+        fontFamily: chartFont,
+        fontSize: 11,
+      },
+    },
+    xAxis: {
+      type: 'category',
+      boundaryGap: false,
+      data: labels,
+      axisLabel: {
+        color: labelColor,
+        fontFamily: chartFont,
+        fontSize: 10,
+      },
+      axisLine: { lineStyle: { color: axisLineColor } },
+      axisTick: { show: false },
+    },
+    yAxis: {
+      type: 'value',
+      min: 0,
+      splitNumber: 4,
+      axisLabel: {
+        color: labelColor,
+        fontFamily: chartFont,
+        fontSize: 10,
+      },
+      splitLine: {
+        lineStyle: { color: splitLineColor, type: 'dashed' as const },
+      },
+      axisLine: { show: false },
+      axisTick: { show: false },
+    },
+    series: [
+      {
+        name: 'Opened',
+        type: 'line',
+        smooth: 0.2,
+        showSymbol: true,
+        symbol: 'circle',
+        symbolSize: 5,
+        data: opened,
+        lineStyle: { width: 2, color: openedColor },
+        areaStyle: { color: areaFill(theme, openedColor) },
+      },
+      {
+        name: 'Merged',
+        type: 'line',
+        smooth: 0.2,
+        showSymbol: true,
+        symbol: 'circle',
+        symbolSize: 5,
+        data: merged,
+        lineStyle: { width: 2, color: mergedColor },
+        areaStyle: { color: areaFill(theme, mergedColor) },
+      },
+    ],
+  };
+}
+
+interface RepositoryPrActivityChartProps {
+  repositoryFullName: string;
+}
+
+const RepositoryPrActivityChart: React.FC<RepositoryPrActivityChartProps> = ({
+  repositoryFullName,
+}) => {
+  const theme = useTheme();
+  const [range, setRange] = useState<ActivityRange>('7d');
+  const { data: allPrs, isLoading } = useAllPrs();
+
+  const repoPrs = useMemo(() => {
+    if (!allPrs) return [];
+    const lower = repositoryFullName.toLowerCase();
+    return allPrs.filter((pr) => pr.repository.toLowerCase() === lower);
+  }, [allPrs, repositoryFullName]);
+
+  const { labels, openedSeries, mergedSeries, hasAny } = useMemo(() => {
+    const axis = buildAxis(repoPrs, range);
+    const axisKeys = axis.map((item) => item.key);
+    const labelsLocal = axis.map((item) => item.label);
+    const bucket = axis[0]?.bucket ?? bucketDayKey;
+    const opened = countByKey(
+      repoPrs,
+      axisKeys,
+      (pr) => pr.prCreatedAt,
+      bucket,
+    );
+    const merged = countByKey(repoPrs, axisKeys, (pr) => pr.mergedAt, bucket);
+    const hasAnyLocal = opened.some((n) => n > 0) || merged.some((n) => n > 0);
+    return {
+      labels: labelsLocal,
+      openedSeries: opened,
+      mergedSeries: merged,
+      hasAny: hasAnyLocal,
+    };
+  }, [repoPrs, range]);
+
+  const chartOption = useMemo(
+    () => buildChartOption(theme, labels, openedSeries, mergedSeries),
+    [theme, labels, openedSeries, mergedSeries],
+  );
+
+  if (isLoading && !allPrs) {
+    return (
+      <Box sx={{ mb: 4 }}>
+        <Typography
+          variant="subtitle2"
+          sx={{
+            color: 'text.primary',
+            fontWeight: 600,
+            mb: 2,
+            fontSize: '14px',
+          }}
+        >
+          PR Activity
+        </Typography>
+        <Skeleton
+          variant="rectangular"
+          height={220}
+          sx={{ bgcolor: 'surface.light', borderRadius: 2 }}
+        />
+      </Box>
+    );
+  }
+
+  return (
+    <Box sx={{ mb: 4 }}>
+      <Stack
+        direction="row"
+        alignItems="center"
+        justifyContent="space-between"
+        spacing={1}
+        sx={{ mb: 1.5 }}
+      >
+        <Typography
+          variant="subtitle2"
+          sx={{
+            color: 'text.primary',
+            fontWeight: 600,
+            fontSize: '14px',
+          }}
+        >
+          PR Activity
+        </Typography>
+        <FormControl size="small" sx={{ minWidth: 88 }}>
+          <Select
+            value={range}
+            onChange={(e) => setRange(e.target.value as ActivityRange)}
+            variant="outlined"
+            sx={{
+              fontSize: '0.75rem',
+              height: 30,
+              '& .MuiOutlinedInput-notchedOutline': {
+                borderColor: alpha(theme.palette.text.primary, 0.2),
+              },
+            }}
+          >
+            {RANGE_OPTIONS.map((opt) => (
+              <MenuItem key={opt.value} value={opt.value} dense>
+                {opt.label}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+      </Stack>
+
+      <Box
+        sx={{
+          width: '100%',
+          height: 220,
+          borderRadius: 2,
+          border: '1px solid',
+          borderColor: 'border.light',
+          bgcolor: 'surface.subtle',
+          '& > div': { width: '100%', height: '100%' },
+        }}
+      >
+        {!hasAny ? (
+          <Stack
+            alignItems="center"
+            justifyContent="center"
+            sx={{ height: '100%', px: 2, textAlign: 'center' }}
+          >
+            <Typography
+              sx={{
+                color: alpha(theme.palette.text.primary, 0.65),
+                fontSize: '0.8rem',
+                fontWeight: 600,
+              }}
+            >
+              No PRs in this range
+            </Typography>
+            <Typography
+              sx={{
+                color: alpha(theme.palette.text.primary, 0.45),
+                fontSize: '0.72rem',
+                mt: 0.5,
+              }}
+            >
+              Try a longer window or check back later.
+            </Typography>
+          </Stack>
+        ) : (
+          <ReactECharts
+            option={chartOption}
+            notMerge
+            style={{ width: '100%', height: '100%' }}
+            opts={{ renderer: 'svg' }}
+          />
+        )}
+      </Box>
+    </Box>
+  );
+};
+
+export default RepositoryPrActivityChart;

--- a/src/components/repositories/RepositoryPrActivityChart.tsx
+++ b/src/components/repositories/RepositoryPrActivityChart.tsx
@@ -6,9 +6,13 @@ import {
   Select,
   Skeleton,
   Stack,
+  ToggleButton,
+  ToggleButtonGroup,
   Typography,
 } from '@mui/material';
 import { alpha, useTheme, type Theme } from '@mui/material/styles';
+import ShowChartIcon from '@mui/icons-material/ShowChart';
+import BarChartIcon from '@mui/icons-material/BarChart';
 import ReactECharts from 'echarts-for-react';
 import {
   eachDayOfInterval,
@@ -22,7 +26,7 @@ import {
   startOfMonth,
   subDays,
 } from 'date-fns';
-import { useAllPrs, type CommitLog } from '../../api';
+import { useAllPrs, useRepositoryIssues } from '../../api';
 import { STATUS_COLORS } from '../../theme';
 import {
   echartsAxisTooltipChrome,
@@ -32,6 +36,7 @@ import {
 } from '../../utils/echarts/gittensorChartTheme';
 
 type ActivityRange = '7d' | '35d' | 'all';
+type ChartMode = 'line' | 'bar';
 
 const RANGE_OPTIONS: { value: ActivityRange; label: string }[] = [
   { value: '7d', label: '7D' },
@@ -52,17 +57,17 @@ function bucketDayKey(d: Date): string {
   return format(startOfDay(d), 'yyyy-MM-dd');
 }
 
-function countByKey(
-  prs: CommitLog[],
+function countByKey<T>(
+  items: T[],
   axisKeys: string[],
-  pickDate: (pr: CommitLog) => string | null,
+  pickDate: (item: T) => string | null,
   bucketKey: (d: Date) => string,
 ): number[] {
   const counts = new Map<string, number>();
   axisKeys.forEach((k) => counts.set(k, 0));
 
-  for (const pr of prs) {
-    const raw = pickDate(pr);
+  for (const item of items) {
+    const raw = pickDate(item);
     if (!raw) continue;
     const d = parseISO(raw);
     if (!isValid(d)) continue;
@@ -75,7 +80,7 @@ function countByKey(
 }
 
 function buildAxis(
-  prs: CommitLog[],
+  dateStrings: string[],
   range: ActivityRange,
 ): { key: string; label: string; bucket: (d: Date) => string }[] {
   const today = new Date();
@@ -91,12 +96,10 @@ function buildAxis(
     }));
   }
 
-  const dates = prs.flatMap((pr) => {
-    const rawDates = [pr.prCreatedAt, pr.mergedAt, pr.closedAt].filter(
-      (raw): raw is string => !!raw,
-    );
-    return rawDates.map((raw) => parseISO(raw)).filter((d) => isValid(d));
-  });
+  const dates = dateStrings
+    .filter((raw): raw is string => !!raw)
+    .map((raw) => parseISO(raw))
+    .filter((d) => isValid(d));
 
   const earliest = dates.length > 0 ? min(dates) : today;
   const latest = dates.length > 0 ? max(dates) : today;
@@ -127,11 +130,15 @@ function areaFill(theme: Theme, color: string) {
 function buildChartOption(
   theme: Theme,
   labels: string[],
-  opened: number[],
-  merged: number[],
+  prOpened: number[],
+  prMerged: number[],
+  mode: ChartMode,
+  firstLabel = 'Opened',
+  secondLabel = 'Merged',
+  secondSeriesColor?: string,
 ) {
-  const openedColor = alpha(theme.palette.primary.main, 0.92);
-  const mergedColor = alpha(STATUS_COLORS.merged, 0.95);
+  const prOpenedColor = alpha(theme.palette.primary.main, 0.92);
+  const prMergedColor = secondSeriesColor ?? alpha(STATUS_COLORS.merged, 0.95);
   const chartFont = echartsFontFamily(theme);
   const { labelColor, axisLineColor, splitLineColor } =
     echartsMutedCartesianAxisColors(theme);
@@ -139,9 +146,9 @@ function buildChartOption(
   return {
     ...echartsTransparentBackground(),
     animationDuration: 380,
-    color: [openedColor, mergedColor],
+    color: [prOpenedColor, prMergedColor],
     legend: {
-      data: ['Opened', 'Merged'],
+      data: [firstLabel, secondLabel],
       top: 0,
       left: 'center',
       itemGap: 16,
@@ -182,7 +189,7 @@ function buildChartOption(
     },
     xAxis: {
       type: 'category',
-      boundaryGap: false,
+      boundaryGap: mode === 'bar',
       data: labels,
       axisLabel: {
         color: labelColor,
@@ -209,26 +216,48 @@ function buildChartOption(
     },
     series: [
       {
-        name: 'Opened',
-        type: 'line',
+        name: firstLabel,
+        type: mode,
         smooth: 0.2,
-        showSymbol: true,
-        symbol: 'circle',
-        symbolSize: 5,
-        data: opened,
-        lineStyle: { width: 2, color: openedColor },
-        areaStyle: { color: areaFill(theme, openedColor) },
+        showSymbol: false,
+        symbol: mode === 'line' ? 'circle' : undefined,
+        symbolSize: mode === 'line' ? 6 : undefined,
+        data: prOpened,
+        lineStyle: { width: 2, color: prOpenedColor },
+        areaStyle:
+          mode === 'line'
+            ? { color: areaFill(theme, prOpenedColor) }
+            : undefined,
+        itemStyle: mode === 'bar' ? { borderRadius: [4, 4, 0, 0] } : undefined,
+        emphasis:
+          mode === 'line'
+            ? {
+                focus: 'series',
+                scale: true,
+              }
+            : undefined,
       },
       {
-        name: 'Merged',
-        type: 'line',
+        name: secondLabel,
+        type: mode,
         smooth: 0.2,
-        showSymbol: true,
-        symbol: 'circle',
-        symbolSize: 5,
-        data: merged,
-        lineStyle: { width: 2, color: mergedColor },
-        areaStyle: { color: areaFill(theme, mergedColor) },
+        showSymbol: false,
+        symbol: mode === 'line' ? 'circle' : undefined,
+        symbolSize: mode === 'line' ? 6 : undefined,
+        data: prMerged,
+        lineStyle: { width: 2, color: prMergedColor },
+        areaStyle:
+          mode === 'line'
+            ? { color: areaFill(theme, prMergedColor) }
+            : undefined,
+        itemStyle: mode === 'bar' ? { borderRadius: [4, 4, 0, 0] } : undefined,
+        emphasis:
+          mode === 'line'
+            ? {
+                focus: 'series',
+                scale: true,
+              }
+            : undefined,
       },
     ],
   };
@@ -236,14 +265,20 @@ function buildChartOption(
 
 interface RepositoryPrActivityChartProps {
   repositoryFullName: string;
+  viewMode?: 'prs' | 'issues';
 }
 
 const RepositoryPrActivityChart: React.FC<RepositoryPrActivityChartProps> = ({
   repositoryFullName,
+  viewMode = 'prs',
 }) => {
   const theme = useTheme();
-  const [range, setRange] = useState<ActivityRange>('7d');
+  const [range, setRange] = useState<ActivityRange>('35d');
+  const [chartMode, setChartMode] = useState<ChartMode>('line');
   const { data: allPrs, isLoading } = useAllPrs();
+  const { data: issues, isLoading: isLoadingIssues } =
+    useRepositoryIssues(repositoryFullName);
+  const isIssueMode = viewMode === 'issues';
 
   const repoPrs = useMemo(() => {
     if (!allPrs) return [];
@@ -251,33 +286,70 @@ const RepositoryPrActivityChart: React.FC<RepositoryPrActivityChartProps> = ({
     return allPrs.filter((pr) => pr.repository.toLowerCase() === lower);
   }, [allPrs, repositoryFullName]);
 
-  const { labels, openedSeries, mergedSeries, hasAny } = useMemo(() => {
-    const axis = buildAxis(repoPrs, range);
+  const { labels, firstSeries, secondSeries, hasAny } = useMemo(() => {
+    const issueRows = issues ?? [];
+    const axis = buildAxis(
+      isIssueMode
+        ? issueRows
+            .flatMap((issue) => [issue.createdAt, issue.closedAt])
+            .filter((v): v is string => Boolean(v))
+        : repoPrs
+            .flatMap((pr) => [pr.prCreatedAt, pr.mergedAt, pr.closedAt])
+            .filter((v): v is string => Boolean(v)),
+      range,
+    );
     const axisKeys = axis.map((item) => item.key);
     const labelsLocal = axis.map((item) => item.label);
     const bucket = axis[0]?.bucket ?? bucketDayKey;
-    const opened = countByKey(
-      repoPrs,
-      axisKeys,
-      (pr) => pr.prCreatedAt,
-      bucket,
-    );
-    const merged = countByKey(repoPrs, axisKeys, (pr) => pr.mergedAt, bucket);
-    const hasAnyLocal = opened.some((n) => n > 0) || merged.some((n) => n > 0);
+    const first = isIssueMode
+      ? countByKey(issueRows, axisKeys, (issue) => issue.createdAt, bucket)
+      : countByKey(repoPrs, axisKeys, (pr) => pr.prCreatedAt, bucket);
+    const second = isIssueMode
+      ? countByKey(issueRows, axisKeys, (issue) => issue.closedAt, bucket)
+      : countByKey(repoPrs, axisKeys, (pr) => pr.mergedAt, bucket);
+    const hasAnyLocal = first.some((n) => n > 0) || second.some((n) => n > 0);
     return {
       labels: labelsLocal,
-      openedSeries: opened,
-      mergedSeries: merged,
+      firstSeries: first,
+      secondSeries: second,
       hasAny: hasAnyLocal,
     };
-  }, [repoPrs, range]);
+  }, [repoPrs, issues, range, isIssueMode]);
+
+  const firstLabel = isIssueMode ? 'Opened' : 'Opened';
+  const secondLabel = isIssueMode ? 'Closed' : 'Merged';
+  const secondColor = isIssueMode
+    ? alpha(STATUS_COLORS.closed, 0.95)
+    : alpha(STATUS_COLORS.merged, 0.95);
 
   const chartOption = useMemo(
-    () => buildChartOption(theme, labels, openedSeries, mergedSeries),
-    [theme, labels, openedSeries, mergedSeries],
+    () =>
+      buildChartOption(
+        theme,
+        labels,
+        firstSeries,
+        secondSeries,
+        chartMode,
+        firstLabel,
+        secondLabel,
+        secondColor,
+      ),
+    [
+      theme,
+      labels,
+      firstSeries,
+      secondSeries,
+      chartMode,
+      firstLabel,
+      secondLabel,
+      secondColor,
+    ],
   );
 
-  if (isLoading && !allPrs) {
+  if (
+    (isLoading && !allPrs && !isIssueMode) ||
+    (isLoadingIssues && !issues && isIssueMode)
+  ) {
     return (
       <Box sx={{ mb: 4 }}>
         <Typography
@@ -289,7 +361,7 @@ const RepositoryPrActivityChart: React.FC<RepositoryPrActivityChartProps> = ({
             fontSize: '14px',
           }}
         >
-          PR Activity
+          {isIssueMode ? 'Issue Activity' : 'PR Activity'}
         </Typography>
         <Skeleton
           variant="rectangular"
@@ -301,13 +373,13 @@ const RepositoryPrActivityChart: React.FC<RepositoryPrActivityChartProps> = ({
   }
 
   return (
-    <Box sx={{ mb: 4 }}>
+    <Box sx={{ mb: 4, minWidth: 0 }}>
       <Stack
-        direction="row"
-        alignItems="center"
+        direction={{ xs: 'column', sm: 'row' }}
+        alignItems={{ xs: 'stretch', sm: 'center' }}
         justifyContent="space-between"
         spacing={1}
-        sx={{ mb: 1.5 }}
+        sx={{ mb: 1.5, flexWrap: 'wrap', rowGap: 1 }}
       >
         <Typography
           variant="subtitle2"
@@ -317,34 +389,82 @@ const RepositoryPrActivityChart: React.FC<RepositoryPrActivityChartProps> = ({
             fontSize: '14px',
           }}
         >
-          PR Activity
+          {isIssueMode ? 'Issue Activity' : 'PR Activity'}
         </Typography>
-        <FormControl size="small" sx={{ minWidth: 88 }}>
-          <Select
-            value={range}
-            onChange={(e) => setRange(e.target.value as ActivityRange)}
-            variant="outlined"
+        <Stack
+          direction="row"
+          spacing={1}
+          alignItems="center"
+          sx={{
+            width: { xs: '100%', sm: 'auto' },
+            justifyContent: { xs: 'space-between', sm: 'flex-end' },
+            minWidth: 0,
+          }}
+        >
+          <ToggleButtonGroup
+            value={chartMode}
+            exclusive
+            onChange={(_, next) => {
+              if (next) setChartMode(next as ChartMode);
+            }}
+            size="small"
             sx={{
-              fontSize: '0.75rem',
-              height: 30,
-              '& .MuiOutlinedInput-notchedOutline': {
-                borderColor: alpha(theme.palette.text.primary, 0.2),
+              bgcolor: alpha(theme.palette.common.black, 0.45),
+              borderRadius: 999,
+              p: 0.25,
+              flexShrink: 0,
+              border: `1px solid ${alpha(theme.palette.text.primary, 0.12)}`,
+              '& .MuiToggleButtonGroup-grouped': {
+                border: 0,
+                borderRadius: '999px !important',
+                minWidth: 34,
+                height: 26,
+                color: alpha(theme.palette.text.primary, 0.68),
+                px: 0.75,
+                '&.Mui-selected': {
+                  color: theme.palette.background.paper,
+                  bgcolor: alpha(theme.palette.diff.additions, 0.92),
+                },
               },
             }}
           >
-            {RANGE_OPTIONS.map((opt) => (
-              <MenuItem key={opt.value} value={opt.value} dense>
-                {opt.label}
-              </MenuItem>
-            ))}
-          </Select>
-        </FormControl>
+            <ToggleButton value="line" aria-label="Line chart">
+              <ShowChartIcon sx={{ fontSize: 14 }} />
+            </ToggleButton>
+            <ToggleButton value="bar" aria-label="Bar chart">
+              <BarChartIcon sx={{ fontSize: 14 }} />
+            </ToggleButton>
+          </ToggleButtonGroup>
+          <FormControl
+            size="small"
+            sx={{ minWidth: 78, width: { xs: 'auto', sm: 84 }, flexShrink: 0 }}
+          >
+            <Select
+              value={range}
+              onChange={(e) => setRange(e.target.value as ActivityRange)}
+              sx={{
+                height: 28,
+                fontSize: '0.75rem',
+                '& .MuiOutlinedInput-notchedOutline': {
+                  borderColor: alpha(theme.palette.text.primary, 0.2),
+                },
+              }}
+            >
+              {RANGE_OPTIONS.map((opt) => (
+                <MenuItem key={opt.value} value={opt.value} dense>
+                  {opt.label}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        </Stack>
       </Stack>
 
       <Box
         sx={{
           width: '100%',
           height: 220,
+          overflow: 'hidden',
           borderRadius: 2,
           border: '1px solid',
           borderColor: 'border.light',
@@ -365,7 +485,7 @@ const RepositoryPrActivityChart: React.FC<RepositoryPrActivityChartProps> = ({
                 fontWeight: 600,
               }}
             >
-              No PRs in this range
+              No activity in this range
             </Typography>
             <Typography
               sx={{

--- a/src/components/repositories/RepositoryPrActivityChart.tsx
+++ b/src/components/repositories/RepositoryPrActivityChart.tsx
@@ -409,7 +409,7 @@ const RepositoryPrActivityChart: React.FC<RepositoryPrActivityChartProps> = ({
             }}
             size="small"
             sx={{
-              bgcolor: alpha(theme.palette.common.black, 0.45),
+              bgcolor: 'surface.tooltip',
               borderRadius: 999,
               p: 0.25,
               flexShrink: 0,

--- a/src/components/repositories/index.ts
+++ b/src/components/repositories/index.ts
@@ -1,6 +1,7 @@
 export { default as LanguageWeightsTable } from './LanguageWeightsTable';
 export { default as RepositoryContributorsTable } from './RepositoryContributorsTable';
 export { default as RepositoryStats } from './RepositoryStats';
+export { default as RepositoryPrActivityChart } from './RepositoryPrActivityChart';
 export { default as ContributingViewer } from './ContributingViewer';
 export { default as RepositoryPRsTable } from './RepositoryPRsTable';
 export { default as RepositoryIssuesTable } from './RepositoryIssuesTable';

--- a/src/pages/RepositoryDetailsPage.tsx
+++ b/src/pages/RepositoryDetailsPage.tsx
@@ -207,6 +207,7 @@ const RepositoryDetailsPage: React.FC = () => {
   const navigate = useNavigate();
   const repo = searchParams.get('name');
   const tabValue = tabIndexFromSearchParam(searchParams.get('tab'));
+  const isPrActivityVisible = searchParams.get('prView') === 'graph';
   const { data: repos, isLoading: isLoadingRepos } = useReposAndWeights();
   const { data: bountySummary } = useRepoBountySummary(repo || '');
   const trackedRepo = repos?.find(
@@ -238,6 +239,18 @@ const RepositoryDetailsPage: React.FC = () => {
     },
     [repo, setSearchParams],
   );
+
+  const handleTogglePrActivity = useCallback(() => {
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        if (next.get('prView') === 'graph') next.delete('prView');
+        else next.set('prView', 'graph');
+        return next;
+      },
+      { replace: true },
+    );
+  }, [setSearchParams]);
 
   const statusChips = useMemo(() => {
     const inactiveAt = trackedRepo?.config?.inactiveAt ?? null;
@@ -614,7 +627,12 @@ const RepositoryDetailsPage: React.FC = () => {
             <CustomTabPanel value={tabValue} index={3}>
               <Grid container spacing={3}>
                 <Grid item xs={12} md={12}>
-                  <RepositoryPRsTable repositoryFullName={repo} state="all" />
+                  <RepositoryPRsTable
+                    repositoryFullName={repo}
+                    state="all"
+                    showActivity={isPrActivityVisible}
+                    onToggleActivity={handleTogglePrActivity}
+                  />
                 </Grid>
               </Grid>
             </CustomTabPanel>

--- a/src/pages/RepositoryDetailsPage.tsx
+++ b/src/pages/RepositoryDetailsPage.tsx
@@ -45,6 +45,7 @@ import {
   RepositoryCodeBrowser,
   ReadmeViewer,
   RepositoryStats,
+  RepositoryPrActivityChart,
   ContributingViewer,
   RepositoryMaintainers,
   RepositoryCheckTab,
@@ -207,7 +208,6 @@ const RepositoryDetailsPage: React.FC = () => {
   const navigate = useNavigate();
   const repo = searchParams.get('name');
   const tabValue = tabIndexFromSearchParam(searchParams.get('tab'));
-  const isPrActivityVisible = searchParams.get('prView') === 'graph';
   const { data: repos, isLoading: isLoadingRepos } = useReposAndWeights();
   const { data: bountySummary } = useRepoBountySummary(repo || '');
   const trackedRepo = repos?.find(
@@ -239,18 +239,6 @@ const RepositoryDetailsPage: React.FC = () => {
     },
     [repo, setSearchParams],
   );
-
-  const handleTogglePrActivity = useCallback(() => {
-    setSearchParams(
-      (prev) => {
-        const next = new URLSearchParams(prev);
-        if (next.get('prView') === 'graph') next.delete('prView');
-        else next.set('prView', 'graph');
-        return next;
-      },
-      { replace: true },
-    );
-  }, [setSearchParams]);
 
   const statusChips = useMemo(() => {
     const inactiveAt = trackedRepo?.config?.inactiveAt ?? null;
@@ -627,12 +615,7 @@ const RepositoryDetailsPage: React.FC = () => {
             <CustomTabPanel value={tabValue} index={3}>
               <Grid container spacing={3}>
                 <Grid item xs={12} md={12}>
-                  <RepositoryPRsTable
-                    repositoryFullName={repo}
-                    state="all"
-                    showActivity={isPrActivityVisible}
-                    onToggleActivity={handleTogglePrActivity}
-                  />
+                  <RepositoryPRsTable repositoryFullName={repo} state="all" />
                 </Grid>
               </Grid>
             </CustomTabPanel>
@@ -654,6 +637,13 @@ const RepositoryDetailsPage: React.FC = () => {
               <Box sx={{ pt: 0 }}>
                 {/* Repository Stats */}
                 <RepositoryStats repositoryFullName={repo} />
+
+                {tabValue === 2 || tabValue === 3 ? (
+                  <RepositoryPrActivityChart
+                    repositoryFullName={repo}
+                    viewMode={tabValue === 2 ? 'issues' : 'prs'}
+                  />
+                ) : null}
 
                 {/* Maintainers */}
                 <RepositoryMaintainers repositoryFullName={repo} />


### PR DESCRIPTION
## Summary

Added tab-aware repository activity cards in the right sidebar:
- **PR Activity** on the Pull Requests tab (`Opened`, `Merged`)
- **Issue Activity** on the Issues tab (`Opened`, `Closed`)

Also updated chart UX with range selection (`7D`, `35D`, `All`), line/bar toggle, improved responsiveness, and hover-only point visibility in line mode.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

- Added for:
  - PR Activity (sidebar)
  
<img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/474a55fb-9a6c-420a-9f90-9dafe6df1ad6" />

----------------------------------------------------------------------
  - Issue Activity (sidebar)
<img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/d4affe6e-16b6-4ba6-b44a-ef01fbc18829" />


## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes