### PR TITLE
Restore pagination on bounties list

### DIFF
--- a/src/components/common/TablePagination.tsx
+++ b/src/components/common/TablePagination.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import {
+  Box,
+  IconButton,
+  Typography,
+  alpha,
+  type SxProps,
+  type Theme,
+} from '@mui/material';
+import {
+  NavigateBefore as PrevIcon,
+  NavigateNext as NextIcon,
+} from '@mui/icons-material';
+
+interface TablePaginationProps {
+  page: number;
+  totalPages: number;
+  onPageChange: (newPage: number) => void;
+}
+
+const navButtonSx: SxProps<Theme> = {
+  p: 0.25,
+  color: (t) => alpha(t.palette.text.primary, 0.6),
+  '&:hover': { color: 'text.primary' },
+  '&.Mui-focusVisible': {
+    backgroundColor: (t) => alpha(t.palette.primary.main, 0.2),
+    outline: '2px solid',
+    outlineColor: 'primary.main',
+    outlineOffset: '-2px',
+    color: 'text.primary',
+  },
+  '&.Mui-disabled': { opacity: 0.3 },
+};
+
+const navIconSx = { fontSize: '1.2rem' };
+
+const TablePagination: React.FC<TablePaginationProps> = ({
+  page,
+  totalPages,
+  onPageChange,
+}) => {
+  if (totalPages <= 1) {
+    return null;
+  }
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 2,
+        py: 1.5,
+        borderTop: '1px solid',
+        borderColor: 'border.subtle',
+      }}
+    >
+      <IconButton
+        onClick={() => onPageChange(page - 1)}
+        disabled={page === 0}
+        aria-label="Previous page"
+        size="small"
+        sx={navButtonSx}
+      >
+        <PrevIcon sx={navIconSx} />
+      </IconButton>
+      <Typography
+        sx={{
+          fontSize: '0.75rem',
+          color: (t) => alpha(t.palette.text.primary, 0.5),
+        }}
+      >
+        {page + 1} / {totalPages}
+      </Typography>
+      <IconButton
+        onClick={() => onPageChange(page + 1)}
+        disabled={page >= totalPages - 1}
+        aria-label="Next page"
+        size="small"
+        sx={navButtonSx}
+      >
+        <NextIcon sx={navIconSx} />
+      </IconButton>
+    </Box>
+  );
+};
+
+export default TablePagination;

--- a/src/components/issues/IssuesList.tsx
+++ b/src/components/issues/IssuesList.tsx
@@ -46,6 +46,7 @@ import { isOutsideScoringWindow } from '../../utils/ExplorerUtils';
 import { STATUS_COLORS, TEXT_OPACITY } from '../../theme';
 import { DataTable, type DataTableColumn } from '../common/DataTable';
 import { ClearSearchAdornment } from '../common/ClearSearchAdornment';
+import TablePagination from '../common/TablePagination';
 import { WatchlistButton } from '../common/WatchlistButton';
 import BountyProgress from './BountyProgress';
 import { BountyCard } from './BountyCard';
