### PR TITLE
fix(ui): mobile responsive improvements and scroll-aware tooltips

### DIFF
--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -4,3 +4,4 @@ export * from './WatchlistButton';
 export * from './DataTable';
 export { default as ConversationTimeline } from './ConversationTimeline';
 export * from './ConversationTimeline';
+export * from './ScrollAwareTooltip';

--- a/src/components/issues/IssueHeaderCard.tsx
+++ b/src/components/issues/IssueHeaderCard.tsx
@@ -94,9 +94,10 @@ const IssueHeaderCard: React.FC<IssueHeaderCardProps> = ({ issue }) => {
             sx={{
               fontFamily:
                 '-apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif',
-              fontSize: '1.5rem',
+              fontSize: { xs: '1.15rem', sm: '1.5rem' },
               fontWeight: 600,
               color: 'text.primary',
+              wordBreak: 'break-word',
             }}
           >
             {issue.title}

--- a/src/components/leaderboard/MinersList.tsx
+++ b/src/components/leaderboard/MinersList.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import { Avatar, Box, Card, Tooltip, Typography } from '@mui/material';
+import { Avatar, Box, Card, Typography } from '@mui/material';
 import { useMinerGithubData, useMinerPRs } from '../../api';
 import { CHART_COLORS } from '../../theme';
 import { getGithubAvatarSrc, type SortOrder } from '../../utils/ExplorerUtils';
-import { DataTable, type DataTableColumn, WatchlistButton } from '../common';
+import { DataTable, type DataTableColumn, ScrollAwareTooltip, WatchlistButton } from '../common';
 import { RankIcon } from './RankIcon';
 import {
   type LeaderboardVariant,
@@ -246,7 +246,7 @@ const MinerIdentityCell: React.FC<MinerIdentityCellProps> = ({ miner }) => {
           borderColor: 'border.medium',
         }}
       />
-      <Tooltip title={username} placement="top">
+      <ScrollAwareTooltip title={username} placement="top">
         <Typography
           component="span"
           sx={{
@@ -262,7 +262,7 @@ const MinerIdentityCell: React.FC<MinerIdentityCellProps> = ({ miner }) => {
         >
           {username}
         </Typography>
-      </Tooltip>
+      </ScrollAwareTooltip>
     </Box>
   );
 };
@@ -299,7 +299,7 @@ const MinerActivitySegments: React.FC<MinerActivitySegmentsProps> = ({
       }}
     >
       {segments.map((segment, i) => (
-        <Tooltip
+        <ScrollAwareTooltip
           key={segment.label}
           title={segment.label}
           arrow
@@ -321,7 +321,7 @@ const MinerActivitySegments: React.FC<MinerActivitySegmentsProps> = ({
               {segment.value}
             </Typography>
           </Box>
-        </Tooltip>
+        </ScrollAwareTooltip>
       ))}
     </Box>
   );

--- a/src/pages/IssueDetailsPage.tsx
+++ b/src/pages/IssueDetailsPage.tsx
@@ -131,12 +131,18 @@ const IssueDetailsPage: React.FC = () => {
               sx={(theme) => ({
                 borderBottom: 1,
                 borderColor: theme.palette.border.light,
+                overflowX: 'auto',
+                WebkitOverflowScrolling: 'touch',
+                '&::-webkit-scrollbar': { display: 'none' },
+                scrollbarWidth: 'none',
               })}
             >
               <Tabs
                 value={tabValue}
                 onChange={handleTabChange}
                 aria-label="issue details tabs"
+                variant="scrollable"
+                scrollButtons="auto"
                 sx={(theme) => ({
                   '& .MuiTab-root': {
                     color: STATUS_COLORS.open,


### PR DESCRIPTION
## Summary

Two targeted UI fixes resubmitted against the **test** branch.

### Changes

**1. IssueDetailsPage mobile responsiveness** (partial fix for #943)
- `IssueHeaderCard`: responsive title font size (`xs: 1.15rem` / `sm: 1.5rem`) and `word-break: break-word` to prevent long titles from overflowing on mobile
- `IssueDetailsPage`: added `variant="scrollable"` + `scrollButtons="auto"` to MUI Tabs, with hidden-scrollbar horizontal overflow container

**2. ScrollAwareTooltip in MinersList** (fixes #920, from #931)
- Replaced `Tooltip` with `ScrollAwareTooltip` for username and activity-segment tooltips in `MinersList.tsx`
- Tooltips now auto-close when the table is scrolled, preventing them from floating over the sticky header
- Exported `ScrollAwareTooltip` from the common barrel file

### Notes
- IssueConversation and IssueSubmissionsTable changes from #943 were already addressed differently in the current test branch
- Bounty Pool chart label fix (#928) was already merged into test

Fixes #920
Partially addresses #943