### PR TITLE
 refactor:miner-issue-repo-section

### DIFF
--- a/src/components/miners/MinerIssueRepoSection.tsx
+++ b/src/components/miners/MinerIssueRepoSection.tsx
@@ -1,0 +1,612 @@
+import React, { useCallback, useMemo, useState } from 'react';
+import { formatDistanceToNow } from 'date-fns';
+import {
+  Avatar,
+  Box,
+  Card,
+  Chip,
+  Collapse,
+  InputAdornment,
+  TextField,
+  Tooltip,
+  Typography,
+  alpha,
+  useTheme,
+} from '@mui/material';
+import {
+  ExpandMore as ExpandMoreIcon,
+  Search as SearchIcon,
+} from '@mui/icons-material';
+import { getRepositoryOwnerAvatarSrc, paginateItems } from '../../utils';
+import { DataTable, type DataTableColumn } from '../common/DataTable';
+import { ClearSearchAdornment } from '../common/ClearSearchAdornment';
+import ExplorerFilterButton from './ExplorerFilterButton';
+import TablePagination from './TablePagination';
+import { type RepositoryIssue } from '../../api/models/Miner';
+
+export type IssueFilter = 'all' | 'open' | 'solved' | 'closed';
+export type IssueSortField = 'number' | 'repository' | 'opened';
+export type SortDir = 'asc' | 'desc';
+
+const PAGE_SIZE = 20;
+
+const DEFAULT_SORT_DIR: Record<IssueSortField, SortDir> = {
+  number: 'desc',
+  repository: 'asc',
+  opened: 'desc',
+};
+
+const isOpenIssue = (i: RepositoryIssue) => !i.closedAt;
+const isSolvedIssue = (i: RepositoryIssue) =>
+  !!i.closedAt && i.prNumber != null;
+const isClosedIssue = (i: RepositoryIssue) =>
+  !!i.closedAt && i.prNumber == null;
+
+export const githubIssueUrl = (issue: RepositoryIssue) =>
+  issue.url ??
+  `https://github.com/${issue.repositoryFullName}/issues/${issue.number}`;
+
+const getIssueCounts = (issues: RepositoryIssue[]) => ({
+  all: issues.length,
+  open: issues.filter(isOpenIssue).length,
+  solved: issues.filter(isSolvedIssue).length,
+  closed: issues.filter(isClosedIssue).length,
+});
+
+const applyIssueFilter = (
+  issues: RepositoryIssue[],
+  filter: IssueFilter,
+  search: string,
+  sortField: IssueSortField,
+  sortDir: SortDir,
+): RepositoryIssue[] => {
+  let result = issues;
+  if (filter === 'open') result = result.filter(isOpenIssue);
+  else if (filter === 'solved') result = result.filter(isSolvedIssue);
+  else if (filter === 'closed') result = result.filter(isClosedIssue);
+  const q = search.trim().toLowerCase();
+  if (q) {
+    result = result.filter(
+      (i) =>
+        i.title.toLowerCase().includes(q) ||
+        i.repositoryFullName.toLowerCase().includes(q) ||
+        String(i.number).includes(q),
+    );
+  }
+  return [...result].sort((a, b) => {
+    let cmp = 0;
+    if (sortField === 'number') cmp = a.number - b.number;
+    else if (sortField === 'repository')
+      cmp = a.repositoryFullName.localeCompare(b.repositoryFullName);
+    else cmp = (a.createdAt ?? '').localeCompare(b.createdAt ?? '');
+    return sortDir === 'asc' ? cmp : -cmp;
+  });
+};
+
+type LayoutInline = {
+  layout: 'inline';
+  toolbarTitle: string;
+  stickyHeader?: boolean;
+};
+
+type LayoutCollapsible = {
+  layout: 'collapsible';
+  summaryTitle: string;
+  initialExpanded?: boolean;
+};
+
+export type MinerIssueRepoSectionProps = {
+  issues: RepositoryIssue[];
+  isLoading: boolean;
+  getRowKey: (issue: RepositoryIssue) => string;
+  toolbarSubtitle?: string;
+  emptyWhenNoIssues: React.ReactNode;
+  emptyWhenFiltered: React.ReactNode;
+} & (LayoutInline | LayoutCollapsible);
+
+const useIssueRepoColumns = (): DataTableColumn<
+  RepositoryIssue,
+  IssueSortField
+>[] =>
+  useMemo(
+    () => [
+      {
+        key: 'number',
+        header: (
+          <>
+            <Box
+              component="span"
+              sx={{ display: { xs: 'none', sm: 'inline' } }}
+            >
+              Issue{' '}
+            </Box>
+            #
+          </>
+        ),
+        width: '9%',
+        sortKey: 'number',
+        headerSx: { verticalAlign: 'middle', whiteSpace: 'nowrap' },
+        cellSx: { fontSize: { xs: '0.75rem', sm: '0.85rem' } },
+        renderCell: (issue) => (
+          <a
+            href={githubIssueUrl(issue)}
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{
+              color: 'inherit',
+              textDecoration: 'none',
+              fontWeight: 500,
+            }}
+            onClick={(e) => e.stopPropagation()}
+          >
+            #{issue.number}
+          </a>
+        ),
+      },
+      {
+        key: 'title',
+        header: 'Title',
+        width: '38%',
+        headerSx: { verticalAlign: 'middle' },
+        cellSx: { fontSize: { xs: '0.75rem', sm: '0.85rem' } },
+        renderCell: (issue) => (
+          <Tooltip title={issue.title} placement="bottom" arrow>
+            <Box
+              sx={{
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+              }}
+            >
+              {issue.title}
+            </Box>
+          </Tooltip>
+        ),
+      },
+      {
+        key: 'repository',
+        header: 'Repository',
+        width: '20%',
+        sortKey: 'repository',
+        headerSx: { verticalAlign: 'middle' },
+        renderCell: (issue) => {
+          const owner = issue.repositoryFullName.split('/')[0];
+          return (
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 1.5,
+                overflow: 'hidden',
+              }}
+            >
+              <Avatar
+                src={getRepositoryOwnerAvatarSrc(owner)}
+                alt={owner}
+                sx={{
+                  width: 20,
+                  height: 20,
+                  flexShrink: 0,
+                  border: '1px solid',
+                  borderColor: 'border.medium',
+                }}
+              />
+              <Tooltip
+                title={issue.repositoryFullName}
+                placement="bottom"
+                arrow
+              >
+                <Box
+                  component="span"
+                  sx={{ wordBreak: 'break-word', lineHeight: 1.3 }}
+                >
+                  {issue.repositoryFullName}
+                </Box>
+              </Tooltip>
+            </Box>
+          );
+        },
+      },
+      {
+        key: 'linked_pr',
+        header: 'Linked PR',
+        width: '14%',
+        headerSx: { verticalAlign: 'middle' },
+        renderCell: (issue) =>
+          issue.prNumber != null ? (
+            <a
+              href={`https://github.com/${issue.repositoryFullName}/pull/${issue.prNumber}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{ textDecoration: 'none' }}
+              onClick={(e) => e.stopPropagation()}
+            >
+              <Chip
+                size="small"
+                label={`PR #${issue.prNumber}`}
+                sx={{
+                  height: 20,
+                  fontSize: '0.72rem',
+                  cursor: 'pointer',
+                  bgcolor: (t) => alpha(t.palette.success.main, 0.14),
+                  color: 'success.light',
+                  borderColor: (t) => alpha(t.palette.success.main, 0.35),
+                  '& .MuiChip-label': { px: 1 },
+                  '&:hover': {
+                    bgcolor: (t) => alpha(t.palette.success.main, 0.25),
+                  },
+                }}
+                variant="outlined"
+              />
+            </a>
+          ) : (
+            <Chip
+              size="small"
+              label="No PR yet"
+              sx={{
+                height: 20,
+                fontSize: '0.72rem',
+                bgcolor: (t) => alpha(t.palette.warning.main, 0.1),
+                color: (t) => alpha(t.palette.warning.light, 0.75),
+                borderColor: (t) => alpha(t.palette.warning.main, 0.25),
+                '& .MuiChip-label': { px: 1 },
+              }}
+              variant="outlined"
+            />
+          ),
+      },
+      {
+        key: 'opened',
+        header: 'Opened',
+        width: '19%',
+        align: 'right',
+        sortKey: 'opened',
+        headerSx: { verticalAlign: 'middle' },
+        cellSx: {
+          fontSize: { xs: '0.75rem', sm: '0.85rem' },
+          color: (t) => alpha(t.palette.text.primary, 0.7),
+        },
+        renderCell: (issue) =>
+          issue.createdAt ? (
+            <Tooltip
+              title={new Date(issue.createdAt).toLocaleDateString()}
+              placement="bottom"
+              arrow
+            >
+              <span style={{ cursor: 'default' }}>
+                {formatDistanceToNow(new Date(issue.createdAt), {
+                  addSuffix: true,
+                })}
+              </span>
+            </Tooltip>
+          ) : null,
+      },
+    ],
+    [],
+  );
+
+export const MinerIssueRepoSection: React.FC<MinerIssueRepoSectionProps> = (
+  props,
+) => {
+  const theme = useTheme();
+  const { issues, isLoading, getRowKey, emptyWhenNoIssues, emptyWhenFiltered } =
+    props;
+
+  const [filter, setFilter] = useState<IssueFilter>('all');
+  const [search, setSearch] = useState('');
+  const [sortField, setSortField] = useState<IssueSortField>('opened');
+  const [sortDir, setSortDir] = useState<SortDir>('desc');
+  const [page, setPage] = useState(0);
+  const [expanded, setExpanded] = useState(
+    props.layout === 'collapsible' ? Boolean(props.initialExpanded) : true,
+  );
+
+  const handleSort = useCallback(
+    (field: IssueSortField) => {
+      if (sortField === field) {
+        setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
+      } else {
+        setSortField(field);
+        setSortDir(DEFAULT_SORT_DIR[field]);
+      }
+      setPage(0);
+    },
+    [sortField],
+  );
+
+  const handleRowClick = useCallback((issue: RepositoryIssue) => {
+    window.open(githubIssueUrl(issue), '_blank', 'noopener,noreferrer');
+  }, []);
+
+  const filtered = useMemo(
+    () => applyIssueFilter(issues, filter, search, sortField, sortDir),
+    [issues, filter, search, sortField, sortDir],
+  );
+
+  const paged = useMemo(
+    () => paginateItems(filtered, page, PAGE_SIZE),
+    [filtered, page],
+  );
+
+  const totalPages = Math.ceil(filtered.length / PAGE_SIZE);
+  const counts = useMemo(() => getIssueCounts(issues), [issues]);
+  const sectionHasFilters = filter !== 'all' || search.trim() !== '';
+
+  const columns = useIssueRepoColumns();
+
+  const toolbarTitle = props.layout === 'inline' ? props.toolbarTitle : null;
+  const toolbarSubtitle = props.toolbarSubtitle;
+  const stickyHeader =
+    props.layout === 'inline' ? Boolean(props.stickyHeader) : false;
+
+  const toolbar = (
+    <Box
+      sx={{
+        p: { xs: 2, sm: 3 },
+        borderBottom: '1px solid',
+        borderColor: 'border.light',
+      }}
+    >
+      {toolbarTitle != null && (
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'baseline',
+            gap: 1.5,
+            mb: toolbarSubtitle ? 0.75 : 2,
+          }}
+        >
+          <Typography
+            variant="h6"
+            sx={{
+              color: 'text.primary',
+              fontSize: { xs: '0.95rem', sm: '1.1rem' },
+            }}
+          >
+            {toolbarTitle}
+          </Typography>
+          <Typography
+            sx={{
+              color: (t) => alpha(t.palette.text.primary, 0.5),
+              fontSize: '0.75rem',
+            }}
+          >
+            ({filtered.length}
+            {sectionHasFilters ? ` of ${issues.length}` : ''})
+          </Typography>
+        </Box>
+      )}
+
+      {toolbarSubtitle && (
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+          {toolbarSubtitle}
+        </Typography>
+      )}
+
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: { xs: 'column', sm: 'row' },
+          alignItems: { xs: 'stretch', sm: 'center' },
+          gap: { xs: 1.25, sm: 1 },
+          flexWrap: 'wrap',
+        }}
+      >
+        <TextField
+          size="small"
+          placeholder="Search by title, repo, or issue #..."
+          value={search}
+          onChange={(e) => {
+            setSearch(e.target.value);
+            setPage(0);
+          }}
+          InputProps={{
+            startAdornment: (
+              <InputAdornment position="start">
+                <SearchIcon
+                  sx={{
+                    color: (t) => alpha(t.palette.text.primary, 0.3),
+                    fontSize: '1rem',
+                  }}
+                />
+              </InputAdornment>
+            ),
+            endAdornment: (
+              <ClearSearchAdornment
+                visible={Boolean(search)}
+                onClear={() => {
+                  setSearch('');
+                  setPage(0);
+                }}
+              />
+            ),
+          }}
+          sx={{
+            width: { xs: '100%', sm: 'auto' },
+            maxWidth: { xs: '100%', sm: 400 },
+            minWidth: { xs: 0, sm: 350 },
+            '& .MuiOutlinedInput-root': {
+              fontSize: '0.8rem',
+              color: 'text.primary',
+              backgroundColor: 'surface.subtle',
+              borderRadius: 2,
+              '& fieldset': { borderColor: 'border.light' },
+              '&:hover fieldset': { borderColor: 'border.medium' },
+              '&.Mui-focused fieldset': { borderColor: 'primary.main' },
+            },
+          }}
+        />
+
+        <Box
+          sx={{
+            display: 'flex',
+            gap: { xs: 0.75, sm: 0.5 },
+            flexWrap: 'wrap',
+            ml: { xs: 0, sm: 'auto' },
+            width: { xs: '100%', sm: 'auto' },
+            '& > .MuiButton-root': {
+              flex: { xs: 1, sm: 'none' },
+              minWidth: 0,
+            },
+          }}
+        >
+          <ExplorerFilterButton
+            label="All"
+            count={counts.all}
+            color={theme.palette.status.neutral}
+            selected={filter === 'all'}
+            onClick={() => {
+              setFilter('all');
+              setPage(0);
+            }}
+          />
+          <ExplorerFilterButton
+            label="Open"
+            count={counts.open}
+            color={theme.palette.status.open}
+            selected={filter === 'open'}
+            onClick={() => {
+              setFilter('open');
+              setPage(0);
+            }}
+          />
+          <ExplorerFilterButton
+            label="Solved"
+            count={counts.solved}
+            color={theme.palette.status.merged}
+            selected={filter === 'solved'}
+            onClick={() => {
+              setFilter('solved');
+              setPage(0);
+            }}
+          />
+          <ExplorerFilterButton
+            label="Closed"
+            count={counts.closed}
+            color={theme.palette.status.closed}
+            selected={filter === 'closed'}
+            onClick={() => {
+              setFilter('closed');
+              setPage(0);
+            }}
+          />
+        </Box>
+      </Box>
+    </Box>
+  );
+
+  const table = (
+    <DataTable<RepositoryIssue, IssueSortField>
+      columns={columns}
+      rows={paged}
+      getRowKey={getRowKey}
+      isLoading={isLoading}
+      minWidth="700px"
+      stickyHeader={stickyHeader}
+      size="medium"
+      header={toolbar}
+      emptyState={
+        <Box sx={{ px: 3, py: issues.length === 0 ? 2.5 : 6 }}>
+          {issues.length === 0 ? emptyWhenNoIssues : emptyWhenFiltered}
+        </Box>
+      }
+      onRowClick={handleRowClick}
+      sort={{
+        field: sortField,
+        order: sortDir,
+        onChange: handleSort,
+      }}
+      pagination={
+        <TablePagination
+          page={page}
+          totalPages={totalPages}
+          onPageChange={setPage}
+        />
+      }
+    />
+  );
+
+  if (props.layout === 'inline') {
+    return (
+      <Card
+        sx={{
+          p: 0,
+          display: 'flex',
+          flexDirection: 'column',
+          overflow: 'hidden',
+        }}
+        elevation={0}
+      >
+        {table}
+      </Card>
+    );
+  }
+
+  const { summaryTitle } = props;
+
+  return (
+    <Card
+      sx={{
+        p: 0,
+        display: 'flex',
+        flexDirection: 'column',
+        overflow: 'hidden',
+      }}
+      elevation={0}
+    >
+      <Box
+        role="button"
+        tabIndex={0}
+        onClick={() => setExpanded((v) => !v)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            setExpanded((v) => !v);
+          }
+        }}
+        sx={{
+          p: { xs: 2, sm: 3 },
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          cursor: 'pointer',
+          userSelect: 'none',
+          borderBottom: expanded ? '1px solid' : 'none',
+          borderColor: 'border.light',
+          '&:hover': {
+            bgcolor: (t) => alpha(t.palette.common.white, 0.03),
+          },
+        }}
+      >
+        <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 1.5 }}>
+          <Typography
+            variant="h6"
+            sx={{
+              color: 'text.primary',
+              fontSize: { xs: '0.95rem', sm: '1.1rem' },
+            }}
+          >
+            {summaryTitle}
+          </Typography>
+          <Typography
+            sx={{
+              color: (t) => alpha(t.palette.text.primary, 0.5),
+              fontSize: '0.75rem',
+            }}
+          >
+            ({issues.length})
+          </Typography>
+        </Box>
+        <ExpandMoreIcon
+          sx={{
+            color: 'text.secondary',
+            transition: 'transform 0.2s',
+            transform: expanded ? 'rotate(180deg)' : 'rotate(0deg)',
+          }}
+        />
+      </Box>
+
+      <Collapse in={expanded}>{table}</Collapse>
+    </Card>
+  );
+};

