### PR TITLE
fix(discoveries): sort Credibility column by issue credibility

### DIFF
--- a/src/components/leaderboard/TopMinersTable.tsx
+++ b/src/components/leaderboard/TopMinersTable.tsx
@@ -172,11 +172,12 @@ const passesSingleProgramEligibility = (
   filter === 'all' ||
   (filter === 'eligible' ? Boolean(miner.isEligible) : !miner.isEligible);
 
-const compareMiners = (
+export const compareMiners = (
   a: MinerStats,
   b: MinerStats,
   option: SortOption,
   isWatched: (key: string) => boolean,
+  variant: LeaderboardVariant = 'oss',
 ): number => {
   switch (option) {
     case 'totalScore':
@@ -191,8 +192,21 @@ const compareMiners = (
       return (
         Number(a.issueDiscoveryScore ?? 0) - Number(b.issueDiscoveryScore ?? 0)
       );
-    case 'credibility':
-      return (a.credibility ?? 0) - (b.credibility ?? 0);
+    case 'credibility': {
+      // The Discoveries variant displays issue credibility on each card
+      // (MinerCard chooses issueCredibility when isDiscoveries), so the
+      // sort needs to read the same field for the column to match the UI.
+      // Other variants keep PR credibility.
+      const credA =
+        variant === 'discoveries'
+          ? (a.issueCredibility ?? 0)
+          : (a.credibility ?? 0);
+      const credB =
+        variant === 'discoveries'
+          ? (b.issueCredibility ?? 0)
+          : (b.credibility ?? 0);
+      return credA - credB;
+    }
     case 'watch':
       return compareByWatchlist(a, b, (m) => m.githubId, isWatched);
     default:
@@ -321,9 +335,9 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
   const rankedMiners = useMemo(() => {
     const dir = sortDirection === 'asc' ? 1 : -1;
     return [...miners]
-      .sort((a, b) => compareMiners(a, b, sortOption, isWatched) * dir)
+      .sort((a, b) => compareMiners(a, b, sortOption, isWatched, variant) * dir)
       .map((miner, index) => ({ ...miner, rank: index + 1 }));
-  }, [miners, sortOption, sortDirection, isWatched]);
+  }, [miners, sortOption, sortDirection, isWatched, variant]);
 
   const filteredMiners = useMemo(() => {
     let result = rankedMiners;

--- a/src/tests/topMinersSort.test.ts
+++ b/src/tests/topMinersSort.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { compareMiners } from '../components/leaderboard/TopMinersTable';
+import type { MinerStats } from '../components/leaderboard/types';
+
+const baseMiner = (overrides: Partial<MinerStats>): MinerStats => ({
+  id: overrides.id ?? '0',
+  githubId: overrides.githubId ?? '',
+  totalScore: 0,
+  baseTotalScore: 0,
+  totalPRs: 0,
+  linesChanged: 0,
+  linesAdded: 0,
+  linesDeleted: 0,
+  hotkey: 'N/A',
+  ...overrides,
+});
+
+const noWatch = () => false;
+
+describe('compareMiners credibility sort', () => {
+  it('uses PR credibility on the OSS variant', () => {
+    const high = baseMiner({ id: 'h', credibility: 0.95, issueCredibility: 0 });
+    const low = baseMiner({ id: 'l', credibility: 0.5, issueCredibility: 1 });
+
+    // OSS variant should rank by credibility, not issueCredibility,
+    // so `high` (credibility 0.95) outranks `low` (credibility 0.5).
+    expect(
+      compareMiners(high, low, 'credibility', noWatch, 'oss'),
+    ).toBeGreaterThan(0);
+  });
+
+  it('uses issue credibility on the Discoveries variant', () => {
+    // On the Discoveries page MinerCard renders issueCredibility, so the
+    // Credibility column must sort by the same field.
+    const a = baseMiner({ id: 'a', credibility: 0.5, issueCredibility: 0.9 });
+    const b = baseMiner({ id: 'b', credibility: 0.95, issueCredibility: 0.4 });
+
+    expect(
+      compareMiners(a, b, 'credibility', noWatch, 'discoveries'),
+    ).toBeGreaterThan(0);
+  });
+
+  it('treats missing credibility as 0 on either variant', () => {
+    const populated = baseMiner({
+      id: 'p',
+      credibility: 0.7,
+      issueCredibility: 0.7,
+    });
+    const empty = baseMiner({ id: 'e' });
+
+    expect(
+      compareMiners(populated, empty, 'credibility', noWatch, 'oss'),
+    ).toBeGreaterThan(0);
+    expect(
+      compareMiners(populated, empty, 'credibility', noWatch, 'discoveries'),
+    ).toBeGreaterThan(0);
+  });
+
+  it('defaults to the OSS comparator when no variant is supplied', () => {
+    const a = baseMiner({ id: 'a', credibility: 0.9, issueCredibility: 0.1 });
+    const b = baseMiner({ id: 'b', credibility: 0.1, issueCredibility: 0.9 });
+
+    expect(compareMiners(a, b, 'credibility', noWatch)).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

On the Discoveries leaderboard the **Credibility** column never produces
a real ordering: each `MinerCard` already displays `issueCredibility`
(selected via the `isDiscoveries` branch), but the comparator in
`TopMinersTable` sorts by `miner.credibility` instead. `DiscoveriesPage`'s
local stats mapping never populates `credibility`, so every row ties
at `0` and the sort has no visible effect — confirmed by the reporter's
screenshots in #787 (issue 4).

This PR passes the `LeaderboardVariant` into `compareMiners` and reads
`issueCredibility` on the `discoveries` variant so the sort key matches
the displayed value. OSS and Watchlist variants keep reading
`credibility` unchanged.

Adds 4 new vitest cases in `src/tests/topMinersSort.test.ts` covering
both variants and the missing-data fallback, mirroring the existing
`src/tests/watchlistSort.test.ts` pattern.

## What changed

- `src/components/leaderboard/TopMinersTable.tsx`: `compareMiners`
  exported and accepts an optional `variant` parameter (defaults to
  `'oss'` so any future caller stays at parity with current behavior).
  The `case 'credibility':` branch now reads `issueCredibility` when
  `variant === 'discoveries'`. The `useMemo` deps for `rankedMiners`
  pick up `variant`.
- `src/tests/topMinersSort.test.ts` (new): 4 unit tests covering OSS
  variant, Discoveries variant, missing-data fallback, and the default
  parameter.

## Verification

- `npm run test` — 79 tests, 5 files, all passing.
- `npm run build` — TypeScript + Vite, no errors.
- `npm run lint` — no warnings.
- `npm run format:check` — clean.

## Scope

Closes part of #787 — specifically issue 4 ("Sort by Credibility not
working on Discoveries page"). The other three bugs in #787
(Open/Closed filter case, duplicate issue rows, mobile table layout)
are intentionally left to a focused follow-up rather than bundled
here. Bug 1 in particular doesn't reproduce against the current
`RepositoryIssuesTable.tsx`, which already filters on `!issue.closedAt`
rather than a `state === 'CLOSED'` string.