### PR TITLE
fix: stabilize Live Activity infinite scroll pagination

### DIFF
--- a/src/api/DashboardApi.ts
+++ b/src/api/DashboardApi.ts
@@ -51,13 +51,17 @@ export const useInfiniteCommitLog = (options?: {
       });
       return data;
     },
-    getNextPageParam: (lastPage: CommitLog[], allPages: CommitLog[][]) => {
+    getNextPageParam: (
+      lastPage: CommitLog[],
+      _allPages: CommitLog[][],
+      lastPageParam: number,
+    ) => {
       // If the last page has fewer items than the limit, we've reached the end
       if (lastPage.length < limit) {
         return undefined;
       }
-      // Otherwise, return the next page number
-      return allPages.length + 1;
+      // Use lastPageParam to avoid stale allPages count during background refetches
+      return lastPageParam + 1;
     },
     initialPageParam: 1,
     refetchInterval: options?.refetchInterval,

--- a/src/pages/dashboard/views/LiveCommitLog.tsx
+++ b/src/pages/dashboard/views/LiveCommitLog.tsx
@@ -1,4 +1,10 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import {
   Card,
   CardContent,
@@ -95,6 +101,11 @@ const COMMIT_STATUS_META: Record<
     color: theme.palette.status.closed,
   },
 };
