### PR TITLE
fix:Miner Overview “Score Breakdown” search lacks a clear control

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7568,24 +7568,6 @@
         }
       }
     },
-    "node_modules/vitest/node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
-    },
     "node_modules/web-namespaces": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",

--- a/src/components/miners/MinerScoreBreakdown.tsx
+++ b/src/components/miners/MinerScoreBreakdown.tsx
@@ -52,6 +52,7 @@ import { credibilityColor } from '../../utils/format';
 import { buildMergedPillDefs } from '../../utils/multiplierDefs';
 import { filterPrs, getPrStatusCounts, type PrStatusFilter } from '../../utils';
 import FilterButton from '../FilterButton';
+import { ClearSearchAdornment } from '../common/ClearSearchAdornment';
 
 type ViewMode = 'prs' | 'issues';
 
@@ -1133,6 +1134,12 @@ const PrBreakdownView: React.FC<{ githubId: string }> = ({ githubId }) => {
               }}
             />
           </InputAdornment>
+        ),
+        endAdornment: (
+          <ClearSearchAdornment
+            visible={Boolean(searchQuery)}
+            onClear={() => setSearchQuery('')}
+          />
         ),
       }}
       sx={{


### PR DESCRIPTION
## Summary

Adds the shared `ClearSearchAdornment` to the Score Breakdown PR search field on the miner profile **Overview** tab (`MinerScoreBreakdown`), so users get a one-click clear control when the field has text—aligned with `MinerPRsTable`, `MinerRepositoriesTable`, and other search fields. Clearing only resets the query; the existing `searchQuery` effect continues to drop `scorePage` from the URL.

## Related Issues

Closes #1054

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Testing

- [ ] Tests added/updated *(none required for this small UI parity change; add if you have a component test harness for search fields.)*
- [x] Manual testing: open a miner with PRs in score breakdown → Overview → type in search → confirm clear icon appears and clears text; confirm pagination/URL behavior unchanged after clear.

## Checklist

- [x] Code style / lint clean for touched files
- [x] Self-review completed
- [ ] Documentation updated *(not applicable)*