### PR TITLE
feat: add miner hover cards

### DIFF
--- a/src/components/leaderboard/LeaderboardSidebar.tsx
+++ b/src/components/leaderboard/LeaderboardSidebar.tsx
@@ -1,9 +1,10 @@
 import React, { useMemo, useState } from 'react';
-import { Box, Stack, Typography, Avatar } from '@mui/material';
+import { Box, Stack, Typography } from '@mui/material';
 import { alpha } from '@mui/material/styles';
 import { SectionCard } from './SectionCard';
 import { STATUS_COLORS, scrollbarSx } from '../../theme';
 import { getGithubAvatarSrc } from '../../utils/ExplorerUtils';
+import MinerAvatarWithPreview from '../miners/MinerAvatarWithPreview';
 import { LinkBox } from '../common/linkBehavior';
 import { type MinerStats, FONTS } from './types';
 import { ActivitySidebarCards } from './ActivitySidebarCards';
@@ -273,7 +274,9 @@ const LeaderboardRow: React.FC<LeaderboardRowProps> = ({
           minWidth: 0,
         }}
       >
-        <Avatar
+        <MinerAvatarWithPreview
+          githubId={miner.githubId}
+          username={miner.author}
           src={getGithubAvatarSrc(miner.author || miner.githubId)}
           alt={miner.author || miner.githubId}
           sx={{ width: 20, height: 20 }}

