### PR TITLE
fix(onboard): add language weights row numbers

### DIFF
--- a/src/components/repositories/LanguageWeightsTable.tsx
+++ b/src/components/repositories/LanguageWeightsTable.tsx
@@ -40,6 +40,10 @@ interface LanguageRow {
   weight: string;
 }
 
+type IndexedLanguageRow = LanguageRow & {
+  displayIndex: number;
+};
+
 const LanguageWeightsTable: React.FC = () => {
   const theme = useTheme();
   const { data: languages, isLoading } = useLanguagesAndWeights();
@@ -117,10 +121,15 @@ const LanguageWeightsTable: React.FC = () => {
     return filtered;
   }, [languages, searchQuery, sortField, sortOrder]);
 
-  const paginatedLanguages = useMemo(() => {
+  const paginatedLanguages = useMemo<IndexedLanguageRow[]>(() => {
     const startIndex = page * rowsPerPage;
     const endIndex = startIndex + rowsPerPage;
-    return filteredAndSortedLanguages.slice(startIndex, endIndex);
+    return filteredAndSortedLanguages
+      .slice(startIndex, endIndex)
+      .map((lang, index) => ({
+        ...lang,
+        displayIndex: startIndex + index + 1,
+      }));
   }, [filteredAndSortedLanguages, page, rowsPerPage]);
 
   const chartOption = useMemo(() => {
@@ -207,8 +216,19 @@ const LanguageWeightsTable: React.FC = () => {
     },
   } as const;
 
-  const columns = useMemo<DataTableColumn<LanguageRow, SortField>[]>(
+  const columns = useMemo<DataTableColumn<IndexedLanguageRow, SortField>[]>(
     () => [
+      {
+        key: 'rowNumber',
+        header: 'No.',
+        width: 72,
+        align: 'right',
+        cellSx: {
+          color: 'text.secondary',
+          fontVariantNumeric: 'tabular-nums',
+        },
+        renderCell: (lang) => lang.displayIndex,
+      },
       {
         key: 'extension',
         header: 'Extension',
@@ -440,7 +460,7 @@ const LanguageWeightsTable: React.FC = () => {
           ...scrollbarSx,
         }}
       >
-        <DataTable<LanguageRow, SortField>
+        <DataTable<IndexedLanguageRow, SortField>
           columns={columns}
           rows={paginatedLanguages}
           getRowKey={(lang) => lang.extension}


### PR DESCRIPTION
## Summary
- Adds a leftmost `No.` column to the Onboard → Languages weights table.
- Keeps row numbers stable across sorting/searching/pagination by deriving them from the current paginated slice offset.
- Uses tabular numeric styling so row references are easy to scan.

Closes #628

## Test Plan
- `npm run lint -- --quiet`
- `npm run build`
