### PR TITLE
feat: Add clear control to Score Breakdown PR search on miner Overview

### DIFF
--- a/src/components/miners/MinerScoreBreakdown.tsx
+++ b/src/components/miners/MinerScoreBreakdown.tsx
@@ -35,6 +35,7 @@ import {
   East as EastIcon,
 } from '@mui/icons-material';
 import { useSearchParams } from 'react-router-dom';
+import { ClearSearchAdornment } from '../common/ClearSearchAdornment';
 import { linkResetSx, useLinkBehavior } from '../common/linkBehavior';
 import {
   useMinerStats,
@@ -1133,6 +1134,12 @@ const PrBreakdownView: React.FC<{ githubId: string }> = ({ githubId }) => {
               }}
             />
           </InputAdornment>
+        ),
+        endAdornment: (
+          <ClearSearchAdornment
+            visible={Boolean(searchQuery)}
+            onClear={() => setSearchQuery('')}
+          />
         ),
       }}
       sx={{


### PR DESCRIPTION
## Summary

Adds the shared **`ClearSearchAdornment`** to the miner profile **Overview → Score Breakdown** PR search field in `MinerScoreBreakdown` (`PrBreakdownView`). When the field has any text, users get the same end-aligned clear control (`aria-label="clear search"`) used on **MinerPRsTable**, **MinerRepositoriesTable**, and other search inputs, instead of having to select all or backspace to empty the query.

Clearing runs `setSearchQuery('')`, which keeps existing behavior: the **`searchQuery`** effect still drops **`scorePage`** from the URL when the query changes, so pagination stays consistent with manual edits.

<!-- Brief description of the changes -->

## Related Issues

<!-- Link to related issues: Fixes #123, Closes #456 -->

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots
<img width="929" height="181" alt="image" src="https://github.com/user-attachments/assets/dc025dc2-f398-441b-a952-908843da5336" />

<!-- Include before/after screenshots for every UI/visual change. Remove this section if not applicable. -->

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
