### PR TITLE
feat : Standardize miner table pagination and shared pager UX

### DIFF
--- a/src/components/common/TablePagination.tsx
+++ b/src/components/common/TablePagination.tsx
@@ -1,88 +1,473 @@
-import React from 'react';
-import {
-  Box,
-  IconButton,
-  Typography,
-  alpha,
-  type SxProps,
-  type Theme,
-} from '@mui/material';
-import {
-  NavigateBefore as PrevIcon,
-  NavigateNext as NextIcon,
-} from '@mui/icons-material';
+/**
+ * Miner list pagination: URL-backed page/rows (`minerPage` / `minerRows`),
+ * paging helpers, `useMinerExplorerPagination`, and the shared page bar
+ * (Prev / numbers / Next). Overview Score Breakdown uses `scorePage` /
+ * `scoreRows` separately.
+ */
 
-interface TablePaginationProps {
+import React, { memo, useCallback, useEffect, useMemo, useRef } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { Box, Typography, alpha, useTheme, useMediaQuery } from '@mui/material';
+import { West as WestIcon, East as EastIcon } from '@mui/icons-material';
+
+// --- URL + slice helpers ----------------------------------------------------
+
+/** Allowed numeric page sizes (single source of truth for URL + UI). */
+export const MINER_PAGE_SIZES = [5, 10, 20, 50] as const;
+
+export type MinerExplorerNumericRows = (typeof MINER_PAGE_SIZES)[number];
+export type MinerExplorerRowsOption = MinerExplorerNumericRows | 'all';
+
+export const MINER_EXPLORER_ROWS_OPTIONS: readonly MinerExplorerRowsOption[] = [
+  ...MINER_PAGE_SIZES,
+  'all',
+];
+
+const PAGE_SIZE_WHITELIST = new Set<number>(MINER_PAGE_SIZES);
+
+export const DEFAULT_MINER_EXPLORER_ROWS: MinerExplorerRowsOption = 10;
+
+export const MINER_EXPLORER_PAGE_PARAM = 'minerPage';
+export const MINER_EXPLORER_ROWS_PARAM = 'minerRows';
+
+/** @deprecated Old PR tab param — migrated to `minerPage` */
+export const LEGACY_MINER_PAGE_PARAMS = ['prPage'] as const;
+
+export const MINER_EXPLORER_ROWS_SELECT_SX = {
+  color: 'text.primary',
+  backgroundColor: 'background.default',
+  fontSize: '0.8rem',
+  height: '36px',
+  borderRadius: 2,
+  minWidth: '80px',
+  '& fieldset': { borderColor: 'border.light' },
+  '&:hover fieldset': {
+    borderColor: 'border.medium',
+  },
+  '&.Mui-focused fieldset': { borderColor: 'primary.main' },
+  '& .MuiSelect-select': { py: 0.75 },
+} as const;
+
+export function parseMinerExplorerRowsParam(
+  raw: string | null,
+): MinerExplorerRowsOption {
+  if (raw === 'all') return 'all';
+  if (raw == null || raw === '') return DEFAULT_MINER_EXPLORER_ROWS;
+  const n = parseInt(raw, 10);
+  if (Number.isNaN(n)) return DEFAULT_MINER_EXPLORER_ROWS;
+  if (PAGE_SIZE_WHITELIST.has(n)) return n as MinerExplorerNumericRows;
+  return DEFAULT_MINER_EXPLORER_ROWS;
+}
+
+export function parseMinerExplorerPageParam(raw: string | null): number {
+  if (!raw) return 0;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : 0;
+}
+
+export function getMinerExplorerPaging<T>(
+  items: readonly T[],
+  page: number,
+  rows: MinerExplorerRowsOption,
+): {
+  totalPages: number;
+  safePage: number;
+  slice: T[];
+  showPageNav: boolean;
+  pageSize: number;
+  rankOffset: number;
+} {
+  const isAll = rows === 'all';
+  const pageSize = isAll ? Math.max(items.length, 1) : rows;
+  const totalPages = isAll
+    ? 1
+    : Math.max(1, Math.ceil(items.length / pageSize));
+  const safePage = Math.min(page, totalPages - 1);
+  const start = safePage * pageSize;
+  const slice = isAll ? [...items] : items.slice(start, start + pageSize);
+  const showPageNav = !isAll && totalPages > 1;
+  const rankOffset = isAll ? 0 : safePage * pageSize;
+  return { totalPages, safePage, slice, showPageNav, pageSize, rankOffset };
+}
+
+export function stripLegacyMinerPaginationParams(
+  params: URLSearchParams,
+): void {
+  params.delete('prPage');
+}
+
+// --- Hook -------------------------------------------------------------------
+
+type UseMinerExplorerPaginationOptions = {
+  resetKey?: string;
+  totalItemCount: number;
+};
+
+export function useMinerExplorerPagination({
+  resetKey,
+  totalItemCount,
+}: UseMinerExplorerPaginationOptions) {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const rowsPerPage = useMemo(
+    () =>
+      parseMinerExplorerRowsParam(searchParams.get(MINER_EXPLORER_ROWS_PARAM)),
+    [searchParams],
+  );
+
+  const page = useMemo(() => {
+    const primary = searchParams.get(MINER_EXPLORER_PAGE_PARAM);
+    if (primary !== null) return parseMinerExplorerPageParam(primary);
+    for (const key of LEGACY_MINER_PAGE_PARAMS) {
+      const v = searchParams.get(key);
+      if (v !== null) return parseMinerExplorerPageParam(v);
+    }
+    return 0;
+  }, [searchParams]);
+
+  const setPage = useCallback(
+    (updater: number | ((prev: number) => number)) => {
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          let current = parseMinerExplorerPageParam(
+            next.get(MINER_EXPLORER_PAGE_PARAM),
+          );
+          if (next.get(MINER_EXPLORER_PAGE_PARAM) === null) {
+            for (const key of LEGACY_MINER_PAGE_PARAMS) {
+              const v = next.get(key);
+              if (v !== null) {
+                current = parseMinerExplorerPageParam(v);
+                break;
+              }
+            }
+          }
+          const resolved =
+            typeof updater === 'function' ? updater(current) : updater;
+          stripLegacyMinerPaginationParams(next);
+          if (resolved <= 0) next.delete(MINER_EXPLORER_PAGE_PARAM);
+          else next.set(MINER_EXPLORER_PAGE_PARAM, String(resolved));
+          return next;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
+  );
+
+  const setPageRef = useRef(setPage);
+  setPageRef.current = setPage;
+
+  const setRowsPerPage = useCallback(
+    (nextRows: MinerExplorerRowsOption) => {
+      setSearchParams(
+        (prev) => {
+          const p = new URLSearchParams(prev);
+          stripLegacyMinerPaginationParams(p);
+          p.delete(MINER_EXPLORER_PAGE_PARAM);
+          if (nextRows === DEFAULT_MINER_EXPLORER_ROWS)
+            p.delete(MINER_EXPLORER_ROWS_PARAM);
+          else p.set(MINER_EXPLORER_ROWS_PARAM, String(nextRows));
+          return p;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
+  );
+
+  const prevResetKey = useRef(resetKey);
+  useEffect(() => {
+    if (resetKey === undefined) return;
+    if (prevResetKey.current === resetKey) return;
+    prevResetKey.current = resetKey;
+    setPageRef.current(0);
+  }, [resetKey]);
+
+  useEffect(() => {
+    const isAll = rowsPerPage === 'all';
+    const size = isAll ? Math.max(totalItemCount, 1) : rowsPerPage;
+    const totalPages = Math.max(1, Math.ceil(totalItemCount / size));
+    const last = totalPages - 1;
+    if (page > last) setPageRef.current(last);
+  }, [totalItemCount, rowsPerPage, page]);
+
+  return {
+    page,
+    setPage,
+    rowsPerPage,
+    setRowsPerPage,
+  };
+}
+
+// --- Page bar UI ------------------------------------------------------------
+
+/** Pages shown around current when using ellipsis (1 … 4 5 6 … 20). */
+const PAGER_WINDOW_DELTA = 2;
+/** Below this many pages, show every page number (no ellipsis). */
+const PAGER_FULL_LIST_MAX = PAGER_WINDOW_DELTA * 2 + 5;
+
+const PAGER_BUTTON_RESET = {
+  border: 'none',
+  background: 'none',
+  fontFamily: 'inherit',
+  p: 0,
+} as const;
+
+function buildPaginationItems(
+  currentPageOneBased: number,
+  totalPages: number,
+  delta = PAGER_WINDOW_DELTA,
+): Array<number | 'ellipsis'> {
+  if (totalPages <= 1) return [];
+  if (totalPages <= PAGER_FULL_LIST_MAX) {
+    return Array.from({ length: totalPages }, (_, i) => i + 1);
+  }
+  const pages = new Set<number>();
+  pages.add(1);
+  pages.add(totalPages);
+  for (
+    let i = Math.max(1, currentPageOneBased - delta);
+    i <= Math.min(totalPages, currentPageOneBased + delta);
+    i++
+  ) {
+    pages.add(i);
+  }
+  const sorted = [...pages].sort((a, b) => a - b);
+  const result: Array<number | 'ellipsis'> = [];
+  let prev: number | undefined;
+  for (const p of sorted) {
+    if (prev !== undefined && p - prev > 1) {
+      result.push('ellipsis');
+    }
+    result.push(p);
+    prev = p;
+  }
+  return result;
+}
+
+export interface TablePaginationProps {
   page: number;
   totalPages: number;
   onPageChange: (newPage: number) => void;
 }
 
-const navButtonSx: SxProps<Theme> = {
-  p: 0.25,
-  color: (t) => alpha(t.palette.text.primary, 0.6),
-  '&:hover': { color: 'text.primary' },
-  '&.Mui-focusVisible': {
-    backgroundColor: (t) => alpha(t.palette.primary.main, 0.2),
-    outline: '2px solid',
-    outlineColor: 'primary.main',
-    outlineOffset: '-2px',
-    color: 'text.primary',
-  },
-  '&.Mui-disabled': { opacity: 0.3 },
-};
-
-const navIconSx = { fontSize: '1.2rem' };
-
-const TablePagination: React.FC<TablePaginationProps> = ({
+const TablePagination = memo(function TablePagination({
   page,
   totalPages,
   onPageChange,
-}) => {
+}: TablePaginationProps) {
+  const theme = useTheme();
+  const isMobilePager = useMediaQuery(theme.breakpoints.down('sm'));
+  const primary = theme.palette.primary.main;
+  const activeFg =
+    theme.palette.primary.contrastText ?? theme.palette.common.white;
+  const items = useMemo(
+    () => buildPaginationItems(page + 1, totalPages),
+    [page, totalPages],
+  );
+
+  const navSx = (enabled: boolean) => ({
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: 0.25,
+    fontSize: '0.8125rem',
+    fontWeight: 500,
+    color: enabled ? primary : alpha(theme.palette.text.primary, 0.22),
+    cursor: enabled ? 'pointer' : 'default',
+    userSelect: 'none' as const,
+    '&:hover': enabled ? { opacity: 0.88 } : {},
+  });
+
+  const outerBarSx = {
+    py: 1.5,
+    px: 1,
+    borderTop: '1px solid',
+    borderColor: 'border.subtle',
+  } as const;
+
   if (totalPages <= 1) {
     return null;
+  }
+
+  if (isMobilePager) {
+    const canPrev = page > 0;
+    const canNext = page < totalPages - 1;
+    return (
+      <Box sx={outerBarSx}>
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            width: '100%',
+            gap: 1,
+          }}
+        >
+          <Box
+            component="button"
+            type="button"
+            aria-label="Previous page"
+            onClick={() => canPrev && onPageChange(page - 1)}
+            sx={{
+              ...navSx(canPrev),
+              ...PAGER_BUTTON_RESET,
+              flexShrink: 0,
+            }}
+          >
+            <Box
+              sx={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: 0.35,
+              }}
+            >
+              <WestIcon
+                sx={{ fontSize: '1.05rem', color: 'inherit', flexShrink: 0 }}
+              />
+              Prev
+            </Box>
+          </Box>
+
+          <Typography
+            component="span"
+            sx={{
+              fontSize: '0.8125rem',
+              fontWeight: 700,
+              fontVariantNumeric: 'tabular-nums',
+              color: 'text.primary',
+              userSelect: 'none',
+              flexShrink: 0,
+            }}
+          >
+            {page + 1} / {totalPages}
+          </Typography>
+
+          <Box
+            component="button"
+            type="button"
+            aria-label="Next page"
+            onClick={() => canNext && onPageChange(page + 1)}
+            sx={{
+              ...navSx(canNext),
+              ...PAGER_BUTTON_RESET,
+              flexShrink: 0,
+            }}
+          >
+            <Box
+              sx={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: 0.35,
+              }}
+            >
+              Next
+              <EastIcon
+                sx={{ fontSize: '1.05rem', color: 'inherit', flexShrink: 0 }}
+              />
+            </Box>
+          </Box>
+        </Box>
+      </Box>
+    );
   }
 
   return (
     <Box
       sx={{
+        ...outerBarSx,
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
-        gap: 2,
-        py: 1.5,
-        borderTop: '1px solid',
-        borderColor: 'border.subtle',
+        flexWrap: 'wrap',
+        gap: { xs: 0.75, sm: 1 },
       }}
     >
-      <IconButton
-        onClick={() => onPageChange(page - 1)}
-        disabled={page === 0}
+      <Box
+        component="button"
+        type="button"
         aria-label="Previous page"
-        size="small"
-        sx={navButtonSx}
-      >
-        <PrevIcon sx={navIconSx} />
-      </IconButton>
-      <Typography
+        onClick={() => page > 0 && onPageChange(page - 1)}
         sx={{
-          fontSize: '0.75rem',
-          color: (t) => alpha(t.palette.text.primary, 0.5),
+          ...navSx(page > 0),
+          ...PAGER_BUTTON_RESET,
         }}
       >
-        {page + 1} / {totalPages}
-      </Typography>
-      <IconButton
-        onClick={() => onPageChange(page + 1)}
-        disabled={page >= totalPages - 1}
-        aria-label="Next page"
-        size="small"
-        sx={navButtonSx}
+        <WestIcon sx={{ fontSize: '1.1rem', color: 'inherit' }} />
+        Prev
+      </Box>
+
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: { xs: 0.35, sm: 0.5 },
+          mx: { xs: 0.5, sm: 1 },
+        }}
       >
-        <NextIcon sx={navIconSx} />
-      </IconButton>
+        {items.map((item, idx) =>
+          item === 'ellipsis' ? (
+            <Typography
+              key={`ellipsis-${idx}`}
+              component="span"
+              sx={{
+                fontSize: '0.8125rem',
+                color: alpha(theme.palette.text.primary, 0.45),
+                px: 0.25,
+                userSelect: 'none',
+              }}
+            >
+              ...
+            </Typography>
+          ) : (
+            <Box
+              key={item}
+              component="button"
+              type="button"
+              aria-label={`Page ${item}`}
+              aria-current={item === page + 1 ? 'page' : undefined}
+              onClick={() => onPageChange(item - 1)}
+              sx={{
+                ...PAGER_BUTTON_RESET,
+                minWidth: 36,
+                height: 32,
+                px: 1,
+                borderRadius: 1,
+                backgroundColor: item === page + 1 ? primary : 'transparent',
+                color: item === page + 1 ? activeFg : 'text.primary',
+                fontSize: '0.8125rem',
+                fontWeight: item === page + 1 ? 600 : 400,
+                cursor: 'pointer',
+                lineHeight: 1,
+                '&:hover': {
+                  backgroundColor:
+                    item === page + 1
+                      ? primary
+                      : alpha(theme.palette.text.primary, 0.06),
+                },
+              }}
+            >
+              {item}
+            </Box>
+          ),
+        )}
+      </Box>
+
+      <Box
+        component="button"
+        type="button"
+        aria-label="Next page"
+        onClick={() => page < totalPages - 1 && onPageChange(page + 1)}
+        sx={{
+          ...navSx(page < totalPages - 1),
+          ...PAGER_BUTTON_RESET,
+        }}
+      >
+        Next
+        <EastIcon sx={{ fontSize: '1.1rem', color: 'inherit' }} />
+      </Box>
     </Box>
   );
-};
+});
 
 export default TablePagination;