+
+/** Remaining scroll distance (px) at which the next page starts loading. */
+const SCROLL_BOTTOM_BUFFER_PX = 80;
+/** Debounce delay (ms) for the scroll handler to avoid hammering on fast scroll. */
+const SCROLL_DEBOUNCE_MS = 120;
 
 const COMMIT_STATUS_FILTERS: CommitStatusFilter[] = [
   'all',
@@ -380,7 +391,8 @@ const LiveCommitLog: React.FC = () => {
   const [newEntryIds, setNewEntryIds] = useState<Set<string>>(new Set());
   const [, setRelativeTimeTick] = useState(0);
   const logContainerRef = useRef<HTMLDivElement>(null);
-  const loadMoreRef = useRef<HTMLAnchorElement>(null);
+  const fetchInFlightRef = useRef(false);
+  const scrollDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     const id = window.setInterval(
@@ -446,28 +458,37 @@ const LiveCommitLog: React.FC = () => {
   const showWaitingForActivity = !showInitialLoading && !hasAnyEntries;
   const showFilteredEmptyState = hasAnyEntries && visibleEntries.length === 0;
 
-  // Intersection observer for infinite scroll
-  useEffect(() => {
-    const scrollContainer = logContainerRef.current;
-    const loadMoreElement = loadMoreRef.current;
-    if (!scrollContainer || !loadMoreElement) return;
+  const handleScroll = useCallback(
+    (event: React.UIEvent<HTMLDivElement>) => {
+      const el = event.currentTarget;
 
-    const observer = new IntersectionObserver(
-      (entries) => {
-        if (entries[0].isIntersecting && hasNextPage && !isFetchingNextPage) {
-          fetchNextPage();
-        }
-      },
-      {
-        root: scrollContainer,
-        threshold: 0.1,
-      },
-    );
+      // Debounce: clear any pending check and reschedule
+      if (scrollDebounceRef.current !== null) {
+        clearTimeout(scrollDebounceRef.current);
+      }
 
-    observer.observe(loadMoreElement);
+      scrollDebounceRef.current = setTimeout(() => {
+        scrollDebounceRef.current = null;
 
-    return () => observer.disconnect();
-  }, [fetchNextPage, hasNextPage, isFetchingNextPage, visibleEntries.length]);
+        // Only trigger when within the buffer distance of the bottom.
+        // Using a fixed pixel value is intentional: a percentage would shift
+        // upward as new pages load (growing scrollHeight) and could re-fire
+        // before the user scrolls further down.
+        const distanceFromBottom =
+          el.scrollHeight - el.scrollTop - el.clientHeight;
+        if (distanceFromBottom > SCROLL_BOTTOM_BUFFER_PX) return;
+
+        if (!hasNextPage || isFetchingNextPage || fetchInFlightRef.current)
+          return;
+
+        fetchInFlightRef.current = true;
+        void fetchNextPage().finally(() => {
+          fetchInFlightRef.current = false;
+        });
+      }, SCROLL_DEBOUNCE_MS);
+    },
+    [fetchNextPage, hasNextPage, isFetchingNextPage],
+  );
 
   return (
     <Card
@@ -603,6 +624,7 @@ const LiveCommitLog: React.FC = () => {
         ) : (
           <Box
             ref={logContainerRef}
+            onScroll={handleScroll}
             sx={{
               flex: 1,
               overflowY: 'auto',
@@ -651,8 +673,6 @@ const LiveCommitLog: React.FC = () => {
                 })}
               </Stack>
             )}
-
-            <Box ref={loadMoreRef} sx={{ height: 1 }} />
 
             {isFetchingNextPage && (
               <Box sx={{ display: 'flex', justifyContent: 'center', p: 2 }}>

--- a/src/pages/dashboard/views/LiveCommitLog.tsx
+++ b/src/pages/dashboard/views/LiveCommitLog.tsx
@@ -402,6 +402,15 @@ const LiveCommitLog: React.FC = () => {
     return () => window.clearInterval(id);
   }, []);
 
+  // Clear any pending debounced scroll check on unmount.
+  useEffect(() => {
+    return () => {
+      if (scrollDebounceRef.current !== null) {
+        clearTimeout(scrollDebounceRef.current);
+      }
+    };
+  }, []);
+
   const apiCommits = useMemo<CommitLogEntry[]>(
     () => data?.pages.flat() ?? [],
     [data],
@@ -457,6 +466,21 @@ const LiveCommitLog: React.FC = () => {
   const showInitialLoading = isLoading && !hasAnyEntries;
   const showWaitingForActivity = !showInitialLoading && !hasAnyEntries;
   const showFilteredEmptyState = hasAnyEntries && visibleEntries.length === 0;
+
+  // If the first page doesn't fill the container there is no scroll event to
+  // trigger pagination. Check after each render and fetch the next page when
+  // the container has no overflow yet.
+  useEffect(() => {
+    const el = logContainerRef.current;
+    if (!el || !hasNextPage || isFetchingNextPage || fetchInFlightRef.current)
+      return;
+    if (el.scrollHeight <= el.clientHeight) {
+      fetchInFlightRef.current = true;
+      void fetchNextPage().finally(() => {
+        fetchInFlightRef.current = false;
+      });
+    }
+  }, [visibleEntries, hasNextPage, isFetchingNextPage, fetchNextPage]);
 
   const handleScroll = useCallback(
     (event: React.UIEvent<HTMLDivElement>) => {


### PR DESCRIPTION
## Summary

Fixes the Live Activity infinite scroll on the Dashboard that would enter an endless loading loop when scrolling at a moderate pace.

> **Note:** This PR addresses **Issue 1** (infinite scroll) from #685. **Issue 2** (repo table chart showing incorrect bar heights / empty bars when sorting by Weight with Log Scale enabled) was investigated but could **not be reproduced** — the chart behaved correctly under all tested conditions (ascending, descending, log scale on/off). No changes were made for Issue 2.

Two root causes addressed for Issue 1:

- **`DashboardApi`**: `getNextPageParam` was using `allPages.length + 1` to derive the next page number. During a background `refetchInterval` refetch, `allPages` is rebuilt page-by-page and can be shorter than expected when `getNextPageParam` is evaluated, causing a stale/incorrect page number to be requested. Changed to `lastPageParam + 1` which is always the canonical value.

- **`LiveCommitLog`**: The `IntersectionObserver` had `isFetchingNextPage` and `visibleEntries.length` in its dependency array. Every time a page loaded, the effect would teardown and recreate the observer — which would immediately fire if the sentinel element was still in the viewport, bypassing the in-flight guard and triggering another `fetchNextPage()`. This created the infinite request loop. Replaced with a debounced scroll handler (120ms) that checks a fixed pixel distance from the bottom of the container, with a `fetchInFlightRef` flag to prevent concurrent fetches. Removes the sentinel DOM element entirely.

## Related Issues

See #685 (Issue 1 only — Issue 2 not reproducible, no changes made)

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

## before
https://github.com/user-attachments/assets/4b8f68a7-d1dd-45c9-bcab-43d99a6350ce

## after
https://github.com/user-attachments/assets/4fef8ee9-918c-4727-9aeb-b5647bf693b6

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes