### PR TITLE
fix: persist leaderboard filters panel state

### DIFF
--- a/src/components/leaderboard/TopMinersTable.tsx
+++ b/src/components/leaderboard/TopMinersTable.tsx
@@ -49,6 +49,7 @@ const DISC_ELIGIBLE_QUERY_PARAM = 'discElig';
 const VIEW_QUERY_PARAM = 'view';
 const SEARCH_QUERY_PARAM = 'search';
 const VISIBLE_QUERY_PARAM = 'visible';
+const FILTERS_PANEL_QUERY_PARAM = 'filters';
 const VIEW_STORAGE_KEY_LEADERBOARD = 'leaderboard:viewMode';
 const VIEW_STORAGE_KEY_WATCHLIST = 'watchlist:viewMode';
 
@@ -113,6 +114,7 @@ type EligibilityFilter = 'all' | 'eligible' | 'ineligible';
 type TopMinersUrlFilters = {
   view: ViewMode;
   search: string;
+  filtersOpen: boolean;
   /** OSS Contributions / Discoveries: single toggle. Inactive on watchlist (always `all`). */
   eligible: EligibilityFilter;
   /** Watchlist OSS column. Inactive on other variants (always `all`). */
@@ -241,6 +243,13 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
         parse: (raw: string | null): string => raw ?? '',
         serialize: (value: string): string | null => value.trim() || null,
       },
+      filtersOpen: {
+        paramKey: FILTERS_PANEL_QUERY_PARAM,
+        parse: (raw: string | null): boolean =>
+          raw === 'open' || raw === 'true',
+        serialize: (value: boolean): string | null => (value ? 'open' : null),
+        resetPageOnChange: false,
+      },
       eligible:
         variant === 'watchlist'
           ? inactiveEligibilitySlot('minersEligibleUnusedLegacy')
@@ -276,6 +285,7 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
 
   const viewMode = filters.view;
   const searchQuery = filters.search;
+  const filtersOpen = filters.filtersOpen;
   const eligibleOssFilter: EligibilityFilter =
     variant === 'watchlist' ? filters.eligibleOss : filters.eligible;
   const eligibleDiscoveryFilter: EligibilityFilter =
@@ -297,6 +307,11 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
       setFilter('view', nextMode);
     },
     [setFilter, variant],
+  );
+
+  const handleFiltersOpenChange = useCallback(
+    (nextOpen: boolean) => setFilter('filtersOpen', nextOpen),
+    [setFilter],
   );
 
   const handleEligibleOssChange = useCallback(
@@ -486,6 +501,8 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
             eligibleDiscoveryFilter={eligibleDiscoveryFilter}
             onEligibleOssChange={handleEligibleOssChange}
             onEligibleDiscoveryChange={handleEligibleDiscoveryChange}
+            open={filtersOpen}
+            onOpenChange={handleFiltersOpenChange}
           />
         </Portal>
       ) : (
@@ -1031,9 +1048,16 @@ const sidebarLabelSx = {
   mb: 1,
 } as const;
 
-const ToolbarSidebarPanel: React.FC<ToolbarPopoverProps> = (props) => {
-  const [open, setOpen] = useState(false);
+type ToolbarSidebarPanelProps = ToolbarPopoverProps & {
+  open: boolean;
+  onOpenChange: (nextOpen: boolean) => void;
+};
 
+const ToolbarSidebarPanel: React.FC<ToolbarSidebarPanelProps> = ({
+  open,
+  onOpenChange,
+  ...props
+}) => {
   const defaultOssFilter = props.variant === 'watchlist' ? 'all' : 'eligible';
   const hasActiveFilter =
     props.eligibleOssFilter !== defaultOssFilter ||
@@ -1045,7 +1069,7 @@ const ToolbarSidebarPanel: React.FC<ToolbarPopoverProps> = (props) => {
       <Box
         component="button"
         type="button"
-        onClick={() => setOpen((v) => !v)}
+        onClick={() => onOpenChange(!open)}
         sx={(t) => ({
           display: 'flex',
           alignItems: 'center',


### PR DESCRIPTION
## Summary

- Persist the leaderboard sidebar Filters panel state through the existing URL-backed table params.
- Store expanded state as `filters=open` without resetting pagination/show-more state.
- Make the large-screen sidebar filter panel controlled instead of remounting collapsed.

## Related Issues

Fixes #1081

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

Not applicable; this is a state persistence fix with no visual styling changes.

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [ ] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [ ] Screenshots included for any UI/visual changes