--- a/src/components/common/TablePagination.tsx
+++ b/src/components/common/TablePagination.tsx
@@ -24,7 +24,7 @@ export const MINER_EXPLORER_ROWS_OPTIONS: readonly MinerExplorerRowsOption[] = [
 
 const PAGE_SIZE_WHITELIST = new Set<number>(MINER_PAGE_SIZES);
 
-export const DEFAULT_MINER_EXPLORER_ROWS: MinerExplorerRowsOption = 10;
+export const DEFAULT_MINER_EXPLORER_ROWS: MinerExplorerRowsOption = 20;
 
 export const MINER_EXPLORER_PAGE_PARAM = 'prPage';
 export const MINER_EXPLORER_ROWS_PARAM = 'prRows';
@@ -70,8 +70,6 @@ export function getMinerExplorerPaging<T>(
   safePage: number;
   slice: T[];
   showPageNav: boolean;
-  pageSize: number;
-  rankOffset: number;
 } {
   const isAll = rows === 'all';
   const pageSize = isAll ? Math.max(items.length, 1) : rows;
@@ -82,8 +80,7 @@ export function getMinerExplorerPaging<T>(
   const start = safePage * pageSize;
   const slice = isAll ? [...items] : items.slice(start, start + pageSize);
   const showPageNav = !isAll && totalPages > 1;
-  const rankOffset = isAll ? 0 : safePage * pageSize;
-  return { totalPages, safePage, slice, showPageNav, pageSize, rankOffset };
+  return { totalPages, safePage, slice, showPageNav };
 }
 
 // --- Hook -------------------------------------------------------------------

--- a/src/components/common/TablePagination.tsx
+++ b/src/components/common/TablePagination.tsx
@@ -1,8 +1,7 @@
 /**
- * Miner list pagination: URL-backed page/rows (`minerPage` / `minerRows`),
+ * Miner PRs table pagination: URL-backed page/rows (`prPage` / `prRows`),
  * paging helpers, `useMinerExplorerPagination`, and the shared page bar
- * (Prev / numbers / Next). Overview Score Breakdown uses `scorePage` /
- * `scoreRows` separately.
+ * (Prev / numbers / Next).
  */
 
 import React, { memo, useCallback, useEffect, useMemo, useRef } from 'react';
@@ -27,11 +26,8 @@ const PAGE_SIZE_WHITELIST = new Set<number>(MINER_PAGE_SIZES);
 
 export const DEFAULT_MINER_EXPLORER_ROWS: MinerExplorerRowsOption = 10;
 
-export const MINER_EXPLORER_PAGE_PARAM = 'minerPage';
-export const MINER_EXPLORER_ROWS_PARAM = 'minerRows';
-
-/** @deprecated Old PR tab param — migrated to `minerPage` */
-export const LEGACY_MINER_PAGE_PARAMS = ['prPage'] as const;
+export const MINER_EXPLORER_PAGE_PARAM = 'prPage';
+export const MINER_EXPLORER_ROWS_PARAM = 'prRows';
 
 export const MINER_EXPLORER_ROWS_SELECT_SX = {
   color: 'text.primary',
@@ -90,12 +86,6 @@ export function getMinerExplorerPaging<T>(
   return { totalPages, safePage, slice, showPageNav, pageSize, rankOffset };
 }
 
-export function stripLegacyMinerPaginationParams(
-  params: URLSearchParams,
-): void {
-  params.delete('prPage');
-}
-
 // --- Hook -------------------------------------------------------------------
 
 type UseMinerExplorerPaginationOptions = {
@@ -115,36 +105,22 @@ export function useMinerExplorerPagination({
     [searchParams],
   );
 
-  const page = useMemo(() => {
-    const primary = searchParams.get(MINER_EXPLORER_PAGE_PARAM);
-    if (primary !== null) return parseMinerExplorerPageParam(primary);
-    for (const key of LEGACY_MINER_PAGE_PARAMS) {
-      const v = searchParams.get(key);
-      if (v !== null) return parseMinerExplorerPageParam(v);
-    }
-    return 0;
-  }, [searchParams]);
+  const page = useMemo(
+    () =>
+      parseMinerExplorerPageParam(searchParams.get(MINER_EXPLORER_PAGE_PARAM)),
+    [searchParams],
+  );
 
   const setPage = useCallback(
     (updater: number | ((prev: number) => number)) => {
       setSearchParams(
         (prev) => {
           const next = new URLSearchParams(prev);
-          let current = parseMinerExplorerPageParam(
+          const current = parseMinerExplorerPageParam(
             next.get(MINER_EXPLORER_PAGE_PARAM),
           );
-          if (next.get(MINER_EXPLORER_PAGE_PARAM) === null) {
-            for (const key of LEGACY_MINER_PAGE_PARAMS) {
-              const v = next.get(key);
-              if (v !== null) {
-                current = parseMinerExplorerPageParam(v);
-                break;
-              }
-            }
-          }
           const resolved =
             typeof updater === 'function' ? updater(current) : updater;
-          stripLegacyMinerPaginationParams(next);
           if (resolved <= 0) next.delete(MINER_EXPLORER_PAGE_PARAM);
           else next.set(MINER_EXPLORER_PAGE_PARAM, String(resolved));
           return next;
@@ -163,7 +139,6 @@ export function useMinerExplorerPagination({
       setSearchParams(
         (prev) => {
           const p = new URLSearchParams(prev);
-          stripLegacyMinerPaginationParams(p);
           p.delete(MINER_EXPLORER_PAGE_PARAM);
           if (nextRows === DEFAULT_MINER_EXPLORER_ROWS)
             p.delete(MINER_EXPLORER_ROWS_PARAM);

--- a/src/components/miners/MinerPRsTable.tsx
+++ b/src/components/miners/MinerPRsTable.tsx
@@ -49,7 +49,6 @@ import {
 import MinerTableRowsSelect from './MinerTableRowsSelect';
 import TablePagination, {
   getMinerExplorerPaging,
-  stripLegacyMinerPaginationParams,
   MINER_EXPLORER_PAGE_PARAM,
   useMinerExplorerPagination,
 } from '../common/TablePagination';
@@ -150,7 +149,6 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
           const p = new URLSearchParams(prev);
           if (next === 'all') p.delete('prStatus');
           else p.set('prStatus', next);
-          stripLegacyMinerPaginationParams(p);
           p.delete(MINER_EXPLORER_PAGE_PARAM);
           return p;
         },

--- a/src/components/miners/MinerPRsTable.tsx
+++ b/src/components/miners/MinerPRsTable.tsx
@@ -31,7 +31,6 @@ import {
   getRepositoryOwnerAvatarSrc,
   getPrStatusCounts,
   isOutsideScoringWindow,
-  paginateItems,
   type PrStatusFilter,
 } from '../../utils';
 import {
@@ -47,7 +46,13 @@ import {
   serializePRKey,
   useWatchlist,
 } from '../../hooks/useWatchlist';
-import TablePagination from '../common/TablePagination';
+import MinerTableRowsSelect from './MinerTableRowsSelect';
+import TablePagination, {
+  getMinerExplorerPaging,
+  stripLegacyMinerPaginationParams,
+  MINER_EXPLORER_PAGE_PARAM,
+  useMinerExplorerPagination,
+} from '../common/TablePagination';
 import { formatDate } from '../../utils/format';
 import { tooltipSlotProps } from '../../theme';
 import MinerPrScoreDetail from './MinerPrScoreDetail';
@@ -60,8 +65,6 @@ type PrSortField =
   | 'date'
   | 'watch';
 type SortDir = 'asc' | 'desc';
-
-const PAGE_SIZE = 20;
 
 const PR_STATUS_FILTERS: readonly PrStatusFilter[] = [
   'all',
@@ -140,41 +143,6 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
     setExpandedKeys(new Set());
   }, [githubId]);
 
-  const page = parseInt(searchParams.get('prPage') || '0', 10);
-  const setPage = useCallback(
-    (updater: number | ((prev: number) => number)) => {
-      const next = typeof updater === 'function' ? updater(page) : updater;
-      setSearchParams(
-        (prev) => {
-          const p = new URLSearchParams(prev);
-          if (next === 0) p.delete('prPage');
-          else p.set('prPage', String(next));
-          return p;
-        },
-        { replace: true },
-      );
-    },
-    [page, setSearchParams],
-  );
-
-  // Ref lets the callback read the latest searchQuery without closing over
-  // it (which would re-fire the wrapper's debounce effect on every commit).
-  const searchQueryRef = useRef(searchQuery);
-  useEffect(() => {
-    searchQueryRef.current = searchQuery;
-  });
-
-  // Skip when the wrapper fires with the already-committed value (mount + the
-  // [githubId] reset above) so a deep-linked `?prPage=N` survives.
-  const handleDebouncedSearch = useCallback(
-    (next: string) => {
-      if (next === searchQueryRef.current) return;
-      setSearchQuery(next);
-      setPage(0);
-    },
-    [setPage],
-  );
-
   const setStatusFilter = useCallback(
     (next: PrStatusFilter) => {
       setSearchParams(
@@ -182,26 +150,14 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
           const p = new URLSearchParams(prev);
           if (next === 'all') p.delete('prStatus');
           else p.set('prStatus', next);
-          p.delete('prPage');
+          stripLegacyMinerPaginationParams(p);
+          p.delete(MINER_EXPLORER_PAGE_PARAM);
           return p;
         },
         { replace: true },
       );
     },
     [setSearchParams],
-  );
-
-  const handleSort = useCallback(
-    (field: PrSortField) => {
-      if (sortField === field) {
-        setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
-      } else {
-        setSortField(field);
-        setSortDir(DEFAULT_SORT_DIR[field]);
-      }
-      setPage(0);
-    },
-    [sortField, setPage],
   );
 
   const filteredPRs = useMemo(
@@ -248,12 +204,45 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
     return sorted;
   }, [filteredPRs, sortField, sortDir, isWatched]);
 
-  const pagedPRs = useMemo(
-    () => paginateItems(sortedPRs, page, PAGE_SIZE),
-    [sortedPRs, page],
+  const { page, setPage, rowsPerPage, setRowsPerPage } =
+    useMinerExplorerPagination({
+      resetKey: githubId,
+      totalItemCount: sortedPRs.length,
+    });
+
+  const paging = useMemo(
+    () => getMinerExplorerPaging(sortedPRs, page, rowsPerPage),
+    [sortedPRs, page, rowsPerPage],
   );
 
-  const totalPages = Math.ceil(sortedPRs.length / PAGE_SIZE);
+  const { slice: pagedPRs, totalPages, safePage, showPageNav } = paging;
+
+  const searchQueryRef = useRef(searchQuery);
+  useEffect(() => {
+    searchQueryRef.current = searchQuery;
+  });
+
+  const handleDebouncedSearch = useCallback(
+    (next: string) => {
+      if (next === searchQueryRef.current) return;
+      setSearchQuery(next);
+      setPage(0);
+    },
+    [setPage],
+  );
+
+  const handleSort = useCallback(
+    (field: PrSortField) => {
+      if (sortField === field) {
+        setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
+      } else {
+        setSortField(field);
+        setSortDir(DEFAULT_SORT_DIR[field]);
+      }
+      setPage(0);
+    },
+    [sortField, setPage],
+  );
 
   // Count over the search + author scope (excluding the active status filter)
   // so each button reflects what the user would see if they clicked it.
@@ -616,52 +605,70 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
         </Box>
       </Box>
 
-      <DebouncedSearchInput
-        initialDraft={searchQuery}
-        onDebouncedChange={handleDebouncedSearch}
+      <Box
+        sx={{
+          mt: 2,
+          display: 'flex',
+          flexDirection: 'row',
+          alignItems: 'center',
+          flexWrap: 'nowrap',
+          gap: 2,
+          width: '100%',
+          minWidth: 0,
+        }}
       >
-        {({ draftValue, setDraftValue }) => (
-          <TextField
-            size="small"
-            placeholder="Search by title, repo, or PR number..."
-            value={draftValue}
-            onChange={(e) => setDraftValue(e.target.value)}
-            InputProps={{
-              startAdornment: (
-                <InputAdornment position="start">
-                  <SearchIcon
-                    sx={{
-                      color: (t) => alpha(t.palette.text.primary, 0.3),
-                      fontSize: '1rem',
-                    }}
+        <MinerTableRowsSelect
+          value={rowsPerPage}
+          onChange={setRowsPerPage}
+          id="miner-prs-rows"
+        />
+        <DebouncedSearchInput
+          initialDraft={searchQuery}
+          onDebouncedChange={handleDebouncedSearch}
+        >
+          {({ draftValue, setDraftValue }) => (
+            <TextField
+              size="small"
+              placeholder="Search by title, repo, or PR number..."
+              value={draftValue}
+              onChange={(e) => setDraftValue(e.target.value)}
+              InputProps={{
+                startAdornment: (
+                  <InputAdornment position="start">
+                    <SearchIcon
+                      sx={{
+                        color: (t) => alpha(t.palette.text.primary, 0.3),
+                        fontSize: '1rem',
+                      }}
+                    />
+                  </InputAdornment>
+                ),
+                endAdornment: (
+                  <ClearSearchAdornment
+                    visible={Boolean(draftValue)}
+                    onClear={() => setDraftValue('')}
                   />
-                </InputAdornment>
-              ),
-              endAdornment: (
-                <ClearSearchAdornment
-                  visible={Boolean(draftValue)}
-                  onClear={() => setDraftValue('')}
-                />
-              ),
-            }}
-            sx={{
-              mt: 2,
-              width: { xs: '100%', sm: 'auto' },
-              maxWidth: { xs: '100%', sm: 400 },
-              minWidth: { xs: 0, sm: 350 },
-              '& .MuiOutlinedInput-root': {
-                fontSize: '0.8rem',
-                color: 'text.primary',
-                backgroundColor: 'surface.subtle',
-                borderRadius: 2,
-                '& fieldset': { borderColor: 'border.light' },
-                '&:hover fieldset': { borderColor: 'border.medium' },
-                '&.Mui-focused fieldset': { borderColor: 'primary.main' },
-              },
-            }}
-          />
-        )}
-      </DebouncedSearchInput>
+                ),
+              }}
+              sx={{
+                flex: 1,
+                minWidth: 0,
+                width: 'auto',
+                maxWidth: { xs: '100%', sm: 480 },
+                '& .MuiOutlinedInput-root': {
+                  fontSize: '0.8rem',
+                  color: 'text.primary',
+                  backgroundColor: 'surface.subtle',
+                  borderRadius: 2,
+                  '& fieldset': { borderColor: 'border.light' },
+                  '&:hover fieldset': { borderColor: 'border.medium' },
+                  '&.Mui-focused fieldset': { borderColor: 'primary.main' },
+                },
+              }}
+            />
+          )}
+        </DebouncedSearchInput>
+      </Box>
     </Box>
   );
 
@@ -724,11 +731,13 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
           onChange: handleSort,
         }}
         pagination={
-          <TablePagination
-            page={page}
-            totalPages={totalPages}
-            onPageChange={setPage}
-          />
+          showPageNav ? (
+            <TablePagination
+              page={safePage}
+              totalPages={totalPages}
+              onPageChange={setPage}
+            />
+          ) : null
         }
       />
     </Card>

--- a/src/components/miners/MinerTableRowsSelect.tsx
+++ b/src/components/miners/MinerTableRowsSelect.tsx
@@ -12,7 +12,7 @@ export interface MinerTableRowsSelectProps {
   id?: string;
 }
 
-/** Rows-per-page control for table header toolbars (miner PR / repos tables). */
+/** Rows-per-page control for the Miner PRs table header toolbar. */
 const MinerTableRowsSelect: React.FC<MinerTableRowsSelectProps> = ({
   value,
   onChange,

--- a/src/components/miners/MinerTableRowsSelect.tsx
+++ b/src/components/miners/MinerTableRowsSelect.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { Box, FormControl, MenuItem, Select, Typography } from '@mui/material';
+import {
+  MINER_EXPLORER_ROWS_OPTIONS,
+  MINER_EXPLORER_ROWS_SELECT_SX,
+  type MinerExplorerRowsOption,
+} from '../common/TablePagination';
+
+export interface MinerTableRowsSelectProps {
+  value: MinerExplorerRowsOption;
+  onChange: (next: MinerExplorerRowsOption) => void;
+  id?: string;
+}
+
+/** Rows-per-page control for table header toolbars (miner PR / repos tables). */
+const MinerTableRowsSelect: React.FC<MinerTableRowsSelectProps> = ({
+  value,
+  onChange,
+  id = 'miner-table-rows',
+}) => (
+  <FormControl size="small" sx={{ flexShrink: 0 }}>
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+      <Typography
+        variant="body2"
+        sx={{ color: 'text.secondary', fontSize: '0.8rem' }}
+      >
+        Rows:
+      </Typography>
+      <Select
+        id={id}
+        aria-label="Rows per page"
+        value={value === 'all' ? 'all' : value}
+        onChange={(e) => {
+          const v = e.target.value;
+          onChange(
+            v === 'all' ? 'all' : (Number(v) as MinerExplorerRowsOption),
+          );
+        }}
+        sx={MINER_EXPLORER_ROWS_SELECT_SX}
+      >
+        {MINER_EXPLORER_ROWS_OPTIONS.filter((o) => o !== 'all').map((n) => (
+          <MenuItem key={n} value={n}>
+            {n}
+          </MenuItem>
+        ))}
+        <MenuItem value="all">All</MenuItem>
+      </Select>
+    </Box>
+  </FormControl>
+);
+
+export default MinerTableRowsSelect;


### PR DESCRIPTION
## Summary

- Add URL-backed pagination to the Miner PRs table (``prPage`` / ``prRows``), including a rows-per-page selector.
- Add shared responsive pager UI.
- Centralize pagination helpers and hook in ``TablePagination.tsx``.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

### Before
[Before.webm](https://github.com/user-attachments/assets/bbf6b319-c9ba-4b36-80bd-b1a760ad8285)

-------------------------------------------------------------------------------------
### After
[After.webm](https://github.com/user-attachments/assets/81a3e2f7-24bb-4491-8470-3929add0278a)

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