--- a/src/components/miners/MinerOpenDiscoveryIssuesByRepo.tsx
+++ b/src/components/miners/MinerOpenDiscoveryIssuesByRepo.tsx
@@ -1,63 +1,22 @@
-import React, { useState, useMemo, useCallback } from 'react';
-import { formatDistanceToNow } from 'date-fns';
+import React, { useMemo } from 'react';
 import {
   Alert,
-  Avatar,
   Box,
   Button,
   Card,
-  Chip,
   CircularProgress,
-  Collapse,
-  InputAdornment,
-  TextField,
-  Tooltip,
   Typography,
   alpha,
-  useTheme,
 } from '@mui/material';
-import {
-  ExpandMore as ExpandMoreIcon,
-  Search as SearchIcon,
-  OpenInNew as OpenInNewIcon,
-} from '@mui/icons-material';
+import { OpenInNew as OpenInNewIcon } from '@mui/icons-material';
 import { useQuery } from '@tanstack/react-query';
 import { githubFetch, useMinerGithubData, useMinerPRs } from '../../api';
-import { getRepositoryOwnerAvatarSrc, paginateItems } from '../../utils';
-import { DataTable, type DataTableColumn } from '../common/DataTable';
-import { ClearSearchAdornment } from '../common/ClearSearchAdornment';
-import ExplorerFilterButton from './ExplorerFilterButton';
-import TablePagination from './TablePagination';
 import {
   selectMinerIssueScanRepos,
   useMinerRepositoriesOpenIssues,
 } from '../../hooks/useMinerRepositoriesOpenIssues';
 import { type RepositoryIssue } from '../../api/models/Miner';
-
-type IssueFilter = 'all' | 'open' | 'solved' | 'closed';
-type IssueSortField = 'number' | 'repository' | 'opened';
-type SortDir = 'asc' | 'desc';
-
-const PAGE_SIZE = 20;
-
-const DEFAULT_SORT_DIR: Record<IssueSortField, SortDir> = {
-  number: 'desc',
-  repository: 'asc',
-  opened: 'desc',
-};
-
-// Issue is still open
-const isOpenIssue = (i: RepositoryIssue) => !i.closedAt;
-// Issue was closed and has a linked PR (solved by a contributor)
-const isSolvedIssue = (i: RepositoryIssue) =>
-  !!i.closedAt && i.prNumber != null;
-// Issue was closed without a linked PR (rejected, duplicate, etc.)
-const isClosedIssue = (i: RepositoryIssue) =>
-  !!i.closedAt && i.prNumber == null;
-
-const githubIssueUrl = (issue: RepositoryIssue) =>
-  issue.url ??
-  `https://github.com/${issue.repositoryFullName}/issues/${issue.number}`;
+import { MinerIssueRepoSection } from './MinerIssueRepoSection';
 
 const githubSearchIssuesByAuthor = (login: string) =>
   `https://github.com/search?q=${encodeURIComponent(`is:issue author:${login}`)}&type=issues`;
@@ -177,43 +136,6 @@ const fetchGithubIssuesByAuthor = async (
   return enriched;
 };
 
-const getIssueCounts = (issues: RepositoryIssue[]) => ({
-  all: issues.length,
-  open: issues.filter(isOpenIssue).length,
-  solved: issues.filter(isSolvedIssue).length,
-  closed: issues.filter(isClosedIssue).length,
-});
-
-const applyIssueFilter = (
-  issues: RepositoryIssue[],
-  filter: IssueFilter,
-  search: string,
-  sortField: IssueSortField,
-  sortDir: SortDir,
-): RepositoryIssue[] => {
-  let result = issues;
-  if (filter === 'open') result = result.filter(isOpenIssue);
-  else if (filter === 'solved') result = result.filter(isSolvedIssue);
-  else if (filter === 'closed') result = result.filter(isClosedIssue);
-  const q = search.trim().toLowerCase();
-  if (q) {
-    result = result.filter(
-      (i) =>
-        i.title.toLowerCase().includes(q) ||
-        i.repositoryFullName.toLowerCase().includes(q) ||
-        String(i.number).includes(q),
-    );
-  }
-  return [...result].sort((a, b) => {
-    let cmp = 0;
-    if (sortField === 'number') cmp = a.number - b.number;
-    else if (sortField === 'repository')
-      cmp = a.repositoryFullName.localeCompare(b.repositoryFullName);
-    else cmp = (a.createdAt ?? '').localeCompare(b.createdAt ?? '');
-    return sortDir === 'asc' ? cmp : -cmp;
-  });
-};
-
 interface MinerOpenDiscoveryIssuesByRepoProps {
   githubId: string;
 }
@@ -221,27 +143,9 @@ interface MinerOpenDiscoveryIssuesByRepoProps {
 const MinerOpenDiscoveryIssuesByRepo: React.FC<
   MinerOpenDiscoveryIssuesByRepoProps
 > = ({ githubId }) => {
-  const theme = useTheme();
-
   const { data: prs, isLoading: isLoadingPrs } = useMinerPRs(githubId);
   const { data: githubProfile, isLoading: isLoadingGithub } =
     useMinerGithubData(githubId);
-
-  // Mine section state
-  const [mineFilter, setMineFilter] = useState<IssueFilter>('all');
-  const [mineSearch, setMineSearch] = useState('');
-  const [mineSortField, setMineSortField] = useState<IssueSortField>('opened');
-  const [mineSortDir, setMineSortDir] = useState<SortDir>('desc');
-  const [minePage, setMinePage] = useState(0);
-
-  // Other section state
-  const [otherFilter, setOtherFilter] = useState<IssueFilter>('all');
-  const [otherSearch, setOtherSearch] = useState('');
-  const [otherSortField, setOtherSortField] =
-    useState<IssueSortField>('opened');
-  const [otherSortDir, setOtherSortDir] = useState<SortDir>('desc');
-  const [otherPage, setOtherPage] = useState(0);
-  const [otherExpanded, setOtherExpanded] = useState(false);
 
   const scanRepos = useMemo(() => selectMinerIssueScanRepos(prs), [prs]);
   const login = githubProfile?.login ?? '';
@@ -344,591 +248,6 @@ const MinerOpenDiscoveryIssuesByRepo: React.FC<
     reposForGrouping,
   ]);
 
-  const handleMineSort = useCallback(
-    (field: IssueSortField) => {
-      if (mineSortField === field) {
-        setMineSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
-      } else {
-        setMineSortField(field);
-        setMineSortDir(DEFAULT_SORT_DIR[field]);
-      }
-      setMinePage(0);
-    },
-    [mineSortField],
-  );
-
-  const handleOtherSort = useCallback(
-    (field: IssueSortField) => {
-      if (otherSortField === field) {
-        setOtherSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
-      } else {
-        setOtherSortField(field);
-        setOtherSortDir(DEFAULT_SORT_DIR[field]);
-      }
-      setOtherPage(0);
-    },
-    [otherSortField],
-  );
-
-  const handleRowClick = useCallback((issue: RepositoryIssue) => {
-    window.open(githubIssueUrl(issue), '_blank', 'noopener,noreferrer');
-  }, []);
-
-  const filteredMine = useMemo(
-    () =>
-      applyIssueFilter(
-        mineIssues,
-        mineFilter,
-        mineSearch,
-        mineSortField,
-        mineSortDir,
-      ),
-    [mineIssues, mineFilter, mineSearch, mineSortField, mineSortDir],
-  );
-  const filteredOther = useMemo(
-    () =>
-      applyIssueFilter(
-        otherIssues,
-        otherFilter,
-        otherSearch,
-        otherSortField,
-        otherSortDir,
-      ),
-    [otherIssues, otherFilter, otherSearch, otherSortField, otherSortDir],
-  );
-
-  const pagedMine = useMemo(
-    () => paginateItems(filteredMine, minePage, PAGE_SIZE),
-    [filteredMine, minePage],
-  );
-  const pagedOther = useMemo(
-    () => paginateItems(filteredOther, otherPage, PAGE_SIZE),
-    [filteredOther, otherPage],
-  );
-
-  const mineTotalPages = Math.ceil(filteredMine.length / PAGE_SIZE);
-  const otherTotalPages = Math.ceil(filteredOther.length / PAGE_SIZE);
-
-  const mineCounts = useMemo(() => getIssueCounts(mineIssues), [mineIssues]);
-  const otherCounts = useMemo(() => getIssueCounts(otherIssues), [otherIssues]);
-
-  const mineColumns: DataTableColumn<RepositoryIssue, IssueSortField>[] =
-    useMemo(
-      () => [
-        {
-          key: 'number',
-          header: (
-            <>
-              <Box
-                component="span"
-                sx={{ display: { xs: 'none', sm: 'inline' } }}
-              >
-                Issue{' '}
-              </Box>
-              #
-            </>
-          ),
-          width: '9%',
-          sortKey: 'number',
-          headerSx: { verticalAlign: 'middle', whiteSpace: 'nowrap' },
-          cellSx: { fontSize: { xs: '0.75rem', sm: '0.85rem' } },
-          renderCell: (issue) => (
-            // stopPropagation keeps the row's onRowClick from also firing
-            <a
-              href={githubIssueUrl(issue)}
-              target="_blank"
-              rel="noopener noreferrer"
-              style={{
-                color: 'inherit',
-                textDecoration: 'none',
-                fontWeight: 500,
-              }}
-              onClick={(e) => e.stopPropagation()}
-            >
-              #{issue.number}
-            </a>
-          ),
-        },
-        {
-          key: 'title',
-          header: 'Title',
-          width: '38%',
-          headerSx: { verticalAlign: 'middle' },
-          cellSx: { fontSize: { xs: '0.75rem', sm: '0.85rem' } },
-          renderCell: (issue) => (
-            <Tooltip title={issue.title} placement="bottom" arrow>
-              <Box
-                sx={{
-                  overflow: 'hidden',
-                  textOverflow: 'ellipsis',
-                  whiteSpace: 'nowrap',
-                }}
-              >
-                {issue.title}
-              </Box>
-            </Tooltip>
-          ),
-        },
-        {
-          key: 'repository',
-          header: 'Repository',
-          width: '20%',
-          sortKey: 'repository',
-          headerSx: { verticalAlign: 'middle' },
-          renderCell: (issue) => {
-            const owner = issue.repositoryFullName.split('/')[0];
-            return (
-              <Box
-                sx={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: 1.5,
-                  overflow: 'hidden',
-                }}
-              >
-                <Avatar
-                  src={getRepositoryOwnerAvatarSrc(owner)}
-                  alt={owner}
-                  sx={{
-                    width: 20,
-                    height: 20,
-                    flexShrink: 0,
-                    border: '1px solid',
-                    borderColor: 'border.medium',
-                  }}
-                />
-                <Tooltip
-                  title={issue.repositoryFullName}
-                  placement="bottom"
-                  arrow
-                >
-                  <Box
-                    component="span"
-                    sx={{ wordBreak: 'break-word', lineHeight: 1.3 }}
-                  >
-                    {issue.repositoryFullName}
-                  </Box>
-                </Tooltip>
-              </Box>
-            );
-          },
-        },
-        {
-          key: 'linked_pr',
-          header: 'Linked PR',
-          width: '14%',
-          headerSx: { verticalAlign: 'middle' },
-          renderCell: (issue) =>
-            issue.prNumber != null ? (
-              <a
-                href={`https://github.com/${issue.repositoryFullName}/pull/${issue.prNumber}`}
-                target="_blank"
-                rel="noopener noreferrer"
-                style={{ textDecoration: 'none' }}
-                onClick={(e) => e.stopPropagation()}
-              >
-                <Chip
-                  size="small"
-                  label={`PR #${issue.prNumber}`}
-                  sx={{
-                    height: 20,
-                    fontSize: '0.72rem',
-                    cursor: 'pointer',
-                    bgcolor: (t) => alpha(t.palette.success.main, 0.14),
-                    color: 'success.light',
-                    borderColor: (t) => alpha(t.palette.success.main, 0.35),
-                    '& .MuiChip-label': { px: 1 },
-                    '&:hover': {
-                      bgcolor: (t) => alpha(t.palette.success.main, 0.25),
-                    },
-                  }}
-                  variant="outlined"
-                />
-              </a>
-            ) : (
-              <Chip
-                size="small"
-                label="No PR yet"
-                sx={{
-                  height: 20,
-                  fontSize: '0.72rem',
-                  bgcolor: (t) => alpha(t.palette.warning.main, 0.1),
-                  color: (t) => alpha(t.palette.warning.light, 0.75),
-                  borderColor: (t) => alpha(t.palette.warning.main, 0.25),
-                  '& .MuiChip-label': { px: 1 },
-                }}
-                variant="outlined"
-              />
-            ),
-        },
-        {
-          key: 'opened',
-          header: 'Opened',
-          width: '19%',
-          align: 'right',
-          sortKey: 'opened',
-          headerSx: { verticalAlign: 'middle' },
-          cellSx: {
-            fontSize: { xs: '0.75rem', sm: '0.85rem' },
-            color: (t) => alpha(t.palette.text.primary, 0.7),
-          },
-          renderCell: (issue) =>
-            issue.createdAt ? (
-              <Tooltip
-                title={new Date(issue.createdAt).toLocaleDateString()}
-                placement="bottom"
-                arrow
-              >
-                <span style={{ cursor: 'default' }}>
-                  {formatDistanceToNow(new Date(issue.createdAt), {
-                    addSuffix: true,
-                  })}
-                </span>
-              </Tooltip>
-            ) : null,
-        },
-      ],
-      [],
-    );
-
-  const otherColumns: DataTableColumn<RepositoryIssue, IssueSortField>[] =
-    useMemo(
-      () => [
-        {
-          key: 'number',
-          header: (
-            <>
-              <Box
-                component="span"
-                sx={{ display: { xs: 'none', sm: 'inline' } }}
-              >
-                Issue{' '}
-              </Box>
-              #
-            </>
-          ),
-          width: '9%',
-          sortKey: 'number' as IssueSortField,
-          headerSx: { verticalAlign: 'middle', whiteSpace: 'nowrap' },
-          cellSx: { fontSize: { xs: '0.75rem', sm: '0.85rem' } },
-          renderCell: (issue) => (
-            <a
-              href={githubIssueUrl(issue)}
-              target="_blank"
-              rel="noopener noreferrer"
-              style={{
-                color: 'inherit',
-                textDecoration: 'none',
-                fontWeight: 500,
-              }}
-              onClick={(e) => e.stopPropagation()}
-            >
-              #{issue.number}
-            </a>
-          ),
-        },
-        {
-          key: 'title',
-          header: 'Title',
-          width: '38%',
-          headerSx: { verticalAlign: 'middle' },
-          cellSx: { fontSize: { xs: '0.75rem', sm: '0.85rem' } },
-          renderCell: (issue) => (
-            <Tooltip title={issue.title} placement="bottom" arrow>
-              <Box
-                sx={{
-                  overflow: 'hidden',
-                  textOverflow: 'ellipsis',
-                  whiteSpace: 'nowrap',
-                }}
-              >
-                {issue.title}
-              </Box>
-            </Tooltip>
-          ),
-        },
-        {
-          key: 'repository',
-          header: 'Repository',
-          width: '20%',
-          sortKey: 'repository' as IssueSortField,
-          headerSx: { verticalAlign: 'middle' },
-          renderCell: (issue) => {
-            const owner = issue.repositoryFullName.split('/')[0];
-            return (
-              <Box
-                sx={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: 1.5,
-                  overflow: 'hidden',
-                }}
-              >
-                <Avatar
-                  src={getRepositoryOwnerAvatarSrc(owner)}
-                  alt={owner}
-                  sx={{
-                    width: 20,
-                    height: 20,
-                    flexShrink: 0,
-                    border: '1px solid',
-                    borderColor: 'border.medium',
-                  }}
-                />
-                <Tooltip
-                  title={issue.repositoryFullName}
-                  placement="bottom"
-                  arrow
-                >
-                  <Box
-                    component="span"
-                    sx={{ wordBreak: 'break-word', lineHeight: 1.3 }}
-                  >
-                    {issue.repositoryFullName}
-                  </Box>
-                </Tooltip>
-              </Box>
-            );
-          },
-        },
-        {
-          key: 'linked_pr',
-          header: 'Linked PR',
-          width: '14%',
-          headerSx: { verticalAlign: 'middle' },
-          renderCell: (issue) =>
-            issue.prNumber != null ? (
-              <a
-                href={`https://github.com/${issue.repositoryFullName}/pull/${issue.prNumber}`}
-                target="_blank"
-                rel="noopener noreferrer"
-                style={{ textDecoration: 'none' }}
-                onClick={(e) => e.stopPropagation()}
-              >
-                <Chip
-                  size="small"
-                  label={`PR #${issue.prNumber}`}
-                  sx={{
-                    height: 20,
-                    fontSize: '0.72rem',
-                    cursor: 'pointer',
-                    bgcolor: (t) => alpha(t.palette.success.main, 0.14),
-                    color: 'success.light',
-                    borderColor: (t) => alpha(t.palette.success.main, 0.35),
-                    '& .MuiChip-label': { px: 1 },
-                    '&:hover': {
-                      bgcolor: (t) => alpha(t.palette.success.main, 0.25),
-                    },
-                  }}
-                  variant="outlined"
-                />
-              </a>
-            ) : (
-              <Chip
-                size="small"
-                label="No PR yet"
-                sx={{
-                  height: 20,
-                  fontSize: '0.72rem',
-                  bgcolor: (t) => alpha(t.palette.warning.main, 0.1),
-                  color: (t) => alpha(t.palette.warning.light, 0.75),
-                  borderColor: (t) => alpha(t.palette.warning.main, 0.25),
-                  '& .MuiChip-label': { px: 1 },
-                }}
-                variant="outlined"
-              />
-            ),
-        },
-        {
-          key: 'opened',
-          header: 'Opened',
-          width: '19%',
-          align: 'right',
-          sortKey: 'opened' as IssueSortField,
-          headerSx: { verticalAlign: 'middle' },
-          cellSx: {
-            fontSize: { xs: '0.75rem', sm: '0.85rem' },
-            color: (t) => alpha(t.palette.text.primary, 0.7),
-          },
-          renderCell: (issue) =>
-            issue.createdAt ? (
-              <Tooltip
-                title={new Date(issue.createdAt).toLocaleDateString()}
-                placement="bottom"
-                arrow
-              >
-                <span style={{ cursor: 'default' }}>
-                  {formatDistanceToNow(new Date(issue.createdAt), {
-                    addSuffix: true,
-                  })}
-                </span>
-              </Tooltip>
-            ) : null,
-        },
-      ],
-      [],
-    );
-
-  const renderToolbar = (
-    title: string | null,
-    totalIssues: RepositoryIssue[],
-    filteredCount: number,
-    counts: ReturnType<typeof getIssueCounts>,
-    filter: IssueFilter,
-    onFilterChange: (f: IssueFilter) => void,
-    search: string,
-    onSearchChange: (s: string) => void,
-    hasFilters: boolean,
-    subtitle?: string,
-  ) => (
-    <Box
-      sx={{
-        p: { xs: 2, sm: 3 },
-        borderBottom: '1px solid',
-        borderColor: 'border.light',
-      }}
-    >
-      {/* Title row — only when a title is provided */}
-      {title != null && (
-        <Box
-          sx={{
-            display: 'flex',
-            alignItems: 'baseline',
-            gap: 1.5,
-            mb: subtitle ? 0.75 : 2,
-          }}
-        >
-          <Typography
-            variant="h6"
-            sx={{
-              color: 'text.primary',
-              fontSize: { xs: '0.95rem', sm: '1.1rem' },
-            }}
-          >
-            {title}
-          </Typography>
-          <Typography
-            sx={{
-              color: (t) => alpha(t.palette.text.primary, 0.5),
-              fontSize: '0.75rem',
-            }}
-          >
-            ({filteredCount}
-            {hasFilters ? ` of ${totalIssues.length}` : ''})
-          </Typography>
-        </Box>
-      )}
-
-      {/* Subtitle description */}
-      {subtitle && (
-        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-          {subtitle}
-        </Typography>
-      )}
-
-      {/* Search + filters on one line */}
-      <Box
-        sx={{
-          display: 'flex',
-          flexDirection: { xs: 'column', sm: 'row' },
-          alignItems: { xs: 'stretch', sm: 'center' },
-          gap: { xs: 1.25, sm: 1 },
-          flexWrap: 'wrap',
-        }}
-      >
-        <TextField
-          size="small"
-          placeholder="Search by title, repo, or issue #..."
-          value={search}
-          onChange={(e) => onSearchChange(e.target.value)}
-          InputProps={{
-            startAdornment: (
-              <InputAdornment position="start">
-                <SearchIcon
-                  sx={{
-                    color: (t) => alpha(t.palette.text.primary, 0.3),
-                    fontSize: '1rem',
-                  }}
-                />
-              </InputAdornment>
-            ),
-            endAdornment: (
-              <ClearSearchAdornment
-                visible={Boolean(search)}
-                onClear={() => onSearchChange('')}
-              />
-            ),
-          }}
-          sx={{
-            width: { xs: '100%', sm: 'auto' },
-            maxWidth: { xs: '100%', sm: 400 },
-            minWidth: { xs: 0, sm: 350 },
-            '& .MuiOutlinedInput-root': {
-              fontSize: '0.8rem',
-              color: 'text.primary',
-              backgroundColor: 'surface.subtle',
-              borderRadius: 2,
-              '& fieldset': { borderColor: 'border.light' },
-              '&:hover fieldset': { borderColor: 'border.medium' },
-              '&.Mui-focused fieldset': { borderColor: 'primary.main' },
-            },
-          }}
-        />
-
-        <Box
-          sx={{
-            display: 'flex',
-            gap: { xs: 0.75, sm: 0.5 },
-            flexWrap: 'wrap',
-            ml: { xs: 0, sm: 'auto' },
-            width: { xs: '100%', sm: 'auto' },
-            '& > .MuiButton-root': {
-              flex: { xs: 1, sm: 'none' },
-              minWidth: 0,
-            },
-          }}
-        >
-          <ExplorerFilterButton
-            label="All"
-            count={counts.all}
-            color={theme.palette.status.neutral}
-            selected={filter === 'all'}
-            onClick={() => {
-              onFilterChange('all');
-            }}
-          />
-          <ExplorerFilterButton
-            label="Open"
-            count={counts.open}
-            color={theme.palette.status.open}
-            selected={filter === 'open'}
-            onClick={() => {
-              onFilterChange('open');
-            }}
-          />
-          <ExplorerFilterButton
-            label="Solved"
-            count={counts.solved}
-            color={theme.palette.status.merged}
-            selected={filter === 'solved'}
-            onClick={() => {
-              onFilterChange('solved');
-            }}
-          />
-          <ExplorerFilterButton
-            label="Closed"
-            count={counts.closed}
-            color={theme.palette.status.closed}
-            selected={filter === 'closed'}
-            onClick={() => {
-              onFilterChange('closed');
-            }}
-          />
-        </Box>
-      </Box>
-    </Box>
-  );
-
   if (isLoadingPrs || isLoadingGithub) {
     return (
       <Card
@@ -990,11 +309,6 @@ const MinerOpenDiscoveryIssuesByRepo: React.FC<
     isLoadingAuthoredIssues ||
     isFetchingAuthoredIssues ||
     isLoadingAuthoredRepoIssues;
-
-  const mineSectionHasFilters =
-    mineFilter !== 'all' || mineSearch.trim() !== '';
-  const otherSectionHasFilters =
-    otherFilter !== 'all' || otherSearch.trim() !== '';
 
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
@@ -1060,206 +374,61 @@ const MinerOpenDiscoveryIssuesByRepo: React.FC<
         </Alert>
       )}
 
-      {/* Your open discovery issues */}
-      <Card
-        sx={{
-          p: 0,
-          display: 'flex',
-          flexDirection: 'column',
-          overflow: 'hidden',
-        }}
-        elevation={0}
-      >
-        <DataTable<RepositoryIssue, IssueSortField>
-          columns={mineColumns}
-          rows={pagedMine}
-          getRowKey={(issue) => `${issue.repositoryFullName}-${issue.number}`}
-          isLoading={isDataLoading}
-          minWidth="700px"
-          stickyHeader
-          size="medium"
-          header={renderToolbar(
-            'Your open discovery issues',
-            mineIssues,
-            filteredMine.length,
-            mineCounts,
-            mineFilter,
-            (f) => {
-              setMineFilter(f);
-              setMinePage(0);
-            },
-            mineSearch,
-            (s) => {
-              setMineSearch(s);
-              setMinePage(0);
-            },
-            mineSectionHasFilters,
-            'Open issues authored by you in the scanned repositories (discovery index plus GitHub fallback). Use this list to track your own active reports.',
-          )}
-          emptyState={
-            <Box sx={{ px: 3, py: mineIssues.length === 0 ? 2.5 : 6 }}>
-              {mineIssues.length === 0 ? (
-                <Typography color="text.secondary">
-                  No open issues in this index matched your GitHub login as
-                  author. That usually means the API response does not yet
-                  include author fields, or you have no open reports in these
-                  repositories. Use the GitHub button above for a definitive
-                  list.
-                </Typography>
-              ) : (
-                <Typography
-                  sx={{
-                    color: (t) => alpha(t.palette.text.primary, 0.5),
-                    fontSize: '0.9rem',
-                    textAlign: 'center',
-                  }}
-                >
-                  No matching open issues in the scanned repositories.
-                </Typography>
-              )}
-            </Box>
-          }
-          onRowClick={handleRowClick}
-          sort={{
-            field: mineSortField,
-            order: mineSortDir,
-            onChange: handleMineSort,
-          }}
-          pagination={
-            <TablePagination
-              page={minePage}
-              totalPages={mineTotalPages}
-              onPageChange={setMinePage}
-            />
-          }
-        />
-      </Card>
-
-      {/* Other open discovery issues — collapsed by default */}
-      <Card
-        sx={{
-          p: 0,
-          display: 'flex',
-          flexDirection: 'column',
-          overflow: 'hidden',
-        }}
-        elevation={0}
-      >
-        <Box
-          role="button"
-          tabIndex={0}
-          onClick={() => setOtherExpanded((v) => !v)}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter' || e.key === ' ') {
-              e.preventDefault();
-              setOtherExpanded((v) => !v);
-            }
-          }}
-          sx={{
-            p: { xs: 2, sm: 3 },
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'space-between',
-            cursor: 'pointer',
-            userSelect: 'none',
-            borderBottom: otherExpanded ? '1px solid' : 'none',
-            borderColor: 'border.light',
-            '&:hover': {
-              bgcolor: (t) => alpha(t.palette.common.white, 0.03),
-            },
-          }}
-        >
-          <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 1.5 }}>
-            <Typography
-              variant="h6"
-              sx={{
-                color: 'text.primary',
-                fontSize: { xs: '0.95rem', sm: '1.1rem' },
-              }}
-            >
-              Other open discovery issues
-            </Typography>
-            <Typography
-              sx={{
-                color: (t) => alpha(t.palette.text.primary, 0.5),
-                fontSize: '0.75rem',
-              }}
-            >
-              ({otherIssues.length})
-            </Typography>
-          </Box>
-          <ExpandMoreIcon
+      <MinerIssueRepoSection
+        layout="inline"
+        toolbarTitle="Your open discovery issues"
+        toolbarSubtitle="Open issues authored by you in the scanned repositories (discovery index plus GitHub fallback). Use this list to track your own active reports."
+        stickyHeader
+        issues={mineIssues}
+        isLoading={isDataLoading}
+        getRowKey={(issue) => `${issue.repositoryFullName}-${issue.number}`}
+        emptyWhenNoIssues={
+          <Typography color="text.secondary">
+            No open issues in this index matched your GitHub login as author.
+            That usually means the API response does not yet include author
+            fields, or you have no open reports in these repositories. Use the
+            GitHub button above for a definitive list.
+          </Typography>
+        }
+        emptyWhenFiltered={
+          <Typography
             sx={{
-              color: 'text.secondary',
-              transition: 'transform 0.2s',
-              transform: otherExpanded ? 'rotate(180deg)' : 'rotate(0deg)',
+              color: (t) => alpha(t.palette.text.primary, 0.5),
+              fontSize: '0.9rem',
+              textAlign: 'center',
             }}
-          />
-        </Box>
+          >
+            No matching open issues in the scanned repositories.
+          </Typography>
+        }
+      />
 
-        <Collapse in={otherExpanded}>
-          <DataTable<RepositoryIssue, IssueSortField>
-            columns={otherColumns}
-            rows={pagedOther}
-            getRowKey={(issue) =>
-              `other-${issue.repositoryFullName}-${issue.number}`
-            }
-            isLoading={isDataLoading}
-            minWidth="700px"
-            size="medium"
-            header={renderToolbar(
-              null,
-              otherIssues,
-              filteredOther.length,
-              otherCounts,
-              otherFilter,
-              (f) => {
-                setOtherFilter(f);
-                setOtherPage(0);
-              },
-              otherSearch,
-              (s) => {
-                setOtherSearch(s);
-                setOtherPage(0);
-              },
-              otherSectionHasFilters,
-              "Other people's open issues in the same repositories (still part of the discovery index). Useful for triage and collaboration.",
-            )}
-            emptyState={
-              <Box sx={{ px: 3, py: otherIssues.length === 0 ? 2.5 : 6 }}>
-                {otherIssues.length === 0 ? (
-                  <Typography color="text.secondary">
-                    No other open issues in the scanned repositories.
-                  </Typography>
-                ) : (
-                  <Typography
-                    sx={{
-                      color: (t) => alpha(t.palette.text.primary, 0.5),
-                      fontSize: '0.9rem',
-                      textAlign: 'center',
-                    }}
-                  >
-                    No issues match the selected filters.
-                  </Typography>
-                )}
-              </Box>
-            }
-            onRowClick={handleRowClick}
-            sort={{
-              field: otherSortField,
-              order: otherSortDir,
-              onChange: handleOtherSort,
+      <MinerIssueRepoSection
+        layout="collapsible"
+        summaryTitle="Other open discovery issues"
+        toolbarSubtitle="Other people's open issues in the same repositories (still part of the discovery index). Useful for triage and collaboration."
+        issues={otherIssues}
+        isLoading={isDataLoading}
+        getRowKey={(issue) =>
+          `other-${issue.repositoryFullName}-${issue.number}`
+        }
+        emptyWhenNoIssues={
+          <Typography color="text.secondary">
+            No other open issues in the scanned repositories.
+          </Typography>
+        }
+        emptyWhenFiltered={
+          <Typography
+            sx={{
+              color: (t) => alpha(t.palette.text.primary, 0.5),
+              fontSize: '0.9rem',
+              textAlign: 'center',
             }}
-            pagination={
-              <TablePagination
-                page={otherPage}
-                totalPages={otherTotalPages}
-                onPageChange={setOtherPage}
-              />
-            }
-          />
-        </Collapse>
-      </Card>
+          >
+            No issues match the selected filters.
+          </Typography>
+        }
+      />
     </Box>
   );
 };


### PR DESCRIPTION
## Summary

Extracts a shared `MinerIssueRepoSection` component that owns per-section state (filter, search, sort, pagination) and the issue table UI (toolbar, columns, empty states, pagination). `MinerOpenDiscoveryIssuesByRepo` now focuses on data loading and grouping into “mine” vs “other” issues, and renders one inline section (yours) and one collapsible section (other). Removes duplicated column definitions and parallel state machines so toolbar/sort/pagination/empty-state behavior stays in one place.

## Related Issues

<!-- e.g. Fixes #123 or Closes #456 — replace or remove if none -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- `npm run build` — passes (TypeScript + Vite production build).
- Manual: not run in this session; recommend spot-checking Miner open discovery issues: both sections load, filters/search/sort/pagination behave as before, “Other” expand/collapse and counts match prior behavior.

## Screenshots

N/A — behavior and layout intended to match pre-refactor UI.

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [ ] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes (N/A)