### PR TITLE
fix: remove sticky gap between global search and timeline tabs

### DIFF
--- a/src/pages/TopMinersPage.tsx
+++ b/src/pages/TopMinersPage.tsx
@@ -190,7 +190,7 @@ const TopMinersPage: React.FC = () => {
               borderBottom: '1px solid',
               borderColor: 'border.light',
               position: 'sticky',
-              top: 64,
+              top: 60,
               zIndex: 50,
               backgroundColor: (t) => alpha(t.palette.background.default, 0.85),
               backdropFilter: 'blur(12px)',

--- a/src/pages/WatchlistPage.tsx
+++ b/src/pages/WatchlistPage.tsx
@@ -249,7 +249,7 @@ export const WatchlistContent: React.FC = () => {
           borderBottom: '1px solid',
           borderColor: 'border.light',
           position: 'sticky',
-          top: 64,
+          top: 60,
           zIndex: 50,
           backgroundColor: (t) => alpha(t.palette.background.default, 0.85),
           backdropFilter: 'blur(12px)',


### PR DESCRIPTION
## Summary

- Fix visual gap between sticky global search bar and sticky leaderboard tabs on scroll.
- Align sticky offset/spacing in TopMinersPage so both headers render as a continuous block.
- Preserve existing layout and behavior of tab content and sidebar.

## Related Issues

Closes #1062

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

### Before
<img width="1960" height="283" alt="image" src="https://github.com/user-attachments/assets/d3668127-8e56-401d-bff8-4781d1a3e2f2" />

<img width="1956" height="272" alt="image" src="https://github.com/user-attachments/assets/53850996-c1f7-4526-a68d-02c05ccd16cb" />


### After
<img width="1966" height="357" alt="image" src="https://github.com/user-attachments/assets/0e9bd442-be86-4909-bf7b-177da1c79a38" />
<img width="1975" height="307" alt="image" src="https://github.com/user-attachments/assets/9a0190fa-1ac2-4a96-bfdb-e63272ad136a" />


## Checklist

- [ ] New components are modularized/separated where sensible
- [ ] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [ ] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
