### PR TITLE
fix: wrap repository header chips

### DIFF
--- a/src/pages/RepositoryDetailsPage.tsx
+++ b/src/pages/RepositoryDetailsPage.tsx
@@ -480,7 +480,15 @@ const RepositoryDetailsPage: React.FC = () => {
 
                 {/* Desktop (md+) — original single-row header */}
                 <Box sx={{ display: { xs: 'none', md: 'block' } }}>
-                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+                  <Box
+                    sx={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 2,
+                      flexWrap: 'wrap',
+                      rowGap: 1,
+                    }}
+                  >
                     <Avatar
                       src={getRepositoryOwnerAvatarSrc(owner)}
                       alt={owner}


### PR DESCRIPTION
## Summary

Fixes the Repository Details header layout at narrower desktop widths.

The status chips now wrap when there is not enough horizontal space, preventing the `Inactive since ...` chip from overlapping the `View on GitHub` button.

## Changes

- Added wrapping to the desktop repository header flex row.
- Added row spacing for wrapped chips.

## Related Issue

Fixes #692

## ScreenShots
### Before
<img width="1358" height="738" alt="image" src="https://github.com/user-attachments/assets/d4ccb81d-a1e5-4098-a987-5194f3923c87" />

### After
<img width="1465" height="750" alt="image" src="https://github.com/user-attachments/assets/6fb9dcdd-db66-4bdb-ad80-ac24b5e29ceb" />


## Testing

- `npm run lint -- --quiet`
- `npm run build`