--- a/src/components/miners/MinerAvatarWithPreview.tsx
+++ b/src/components/miners/MinerAvatarWithPreview.tsx
@@ -1,0 +1,164 @@
+import React, { useMemo, useRef, useState } from 'react';
+import { Avatar, Box, Popover, type AvatarProps } from '@mui/material';
+import { useAllMiners } from '../../api';
+import MinerHoverCard from './MinerHoverCard';
+import { type MinerEvaluation } from '../../api/models/Dashboard';
+
+interface MinerAvatarWithPreviewProps extends Omit<AvatarProps, 'children'> {
+  /** Numeric GitHub ID, primary key into the `useAllMiners` cache. */
+  githubId?: string;
+  /** Display name fallback when the miner isn't in the cache. */
+  username?: string;
+  /** Hover delay in ms before the popover opens. */
+  enterDelayMs?: number;
+}
+
+/**
+ * Wraps `<Avatar>` with a hover / focus popover that previews the miner's
+ * headline stats. Read-only: clicking the "View full profile" link inside
+ * the popover navigates; the Avatar itself stays inert (parent surfaces
+ * already own the row-level click target).
+ *
+ * Reads the cached `useAllMiners` result via a memoized id-to-miner map so
+ * no extra network calls are made. If the miner isn't in the cache, the
+ * popover renders a minimal fallback.
+ */
+const MinerAvatarWithPreview: React.FC<MinerAvatarWithPreviewProps> = ({
+  githubId,
+  username,
+  enterDelayMs = 500,
+  ...avatarProps
+}) => {
+  const { data: miners } = useAllMiners();
+  const minerById = useMemo(() => {
+    const map = new Map<string, MinerEvaluation>();
+    if (Array.isArray(miners)) {
+      for (const m of miners) {
+        if (m.githubId) map.set(m.githubId, m);
+      }
+    }
+    return map;
+  }, [miners]);
+
+  const rankById = useMemo(() => {
+    if (!Array.isArray(miners)) return new Map<string, number>();
+    return new Map(
+      [...miners]
+        .sort((a, b) => Number(b.totalScore) - Number(a.totalScore))
+        .map((m, i) => [m.githubId, i + 1] as const),
+    );
+  }, [miners]);
+
+  const miner = githubId ? minerById.get(githubId) : undefined;
+  const rank = githubId ? rankById.get(githubId) : undefined;
+
+  const anchorRef = useRef<HTMLDivElement | null>(null);
+  const closeTimer = useRef<number | null>(null);
+  const openTimer = useRef<number | null>(null);
+  const [open, setOpen] = useState(false);
+
+  const clearTimers = () => {
+    if (openTimer.current !== null) {
+      window.clearTimeout(openTimer.current);
+      openTimer.current = null;
+    }
+    if (closeTimer.current !== null) {
+      window.clearTimeout(closeTimer.current);
+      closeTimer.current = null;
+    }
+  };
+
+  const scheduleOpen = () => {
+    clearTimers();
+    openTimer.current = window.setTimeout(() => {
+      setOpen(true);
+      openTimer.current = null;
+    }, enterDelayMs);
+  };
+
+  const scheduleClose = () => {
+    clearTimers();
+    closeTimer.current = window.setTimeout(() => {
+      setOpen(false);
+      closeTimer.current = null;
+    }, 120);
+  };
+
+  // Open immediately on keyboard focus (no hover delay).
+  const handleFocus = () => {
+    clearTimers();
+    setOpen(true);
+  };
+
+  return (
+    <>
+      <Box
+        ref={anchorRef}
+        component="span"
+        tabIndex={0}
+        aria-describedby={open ? 'miner-hover-card' : undefined}
+        onMouseEnter={scheduleOpen}
+        onMouseLeave={scheduleClose}
+        onFocus={handleFocus}
+        onBlur={scheduleClose}
+        onKeyDown={(e) => {
+          if (e.key === 'Escape' && open) {
+            clearTimers();
+            setOpen(false);
+          }
+        }}
+        sx={{
+          display: 'inline-flex',
+          borderRadius: '50%',
+          '&:focus-visible': {
+            outline: (t) => `2px solid ${t.palette.primary.main}`,
+            outlineOffset: '2px',
+          },
+        }}
+      >
+        <Avatar {...avatarProps} />
+      </Box>
+      <Popover
+        id="miner-hover-card"
+        open={open}
+        anchorEl={anchorRef.current}
+        onClose={() => setOpen(false)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+        transformOrigin={{ vertical: 'top', horizontal: 'center' }}
+        // Reduced-motion users skip the slide/fade.
+        transitionDuration={{
+          appear: 0,
+          enter:
+            typeof window !== 'undefined' &&
+            window.matchMedia('(prefers-reduced-motion: reduce)').matches
+              ? 0
+              : 150,
+          exit: 0,
+        }}
+        slotProps={{
+          paper: {
+            onMouseEnter: clearTimers,
+            onMouseLeave: scheduleClose,
+            elevation: 8,
+            sx: {
+              mt: 0.5,
+              border: '1px solid',
+              borderColor: 'border.medium',
+              backgroundColor: 'background.paper',
+            },
+          },
+        }}
+        disableRestoreFocus={false}
+      >
+        <MinerHoverCard
+          miner={miner}
+          rank={rank}
+          fallbackGithubId={githubId}
+          fallbackUsername={username}
+        />
+      </Popover>
+    </>
+  );
+};
+
+export default MinerAvatarWithPreview;

--- a/src/components/miners/MinerHoverCard.tsx
+++ b/src/components/miners/MinerHoverCard.tsx
@@ -1,0 +1,174 @@
+import React from 'react';
+import {
+  Avatar,
+  Box,
+  Chip,
+  Stack,
+  Typography,
+  alpha,
+  useTheme,
+} from '@mui/material';
+import { LinkBox } from '../common/linkBehavior';
+import { getGithubAvatarSrc, parseNumber } from '../../utils/ExplorerUtils';
+import { type MinerEvaluation } from '../../api/models/Dashboard';
+
+interface MinerHoverCardProps {
+  miner?: MinerEvaluation;
+  /** Pre-computed rank among all miners by `totalScore`, if available. */
+  rank?: number;
+  /** Used when `miner` isn't present in the cache; renders a minimal fallback. */
+  fallbackGithubId?: string;
+  fallbackUsername?: string;
+}
+
+const StatRow: React.FC<{ label: string; value: string }> = ({
+  label,
+  value,
+}) => (
+  <Box
+    sx={{
+      display: 'flex',
+      justifyContent: 'space-between',
+      alignItems: 'baseline',
+      gap: 1,
+    }}
+  >
+    <Typography
+      variant="caption"
+      sx={(t) => ({
+        color: alpha(t.palette.text.primary, 0.55),
+        fontSize: '0.7rem',
+        textTransform: 'uppercase',
+        letterSpacing: 0,
+      })}
+    >
+      {label}
+    </Typography>
+    <Typography
+      sx={(t) => ({
+        color: t.palette.text.primary,
+        fontSize: '0.85rem',
+        fontWeight: 600,
+        fontVariantNumeric: 'tabular-nums',
+      })}
+    >
+      {value}
+    </Typography>
+  </Box>
+);
+
+const formatUsdPerDay = (value: number): string =>
+  value > 0 ? `$${value.toFixed(2)}/d` : '-';
+
+const formatCredibility = (value: number): string =>
+  value > 0 ? `${(value * 100).toFixed(1)}%` : '-';
+
+const MinerHoverCard: React.FC<MinerHoverCardProps> = ({
+  miner,
+  rank,
+  fallbackGithubId,
+  fallbackUsername,
+}) => {
+  const theme = useTheme();
+
+  const githubId = miner?.githubId ?? fallbackGithubId ?? '';
+  const username = miner?.githubUsername ?? fallbackUsername ?? githubId;
+  const href = githubId
+    ? `/miners/details?githubId=${encodeURIComponent(githubId)}`
+    : undefined;
+
+  return (
+    <Box
+      role="dialog"
+      aria-label={`${username} preview`}
+      sx={{
+        p: 2,
+        minWidth: 260,
+        maxWidth: 320,
+        backgroundColor: 'background.paper',
+      }}
+    >
+      <Stack direction="row" spacing={1.5} alignItems="center" sx={{ mb: 1.5 }}>
+        <Avatar
+          src={getGithubAvatarSrc(username)}
+          alt={username}
+          sx={{ width: 40, height: 40 }}
+        />
+        <Box sx={{ minWidth: 0, flex: 1 }}>
+          <Typography
+            sx={{
+              fontSize: '0.95rem',
+              fontWeight: 600,
+              color: 'text.primary',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {username}
+          </Typography>
+          {typeof rank === 'number' && rank > 0 && (
+            <Chip
+              label={`Rank #${rank}`}
+              size="small"
+              sx={(t) => ({
+                mt: 0.25,
+                height: 20,
+                fontSize: '0.65rem',
+                backgroundColor: alpha(t.palette.text.primary, 0.08),
+                color: t.palette.text.primary,
+              })}
+            />
+          )}
+        </Box>
+      </Stack>
+
+      {miner ? (
+        <Stack spacing={0.5}>
+          <StatRow
+            label="Score"
+            value={parseNumber(miner.totalScore).toFixed(2)}
+          />
+          <StatRow
+            label="Credibility"
+            value={formatCredibility(parseNumber(miner.credibility))}
+          />
+          <StatRow
+            label="USD / day"
+            value={formatUsdPerDay(parseNumber(miner.usdPerDay))}
+          />
+          <StatRow label="PRs" value={String(parseNumber(miner.totalPrs))} />
+        </Stack>
+      ) : (
+        <Typography
+          variant="body2"
+          sx={{
+            fontSize: '0.78rem',
+            color: alpha(theme.palette.text.primary, 0.6),
+            mb: 1.5,
+          }}
+        >
+          Not a tracked miner. View this account on GitHub for details.
+        </Typography>
+      )}
+
+      {href && (
+        <LinkBox
+          href={href}
+          sx={{
+            mt: 1.5,
+            display: 'inline-block',
+            fontSize: '0.78rem',
+            color: 'primary.main',
+            textDecoration: 'none',
+            '&:hover': { textDecoration: 'underline' },
+          }}
+        >
+          View full profile
+        </LinkBox>
+      )}
+    </Box>
+  );
+};
+
+export default MinerHoverCard;

--- a/src/components/miners/index.ts
+++ b/src/components/miners/index.ts
@@ -1,4 +1,6 @@
 export { default as MinerActivity } from './MinerActivity';
+export { default as MinerAvatarWithPreview } from './MinerAvatarWithPreview';
+export { default as MinerHoverCard } from './MinerHoverCard';
 export { default as MinerInsightsCard } from './MinerInsightsCard';
 export { default as MinerOpenDiscoveryIssuesByRepo } from './MinerOpenDiscoveryIssuesByRepo';
 export { default as MinerPRsTable } from './MinerPRsTable';

--- a/src/components/repositories/RepositoryContributorsTable.tsx
+++ b/src/components/repositories/RepositoryContributorsTable.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useMemo, useState } from 'react';
 import {
   Box,
   Typography,
-  Avatar,
   CircularProgress,
   alpha,
   useTheme,
@@ -17,6 +16,7 @@ import { isMergedPr } from '../../utils/prStatus';
 import { parseNumber } from '../../utils/ExplorerUtils';
 import { getRepositoryOwnerAvatarSrc } from '../../utils/avatar';
 import { DataTable, type DataTableColumn } from '../common/DataTable';
+import MinerAvatarWithPreview from '../miners/MinerAvatarWithPreview';
 
 interface RepositoryContributorsTableProps {
   repositoryFullName: string;
@@ -252,7 +252,9 @@ const RepositoryContributorsTable: React.FC<
                 },
               }}
             >
-              <Avatar
+              <MinerAvatarWithPreview
+                githubId={c.githubId}
+                username={c.author}
                 src={getRepositoryOwnerAvatarSrc(c.author)}
                 alt={c.author}
                 sx={{


### PR DESCRIPTION
## Summary

Closes #1076. Adds a reusable `MinerAvatarWithPreview` wrapper that opens a read-only miner preview when users hover or keyboard-focus miner avatars, without navigating away from the current page.

The popover shows the miner's avatar, username, rank, total score, credibility, USD/day, PR count, and a link to the full miner profile. It reads from the existing `useAllMiners()` React Query cache, so opening hover cards does not create per-hover network requests.

## What changed

1. Added `src/components/miners/MinerHoverCard.tsx`
   - Compact read-only preview UI for tracked miners.
   - Falls back to a minimal untracked-account panel when the GitHub account is not present in the miner cache.
   - Uses existing theme colors and shared GitHub avatar/profile helpers.

2. Added `src/components/miners/MinerAvatarWithPreview.tsx`
   - Wraps MUI `Avatar` with hover, focus, Escape-to-dismiss, and outside-dismiss behavior.
   - Builds memoized `githubId -> miner` and rank maps from the already-cached `useAllMiners()` result.
   - Keeps the avatar itself inert so row/card click behavior remains owned by the parent surface.

3. Migrated the current avatar surfaces where this changes behavior on `test`
   - `LeaderboardSidebar`
   - `RepositoryContributorsTable`

## Scope note

The issue lists several possible surfaces, but the current `test` branch does not render miner avatars everywhere in that list:

- `LiveCommitLog` renders the repository owner avatar, not the miner avatar.
- `IssuesList` solver rows render `solverHotkey` text, not an avatar.
- `TopMinersTable` already renders `MinerCard`, which displays the core miner metrics inline.

This PR therefore ships the reusable preview primitive and applies it only to the two live miner-avatar surfaces that benefit from it today. Future miner-avatar surfaces can opt in by replacing `Avatar` with `MinerAvatarWithPreview`.

## Accessibility

- Trigger is keyboard focusable with `tabIndex={0}`.
- `aria-describedby` is applied while the popover is open.
- Popover uses `role="dialog"` and an accessible preview label.
- Focus opens immediately; hover uses a short delay.
- Escape closes the preview.
- `prefers-reduced-motion: reduce` disables the enter transition.

## Screenshots / Demo

https://github.com/user-attachments/assets/a48d7350-2566-45b5-89ff-7f966f75a35b

## Type of Change

- [x] New feature

## Validation

- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm test`

Build completed successfully. Vite still reports the existing chunk-size/dynamic-import warnings; no new build errors were introduced.

Vitest completed successfully: 3 test files and 27 tests passed.

## Checklist

- [x] No new dependencies
- [x] Uses existing cached miner data; no per-hover network calls
- [x] Keyboard parity with hover behavior
- [x] Escape/outside dismiss behavior
- [x] Respects reduced-motion preference
- [x] Keeps existing row/card click behavior intact
- [x] Targets the `test` branch