@@ -53,6 +54,7 @@ import {
   type IssuesViewMode,
   ISSUES_VIEW_QUERY_PARAM,
   ISSUES_DEFAULT_CARD_ROWS,
+  ISSUES_DEFAULT_LIST_ROWS,
   getIssuesViewModeFromQuery,
   readStoredIssuesViewMode,
   writeStoredIssuesViewMode,
@@ -208,6 +210,10 @@ const IssuesList: React.FC<IssuesListProps> = ({
   const [sortDirection, setSortDirection] = useState<SortDirection>('desc');
   const [searchQuery, setSearchQuery] = useState('');
   const [showChart, setShowChart] = useState(false);
+  const [paginationState, setPaginationState] = useState({
+    key: '',
+    page: 0,
+  });
 
   const isLargeScreen = useMediaQuery(theme.breakpoints.up('xl'));
   const [portalTarget, setPortalTarget] = useState<HTMLElement | null>(null);
@@ -356,6 +362,46 @@ const IssuesList: React.FC<IssuesListProps> = ({
     });
     return decorated.map((d) => d.row);
   }, [filteredIssues, getSortValue, sortKey, sortDirection]);
+
+  const paginationKey = [
+    filterType,
+    searchQuery,
+    sortKey,
+    sortDirection,
+    viewMode,
+  ].join('::');
+
+  if (paginationState.key !== paginationKey) {
+    setPaginationState({ key: paginationKey, page: 0 });
+  }
+
+  const rowsPerPage =
+    viewMode === 'cards' ? ISSUES_DEFAULT_CARD_ROWS : ISSUES_DEFAULT_LIST_ROWS;
+  const totalPages = Math.max(1, Math.ceil(sortedIssues.length / rowsPerPage));
+  const currentPage =
+    paginationState.key === paginationKey
+      ? Math.min(paginationState.page, totalPages - 1)
+      : 0;
+
+  if (
+    paginationState.key === paginationKey &&
+    paginationState.page !== currentPage
+  ) {
+    setPaginationState({ key: paginationKey, page: currentPage });
+  }
+
+  const visibleIssues = useMemo(() => {
+    const start = currentPage * rowsPerPage;
+    return sortedIssues.slice(start, start + rowsPerPage);
+  }, [sortedIssues, currentPage, rowsPerPage]);
+
+  const handlePageChange = useCallback(
+    (newPage: number) => {
+      const clampedPage = Math.min(Math.max(newPage, 0), totalPages - 1);
+      setPaginationState({ key: paginationKey, page: clampedPage });
+    },
+    [paginationKey, totalPages],
+  );
 
   const chartOption = useMemo(() => {
     const repoTotals = new Map<string, number>();
@@ -1161,50 +1207,64 @@ const IssuesList: React.FC<IssuesListProps> = ({
 
       {viewMode === 'cards' ? (
         sortedIssues.length > 0 ? (
-          <Grid container spacing={2}>
-            {sortedIssues.map((issue) => (
-              <Grid item xs={12} sm={6} md={4} key={issue.id}>
-                <BountyCard
-                  issue={issue}
-                  href={getIssueHref ? getIssueHref(issue.id) : undefined}
-                  linkState={linkState}
-                  taoPrice={taoPrice}
-                  alphaPrice={alphaPrice}
-                />
-              </Grid>
-            ))}
-          </Grid>
+          <>
+            <Grid container spacing={2}>
+              {visibleIssues.map((issue) => (
+                <Grid item xs={12} sm={6} md={4} key={issue.id}>
+                  <BountyCard
+                    issue={issue}
+                    href={getIssueHref ? getIssueHref(issue.id) : undefined}
+                    linkState={linkState}
+                    taoPrice={taoPrice}
+                    alphaPrice={alphaPrice}
+                  />
+                </Grid>
+              ))}
+            </Grid>
+            <TablePagination
+              page={currentPage}
+              totalPages={totalPages}
+              onPageChange={handlePageChange}
+            />
+          </>
         ) : (
           emptyState
         )
       ) : (
-        <DataTable<IssueBounty, SortKey>
-          columns={columns}
-          rows={sortedIssues}
-          getRowKey={(issue) => issue.id}
-          getRowHref={
-            getIssueHref ? (issue) => getIssueHref(issue.id) : undefined
-          }
-          linkState={linkState}
-          minWidth={
-            filterType === 'history'
-              ? '1000px'
-              : filterType === 'pending'
-                ? '900px'
-                : '750px'
-          }
-          emptyState={emptyState}
-          getRowSx={(issue) =>
-            issue.completedAt && isOutsideScoringWindow(issue.completedAt)
-              ? { opacity: 0.4, filter: 'grayscale(0.5)' }
-              : {}
-          }
-          sort={{
-            field: sortKey,
-            order: sortDirection,
-            onChange: handleSort,
-          }}
-        />
+        <>
+          <DataTable<IssueBounty, SortKey>
+            columns={columns}
+            rows={visibleIssues}
+            getRowKey={(issue) => issue.id}
+            getRowHref={
+              getIssueHref ? (issue) => getIssueHref(issue.id) : undefined
+            }
+            linkState={linkState}
+            minWidth={
+              filterType === 'history'
+                ? '1000px'
+                : filterType === 'pending'
+                  ? '900px'
+                  : '750px'
+            }
+            emptyState={emptyState}
+            getRowSx={(issue) =>
+              issue.completedAt && isOutsideScoringWindow(issue.completedAt)
+                ? { opacity: 0.4, filter: 'grayscale(0.5)' }
+                : {}
+            }
+            sort={{
+              field: sortKey,
+              order: sortDirection,
+              onChange: handleSort,
+            }}
+          />
+          <TablePagination
+            page={currentPage}
+            totalPages={totalPages}
+            onPageChange={handlePageChange}
+          />
+        </>
       )}
     </Card>
   );


### PR DESCRIPTION
## Summary

Restores pagination on the `/bounties` issues list so the page no longer renders the full sorted issues array on first paint.

Changes:
- Adds shared `TablePagination` under `src/components/common`.
- Uses 10 rows for list view and 12 cards for card view, matching the existing defaults.
- Renders only the current page slice for both card and table views.
- Resets pagination to page 0 when filter, search, sort, direction, or view mode changes.
- Clamps the current page when result count shrinks.

## Related Issues

Fixes #1027

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

Not included. This restores existing pagination behavior and was verified with build/lint locally.

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked by preserving the existing card/list row defaults
- [ ] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run via lint-staged/prettier on touched files
- [x] `npm run build` passes
- [ ] Screenshots included for any UI/visual changes