### PR TITLE
feat: add global keyboard shortcuts

### DIFF
--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -12,9 +12,11 @@ import { Outlet, useLocation } from 'react-router-dom';
 import MenuIcon from '@mui/icons-material/Menu';
 import { LoadingPage } from '../../pages';
 import useOnNavigate from '../../hooks/useOnNavigate';
+import { useKeyboardShortcuts } from '../../hooks/useKeyboardShortcuts';
 import { Sidebar } from '..';
 import ErrorBoundary from '../ErrorBoundary';
 import GlobalSearchBar from './GlobalSearchBar';
+import ShortcutsHelpDialog from './ShortcutsHelpDialog';
 import theme, { scrollbarSx } from '../../theme';
 import { getRouteForPathname } from '../../routes';
 
@@ -30,6 +32,7 @@ const AppLayout: React.FC = () => {
   const isCompactDesktop = useMediaQuery(theme.breakpoints.down('lg'));
   const isDesktopSidebarCollapsed = !isMobile && isCompactDesktop;
   const [mobileOpen, setMobileOpen] = useState(false);
+  const { isHelpOpen, closeHelp, shortcuts } = useKeyboardShortcuts();
   const shouldShowGlobalSearch = Boolean(
     getRouteForPathname(location.pathname)?.showGlobalSearch,
   );
@@ -177,6 +180,11 @@ const AppLayout: React.FC = () => {
           </ErrorBoundary>
         </Suspense>
       </Box>
+      <ShortcutsHelpDialog
+        open={isHelpOpen}
+        shortcuts={shortcuts}
+        onClose={closeHelp}
+      />
     </Box>
   );
 };

