### PR TITLE
fix: debounce list search filtering

### DIFF
--- a/src/components/issues/IssuesList.tsx
+++ b/src/components/issues/IssuesList.tsx
@@ -34,6 +34,7 @@ import ViewModuleIcon from '@mui/icons-material/ViewModule';
 import ReactECharts from 'echarts-for-react';
 import { format } from 'date-fns';
 import { IssueBounty } from '../../api/models/Issues';
+import { useDebouncedValue } from '../../hooks/useDebouncedValue';
 import { usePrices } from '../../hooks/usePrices';
 import {
   formatAlphaToUsd,
@@ -207,6 +208,7 @@ const IssuesList: React.FC<IssuesListProps> = ({
   const [sortKey, setSortKey] = useState<SortKey>('id');
   const [sortDirection, setSortDirection] = useState<SortDirection>('desc');
   const [searchQuery, setSearchQuery] = useState('');
+  const debouncedSearchQuery = useDebouncedValue(searchQuery);
   const [showChart, setShowChart] = useState(false);
 
   const isLargeScreen = useMediaQuery(theme.breakpoints.up('xl'));
@@ -263,15 +265,15 @@ const IssuesList: React.FC<IssuesListProps> = ({
   }, [issues, filterType]);
 
   const filteredIssues = useMemo(() => {
-    if (!searchQuery) return filteredByType;
-    const q = searchQuery.toLowerCase();
+    if (!debouncedSearchQuery) return filteredByType;
+    const q = debouncedSearchQuery.toLowerCase();
     return filteredByType.filter(
       (i) =>
         i.repositoryFullName.toLowerCase().includes(q) ||
         i.title?.toLowerCase().includes(q) ||
         String(i.issueNumber).includes(q),
     );
-  }, [filteredByType, searchQuery]);
+  }, [filteredByType, debouncedSearchQuery]);
 
   const getDefaultSortDirection = useCallback(
     (key: SortKey): SortDirection =>

--- a/src/components/leaderboard/TopRepositoriesTable.tsx
+++ b/src/components/leaderboard/TopRepositoriesTable.tsx
@@ -61,6 +61,7 @@ import {
   getRepositoryOwnerAvatarSrc,
   truncateText,
 } from '../../utils';
+import { useDebouncedValue } from '../../hooks/useDebouncedValue';
 import { useWatchlist } from '../../hooks/useWatchlist';
 import { RankIcon } from './RankIcon';
 import { getRepositoryOwnerAvatarBackground, type RepoStats } from './types';
@@ -238,6 +239,7 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
     urlDir === 'asc' || urlDir === 'desc' ? urlDir : 'desc',
   );
   const [useLogScale, setUseLogScale] = useState(true);
+  const debouncedSearchQuery = useDebouncedValue(searchQuery);
   const chartMetricKey: ChartMetricKey = VALID_CHART_METRIC_KEYS.has(
     sortColumn as ChartMetricKey,
   )
@@ -392,15 +394,15 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
     }
 
     // Apply search filter
-    if (searchQuery) {
-      const lowerQuery = searchQuery.toLowerCase();
+    if (debouncedSearchQuery) {
+      const lowerQuery = debouncedSearchQuery.toLowerCase();
       filtered = filtered.filter((repo) =>
         repo.repository?.toLowerCase().includes(lowerQuery),
       );
     }
 
     return filtered;
-  }, [rankedRepositories, statusFilter, searchQuery]);
+  }, [rankedRepositories, statusFilter, debouncedSearchQuery]);
 
   const maxWeight = useMemo(
     () => rankedRepositories.reduce((m, r) => (r.weight > m ? r.weight : m), 0),
@@ -1122,8 +1124,8 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
       return;
     }
     setPage(0);
-    syncToUrl({ search: searchQuery, page: '0' });
-  }, [searchQuery]); // eslint-disable-line react-hooks/exhaustive-deps
+    syncToUrl({ search: debouncedSearchQuery, page: '0' });
+  }, [debouncedSearchQuery]); // eslint-disable-line react-hooks/exhaustive-deps
 
   if (isLoading) {
     return (

--- a/src/components/miners/MinerRepositoriesTable.tsx
+++ b/src/components/miners/MinerRepositoriesTable.tsx
@@ -12,6 +12,7 @@ import {
 } from '@mui/material';
 import { Search as SearchIcon } from '@mui/icons-material';
 import { useMinerPRs, useReposAndWeights, useIssues } from '../../api';
+import { useDebouncedValue } from '../../hooks/useDebouncedValue';
 import { LinkBox } from '../common/linkBehavior';
 import {
   DataTable,
@@ -84,6 +85,7 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
     useState<IssueRepoSortField>('issueTokenScore');
   const [issueSortOrder, setIssueSortOrder] = useState<SortOrder>('desc');
   const [searchQuery, setSearchQuery] = useState('');
+  const debouncedSearchQuery = useDebouncedValue(searchQuery);
   const [statusFilter, setStatusFilter] = useState<RepoStatusFilter>('all');
   const [page, setPage] = useState(0);
 
@@ -180,13 +182,13 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
   );
 
   const filteredRepoStats = useMemo(
-    () => filterBySearch(statusFilteredRepoStats, searchQuery),
-    [statusFilteredRepoStats, searchQuery],
+    () => filterBySearch(statusFilteredRepoStats, debouncedSearchQuery),
+    [statusFilteredRepoStats, debouncedSearchQuery],
   );
 
   const filteredIssueRepoStats = useMemo(
-    () => filterBySearch(statusFilteredIssueRepoStats, searchQuery),
-    [statusFilteredIssueRepoStats, searchQuery],
+    () => filterBySearch(statusFilteredIssueRepoStats, debouncedSearchQuery),
+    [statusFilteredIssueRepoStats, debouncedSearchQuery],
   );
 
   const sortedRepoStats = useMemo(

--- a/src/components/miners/MinerScoreBreakdown.tsx
+++ b/src/components/miners/MinerScoreBreakdown.tsx
@@ -42,6 +42,7 @@ import {
   usePullRequestDetails,
   type CommitLog,
 } from '../../api';
+import { useDebouncedValue } from '../../hooks/useDebouncedValue';
 import { STATUS_COLORS, tooltipSlotProps } from '../../theme';
 import {
   parseNumber,
@@ -953,6 +954,7 @@ const PrBreakdownView: React.FC<{ githubId: string }> = ({ githubId }) => {
   const [searchParams, setSearchParams] = useSearchParams();
   const { data: prs, isLoading } = useMinerPRs(githubId);
   const [searchQuery, setSearchQuery] = useState('');
+  const debouncedSearchQuery = useDebouncedValue(searchQuery);
   const [isMobileSearchOpen, setIsMobileSearchOpen] = useState(false);
 
   const statusFilter = scoreStatusFromSearchParam(
@@ -1017,11 +1019,11 @@ const PrBreakdownView: React.FC<{ githubId: string }> = ({ githubId }) => {
   const prevSearchRef = useRef<string | null>(null);
   useEffect(() => {
     if (prevSearchRef.current === null) {
-      prevSearchRef.current = searchQuery;
+      prevSearchRef.current = debouncedSearchQuery;
       return;
     }
-    if (prevSearchRef.current === searchQuery) return;
-    prevSearchRef.current = searchQuery;
+    if (prevSearchRef.current === debouncedSearchQuery) return;
+    prevSearchRef.current = debouncedSearchQuery;
     setSearchParams(
       (prev) => {
         const p = new URLSearchParams(prev);
@@ -1030,7 +1032,7 @@ const PrBreakdownView: React.FC<{ githubId: string }> = ({ githubId }) => {
       },
       { replace: true },
     );
-  }, [searchQuery, setSearchParams]);
+  }, [debouncedSearchQuery, setSearchParams]);
 
   useEffect(() => {
     if (!isMobile) setIsMobileSearchOpen(false);
@@ -1058,7 +1060,7 @@ const PrBreakdownView: React.FC<{ githubId: string }> = ({ githubId }) => {
     let list = [...filterPrs(prs, { statusFilter })].sort(
       (a, b) => parseFloat(b.score || '0') - parseFloat(a.score || '0'),
     );
-    const q = searchQuery.trim().toLowerCase();
+    const q = debouncedSearchQuery.trim().toLowerCase();
     if (q) {
       list = list.filter((pr) => {
         const title = (pr.pullRequestTitle || '').toLowerCase();
@@ -1073,7 +1075,7 @@ const PrBreakdownView: React.FC<{ githubId: string }> = ({ githubId }) => {
       });
     }
     return list;
-  }, [prs, statusFilter, searchQuery]);
+  }, [prs, statusFilter, debouncedSearchQuery]);
 
   const paging = useMemo(() => {
     const isAllRows = pageSize === 'all';

--- a/src/components/repositories/LanguageWeightsTable.tsx
+++ b/src/components/repositories/LanguageWeightsTable.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useRef } from 'react';
+import React, { useEffect, useState, useMemo, useRef } from 'react';
 import {
   Box,
   TablePagination,
@@ -20,6 +20,7 @@ import BarChartIcon from '@mui/icons-material/BarChart';
 import TableChartIcon from '@mui/icons-material/TableChart';
 import { TEXT_OPACITY, scrollbarSx } from '../../theme';
 import { useLanguagesAndWeights } from '../../api';
+import { useDebouncedValue } from '../../hooks/useDebouncedValue';
 import { ClearSearchAdornment } from '../common/ClearSearchAdornment';
 import {
   echartsAxisTooltipChrome,
@@ -49,6 +50,7 @@ const LanguageWeightsTable: React.FC = () => {
   const theme = useTheme();
   const { data: languages, isLoading } = useLanguagesAndWeights();
   const [searchQuery, setSearchQuery] = useState('');
+  const debouncedSearchQuery = useDebouncedValue(searchQuery);
   const [sortField, setSortField] = useState<SortField>('weight');
   const [sortOrder, setSortOrder] = useState<SortOrder>('desc');
   const [showChart, setShowChart] = useState(false);
@@ -90,14 +92,17 @@ const LanguageWeightsTable: React.FC = () => {
 
   const handleSearchChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setSearchQuery(event.target.value);
-    setPage(0);
   };
+
+  useEffect(() => {
+    setPage(0);
+  }, [debouncedSearchQuery]);
 
   const filteredAndSortedLanguages = useMemo<LanguageRow[]>(() => {
     if (!languages) return [];
 
     const filtered = languages.filter((lang) => {
-      const searchLower = searchQuery.toLowerCase();
+      const searchLower = debouncedSearchQuery.toLowerCase();
       return (
         lang.extension.toLowerCase().includes(searchLower) ||
         (lang.language && lang.language.toLowerCase().includes(searchLower))
@@ -131,7 +136,7 @@ const LanguageWeightsTable: React.FC = () => {
     });
 
     return filtered;
-  }, [languages, searchQuery, sortField, sortOrder]);
+  }, [languages, debouncedSearchQuery, sortField, sortOrder]);
 
   const paginatedLanguages = useMemo(() => {
     const startIndex = page * rowsPerPage;

--- a/src/hooks/useDebouncedValue.ts
+++ b/src/hooks/useDebouncedValue.ts
@@ -1,0 +1,20 @@
+import { useEffect, useState } from 'react';
+
+const DEFAULT_DEBOUNCE_MS = 250;
+
+export const useDebouncedValue = <T>(
+  value: T,
+  delayMs = DEFAULT_DEBOUNCE_MS,
+): T => {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      setDebouncedValue(value);
+    }, delayMs);
+
+    return () => window.clearTimeout(timer);
+  }, [value, delayMs]);
+
+  return debouncedValue;
+};

--- a/src/pages/WatchlistPage.tsx
+++ b/src/pages/WatchlistPage.tsx
@@ -47,6 +47,7 @@ import TuneOutlinedIcon from '@mui/icons-material/TuneOutlined';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import { Link as RouterLink, useSearchParams } from 'react-router-dom';
 import { Page } from '../components/layout';
+import { useDebouncedValue } from '../hooks/useDebouncedValue';
 import { useTwitterStickySidebar } from '../hooks/useTwitterStickySidebar';
 import {
   TopMinersTable,
@@ -1636,6 +1637,7 @@ const ReposList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
   const { data: allMiners } = useAllMiners();
   const sidebarFixedRight = useWatchlistSidebarFixedRight();
   const [searchQuery, setSearchQuery] = useState('');
+  const debouncedSearchQuery = useDebouncedValue(searchQuery);
   const [statusFilter, setStatusFilter] = useState<RepoStatusFilter>('all');
   const [viewMode, setViewMode] = useWatchlistViewMode();
   const [showChart, setShowChart] = useState(false);
@@ -1653,7 +1655,7 @@ const ReposList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
 
   useEffect(() => {
     setPage(0);
-  }, [statusFilter, searchQuery, sortField, sortOrder, viewMode]);
+  }, [statusFilter, debouncedSearchQuery, sortField, sortOrder, viewMode]);
 
   const handleSort = (field: RepoSortKey) => {
     if (sortField === field) {
@@ -1731,11 +1733,11 @@ const ReposList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
     else if (statusFilter === 'inactive')
       result = result.filter((r) => !isRepoActive(r));
 
-    const q = searchQuery.trim().toLowerCase();
+    const q = debouncedSearchQuery.trim().toLowerCase();
     if (q) result = result.filter((r) => r.fullName.toLowerCase().includes(q));
 
     return result;
-  }, [items, statusFilter, searchQuery]);
+  }, [items, statusFilter, debouncedSearchQuery]);
 
   const sorted = useMemo(() => {
     const dir = sortOrder === 'asc' ? 1 : -1;
@@ -2422,6 +2424,7 @@ const BountiesList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
   }, [allIssues, itemKeys]);
 
   const [searchQuery, setSearchQuery] = useState('');
+  const debouncedSearchQuery = useDebouncedValue(searchQuery);
   const [statusFilter, setStatusFilter] = useState<BountyStatusFilter>('all');
   const [viewMode, setViewMode] = useWatchlistViewMode();
   const [page, setPage] = useState(0);
@@ -2437,7 +2440,7 @@ const BountiesList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
 
   useEffect(() => {
     setPage(0);
-  }, [statusFilter, searchQuery, sortField, sortOrder, viewMode]);
+  }, [statusFilter, debouncedSearchQuery, sortField, sortOrder, viewMode]);
 
   const handleSort = (field: BountySortKey) => {
     if (sortField === field) {
@@ -2452,8 +2455,12 @@ const BountiesList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
   const counts = useMemo(() => getBountyCounts(items), [items]);
 
   const filtered = useMemo(
-    () => filterBounties(items, { statusFilter, searchQuery }),
-    [items, statusFilter, searchQuery],
+    () =>
+      filterBounties(items, {
+        statusFilter,
+        searchQuery: debouncedSearchQuery,
+      }),
+    [items, statusFilter, debouncedSearchQuery],
   );
 
   const sorted = useMemo(() => {
@@ -3210,6 +3217,7 @@ const PRsList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
   const { isWatched } = useWatchlist('prs');
   const sidebarFixedRight = useWatchlistSidebarFixedRight();
   const [searchQuery, setSearchQuery] = useState('');
+  const debouncedSearchQuery = useDebouncedValue(searchQuery);
   const [statusFilter, setStatusFilter] = useState<PrStatusFilter>('all');
   const [viewMode, setViewMode] = useWatchlistViewMode();
   const [page, setPage] = useState(0);
@@ -3225,7 +3233,14 @@ const PRsList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
 
   useEffect(() => {
     setPage(0);
-  }, [statusFilter, searchQuery, sortField, sortOrder, viewMode, isWatched]);
+  }, [
+    statusFilter,
+    debouncedSearchQuery,
+    sortField,
+    sortOrder,
+    viewMode,
+    isWatched,
+  ]);
 
   const handleSort = (field: PrSortKey) => {
     if (sortField === field) {
@@ -3246,10 +3261,10 @@ const PRsList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
   const filtered = useMemo(() => {
     return filterPrs(items, {
       statusFilter,
-      searchQuery,
+      searchQuery: debouncedSearchQuery,
       includeNumber: true,
     });
-  }, [items, statusFilter, searchQuery]);
+  }, [items, statusFilter, debouncedSearchQuery]);
 
   const sorted = useMemo(() => {
     const dir = sortOrder === 'asc' ? 1 : -1;
@@ -4048,6 +4063,7 @@ const IssuesList: React.FC<{ minerIds: string[] }> = ({ minerIds }) => {
   }, [issueQueries]);
 
   const [searchQuery, setSearchQuery] = useState('');
+  const debouncedSearchQuery = useDebouncedValue(searchQuery);
   const [statusFilter, setStatusFilter] = useState<IssueStatusFilter>('all');
   const [viewMode, setViewMode] = useWatchlistViewMode();
   const [page, setPage] = useState(0);
@@ -4063,7 +4079,7 @@ const IssuesList: React.FC<{ minerIds: string[] }> = ({ minerIds }) => {
 
   useEffect(() => {
     setPage(0);
-  }, [statusFilter, searchQuery, sortField, sortOrder, viewMode]);
+  }, [statusFilter, debouncedSearchQuery, sortField, sortOrder, viewMode]);
 
   const handleSort = (field: IssueSortKey) => {
     if (sortField === field) {
@@ -4078,8 +4094,12 @@ const IssuesList: React.FC<{ minerIds: string[] }> = ({ minerIds }) => {
   const counts = useMemo(() => getIssueCounts(items), [items]);
 
   const filtered = useMemo(
-    () => filterIssues(items, { statusFilter, searchQuery }),
-    [items, statusFilter, searchQuery],
+    () =>
+      filterIssues(items, {
+        statusFilter,
+        searchQuery: debouncedSearchQuery,
+      }),
+    [items, statusFilter, debouncedSearchQuery],
   );
 
   const sorted = useMemo(() => {


### PR DESCRIPTION
## Summary

- Add a reusable `useDebouncedValue` hook for responsive list search inputs.
- Debounce expensive filtering and page-reset work on Watchlist repositories, bounties, PRs, and issues.
- Apply the same delayed filtering pattern to the related list-heavy surfaces called out in the issue.

## Related Issues

Fixes #1083

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

Not applicable; this is an interaction performance fix with no visual styling changes.

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [ ] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [ ] Screenshots included for any UI/visual changes