### PR TITLE
feat(watchlist): split OSS vs discovery eligibility in miners UI and fix main layout width

### DIFF
--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -149,7 +149,9 @@ const AppLayout: React.FC = () => {
           flexDirection: 'column',
           px: { xs: 1, sm: 2, md: 3 },
           ...scrollbarSx,
-          alignItems: { xs: 'stretch', md: 'center' },
+          // Stretch cross-axis so routed pages keep width (`center` collapses `width:100%` children on md+).
+          alignItems: 'stretch',
+          minHeight: 0,
         }}
       >
         <Suspense fallback={<LoadingPage />}>
@@ -173,7 +175,19 @@ const AppLayout: React.FC = () => {
             </Box>
           )}
           <ErrorBoundary variant="inline" resetKey={location.pathname}>
-            <Outlet />
+            <Box
+              sx={{
+                width: '100%',
+                maxWidth: '100%',
+                minWidth: 0,
+                minHeight: 0,
+                flex: '1 1 auto',
+                display: 'flex',
+                flexDirection: 'column',
+              }}
+            >
+              <Outlet />
+            </Box>
           </ErrorBoundary>
         </Suspense>
       </Box>

--- a/src/components/leaderboard/MinerCard.tsx
+++ b/src/components/leaderboard/MinerCard.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Box, Card, Typography, Avatar } from '@mui/material';
-import { alpha, useTheme } from '@mui/material/styles';
+import { alpha, useTheme, type Theme } from '@mui/material/styles';
 import ReactECharts from 'echarts-for-react';
 import { useMinerGithubData, useMinerPRs } from '../../api';
 import { CHART_COLORS, STATUS_COLORS } from '../../theme';
@@ -49,6 +49,17 @@ const getSegments = (
 ): Segment[] =>
   variant === 'discoveries' ? getIssueSegments(miner) : getPrSegments(miner);
 
+const buildStatPalette = (eligible: boolean, theme: Theme): string[] => {
+  const inactiveColor = alpha(theme.palette.text.tertiary, INACTIVE_OPACITY);
+  return eligible
+    ? [
+        STATUS_COLORS.merged,
+        alpha(theme.palette.text.primary, 0.84),
+        theme.palette.status.closed,
+      ]
+    : [inactiveColor, inactiveColor, inactiveColor];
+};
+
 export const MinerCard: React.FC<MinerCardProps> = ({
   miner,
   href,
@@ -85,6 +96,10 @@ export const MinerCard: React.FC<MinerCardProps> = ({
     : showDualEligibilityBadges
       ? ossEligible || discoveriesEligible
       : baseEligible;
+
+  const earningsHighlighted = isWatchlist
+    ? ossEligible || discoveriesEligible
+    : isEligible;
 
   const segments = getSegments(miner, variant);
 
@@ -321,10 +336,10 @@ export const MinerCard: React.FC<MinerCardProps> = ({
                 fontFamily: FONTS.mono,
                 fontSize: '1.6rem',
                 fontWeight: 800,
-                color: isEligible
+                color: earningsHighlighted
                   ? theme.palette.status.merged
                   : theme.palette.text.tertiary,
-                opacity: isEligible ? 1 : INACTIVE_OPACITY,
+                opacity: earningsHighlighted ? 1 : INACTIVE_OPACITY,
                 lineHeight: 1,
               })}
             >
@@ -334,10 +349,10 @@ export const MinerCard: React.FC<MinerCardProps> = ({
               sx={(theme) => ({
                 fontFamily: FONTS.mono,
                 fontSize: '0.75rem',
-                color: isEligible
+                color: earningsHighlighted
                   ? theme.palette.status.open
                   : theme.palette.text.tertiary,
-                opacity: isEligible ? 1 : INACTIVE_OPACITY,
+                opacity: earningsHighlighted ? 1 : INACTIVE_OPACITY,
               })}
             >
               /day
@@ -347,10 +362,10 @@ export const MinerCard: React.FC<MinerCardProps> = ({
             sx={(theme) => ({
               fontFamily: FONTS.mono,
               fontSize: '0.7rem',
-              color: isEligible
+              color: earningsHighlighted
                 ? theme.palette.status.merged
                 : theme.palette.text.tertiary,
-              opacity: isEligible ? 0.7 : INACTIVE_OPACITY,
+              opacity: earningsHighlighted ? 0.7 : INACTIVE_OPACITY,
               mt: 0.2,
             })}
           >
@@ -389,6 +404,8 @@ export const MinerCard: React.FC<MinerCardProps> = ({
         segments={segments}
         isEligible={isEligible}
         variant={variant}
+        primaryRowEligible={isWatchlist ? ossEligible : undefined}
+        secondaryRowEligible={isWatchlist ? discoveriesEligible : undefined}
       />
     </Card>
   );
@@ -400,6 +417,10 @@ interface MinerCardFooterProps {
   segments: Segment[];
   isEligible: boolean;
   variant: LeaderboardVariant;
+  /** Watchlist: OSS / PR stats row eligibility (paired with PR donut). */
+  primaryRowEligible?: boolean;
+  /** Watchlist: issue stats row eligibility (paired with Issues donut). */
+  secondaryRowEligible?: boolean;
 }
 
 const MinerCardFooter: React.FC<MinerCardFooterProps> = ({
@@ -408,17 +429,24 @@ const MinerCardFooter: React.FC<MinerCardFooterProps> = ({
   segments,
   isEligible,
   variant,
+  primaryRowEligible,
+  secondaryRowEligible,
 }) => {
   const muiTheme = useTheme();
   const inactiveColor = alpha(muiTheme.palette.text.tertiary, INACTIVE_OPACITY);
 
-  const statColors = isEligible
-    ? [
-        STATUS_COLORS.merged,
-        alpha(muiTheme.palette.text.primary, 0.84),
-        muiTheme.palette.status.closed,
-      ]
-    : [inactiveColor, inactiveColor, inactiveColor];
+  const chromeEligible =
+    variant === 'watchlist'
+      ? Boolean(primaryRowEligible || secondaryRowEligible)
+      : isEligible;
+
+  const primaryEligible =
+    variant === 'watchlist' ? Boolean(primaryRowEligible) : isEligible;
+  const secondaryEligible =
+    variant === 'watchlist' ? Boolean(secondaryRowEligible) : isEligible;
+
+  const primaryPalette = buildStatPalette(primaryEligible, muiTheme);
+  const secondaryPalette = buildStatPalette(secondaryEligible, muiTheme);
 
   const issueSegments = getIssueSegments(miner);
   const issueDiscoveryScore = Number(miner.issueDiscoveryScore ?? 0);
@@ -429,10 +457,10 @@ const MinerCardFooter: React.FC<MinerCardFooterProps> = ({
         display: 'flex',
         flexDirection: 'column',
         gap: variant === 'discoveries' || variant === 'watchlist' ? 0.75 : 0,
-        backgroundColor: isEligible
+        backgroundColor: chromeEligible
           ? alpha(theme.palette.background.default, 0.2)
           : theme.palette.surface.subtle,
-        opacity: isEligible ? 1 : 0.62,
+        opacity: chromeEligible ? 1 : 0.62,
         borderRadius: 1.5,
         p: 1,
       })}
@@ -450,29 +478,31 @@ const MinerCardFooter: React.FC<MinerCardFooterProps> = ({
             key={segment.label}
             label={segment.label}
             value={segment.value}
-            color={statColors[i]}
-            isEligible={isEligible}
+            color={primaryPalette[i]}
+            isEligible={primaryEligible}
           />
         ))}
         <Box
           sx={(theme) => ({
             textAlign: 'right',
             borderLeft: `1px solid ${
-              isEligible
+              primaryEligible
                 ? theme.palette.border.light
                 : theme.palette.border.subtle
             }`,
             pl: 1.5,
           })}
         >
-          <StatLabel isEligible={isEligible}>
+          <StatLabel isEligible={primaryEligible}>
             {variant === 'watchlist' ? 'OSS' : 'Score'}
           </StatLabel>
           <Typography
             sx={{
               fontFamily: FONTS.mono,
               fontSize: '0.9rem',
-              color: isEligible ? muiTheme.palette.text.primary : inactiveColor,
+              color: primaryEligible
+                ? muiTheme.palette.text.primary
+                : inactiveColor,
               fontWeight: 700,
             }}
           >
@@ -501,27 +531,27 @@ const MinerCardFooter: React.FC<MinerCardFooterProps> = ({
                 key={segment.label}
                 label={segment.label}
                 value={segment.value}
-                color={statColors[i]}
-                isEligible={isEligible}
+                color={secondaryPalette[i]}
+                isEligible={secondaryEligible}
               />
             ))}
             <Box
               sx={(theme) => ({
                 textAlign: 'right',
                 borderLeft: `1px solid ${
-                  isEligible
+                  secondaryEligible
                     ? theme.palette.border.light
                     : theme.palette.border.subtle
                 }`,
                 pl: 1.5,
               })}
             >
-              <StatLabel isEligible={isEligible}>Discovery</StatLabel>
+              <StatLabel isEligible={secondaryEligible}>Discovery</StatLabel>
               <Typography
                 sx={{
                   fontFamily: FONTS.mono,
                   fontSize: '0.9rem',
-                  color: isEligible
+                  color: secondaryEligible
                     ? muiTheme.palette.text.primary
                     : inactiveColor,
                   fontWeight: 700,

--- a/src/components/leaderboard/MinersList.tsx
+++ b/src/components/leaderboard/MinersList.tsx
@@ -13,6 +13,23 @@ import {
 
 type ActivityMode = 'prs' | 'issues';
 
+/** OSS / PR rewards track — mirrors `minerMapper` (`ossIsEligible` ← API eligible). */
+const ossTrackEligible = (m: MinerStats) =>
+  Boolean(m.ossIsEligible ?? m.isEligible);
+
+/** Issue-discovery rewards track — mirrors mapper (`discoveriesIsEligible`). */
+const discoveryTrackEligible = (m: MinerStats) =>
+  Boolean(m.discoveriesIsEligible ?? m.isIssueEligible ?? false);
+
+const watchlistAnyRewardEligible = (m: MinerStats) =>
+  ossTrackEligible(m) || discoveryTrackEligible(m);
+
+const watchlistBothTracksIneligible = (m: MinerStats) =>
+  !ossTrackEligible(m) && !discoveryTrackEligible(m);
+
+/** Mute PR/Issue column counts when that watchlist track is ineligible. */
+const TRACK_INACTIVE_OPACITY = 0.48;
+
 const SEGMENT_COLORS = [
   CHART_COLORS.merged,
   CHART_COLORS.open,
@@ -62,7 +79,11 @@ export const MinersList: React.FC<MinersListProps> = ({
           align: 'right',
           sortKey: 'totalPRs',
           renderCell: (miner) => (
-            <MinerActivitySegments miner={miner} mode="prs" />
+            <MinerActivitySegments
+              miner={miner}
+              mode="prs"
+              trackEligible={ossTrackEligible(miner)}
+            />
           ),
         },
         {
@@ -72,7 +93,11 @@ export const MinersList: React.FC<MinersListProps> = ({
           align: 'right',
           sortKey: 'totalIssues',
           renderCell: (miner) => (
-            <MinerActivitySegments miner={miner} mode="issues" />
+            <MinerActivitySegments
+              miner={miner}
+              mode="issues"
+              trackEligible={discoveryTrackEligible(miner)}
+            />
           ),
         },
       ]
@@ -110,16 +135,21 @@ export const MinersList: React.FC<MinersListProps> = ({
       width: '14%',
       align: 'right',
       sortKey: 'usdPerDay',
-      renderCell: (miner) => (
-        <Typography
-          sx={{
-            ...cellTypographySx,
-            color: miner.isEligible ? 'status.merged' : 'text.secondary',
-          }}
-        >
-          ${Math.round(miner.usdPerDay || 0).toLocaleString()}
-        </Typography>
-      ),
+      renderCell: (miner) => {
+        const earningsHighlighted = isWatchlist
+          ? watchlistAnyRewardEligible(miner)
+          : Boolean(miner.isEligible);
+        return (
+          <Typography
+            sx={{
+              ...cellTypographySx,
+              color: earningsHighlighted ? 'status.merged' : 'text.secondary',
+            }}
+          >
+            ${Math.round(miner.usdPerDay || 0).toLocaleString()}
+          </Typography>
+        );
+      },
     },
     ...activityColumns,
     {
@@ -140,11 +170,20 @@ export const MinersList: React.FC<MinersListProps> = ({
       width: '11%',
       align: 'right',
       sortKey: 'totalScore',
-      renderCell: (miner) => (
-        <Typography sx={{ ...cellTypographySx, color: 'text.primary' }}>
-          {Number(miner.totalScore).toFixed(2)}
-        </Typography>
-      ),
+      renderCell: (miner) => {
+        const active = !isWatchlist || ossTrackEligible(miner);
+        return (
+          <Typography
+            sx={{
+              ...cellTypographySx,
+              color: active ? 'text.primary' : 'text.secondary',
+              opacity: active ? 1 : TRACK_INACTIVE_OPACITY,
+            }}
+          >
+            {Number(miner.totalScore).toFixed(2)}
+          </Typography>
+        );
+      },
     },
     ...(isWatchlist
       ? ([
@@ -154,11 +193,20 @@ export const MinersList: React.FC<MinersListProps> = ({
             width: '11%',
             align: 'right' as const,
             sortKey: 'issueDiscoveryScore',
-            renderCell: (miner: MinerStats) => (
-              <Typography sx={{ ...cellTypographySx, color: 'text.primary' }}>
-                {Number(miner.issueDiscoveryScore ?? 0).toFixed(2)}
-              </Typography>
-            ),
+            renderCell: (miner: MinerStats) => {
+              const active = discoveryTrackEligible(miner);
+              return (
+                <Typography
+                  sx={{
+                    ...cellTypographySx,
+                    color: active ? 'text.primary' : 'text.secondary',
+                    opacity: active ? 1 : TRACK_INACTIVE_OPACITY,
+                  }}
+                >
+                  {Number(miner.issueDiscoveryScore ?? 0).toFixed(2)}
+                </Typography>
+              );
+            },
           },
         ] satisfies DataTableColumn<MinerStats, SortOption>[])
       : []),
@@ -199,7 +247,13 @@ export const MinersList: React.FC<MinersListProps> = ({
         getRowHref={getHref}
         linkState={linkState}
         getRowSx={(miner) => ({
-          opacity: (miner.isEligible ?? false) ? 1 : 0.5,
+          opacity: isWatchlist
+            ? watchlistBothTracksIneligible(miner)
+              ? 0.48
+              : 1
+            : miner.isEligible
+              ? 1
+              : 0.5,
           transition: 'opacity 0.2s, background-color 0.2s',
         })}
         minWidth="1020px"
@@ -270,11 +324,14 @@ const MinerIdentityCell: React.FC<MinerIdentityCellProps> = ({ miner }) => {
 interface MinerActivitySegmentsProps {
   miner: MinerStats;
   mode: ActivityMode;
+  /** Watchlist: mute counts when this column's track is ineligible. */
+  trackEligible?: boolean;
 }
 
 const MinerActivitySegments: React.FC<MinerActivitySegmentsProps> = ({
   miner,
   mode,
+  trackEligible = true,
 }) => {
   const segments =
     mode === 'issues'
@@ -296,6 +353,7 @@ const MinerActivitySegments: React.FC<MinerActivitySegmentsProps> = ({
         alignItems: 'center',
         justifyContent: 'flex-end',
         gap: 1.25,
+        opacity: trackEligible ? 1 : TRACK_INACTIVE_OPACITY,
       }}
     >
       {segments.map((segment, i) => (
@@ -316,7 +374,12 @@ const MinerActivitySegments: React.FC<MinerActivitySegmentsProps> = ({
               }}
             />
             <Typography
-              sx={{ fontSize: '0.75rem', fontWeight: 600, lineHeight: 1 }}
+              sx={{
+                fontSize: '0.75rem',
+                fontWeight: 600,
+                lineHeight: 1,
+                color: trackEligible ? 'text.primary' : 'text.secondary',
+              }}
             >
               {segment.value}
             </Typography>

--- a/src/pages/LoadingPage.tsx
+++ b/src/pages/LoadingPage.tsx
@@ -7,7 +7,8 @@ const LoadingPage: React.FC = () => (
       justifyContent: 'center',
       alignItems: 'center',
       width: '100%',
-      height: '100%',
+      minHeight: { xs: '240px', sm: '320px' },
+      flex: '1 1 auto',
     }}
   >
     <CircularProgress sx={{ m: 5, color: 'primary.main' }} />


### PR DESCRIPTION
## Summary

- **Watchlist miners (table):** Treat OSS / PR rewards and issue-discovery rewards separately. PR and Issues activity columns mute per track; OSS and Discovery score cells mute per track; earnings/day uses green styling when either track is reward-eligible; row opacity is reduced only when **both** tracks are ineligible (other leaderboard variants keep existing `isEligible` behavior).
- **Watchlist miners (cards):** Footer stat rows use per-track palettes aligned with the dual PR / Issues donuts; daily earnings tint matches the list logic.
- **App shell:** Stretch the main column, add `minHeight: 0` and an `Outlet` wrapper so routed content keeps full width and avoids collapsed / blank main areas on md+; adjust `LoadingPage` so Suspense fallback lays out reliably.

## Related Issues

Fixes: #1070

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

*(Uncheck one of the above if your repo prefers a single primary type.)*

## Screenshots
-Before fix on list view
<img width="1241" height="359" alt="image" src="https://github.com/user-attachments/assets/880600d6-998c-4a03-a11f-a999d32b13f2" />

-After fix on list view
<img width="1259" height="482" alt="image" src="https://github.com/user-attachments/assets/fbd1b5ce-0716-4cae-995e-0eefacfed607" />


-Before fix on card view
<img width="1303" height="402" alt="image" src="https://github.com/user-attachments/assets/a2e4f7b9-89dc-49f2-a093-7c881a7f13f2" />
-After fix on card view
<img width="1307" height="445" alt="image" src="https://github.com/user-attachments/assets/f89a47dc-55f1-48f5-bac4-40d815eb2193" />
## Testing

- Manual: `/watchlist` miners tab — list + card views with miners eligible on OSS only, discovery only, both, and neither.
- Manual: `/`, `/top-miners`, or another route with global search — confirm main content fills width (no blank black main column).
- `npm run build` passes locally.

## Checklist

- [ ] New components are modularized/separated where sensible
- [ ] Uses predefined theme (e.g. no hardcoded colors)
- [ ] Responsive/mobile checked
- [ ] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes