### PR TITLE
feat(leaderboard): redesign MinerCard with spotlight hover and top-3 top ranked miners

### DIFF
--- a/src/components/leaderboard/MinerCard.tsx
+++ b/src/components/leaderboard/MinerCard.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Box, Card, Typography, Avatar, Tooltip } from '@mui/material';
-import { alpha, useTheme, type Theme } from '@mui/material/styles';
+import { alpha, useTheme } from '@mui/material/styles';
 import ReactECharts from 'echarts-for-react';
 import { useMinerGithubData, useMinerPRs } from '../../api';
 import { CHART_COLORS, STATUS_COLORS } from '../../theme';

--- a/src/components/leaderboard/MinerCard.tsx
+++ b/src/components/leaderboard/MinerCard.tsx
@@ -111,17 +111,10 @@ export const MinerCard: React.FC<MinerCardProps> = ({
   const rankColor = rank ? RANK_COLORS[rank] : undefined;
   const segments = getSegments(miner, variant);
 
-  const handleMouseMove = (e: React.MouseEvent<HTMLAnchorElement>) => {
-    const rect = e.currentTarget.getBoundingClientRect();
-    e.currentTarget.style.setProperty('--mx', `${e.clientX - rect.left}px`);
-    e.currentTarget.style.setProperty('--my', `${e.clientY - rect.top}px`);
-  };
-
   return (
     <Card
       component="a"
       {...linkProps}
-      onMouseMove={handleMouseMove}
       sx={(theme) => ({
         ...linkResetSx,
         position: 'relative',
@@ -164,20 +157,6 @@ export const MinerCard: React.FC<MinerCardProps> = ({
               zIndex: 2,
             }
           : undefined,
-        /* cursor-tracking green spotlight */
-        '&::after': {
-          content: '""',
-          position: 'absolute',
-          inset: 0,
-          background: `radial-gradient(440px circle at var(--mx, 50%) var(--my, 50%), ${alpha(theme.palette.status.merged, 0.14)} 0%, ${alpha(theme.palette.status.merged, 0.04)} 22%, transparent 55%)`,
-          opacity: 0,
-          transition: 'opacity 0.35s ease',
-          pointerEvents: 'none',
-          zIndex: 0,
-        },
-        '&:hover::after': {
-          opacity: 1,
-        },
         '& > *': {
           position: 'relative',
           zIndex: 1,

--- a/src/components/leaderboard/MinerCard.tsx
+++ b/src/components/leaderboard/MinerCard.tsx
@@ -17,7 +17,7 @@ interface MinerCardProps {
   showDualEligibilityBadges?: boolean;
 }
 
-const INACTIVE_OPACITY = 0.24;
+const INACTIVE_OPACITY = 0.42;
 
 const CHART_SEGMENT_COLORS = [
   CHART_COLORS.merged,
@@ -25,6 +25,8 @@ const CHART_SEGMENT_COLORS = [
   CHART_COLORS.closed,
 ];
 const CHART_INACTIVE_RATIOS = [2 / 3, 1, 1 / 2];
+
+const TABULAR_NUMS = '"tnum" 1, "ss01" 1';
 
 interface Segment {
   label: string;
@@ -49,16 +51,18 @@ const getSegments = (
 ): Segment[] =>
   variant === 'discoveries' ? getIssueSegments(miner) : getPrSegments(miner);
 
-const buildStatPalette = (eligible: boolean, theme: Theme): string[] => {
-  const inactiveColor = alpha(theme.palette.text.tertiary, INACTIVE_OPACITY);
-  return eligible
-    ? [
-        STATUS_COLORS.merged,
-        alpha(theme.palette.text.primary, 0.84),
-        theme.palette.status.closed,
-      ]
-    : [inactiveColor, inactiveColor, inactiveColor];
-};
+const formatRank = (rank: number | undefined): string =>
+  rank ? `#${String(rank).padStart(2, '0')}` : '#—';
+
+const formatScore = (score: number): string =>
+  Number.isFinite(score)
+    ? score.toLocaleString(undefined, {
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+      })
+    : '0.00';
+
+/* ═══════════════════════════════════════════════════════════════════ */
 
 export const MinerCard: React.FC<MinerCardProps> = ({
   miner,
@@ -97,220 +101,196 @@ export const MinerCard: React.FC<MinerCardProps> = ({
       ? ossEligible || discoveriesEligible
       : baseEligible;
 
-  const earningsHighlighted = isWatchlist
-    ? ossEligible || discoveriesEligible
-    : isEligible;
-
+  const rank = miner.rank;
+  const isTopRank = !!rank && rank > 0 && rank <= 3;
+  const RANK_COLORS: Record<number, string> = {
+    1: '#FFD700',
+    2: '#C0C0C0',
+    3: '#CD7F32',
+  };
+  const rankColor = rank ? RANK_COLORS[rank] : undefined;
   const segments = getSegments(miner, variant);
+
+  const handleMouseMove = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    const rect = e.currentTarget.getBoundingClientRect();
+    e.currentTarget.style.setProperty('--mx', `${e.clientX - rect.left}px`);
+    e.currentTarget.style.setProperty('--my', `${e.clientY - rect.top}px`);
+  };
 
   return (
     <Card
       component="a"
       {...linkProps}
+      onMouseMove={handleMouseMove}
       sx={(theme) => ({
         ...linkResetSx,
-        p: 1,
-        backgroundColor: isEligible
-          ? theme.palette.background.default
-          : theme.palette.surface.subtle,
-        backdropFilter: 'blur(12px)',
-        border: '1px solid',
-        borderColor: isEligible
-          ? alpha(theme.palette.status.merged, 0.3)
-          : theme.palette.border.subtle,
-        borderRadius: 2,
+        position: 'relative',
+        p: 0,
+        backgroundColor: 'transparent',
+        border: `1px solid ${rankColor ? alpha(rankColor, 0.35) : theme.palette.border.medium}`,
+        borderRadius: 1.5,
         cursor: 'pointer',
-        transition: 'all 0.2s cubic-bezier(0.4, 0, 0.2, 1)',
         height: '100%',
         display: 'flex',
         flexDirection: 'column',
-        gap: 1,
-        position: 'relative',
-        boxShadow: isEligible
-          ? `0 2px 8px ${alpha(theme.palette.background.default, 0.1)}`
-          : 'none',
+        opacity: isEligible ? 1 : 0.6,
+        overflow: 'hidden',
+        transition:
+          'background-color 0.22s ease, border-color 0.22s ease, transform 0.22s ease, box-shadow 0.22s ease',
         '&:hover': {
-          backgroundColor: isEligible
-            ? theme.palette.surface.elevated
-            : theme.palette.surface.light,
-          borderColor: isEligible
-            ? alpha(theme.palette.status.merged, 0.5)
-            : theme.palette.border.subtle,
-          transform: isEligible ? 'translateY(-2px)' : 'none',
-          boxShadow: isEligible
-            ? `0 8px 24px -6px ${alpha(theme.palette.background.default, 0.6)}`
-            : 'none',
+          backgroundColor: alpha(theme.palette.status.merged, 0.04),
+          borderColor: alpha(theme.palette.status.merged, 0.28),
+          transform: 'scale(1.025)',
+          boxShadow: `0 8px 24px -6px ${alpha(theme.palette.common.black, 0.18)}`,
+        },
+        '&:hover .miner-username': {
+          textDecoration: 'underline',
+          textDecorationColor: alpha(theme.palette.status.merged, 0.55),
+          textDecorationThickness: '1px',
+          textUnderlineOffset: '3px',
+        },
+        /* hairline left accent for top-3 */
+        '&::before': rankColor
+          ? {
+              content: '""',
+              position: 'absolute',
+              top: 16,
+              bottom: 16,
+              left: 0,
+              width: '1.5px',
+              backgroundColor: rankColor,
+              borderRadius: '0 1.5px 1.5px 0',
+              pointerEvents: 'none',
+              zIndex: 2,
+            }
+          : undefined,
+        /* cursor-tracking green spotlight */
+        '&::after': {
+          content: '""',
+          position: 'absolute',
+          inset: 0,
+          background: `radial-gradient(440px circle at var(--mx, 50%) var(--my, 50%), ${alpha(theme.palette.status.merged, 0.14)} 0%, ${alpha(theme.palette.status.merged, 0.04)} 22%, transparent 55%)`,
+          opacity: 0,
+          transition: 'opacity 0.35s ease',
+          pointerEvents: 'none',
+          zIndex: 0,
+        },
+        '&:hover::after': {
+          opacity: 1,
+        },
+        '& > *': {
+          position: 'relative',
+          zIndex: 1,
         },
       })}
       elevation={0}
     >
+      {/* ─── HEADER STRIP ─────────────────────────────────────── */}
       <Box
         sx={{
-          display: 'flex',
-          justifyContent: 'space-between',
-          alignItems: 'flex-start',
+          display: 'grid',
+          gridTemplateColumns: 'auto 1fr auto auto',
+          alignItems: 'center',
+          columnGap: 1.25,
+          px: { xs: 1.75, sm: 2 },
+          py: 1.5,
         }}
       >
+        <Avatar
+          src={avatarSrc}
+          alt={username}
+          sx={(theme) => ({
+            width: 38,
+            height: 38,
+            border: `1px solid ${theme.palette.border.light}`,
+            backgroundColor: theme.palette.surface.subtle,
+            filter: isEligible ? 'none' : 'grayscale(100%)',
+          })}
+        />
+
         <Box
           sx={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: 1.5,
             minWidth: 0,
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 0.4,
           }}
         >
-          <Avatar
-            src={avatarSrc}
-            alt={username}
+          <Typography
+            className="miner-username"
             sx={(theme) => ({
-              width: 36,
-              height: 36,
-              border: '2px solid',
-              borderColor: isEligible
-                ? alpha(theme.palette.status.merged, 0.3)
-                : theme.palette.border.subtle,
-              filter: isEligible ? 'none' : 'grayscale(100%)',
+              fontFamily: FONTS.mono,
+              fontSize: '0.95rem',
+              fontWeight: 600,
+              color: theme.palette.text.primary,
               opacity: isEligible ? 1 : INACTIVE_OPACITY,
-              flexShrink: 0,
-            })}
-          />
-          <Box
-            sx={{
-              minWidth: 0,
-              display: 'flex',
-              flexDirection: 'column',
-              gap: 0.4,
               overflow: 'hidden',
-            }}
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+              letterSpacing: '-0.005em',
+              lineHeight: 1.2,
+              transition: 'text-decoration-color 0.18s ease',
+            })}
           >
-            {/* Name + rank on the same line */}
-            <Box
-              sx={{
-                display: 'flex',
-                alignItems: 'baseline',
-                gap: 0.75,
-                minWidth: 0,
-              }}
-            >
-              <Typography
-                sx={(theme) => ({
-                  fontFamily: FONTS.mono,
-                  fontSize: '1rem',
-                  fontWeight: 700,
-                  color: isEligible
-                    ? theme.palette.text.primary
-                    : theme.palette.text.tertiary,
-                  opacity: isEligible ? 1 : INACTIVE_OPACITY,
-                  overflow: 'hidden',
-                  textOverflow: 'ellipsis',
-                  whiteSpace: 'nowrap',
-                })}
-              >
-                {username}
-              </Typography>
-              <Typography
-                sx={(theme) => ({
-                  fontFamily: FONTS.mono,
-                  fontSize: '0.72rem',
-                  fontWeight: 700,
-                  color: isEligible
-                    ? theme.palette.status.merged
-                    : theme.palette.text.tertiary,
-                  opacity: isEligible ? 1 : INACTIVE_OPACITY,
-                  lineHeight: 1,
-                  flexShrink: 0,
-                })}
-              >
-                #{miner.rank}
-              </Typography>
-            </Box>
-            {/* Badges under the name */}
-            <Box
-              sx={{
-                display: 'flex',
-                alignItems: 'center',
-                gap: 0.5,
-                flexWrap: 'wrap',
-                mt: 0.25,
-              }}
-            >
-              {showDualEligibilityBadges ? (
-                <>
-                  <Typography
-                    sx={(theme) => ({
-                      fontFamily: FONTS.mono,
-                      fontSize: '0.65rem',
-                      fontWeight: 700,
-                      textTransform: 'uppercase',
-                      border: `1px solid ${
-                        ossEligible
-                          ? alpha(theme.palette.status.merged, 0.45)
-                          : theme.palette.border.subtle
-                      }`,
-                      borderRadius: 1,
-                      px: 0.75,
-                      py: 0.25,
-                      letterSpacing: '0.06em',
-                      color: ossEligible
-                        ? theme.palette.status.merged
-                        : theme.palette.text.secondary,
-                      backgroundColor: ossEligible
-                        ? alpha(theme.palette.status.merged, 0.08)
-                        : theme.palette.surface.subtle,
-                    })}
-                  >
-                    OSS {ossEligible ? 'Eligible' : 'Ineligible'}
-                  </Typography>
-                  <Typography
-                    sx={(theme) => ({
-                      fontFamily: FONTS.mono,
-                      fontSize: '0.65rem',
-                      fontWeight: 700,
-                      textTransform: 'uppercase',
-                      border: `1px solid ${
-                        discoveriesEligible
-                          ? alpha(theme.palette.status.merged, 0.45)
-                          : theme.palette.border.subtle
-                      }`,
-                      borderRadius: 1,
-                      px: 0.75,
-                      py: 0.25,
-                      letterSpacing: '0.06em',
-                      color: discoveriesEligible
-                        ? theme.palette.status.merged
-                        : theme.palette.text.secondary,
-                      backgroundColor: discoveriesEligible
-                        ? alpha(theme.palette.status.merged, 0.08)
-                        : theme.palette.surface.subtle,
-                    })}
-                  >
-                    Issues {discoveriesEligible ? 'Eligible' : 'Ineligible'}
-                  </Typography>
-                </>
-              ) : !isEligible ? (
-                <Typography
-                  sx={(theme) => ({
-                    fontFamily: FONTS.mono,
-                    fontSize: '0.65rem',
-                    fontWeight: 700,
-                    color: theme.palette.text.secondary,
-                    textTransform: 'uppercase',
-                    border: `1px solid ${theme.palette.border.subtle}`,
-                    borderRadius: 1,
-                    px: 0.75,
-                    py: 0.25,
-                    letterSpacing: '0.06em',
-                    backgroundColor: theme.palette.surface.subtle,
-                  })}
-                >
-                  Ineligible
-                </Typography>
-              ) : null}
-            </Box>
+            {username}
+          </Typography>
+
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.85 }}>
+            {showDualEligibilityBadges ? (
+              <>
+                <EligibilityLabel label="OSS" eligible={ossEligible} />
+                <Divider />
+                <EligibilityLabel
+                  label="Issues"
+                  eligible={discoveriesEligible}
+                />
+              </>
+            ) : (
+              <EligibilityLabel
+                label={isEligible ? 'Eligible' : 'Ineligible'}
+                eligible={isEligible}
+              />
+            )}
           </Box>
         </Box>
-        {/* Watchlist button stays top-right */}
-        <Box sx={{ flexShrink: 0 }}>
+
+        {/* Rank pill */}
+        <Box
+          sx={(theme) => ({
+            display: 'inline-flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            minWidth: 38,
+            height: 24,
+            px: 0.75,
+            borderRadius: 0.85,
+            border: `1px solid ${
+              isTopRank
+                ? alpha(theme.palette.text.primary, 0.32)
+                : theme.palette.border.light
+            }`,
+            backgroundColor: isTopRank
+              ? alpha(theme.palette.text.primary, 0.04)
+              : 'transparent',
+          })}
+        >
+          <Typography
+            sx={(theme) => ({
+              fontFamily: FONTS.mono,
+              fontSize: '0.72rem',
+              fontWeight: isTopRank ? 700 : 500,
+              color: isTopRank
+                ? theme.palette.text.primary
+                : theme.palette.text.secondary,
+              fontFeatureSettings: TABULAR_NUMS,
+              lineHeight: 1,
+            })}
+          >
+            {formatRank(rank)}
+          </Typography>
+        </Box>
+
+        <Box>
           {miner.githubId && (
             <WatchlistButton
               category="miners"
@@ -321,26 +301,42 @@ export const MinerCard: React.FC<MinerCardProps> = ({
         </Box>
       </Box>
 
+      {/* ─── HERO: EARNINGS │ CREDIBILITY ───────────────────── */}
       <Box
-        sx={{
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'space-between',
-          gap: 2,
-        }}
+        sx={(theme) => ({
+          display: 'grid',
+          gridTemplateColumns: '1fr auto',
+          alignItems: 'stretch',
+          borderTop: `1px solid ${theme.palette.border.light}`,
+          borderBottom: `1px solid ${theme.palette.border.light}`,
+          backgroundColor: alpha(theme.palette.text.primary, 0.012),
+        })}
       >
-        <Box>
-          <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 0.5 }}>
+        {/* Earnings */}
+        <Box
+          sx={{
+            px: { xs: 1.75, sm: 2 },
+            py: 1.5,
+            display: 'flex',
+            flexDirection: 'column',
+            justifyContent: 'center',
+            minWidth: 0,
+          }}
+        >
+          <Overline>Earnings</Overline>
+          <Box
+            sx={{ display: 'flex', alignItems: 'baseline', gap: 0.45, mt: 0.7 }}
+          >
             <Typography
               sx={(theme) => ({
                 fontFamily: FONTS.mono,
-                fontSize: '1.6rem',
-                fontWeight: 800,
-                color: earningsHighlighted
-                  ? theme.palette.status.merged
-                  : theme.palette.text.tertiary,
-                opacity: earningsHighlighted ? 1 : INACTIVE_OPACITY,
+                fontSize: '1.65rem',
+                fontWeight: 700,
+                color: theme.palette.text.primary,
+                opacity: isEligible ? 1 : INACTIVE_OPACITY,
                 lineHeight: 1,
+                letterSpacing: '-0.028em',
+                fontFeatureSettings: TABULAR_NUMS,
               })}
             >
               ${Math.round(miner.usdPerDay || 0).toLocaleString()}
@@ -348,11 +344,10 @@ export const MinerCard: React.FC<MinerCardProps> = ({
             <Typography
               sx={(theme) => ({
                 fontFamily: FONTS.mono,
-                fontSize: '0.75rem',
-                color: earningsHighlighted
-                  ? theme.palette.status.open
-                  : theme.palette.text.tertiary,
-                opacity: earningsHighlighted ? 1 : INACTIVE_OPACITY,
+                fontSize: '0.7rem',
+                fontWeight: 500,
+                color: theme.palette.text.secondary,
+                opacity: isEligible ? 1 : INACTIVE_OPACITY,
               })}
             >
               /day
@@ -362,263 +357,320 @@ export const MinerCard: React.FC<MinerCardProps> = ({
             sx={(theme) => ({
               fontFamily: FONTS.mono,
               fontSize: '0.7rem',
-              color: earningsHighlighted
-                ? theme.palette.status.merged
-                : theme.palette.text.tertiary,
-              opacity: earningsHighlighted ? 0.7 : INACTIVE_OPACITY,
-              mt: 0.2,
+              fontWeight: 500,
+              color: theme.palette.text.tertiary,
+              opacity: isEligible ? 1 : INACTIVE_OPACITY,
+              mt: 0.45,
+              fontFeatureSettings: TABULAR_NUMS,
             })}
           >
-            ~${Math.round((miner.usdPerDay || 0) * 30).toLocaleString()}/mo
+            ${Math.round((miner.usdPerDay || 0) * 30).toLocaleString()} / month
           </Typography>
         </Box>
 
-        {isWatchlist ? (
-          <Box sx={{ display: 'flex', gap: 1.5, flexShrink: 0 }}>
+        {/* Credibility */}
+        <Box
+          sx={(theme) => ({
+            px: { xs: 1.75, sm: 2 },
+            py: 1.5,
+            borderLeft: `1px solid ${theme.palette.border.light}`,
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: 0.7,
+            minWidth: isWatchlist ? 144 : 96,
+          })}
+        >
+          <Overline>Credibility</Overline>
+          {isWatchlist ? (
+            <Box sx={{ display: 'flex', gap: 1.25 }}>
+              <CredDonut
+                segments={getPrSegments(miner)}
+                percent={credibilityPercent}
+                isEligible={ossEligible}
+                caption="PRs"
+              />
+              <CredDonut
+                segments={getIssueSegments(miner)}
+                percent={issueCredPercent}
+                isEligible={discoveriesEligible}
+                caption="Issues"
+              />
+            </Box>
+          ) : (
             <CredDonut
-              segments={getPrSegments(miner)}
-              percent={credibilityPercent}
-              isEligible={ossEligible}
-              label="PRs"
+              segments={segments}
+              percent={isDiscoveries ? issueCredPercent : credibilityPercent}
+              isEligible={isEligible}
+              size={56}
             />
-            <CredDonut
-              segments={getIssueSegments(miner)}
-              percent={issueCredPercent}
-              isEligible={discoveriesEligible}
-              label="Issues"
-            />
-          </Box>
-        ) : (
-          <CredDonut
-            segments={segments}
-            percent={isDiscoveries ? issueCredPercent : credibilityPercent}
+          )}
+        </Box>
+      </Box>
+
+      {/* ─── ACTIVITY ROW(S) ───────────────────────────────── */}
+      <Box>
+        <ActivityRow
+          activityLabel={isDiscoveries ? 'Issue activity' : 'PR activity'}
+          segments={segments}
+          scoreLabel={variant === 'watchlist' ? 'OSS' : 'Total Score'}
+          scoreValue={Number(miner.totalScore)}
+          isEligible={isEligible}
+        />
+
+        {variant === 'watchlist' && (
+          <ActivityRow
+            activityLabel="Issue activity"
+            segments={getIssueSegments(miner)}
+            scoreLabel="Discovery"
+            scoreValue={Number(miner.issueDiscoveryScore ?? 0)}
             isEligible={isEligible}
-            size={56}
+            divider
           />
         )}
       </Box>
-
-      <MinerCardFooter
-        miner={miner}
-        totalScore={miner.totalScore}
-        segments={segments}
-        isEligible={isEligible}
-        variant={variant}
-        primaryRowEligible={isWatchlist ? ossEligible : undefined}
-        secondaryRowEligible={isWatchlist ? discoveriesEligible : undefined}
-      />
     </Card>
   );
 };
 
-interface MinerCardFooterProps {
-  miner: MinerStats;
-  totalScore: number;
-  segments: Segment[];
-  isEligible: boolean;
-  variant: LeaderboardVariant;
-  /** Watchlist: OSS / PR stats row eligibility (paired with PR donut). */
-  primaryRowEligible?: boolean;
-  /** Watchlist: issue stats row eligibility (paired with Issues donut). */
-  secondaryRowEligible?: boolean;
+/* ── Eligibility marker — dot + word ──────────────────────────── */
+
+interface EligibilityLabelProps {
+  label: string;
+  eligible: boolean;
 }
 
-const MinerCardFooter: React.FC<MinerCardFooterProps> = ({
-  miner,
-  totalScore,
-  segments,
-  isEligible,
-  variant,
-  primaryRowEligible,
-  secondaryRowEligible,
-}) => {
-  const muiTheme = useTheme();
-  const inactiveColor = alpha(muiTheme.palette.text.tertiary, INACTIVE_OPACITY);
-
-  const chromeEligible =
-    variant === 'watchlist'
-      ? Boolean(primaryRowEligible || secondaryRowEligible)
-      : isEligible;
-
-  const primaryEligible =
-    variant === 'watchlist' ? Boolean(primaryRowEligible) : isEligible;
-  const secondaryEligible =
-    variant === 'watchlist' ? Boolean(secondaryRowEligible) : isEligible;
-
-  const primaryPalette = buildStatPalette(primaryEligible, muiTheme);
-  const secondaryPalette = buildStatPalette(secondaryEligible, muiTheme);
-
-  const issueSegments = getIssueSegments(miner);
-  const issueDiscoveryScore = Number(miner.issueDiscoveryScore ?? 0);
-
-  return (
+const EligibilityLabel: React.FC<EligibilityLabelProps> = ({
+  label,
+  eligible,
+}) => (
+  <Box
+    sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5, minWidth: 0 }}
+  >
     <Box
       sx={(theme) => ({
-        display: 'flex',
-        flexDirection: 'column',
-        gap: variant === 'discoveries' || variant === 'watchlist' ? 0.75 : 0,
-        backgroundColor: chromeEligible
-          ? alpha(theme.palette.background.default, 0.2)
-          : theme.palette.surface.subtle,
-        opacity: chromeEligible ? 1 : 0.62,
-        borderRadius: 1.5,
-        p: 1,
+        width: 5,
+        height: 5,
+        borderRadius: '50%',
+        backgroundColor: eligible
+          ? theme.palette.status.merged
+          : alpha(theme.palette.text.tertiary, 0.6),
+        flexShrink: 0,
+      })}
+    />
+    <Typography
+      sx={(theme) => ({
+        fontFamily: FONTS.mono,
+        fontSize: '0.7rem',
+        fontWeight: 500,
+        color: eligible
+          ? theme.palette.text.primary
+          : theme.palette.text.tertiary,
+        letterSpacing: '0.01em',
+        lineHeight: 1,
+        whiteSpace: 'nowrap',
       })}
     >
-      <Box
-        sx={{
-          display: 'grid',
-          gridTemplateColumns: '1fr 1fr 1fr 4.5rem',
-          gap: 1,
-          alignItems: 'center',
-        }}
-      >
-        {segments.map((segment, i) => (
-          <StatCell
-            key={segment.label}
-            label={segment.label}
-            value={segment.value}
-            color={primaryPalette[i]}
-            isEligible={primaryEligible}
-          />
-        ))}
-        <Box
-          sx={(theme) => ({
-            textAlign: 'right',
-            borderLeft: `1px solid ${
-              primaryEligible
-                ? theme.palette.border.light
-                : theme.palette.border.subtle
-            }`,
-            pl: 1.5,
-          })}
-        >
-          <StatLabel isEligible={primaryEligible}>
-            {variant === 'watchlist' ? 'OSS' : 'Score'}
-          </StatLabel>
-          <Typography
-            sx={{
-              fontFamily: FONTS.mono,
-              fontSize: '0.9rem',
-              color: primaryEligible
-                ? muiTheme.palette.text.primary
-                : inactiveColor,
-              fontWeight: 700,
-            }}
-          >
-            {Number(totalScore).toFixed(2)}
-          </Typography>
-        </Box>
-      </Box>
-
-      {variant === 'watchlist' && (
-        <Box
-          sx={(theme) => ({
-            pt: 0.75,
-            borderTop: `1px solid ${theme.palette.border.light}`,
-          })}
-        >
-          <Box
-            sx={{
-              display: 'grid',
-              gridTemplateColumns: '1fr 1fr 1fr 4.5rem',
-              gap: 1,
-              alignItems: 'center',
-            }}
-          >
-            {issueSegments.map((segment, i) => (
-              <StatCell
-                key={segment.label}
-                label={segment.label}
-                value={segment.value}
-                color={secondaryPalette[i]}
-                isEligible={secondaryEligible}
-              />
-            ))}
-            <Box
-              sx={(theme) => ({
-                textAlign: 'right',
-                borderLeft: `1px solid ${
-                  secondaryEligible
-                    ? theme.palette.border.light
-                    : theme.palette.border.subtle
-                }`,
-                pl: 1.5,
-              })}
-            >
-              <StatLabel isEligible={secondaryEligible}>Discovery</StatLabel>
-              <Typography
-                sx={{
-                  fontFamily: FONTS.mono,
-                  fontSize: '0.9rem',
-                  color: secondaryEligible
-                    ? muiTheme.palette.text.primary
-                    : inactiveColor,
-                  fontWeight: 700,
-                }}
-              >
-                {issueDiscoveryScore.toFixed(2)}
-              </Typography>
-            </Box>
-          </Box>
-        </Box>
-      )}
-    </Box>
-  );
-};
-
-interface StatCellProps {
-  label: string;
-  value: number;
-  color: string;
-  isEligible: boolean;
-}
-
-const StatCell: React.FC<StatCellProps> = ({
-  label,
-  value,
-  color,
-  isEligible,
-}) => (
-  <Box>
-    <StatLabel isEligible={isEligible}>{label}</StatLabel>
-    <Typography
-      sx={{
-        fontFamily: FONTS.mono,
-        fontSize: '0.85rem',
-        color,
-        fontWeight: 600,
-      }}
-    >
-      {value}
+      {label}
     </Typography>
   </Box>
 );
 
-const StatLabel: React.FC<{
+const Divider: React.FC = () => (
+  <Box
+    sx={(theme) => ({
+      width: 1,
+      height: 10,
+      backgroundColor: theme.palette.border.light,
+    })}
+  />
+);
+
+/* ── Activity row: inline stats + score on the right ─────────── */
+
+interface ActivityRowProps {
+  activityLabel: string;
+  segments: Segment[];
+  scoreLabel: string;
+  scoreValue: number;
   isEligible: boolean;
+  divider?: boolean;
+}
+
+const ActivityRow: React.FC<ActivityRowProps> = ({
+  activityLabel,
+  segments,
+  scoreLabel,
+  scoreValue,
+  isEligible,
+  divider,
+}) => {
+  const muiTheme = useTheme();
+  const inactiveColor = alpha(muiTheme.palette.text.tertiary, INACTIVE_OPACITY);
+
+  const cellColor = (i: number): string =>
+    isEligible
+      ? i === 0
+        ? STATUS_COLORS.merged
+        : i === 1
+          ? alpha(muiTheme.palette.text.primary, 0.86)
+          : muiTheme.palette.status.closed
+      : inactiveColor;
+
+  return (
+    <Box
+      sx={(theme) => ({
+        display: 'grid',
+        gridTemplateColumns: '1fr auto',
+        alignItems: 'center',
+        columnGap: 2,
+        px: { xs: 1.75, sm: 2 },
+        py: 1.4,
+        borderTop: divider
+          ? `1px dashed ${theme.palette.border.subtle}`
+          : 'none',
+      })}
+    >
+      <Box sx={{ minWidth: 0 }}>
+        <Overline>{activityLabel}</Overline>
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'baseline',
+            gap: 1,
+            mt: 0.7,
+            flexWrap: 'wrap',
+          }}
+        >
+          {segments.map((segment, i) => (
+            <InlineStat
+              key={segment.label}
+              label={segment.label}
+              value={segment.value}
+              color={cellColor(i)}
+              isLast={i === segments.length - 1}
+            />
+          ))}
+        </Box>
+      </Box>
+
+      <Box
+        sx={{
+          textAlign: 'right',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'flex-end',
+          gap: 0.5,
+        }}
+      >
+        <Overline align="right">{scoreLabel}</Overline>
+        <Typography
+          sx={(theme) => ({
+            fontFamily: FONTS.mono,
+            fontSize: '1.05rem',
+            color: isEligible ? theme.palette.text.primary : inactiveColor,
+            fontWeight: 700,
+            letterSpacing: '-0.02em',
+            fontFeatureSettings: TABULAR_NUMS,
+            lineHeight: 1,
+          })}
+        >
+          {formatScore(scoreValue)}
+        </Typography>
+      </Box>
+    </Box>
+  );
+};
+
+/* ── Inline stat: "Merged 142" with subtle separator dot ──────── */
+
+interface InlineStatProps {
+  label: string;
+  value: number;
+  color: string;
+  isLast: boolean;
+}
+
+const InlineStat: React.FC<InlineStatProps> = ({
+  label,
+  value,
+  color,
+  isLast,
+}) => (
+  <Box sx={{ display: 'inline-flex', alignItems: 'baseline', gap: 0.5 }}>
+    <Typography
+      sx={(theme) => ({
+        fontFamily: FONTS.mono,
+        fontSize: '0.66rem',
+        fontWeight: 500,
+        color: theme.palette.text.tertiary,
+        textTransform: 'uppercase',
+        letterSpacing: '0.1em',
+      })}
+    >
+      {label}
+    </Typography>
+    <Typography
+      sx={{
+        fontFamily: FONTS.mono,
+        fontSize: '0.92rem',
+        fontWeight: 700,
+        color,
+        fontFeatureSettings: TABULAR_NUMS,
+        letterSpacing: '-0.012em',
+        lineHeight: 1,
+      }}
+    >
+      {value.toLocaleString()}
+    </Typography>
+    {!isLast && (
+      <Typography
+        sx={(theme) => ({
+          fontFamily: FONTS.mono,
+          fontSize: '0.85rem',
+          color: alpha(theme.palette.text.tertiary, 0.5),
+          ml: 0.5,
+          lineHeight: 1,
+        })}
+      >
+        ·
+      </Typography>
+    )}
+  </Box>
+);
+
+/* ── Section overline ────────────────────────────────────── */
+
+interface OverlineProps {
   children: React.ReactNode;
-}> = ({ isEligible, children }) => (
+  align?: 'left' | 'right';
+}
+
+const Overline: React.FC<OverlineProps> = ({ children, align = 'left' }) => (
   <Typography
     sx={(theme) => ({
       fontFamily: FONTS.mono,
-      fontSize: '0.6rem',
-      color: isEligible
-        ? theme.palette.status.open
-        : alpha(theme.palette.text.tertiary, INACTIVE_OPACITY),
+      fontSize: '0.58rem',
+      fontWeight: 500,
+      color: theme.palette.text.secondary,
       textTransform: 'uppercase',
-      mb: 0.2,
+      letterSpacing: '0.16em',
+      lineHeight: 1,
+      textAlign: align,
     })}
   >
     {children}
   </Typography>
 );
 
+/* ── Credibility donut ───────────────────────────────────── */
+
 interface CredDonutProps {
   segments: Segment[];
   percent: number;
   isEligible: boolean;
-  label?: string;
+  caption?: string;
   size?: number;
 }
 
@@ -626,7 +678,7 @@ const CredDonut: React.FC<CredDonutProps> = ({
   segments,
   percent,
   isEligible,
-  label,
+  caption,
   size = 48,
 }) => {
   const muiTheme = useTheme();
@@ -694,6 +746,7 @@ const CredDonut: React.FC<CredDonutProps> = ({
         flexDirection: 'column',
         alignItems: 'center',
         flexShrink: 0,
+        gap: 0.4,
       }}
     >
       <Box
@@ -710,10 +763,10 @@ const CredDonut: React.FC<CredDonutProps> = ({
             series: [
               {
                 type: 'pie',
-                radius: ['65%', '90%'],
+                radius: ['70%', '94%'],
                 silent: true,
                 label: { show: false },
-                itemStyle: { borderRadius: 3, borderWidth: 0 },
+                itemStyle: { borderRadius: 1, borderWidth: 0 },
                 data: segments.map((segment, i) => ({
                   value: segment.value,
                   itemStyle: {
@@ -734,10 +787,7 @@ const CredDonut: React.FC<CredDonutProps> = ({
         <Box
           sx={{
             position: 'absolute',
-            top: 0,
-            left: 0,
-            right: 0,
-            bottom: 0,
+            inset: 0,
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'center',
@@ -746,31 +796,32 @@ const CredDonut: React.FC<CredDonutProps> = ({
           <Typography
             sx={(theme) => ({
               fontFamily: FONTS.mono,
-              fontSize: size <= 48 ? '0.65rem' : '0.75rem',
+              fontSize: size <= 48 ? '0.66rem' : '0.74rem',
               color: isEligible
-                ? percent >= 80
-                  ? STATUS_COLORS.merged
-                  : STATUS_COLORS.open
+                ? theme.palette.text.primary
                 : theme.palette.text.tertiary,
               fontWeight: 700,
+              letterSpacing: '-0.01em',
+              fontFeatureSettings: TABULAR_NUMS,
             })}
           >
             {percent.toFixed(0)}%
           </Typography>
         </Box>
       </Box>
-      {label && (
+      {caption && (
         <Typography
           sx={(theme) => ({
             fontFamily: FONTS.mono,
             fontSize: '0.55rem',
-            color: theme.palette.status.open,
+            fontWeight: 500,
+            color: theme.palette.text.secondary,
             textTransform: 'uppercase',
-            mt: 0.25,
-            letterSpacing: '0.04em',
+            letterSpacing: '0.12em',
+            lineHeight: 1,
           })}
         >
-          {label}
+          {caption}
         </Typography>
       )}
     </Box>

--- a/src/components/leaderboard/MinerCard.tsx
+++ b/src/components/leaderboard/MinerCard.tsx
@@ -3,7 +3,7 @@ import { Box, Card, Typography, Avatar, Tooltip } from '@mui/material';
 import { alpha, useTheme } from '@mui/material/styles';
 import ReactECharts from 'echarts-for-react';
 import { useMinerGithubData, useMinerPRs } from '../../api';
-import { CHART_COLORS, STATUS_COLORS } from '../../theme';
+import { CHART_COLORS, RANK_COLORS, STATUS_COLORS } from '../../theme';
 import { getGithubAvatarSrc } from '../../utils/ExplorerUtils';
 import { linkResetSx, useLinkBehavior } from '../common/linkBehavior';
 import { WatchlistButton } from '../common';
@@ -103,12 +103,14 @@ export const MinerCard: React.FC<MinerCardProps> = ({
 
   const rank = miner.rank;
   const isTopRank = !!rank && rank > 0 && rank <= 3;
-  const RANK_COLORS: Record<number, string> = {
-    1: '#FFD700',
-    2: '#C0C0C0',
-    3: '#CD7F32',
-  };
-  const rankColor = rank ? RANK_COLORS[rank] : undefined;
+  const rankColor =
+    rank === 1
+      ? RANK_COLORS.first
+      : rank === 2
+        ? RANK_COLORS.second
+        : rank === 3
+          ? RANK_COLORS.third
+          : undefined;
   const segments = getSegments(miner, variant);
 
   return (
@@ -126,7 +128,6 @@ export const MinerCard: React.FC<MinerCardProps> = ({
         height: '100%',
         display: 'flex',
         flexDirection: 'column',
-        opacity: isEligible ? 1 : 0.6,
         overflow: 'hidden',
         transition:
           'background-color 0.22s ease, border-color 0.22s ease, transform 0.22s ease, box-shadow 0.22s ease',
@@ -343,7 +344,7 @@ export const MinerCard: React.FC<MinerCardProps> = ({
               fontFeatureSettings: TABULAR_NUMS,
             })}
           >
-            ${Math.round((miner.usdPerDay || 0) * 30).toLocaleString()} / month
+            ~${Math.round((miner.usdPerDay || 0) * 30).toLocaleString()}/mo
           </Typography>
         </Box>
 
@@ -395,7 +396,7 @@ export const MinerCard: React.FC<MinerCardProps> = ({
           segments={segments}
           scoreLabel={variant === 'watchlist' ? 'OSS' : 'Total Score'}
           scoreValue={Number(miner.totalScore)}
-          isEligible={isEligible}
+          isEligible={isDiscoveries ? discoveriesEligible : ossEligible}
         />
 
         {variant === 'watchlist' && (
@@ -404,7 +405,7 @@ export const MinerCard: React.FC<MinerCardProps> = ({
             segments={getIssueSegments(miner)}
             scoreLabel="Discovery"
             scoreValue={Number(miner.issueDiscoveryScore ?? 0)}
-            isEligible={isEligible}
+            isEligible={discoveriesEligible}
             divider
           />
         )}
@@ -700,7 +701,7 @@ const CredDonut: React.FC<CredDonutProps> = ({
             </Typography>
           </Box>
         </Tooltip>
-        {label && (
+        {caption && (
           <Typography
             sx={(theme) => ({
               fontFamily: FONTS.mono,
@@ -711,7 +712,7 @@ const CredDonut: React.FC<CredDonutProps> = ({
               letterSpacing: '0.04em',
             })}
           >
-            {label}
+            {caption}
           </Typography>
         )}
       </Box>


### PR DESCRIPTION
## Summary

Redesigns the `MinerCard` component with a cleaner, more elegant visual style — replacing the old elevated/shadowed approach with a flat, border-focused layout that includes a cursor-tracking spotlight, a hover-scale lift, and gold/silver/bronze medal accents for the top-3 ranked miners.

Key changes:

- **Cleaner resting state** — flat card on transparent background with a single `border.medium` hairline (rank #1–#3 get a gold/silver/bronze tinted border at 35% alpha instead). Removes the previous `backdrop-filter`, elevated shadow, and conditional background fills.
- **Cursor-tracking spotlight** — a radial-gradient `::after` layer follows the cursor (`--mx`/`--my` CSS vars updated via `onMouseMove`), fading in on hover for a premium, intentional feel.
- **Hover-scale + soft shadow** — card grows `scale(1.025)` and gains a soft `0 8px 24px -6px` shadow on hover, with a 220 ms eased transition.
- **Top-3 medal accents** — `RANK_COLORS = { 1: gold, 2: silver, 3: bronze }` drives both the tinted border and a 1.5 px hairline left accent strip (`::before`), giving top performers a clear visual cue without badge clutter.
- **Improved inactive legibility** — `INACTIVE_OPACITY` raised from `0.24` → `0.42` so ineligible cards remain readable without appearing active.
- **Standardised number rendering** — adds `formatRank` (zero-padded, e.g. `#03`), `formatScore` (fixed 2 dp via `toLocaleString`), and a `TABULAR_NUMS` font-feature-settings constant to prevent digit jitter in monospace columns.
- **Streamlined layout** — header now uses a 4-column CSS grid (`avatar | name+badges | eligibility | score`) instead of nested flex boxes, reducing DOM depth and making alignment predictable at all breakpoints.
- **Accessibility** — Avatar now carries `alt={username}`.

## Related Issues

Closes #1044

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots
https://github.com/user-attachments/assets/63d1cb5a-6fdc-42f0-b8ae-363d27a6b96d

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [ ] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