--- a/src/components/layout/GlobalSearchBar.tsx
+++ b/src/components/layout/GlobalSearchBar.tsx
@@ -390,7 +390,17 @@ const GlobalSearchBar: React.FC = () => {
   // Global shortcuts: Cmd/Ctrl+K and "/" to focus the search input.
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
+      const target =
+        (e.target as HTMLElement | null) ||
+        (document.activeElement as HTMLElement | null);
+      const isOverlayTarget = Boolean(
+        target?.closest(
+          '[role="dialog"], [role="menu"], [role="listbox"], [aria-modal="true"]',
+        ),
+      );
+
       if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
+        if (isOverlayTarget) return;
         e.preventDefault();
         const input = inputRef.current;
         if (input) {
@@ -401,9 +411,6 @@ const GlobalSearchBar: React.FC = () => {
       }
 
       if (e.key === '/' && !e.metaKey && !e.ctrlKey && !e.altKey) {
-        const target =
-          (e.target as HTMLElement | null) ||
-          (document.activeElement as HTMLElement | null);
         if (!target) return;
         const tag = target.tagName;
         const isEditable =
@@ -412,13 +419,7 @@ const GlobalSearchBar: React.FC = () => {
           target.isContentEditable === true;
         if (isEditable) return;
         // Don't steal focus from open modals / menus / select popovers.
-        if (
-          target.closest(
-            '[role="dialog"], [role="menu"], [role="listbox"], [aria-modal="true"]',
-          )
-        ) {
-          return;
-        }
+        if (isOverlayTarget) return;
         e.preventDefault();
         inputRef.current?.focus();
       }

--- a/src/components/layout/ShortcutsHelpDialog.tsx
+++ b/src/components/layout/ShortcutsHelpDialog.tsx
@@ -1,0 +1,118 @@
+import React from 'react';
+import {
+  Box,
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  Stack,
+  Typography,
+} from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
+import { type KeyboardShortcut } from '../../hooks/useKeyboardShortcuts';
+
+type ShortcutsHelpDialogProps = {
+  open: boolean;
+  shortcuts: KeyboardShortcut[];
+  onClose: () => void;
+};
+
+const shortcutKeySx = {
+  minWidth: 30,
+  px: 0.8,
+  py: 0.35,
+  borderRadius: 1,
+  border: '1px solid',
+  borderColor: 'border.light',
+  backgroundColor: 'surface.light',
+  color: 'text.primary',
+  fontSize: '0.72rem',
+  lineHeight: 1,
+  textAlign: 'center',
+  fontWeight: 700,
+} as const;
+
+const ShortcutsHelpDialog: React.FC<ShortcutsHelpDialogProps> = ({
+  open,
+  shortcuts,
+  onClose,
+}) => (
+  <Dialog
+    open={open}
+    onClose={onClose}
+    fullWidth
+    maxWidth="xs"
+    aria-labelledby="keyboard-shortcuts-title"
+    PaperProps={{
+      sx: (theme) => ({
+        backgroundColor: theme.palette.background.paper,
+        backgroundImage: 'none',
+        border: `1px solid ${theme.palette.border.light}`,
+        borderRadius: 2,
+      }),
+    }}
+  >
+    <DialogTitle
+      id="keyboard-shortcuts-title"
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        gap: 2,
+        pr: 1,
+      }}
+    >
+      <Typography variant="h6" component="span">
+        Keyboard shortcuts
+      </Typography>
+      <IconButton aria-label="close keyboard shortcuts" onClick={onClose}>
+        <CloseIcon fontSize="small" />
+      </IconButton>
+    </DialogTitle>
+    <DialogContent sx={{ pt: 0, pb: 2.5 }}>
+      <Stack spacing={1}>
+        {shortcuts.map((shortcut) => (
+          <Box
+            key={`${shortcut.keys.join('-')}-${shortcut.label}`}
+            sx={(theme) => ({
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              gap: 2,
+              px: 1,
+              py: 0.9,
+              borderRadius: 1.5,
+              backgroundColor: theme.palette.surface.subtle,
+              border: `1px solid ${theme.palette.border.subtle}`,
+            })}
+          >
+            <Typography sx={{ color: 'text.primary', fontSize: '0.9rem' }}>
+              {shortcut.label}
+            </Typography>
+            <Stack
+              direction="row"
+              spacing={0.5}
+              alignItems="center"
+              aria-label={shortcut.keys.join(' then ')}
+            >
+              {shortcut.keys.map((key) => (
+                <Typography
+                  key={key}
+                  component="kbd"
+                  sx={(theme) => ({
+                    ...shortcutKeySx,
+                    fontFamily: theme.typography.fontFamily,
+                  })}
+                >
+                  {key}
+                </Typography>
+              ))}
+            </Stack>
+          </Box>
+        ))}
+      </Stack>
+    </DialogContent>
+  </Dialog>
+);
+
+export default ShortcutsHelpDialog;

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -1,0 +1,151 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+const G_PREFIX_TIMEOUT_MS = 1000;
+
+export type KeyboardShortcut = {
+  keys: string[];
+  label: string;
+  path?: string;
+};
+
+export const keyboardShortcuts: KeyboardShortcut[] = [
+  { keys: ['g', 'd'], label: 'Dashboard', path: '/dashboard' },
+  { keys: ['g', 'l'], label: 'Top Miners', path: '/top-miners' },
+  { keys: ['g', 'r'], label: 'Repositories', path: '/repositories' },
+  { keys: ['g', 'b'], label: 'Bounties', path: '/bounties' },
+  { keys: ['g', 'w'], label: 'Watchlist', path: '/watchlist' },
+  { keys: ['g', 'o'], label: 'Onboard', path: '/onboard' },
+  { keys: ['?'], label: 'Open keyboard shortcuts help' },
+  { keys: ['Esc'], label: 'Close overlay or cancel sequence' },
+];
+
+const gPrefixRoutes = keyboardShortcuts.reduce<Record<string, string>>(
+  (acc, shortcut) => {
+    const [prefix, key] = shortcut.keys;
+    if (prefix === 'g' && key && shortcut.path) {
+      acc[key] = shortcut.path;
+    }
+    return acc;
+  },
+  {},
+);
+
+const isEditableTarget = (target: EventTarget | null) => {
+  if (!(target instanceof HTMLElement)) return false;
+  const tag = target.tagName;
+  return (
+    tag === 'INPUT' || tag === 'TEXTAREA' || target.isContentEditable === true
+  );
+};
+
+const isInsideOverlay = (target: EventTarget | null) =>
+  target instanceof HTMLElement &&
+  Boolean(
+    target.closest(
+      '[role="dialog"], [role="menu"], [role="listbox"], [aria-modal="true"]',
+    ),
+  );
+
+export const useKeyboardShortcuts = () => {
+  const navigate = useNavigate();
+  const timeoutRef = useRef<number | null>(null);
+  const [isHelpOpen, setIsHelpOpen] = useState(false);
+  const [isGPrefixActive, setIsGPrefixActive] = useState(false);
+
+  const clearPrefixTimeout = useCallback(() => {
+    if (timeoutRef.current !== null) {
+      window.clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+  }, []);
+
+  const cancelPrefix = useCallback(() => {
+    clearPrefixTimeout();
+    setIsGPrefixActive(false);
+  }, [clearPrefixTimeout]);
+
+  const startPrefix = useCallback(() => {
+    clearPrefixTimeout();
+    setIsGPrefixActive(true);
+    timeoutRef.current = window.setTimeout(cancelPrefix, G_PREFIX_TIMEOUT_MS);
+  }, [cancelPrefix, clearPrefixTimeout]);
+
+  const openHelp = useCallback(() => {
+    cancelPrefix();
+    setIsHelpOpen(true);
+  }, [cancelPrefix]);
+
+  const closeHelp = useCallback(() => {
+    cancelPrefix();
+    setIsHelpOpen(false);
+  }, [cancelPrefix]);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (isEditableTarget(e.target)) {
+        cancelPrefix();
+        return;
+      }
+
+      if (e.key === 'Escape') {
+        cancelPrefix();
+        if (isHelpOpen) {
+          setIsHelpOpen(false);
+        }
+        return;
+      }
+
+      if (isInsideOverlay(e.target)) {
+        return;
+      }
+
+      if (e.metaKey || e.ctrlKey || e.altKey) {
+        cancelPrefix();
+        return;
+      }
+
+      if (e.key === '?') {
+        e.preventDefault();
+        openHelp();
+        return;
+      }
+
+      const key = e.key.toLowerCase();
+      if (isGPrefixActive) {
+        const path = gPrefixRoutes[key];
+        e.preventDefault();
+        cancelPrefix();
+        if (path) {
+          navigate(path);
+        }
+        return;
+      }
+
+      if (key === 'g') {
+        e.preventDefault();
+        startPrefix();
+      }
+    };
+
+    window.addEventListener('keydown', handler);
+    return () => {
+      window.removeEventListener('keydown', handler);
+      clearPrefixTimeout();
+    };
+  }, [
+    cancelPrefix,
+    clearPrefixTimeout,
+    isGPrefixActive,
+    isHelpOpen,
+    navigate,
+    openHelp,
+    startPrefix,
+  ]);
+
+  return {
+    isHelpOpen,
+    closeHelp,
+    shortcuts: keyboardShortcuts,
+  };
+};


### PR DESCRIPTION
## Summary

- Add a global g-prefix shortcut state machine for primary navigation.
- Add a themed keyboard shortcuts help dialog opened with `?`.
- Preserve existing Cmd/Ctrl+K and `/` search shortcuts while preventing overlay focus leaks.

## Related Issues

Fixes #1075

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

Not captured in this environment; the UI change is a small MUI dialog and was validated through build/lint/test.

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [ ] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [ ] Screenshots included for any UI/visual changes