### PR TITLE
fix/issue-970-landing-page-polish

### DIFF
--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -2,7 +2,10 @@ import React, { useMemo, useState, useEffect } from 'react';
 import { Avatar, Box, Button, Stack, Typography } from '@mui/material';
 import { alpha, useTheme, type Theme } from '@mui/material/styles';
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
+import PersonAddAlt1OutlinedIcon from '@mui/icons-material/PersonAddAlt1Outlined';
+import RouteOutlinedIcon from '@mui/icons-material/RouteOutlined';
 import RocketLaunchIcon from '@mui/icons-material/RocketLaunch';
+import VerifiedOutlinedIcon from '@mui/icons-material/VerifiedOutlined';
 import { Page } from '../components/layout';
 import NetworkCanvas from '../components/landing/NetworkCanvas';
 import useCountUp from '../hooks/useCountUp';
@@ -75,16 +78,25 @@ const getActivityToneColor = (theme: Theme, tone: ActivityTone) => {
 
 const howItWorksItems = [
   {
+    icon: <PersonAddAlt1OutlinedIcon />,
+    label: 'Join',
     title: 'A market of agents',
-    body: 'Anyone can join. New agents arrive every day.',
+    body: 'Anyone can join: register a miner, link GitHub, and make your work visible to validators.',
+    result: 'New agents enter the network every day',
   },
   {
+    icon: <RouteOutlinedIcon />,
+    label: 'Build',
     title: 'Direct them at anything',
-    body: 'Pick a project. The agents get to work.',
+    body: 'Pick a tracked repository, submit pull requests, and let merged code become public contribution signal.',
+    result: 'Merged PRs become contribution signal',
   },
   {
+    icon: <VerifiedOutlinedIcon />,
+    label: 'Reward',
     title: 'Paid for real work',
-    body: 'When the code gets used, agents get paid.',
+    body: 'When code gets used, validators check quality and credibility before publishing reward estimates.',
+    result: 'Agents get paid for verified work',
   },
 ] as const;
 
@@ -288,7 +300,7 @@ const HomePage: React.FC = () => {
   useEffect(() => {
     const interval = setInterval(() => {
       setActivePanel((current) => (current === 'feed' ? 'miners' : 'feed'));
-    }, 5000);
+    }, 7000);
     return () => clearInterval(interval);
   }, []);
 
@@ -374,7 +386,7 @@ const HomePage: React.FC = () => {
           minHeight: { xs: 'calc(100vh - 88px)', md: 'calc(100vh - 32px)' },
           display: 'flex',
           flexDirection: 'column',
-          gap: { xs: 2.5, md: 3 },
+          gap: { xs: 2.25, md: 2.5, xl: 3 },
           color: theme.palette.text.primary,
           maxWidth: { xl: 1760 },
           mx: 'auto',
@@ -403,6 +415,10 @@ const HomePage: React.FC = () => {
               transition: 'none !important',
             },
           },
+          '@media (max-height: 820px) and (min-width: 900px)': {
+            gap: 2,
+            py: 0.75,
+          },
         }}
       >
         <Box
@@ -412,11 +428,16 @@ const HomePage: React.FC = () => {
             display: 'grid',
             gridTemplateColumns: {
               xs: '1fr',
+              lg: 'minmax(0, 1fr) minmax(0, 0.72fr)',
               xl: 'minmax(0, 1.05fr) minmax(0, 0.78fr)',
             },
-            gap: { xs: 2, md: 3, xl: 4 },
-            alignItems: 'center',
+            gap: { xs: 2, md: 2.5, xl: 4 },
+            alignItems: { xs: 'stretch', lg: 'center' },
             position: 'relative',
+            '@media (min-width: 1200px) and (max-width: 1360px)': {
+              gridTemplateColumns: 'minmax(0, 1fr) minmax(0, 0.68fr)',
+              gap: 2,
+            },
           }}
         >
           {/* ── Full-width animated particle mesh ── */}
@@ -450,7 +471,8 @@ const HomePage: React.FC = () => {
               minWidth: 0,
               display: 'grid',
               gridTemplateColumns: '1fr',
-              gridTemplateRows: '1fr',
+              gridTemplateRows: '1fr auto',
+              rowGap: 1,
               alignItems: 'center',
               alignSelf: 'center',
               position: 'relative',
@@ -493,6 +515,11 @@ const HomePage: React.FC = () => {
               }}
             >
               <TopMinersPanel
+                key={
+                  activePanel === 'miners'
+                    ? 'top-miners-visible'
+                    : 'top-miners-hidden'
+                }
                 rows={minerRows}
                 hasLiveData={minerRows.length > 0}
                 isLoading={datasets.miners.isLoading}
@@ -503,10 +530,9 @@ const HomePage: React.FC = () => {
               direction="row"
               spacing={1}
               sx={{
-                position: 'absolute',
-                bottom: -24,
-                left: '50%',
-                transform: 'translateX(-50%)',
+                gridArea: '2 / 1',
+                position: 'relative',
+                justifySelf: 'center',
                 zIndex: 2,
               }}
             >
@@ -546,9 +572,13 @@ const HomePage: React.FC = () => {
           sx={{
             width: '100%',
             display: 'grid',
-            gridTemplateColumns: { xs: '1fr', lg: '1.3fr 0.7fr' },
-            gap: { xs: 2, md: 3, xl: 4 },
+            gridTemplateColumns: '1fr',
+            gap: { xs: 2, md: 2.5, xl: 4 },
+            alignItems: 'stretch',
             pb: { xs: 4, md: 5 },
+            '@media (min-width: 1420px)': {
+              gridTemplateColumns: 'minmax(0, 1.28fr) minmax(360px, 0.72fr)',
+            },
           }}
         >
           <HowItWorksSection
@@ -565,13 +595,14 @@ const HomePage: React.FC = () => {
               alignSelf: 'stretch',
               display: 'grid',
               gridTemplateColumns: '1fr',
-              gridTemplateRows: '1fr',
+              gridTemplateRows: 'auto 1fr',
+              rowGap: 1,
               position: 'relative',
             }}
           >
             <Box
               sx={{
-                gridArea: '1 / 1',
+                gridArea: '2 / 1',
                 display: 'flex',
                 opacity: activeBottomCard === 'maintainer' ? 1 : 0,
                 pointerEvents:
@@ -594,7 +625,7 @@ const HomePage: React.FC = () => {
             </Box>
             <Box
               sx={{
-                gridArea: '1 / 1',
+                gridArea: '2 / 1',
                 display: 'flex',
                 opacity: activeBottomCard === 'miner' ? 1 : 0,
                 pointerEvents: activeBottomCard === 'miner' ? 'auto' : 'none',
@@ -618,10 +649,11 @@ const HomePage: React.FC = () => {
               direction="row"
               spacing={0}
               sx={{
-                position: 'absolute',
-                top: -28,
-                left: '50%',
-                transform: 'translateX(-50%)',
+                gridArea: '1 / 1',
+                position: 'relative',
+                justifySelf: { xs: 'start', sm: 'end', xl: 'center' },
+                maxWidth: '100%',
+                flexWrap: 'wrap',
                 zIndex: 2,
                 borderRadius: 3,
                 overflow: 'hidden',
@@ -641,6 +673,7 @@ const HomePage: React.FC = () => {
                     fontWeight: 700,
                     letterSpacing: '0.08em',
                     textTransform: 'uppercase',
+                    whiteSpace: 'nowrap',
                     transition: 'all 0.25s ease',
                     backgroundColor:
                       activeBottomCard === tab
@@ -701,6 +734,10 @@ const HeroCopy: React.FC<HeroCopyProps> = ({
         py: { xs: 4, md: 5, xl: 4 },
         position: 'relative',
         overflow: 'hidden',
+        '@media (max-height: 820px) and (min-width: 900px)': {
+          gap: 2.25,
+          py: 2.5,
+        },
       }}
     >
       {/* ── Hero copy ── */}
@@ -753,8 +790,8 @@ const HeroCopy: React.FC<HeroCopyProps> = ({
               fontFamily: 'var(--font-heading)',
               fontSize: {
                 xs: 'clamp(2.1rem, 9.2vw, 2.95rem)',
-                sm: '4.2rem',
-                md: '5.35rem',
+                sm: '4rem',
+                md: '4.65rem',
                 xl: '5.55rem',
               },
               fontWeight: 900,
@@ -762,6 +799,9 @@ const HeroCopy: React.FC<HeroCopyProps> = ({
               letterSpacing: 0,
               overflowWrap: 'anywhere',
               ...fadeUp(140),
+              '@media (max-height: 820px) and (min-width: 900px)': {
+                fontSize: '4.1rem',
+              },
             }}
           >
             Autonomous software{' '}
@@ -872,18 +912,22 @@ const HeroCopy: React.FC<HeroCopyProps> = ({
         sx={{
           width: '100%',
           display: 'grid',
+          position: 'relative',
           gridTemplateColumns: {
             xs: '1fr',
-            sm: 'auto 1px auto 1px auto',
+            sm: 'repeat(3, minmax(0, 1fr))',
           },
-          gap: { xs: 0, sm: 0 },
-          maxWidth: 780,
+          gap: 1,
+          maxWidth: 920,
           alignSelf: 'stretch',
-          position: 'relative',
           zIndex: 1,
           mt: { xs: 0.5, md: 0 },
         }}
       >
+        <CornerPlus vertical="top" horizontal="left" />
+        <CornerPlus vertical="top" horizontal="right" />
+        <CornerPlus vertical="bottom" horizontal="left" />
+        <CornerPlus vertical="bottom" horizontal="right" />
         <HeroStat
           rawValue={rewardPoolRaw}
           displayValue={rewardPoolLabel}
@@ -891,27 +935,11 @@ const HeroCopy: React.FC<HeroCopyProps> = ({
           prefix="$"
           delayMs={420}
         />
-        <Box
-          sx={(theme) => ({
-            display: { xs: 'none', sm: 'block' },
-            alignSelf: 'stretch',
-            my: 0.5,
-            backgroundColor: alpha(theme.palette.text.primary, 0.1),
-          })}
-        />
         <HeroStat
           rawValue={minerCountRaw}
           displayValue={minerCountLabel}
           label="competing miners"
           delayMs={500}
-        />
-        <Box
-          sx={(theme) => ({
-            display: { xs: 'none', sm: 'block' },
-            alignSelf: 'stretch',
-            my: 0.5,
-            backgroundColor: alpha(theme.palette.text.primary, 0.1),
-          })}
         />
         <HeroStat
           rawValue={merged35dRaw}
@@ -926,6 +954,60 @@ const HeroCopy: React.FC<HeroCopyProps> = ({
 
 // Removed PlainEnglishPanel
 
+const CornerPlus: React.FC<{
+  vertical: 'top' | 'bottom';
+  horizontal: 'left' | 'right';
+}> = ({ vertical, horizontal }) => (
+  <Box
+    aria-hidden
+    sx={(theme) => ({
+      position: 'absolute',
+      [vertical]: 0,
+      [horizontal]: 0,
+      width: 14,
+      height: 14,
+      transform: `translate(${horizontal === 'left' ? '-50%' : '50%'}, ${
+        vertical === 'top' ? '-50%' : '50%'
+      })`,
+      display: 'grid',
+      placeItems: 'center',
+      color: alpha(theme.palette.status.merged, 0.86),
+      fontFamily: 'var(--font-mono)',
+      fontSize: '0.86rem',
+      fontWeight: 900,
+      lineHeight: 1,
+      pointerEvents: 'none',
+      zIndex: 2,
+    })}
+  >
+    +
+  </Box>
+);
+
+const HeroStatValueSkeleton: React.FC<{ ariaLabel: string }> = ({
+  ariaLabel,
+}) => (
+  <Box
+    role="status"
+    aria-label={ariaLabel}
+    sx={{
+      height: { xs: '1.65rem', sm: '2rem' },
+      display: 'flex',
+      alignItems: 'flex-end',
+      pb: 0.15,
+    }}
+  >
+    <Box
+      sx={(theme) => ({
+        width: { xs: 36, sm: 44 },
+        height: 5,
+        backgroundColor: theme.palette.status.merged,
+        boxShadow: `0 0 12px ${alpha(theme.palette.status.merged, 0.22)}`,
+      })}
+    />
+  </Box>
+);
+
 const HeroStat: React.FC<{
   rawValue: number;
   displayValue: string;
@@ -934,8 +1016,8 @@ const HeroStat: React.FC<{
   delayMs: number;
 }> = ({ rawValue, displayValue, label, prefix, delayMs }) => {
   const animatedNum = useCountUp(rawValue, 2200, delayMs);
+  const showEmptyValue = rawValue <= 0;
 
-  // Show the animated number while counting, then switch to the formatted display value
   const shown =
     rawValue > 0
       ? animatedNum >= rawValue
@@ -945,25 +1027,32 @@ const HeroStat: React.FC<{
 
   return (
     <Box
-      sx={{
+      sx={(theme) => ({
         py: { xs: 1.4, sm: 1.8 },
         px: { xs: 0, sm: 2.5 },
+        borderTop: `1px solid ${theme.palette.border.light}`,
+        borderBottom: `1px solid ${theme.palette.border.light}`,
         minWidth: 0,
         ...fadeUp(delayMs),
-      }}
+      })}
     >
-      <Typography
-        sx={(theme) => ({
-          color: theme.palette.status.merged,
-          fontFamily: 'var(--font-heading)',
-          fontSize: { xs: '1.65rem', sm: '2rem' },
-          fontWeight: 900,
-          lineHeight: 1,
-          textShadow: `0 0 20px ${alpha(theme.palette.status.merged, 0.3)}`,
-        })}
-      >
-        {shown}
-      </Typography>
+      {showEmptyValue ? (
+        <HeroStatValueSkeleton ariaLabel={`${label}: ${displayValue}`} />
+      ) : (
+        <Typography
+          sx={(theme) => ({
+            color: theme.palette.status.merged,
+            fontFamily: 'var(--font-heading)',
+            fontSize: { xs: '1.65rem', sm: '2rem' },
+            fontWeight: 900,
+            fontVariantNumeric: 'tabular-nums',
+            lineHeight: 1,
+            textShadow: `0 0 20px ${alpha(theme.palette.status.merged, 0.3)}`,
+          })}
+        >
+          {shown}
+        </Typography>
+      )}
       <Typography
         sx={(theme) => ({
           mt: 0.75,
@@ -976,6 +1065,86 @@ const HeroStat: React.FC<{
         {label}
       </Typography>
     </Box>
+  );
+};
+
+const TopMinerRewardAmount: React.FC<{ value: number; delayMs: number }> = ({
+  value,
+  delayMs,
+}) => {
+  const animatedValue = useCountUp(value > 0 ? value : 0, 1600, delayMs);
+
+  if (value <= 0) return <>ranked</>;
+  return <>{animatedValue > 0 ? formatUsd(animatedValue) : '_'}</>;
+};
+
+const TopMinerRewardBar: React.FC<{ width: number; delayMs: number }> = ({
+  width,
+  delayMs,
+}) => {
+  const [animatedWidth, setAnimatedWidth] = useState(0);
+
+  useEffect(() => {
+    const durationMs = 1800;
+    let animationFrameId = 0;
+    let timeoutId = 0;
+    let startTime = 0;
+
+    const easeOutCubic = (value: number) => 1 - Math.pow(1 - value, 3);
+
+    const animate = (now: number) => {
+      if (startTime === 0) startTime = now;
+
+      const elapsed = now - startTime;
+      const progress = Math.min(elapsed / durationMs, 1);
+      setAnimatedWidth(width * easeOutCubic(progress));
+
+      if (progress < 1) {
+        animationFrameId = requestAnimationFrame(animate);
+      } else {
+        setAnimatedWidth(width);
+      }
+    };
+
+    setAnimatedWidth(0);
+    timeoutId = window.setTimeout(() => {
+      animationFrameId = requestAnimationFrame(animate);
+    }, delayMs);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+      cancelAnimationFrame(animationFrameId);
+    };
+  }, [delayMs, width]);
+
+  return (
+    <Box
+      aria-hidden
+      data-reward-bar
+      sx={(theme) => ({
+        position: 'absolute',
+        inset: 0,
+        right: 'auto',
+        width: `${animatedWidth}%`,
+        background: `linear-gradient(90deg, ${alpha(
+          theme.palette.status.merged,
+          0.38,
+        )} 0%, ${alpha(theme.palette.status.merged, 0.16)} 100%)`,
+        boxShadow: `0 0 20px ${alpha(theme.palette.status.merged, 0.18)}`,
+        zIndex: 0,
+        pointerEvents: 'none',
+        '&::after': {
+          content: '""',
+          position: 'absolute',
+          top: 0,
+          right: 0,
+          bottom: 0,
+          width: 2,
+          backgroundColor: alpha(theme.palette.status.merged, 0.85),
+          boxShadow: `0 0 12px ${alpha(theme.palette.status.merged, 0.65)}`,
+        },
+      })}
+    />
   );
 };
 
@@ -1245,6 +1414,7 @@ const TopMinersPanel: React.FC<{
               16,
               Math.min(100, (miner.monthlyUsd / topMonthlyUsd) * 100),
             );
+            const rewardDelayMs = 420 + index * 80;
 
             return (
               <LinkBox
@@ -1277,20 +1447,7 @@ const TopMinersPanel: React.FC<{
                   transition:
                     'background-color 0.16s ease, border-color 0.16s ease, transform 0.16s ease',
                   ...slideIn(330 + index * 55),
-                  '&::before': {
-                    content: '""',
-                    position: 'absolute',
-                    inset: 0,
-                    right: 'auto',
-                    width: `${rewardWidth}%`,
-                    backgroundColor: alpha(
-                      theme.palette.status.merged,
-                      index < 3 ? 0.14 : 0.08,
-                    ),
-                    zIndex: 0,
-                    pointerEvents: 'none',
-                  },
-                  '& > *': {
+                  '& > *:not([data-reward-bar])': {
                     position: 'relative',
                     zIndex: 1,
                   },
@@ -1308,6 +1465,10 @@ const TopMinersPanel: React.FC<{
                   },
                 })}
               >
+                <TopMinerRewardBar
+                  width={rewardWidth}
+                  delayMs={rewardDelayMs}
+                />
                 <Typography
                   sx={(theme) => ({
                     color:
@@ -1379,9 +1540,10 @@ const TopMinersPanel: React.FC<{
                       lineHeight: 1,
                     }}
                   >
-                    {miner.monthlyUsd > 0
-                      ? formatUsd(miner.monthlyUsd)
-                      : 'ranked'}
+                    <TopMinerRewardAmount
+                      value={miner.monthlyUsd}
+                      delayMs={rewardDelayMs}
+                    />
                   </Typography>
                   <Typography
                     sx={{ color: 'text.secondary', fontSize: '0.62rem' }}
@@ -1553,10 +1715,15 @@ const HowItWorksSection: React.FC<{
   medianMergeRate,
 }) => (
   <Box
-    sx={{
+    sx={(theme) => ({
       py: { xs: 2.5, md: 3 },
+      borderTop: `1px dashed ${theme.palette.border.medium}`,
+      borderBottom: `1px dashed ${theme.palette.border.medium}`,
       ...fadeUp(620),
-    }}
+      '@media (max-height: 820px) and (min-width: 900px)': {
+        py: 2.25,
+      },
+    })}
   >
     <Stack spacing={0.75} sx={{ mb: { xs: 2, md: 3 } }}>
       <Typography
@@ -1572,9 +1739,16 @@ const HowItWorksSection: React.FC<{
       <Typography
         sx={{
           fontFamily: 'var(--font-heading)',
-          fontSize: { xs: '1.7rem', sm: '2rem', md: '2.2rem', lg: '2.3rem' },
+          fontSize: {
+            xs: '1.7rem',
+            sm: '2rem',
+            md: '2.2rem',
+            lg: '2.35rem',
+            xl: '2.6rem',
+          },
           fontWeight: 900,
-          lineHeight: 1.1,
+          lineHeight: 1.05,
+          maxWidth: 720,
           overflowWrap: 'anywhere',
         }}
       >
@@ -1585,69 +1759,166 @@ const HowItWorksSection: React.FC<{
       sx={{
         display: 'grid',
         gridTemplateColumns: { xs: '1fr', md: 'repeat(3, minmax(0, 1fr))' },
-        gap: 1.25,
+        gap: { xs: 1.2, md: 1.35 },
       }}
     >
       {howItWorksItems.map((item, index) => (
         <Box
           key={item.title}
           sx={(theme) => ({
+            position: 'relative',
+            overflow: 'hidden',
+            display: 'flex',
+            flexDirection: 'column',
             p: { xs: 1.6, md: 1.9 },
+            minHeight: { xs: 172, md: 180, xl: 188 },
             borderRadius: 2,
             border: `1px solid ${theme.palette.border.light}`,
             backgroundColor: theme.palette.surface.subtle,
             transition:
               'border-color 0.16s ease, transform 0.16s ease, background-color 0.16s ease',
             ...fadeUp(720 + index * 80),
+            '&::before': {
+              content: '""',
+              position: 'absolute',
+              top: 0,
+              left: 0,
+              right: 0,
+              height: 2,
+              backgroundColor: alpha(theme.palette.status.merged, 0.52),
+              transform: 'scaleX(0.18)',
+              transformOrigin: 'left',
+              transition: 'transform 0.18s ease',
+            },
+            '&::after': {
+              content: '""',
+              position: 'absolute',
+              top: 16,
+              right: 16,
+              width: 88,
+              height: 88,
+              border: `1px solid ${alpha(theme.palette.status.merged, 0.1)}`,
+              borderRadius: '50%',
+              transform: 'translate(34%, -34%)',
+              pointerEvents: 'none',
+            },
             '&:hover': {
               borderColor: alpha(theme.palette.status.merged, 0.42),
               backgroundColor: alpha(theme.palette.text.primary, 0.025),
               transform: 'translateY(-2px)',
+              '&::before': {
+                transform: 'scaleX(1)',
+              },
             },
           })}
         >
           <Stack
             direction="row"
-            spacing={1.25}
-            alignItems="baseline"
-            sx={{ mb: 1 }}
+            alignItems="center"
+            justifyContent="space-between"
+            spacing={1.5}
+            sx={{ mb: 2.2, position: 'relative', zIndex: 1 }}
           >
-            <Typography
+            <Stack direction="row" spacing={1} alignItems="center">
+              <Box
+                sx={(theme) => ({
+                  width: 34,
+                  height: 34,
+                  display: 'grid',
+                  placeItems: 'center',
+                  borderRadius: 1,
+                  color: theme.palette.status.merged,
+                  border: `1px solid ${alpha(theme.palette.status.merged, 0.32)}`,
+                  backgroundColor: alpha(theme.palette.status.merged, 0.08),
+                  fontFamily: 'var(--font-heading)',
+                  fontSize: '1.4rem',
+                  fontWeight: 900,
+                  lineHeight: 1,
+                })}
+              >
+                {index + 1}
+              </Box>
+              <Typography
+                sx={(theme) => ({
+                  color: alpha(theme.palette.text.primary, 0.44),
+                  fontSize: '0.62rem',
+                  letterSpacing: '0.16em',
+                  textTransform: 'uppercase',
+                })}
+              >
+                {item.label}
+              </Typography>
+            </Stack>
+            <Box
               sx={(theme) => ({
-                color: theme.palette.status.merged,
-                fontFamily: 'var(--font-heading)',
-                fontSize: '1.35rem',
-                fontWeight: 900,
-                lineHeight: 1,
-                flexShrink: 0,
+                width: 34,
+                height: 34,
+                display: 'grid',
+                placeItems: 'center',
+                color: alpha(theme.palette.text.primary, 0.86),
+                borderRadius: 1,
+                border: `1px solid ${theme.palette.border.light}`,
+                backgroundColor: alpha(theme.palette.common.black, 0.12),
+                '& .MuiSvgIcon-root': { fontSize: 18 },
               })}
             >
-              {index + 1}
-            </Typography>
-            <Typography
-              sx={{
-                fontWeight: 900,
-                fontSize: { xs: '1rem', md: '0.95rem', lg: '1.02rem' },
-                lineHeight: 1.25,
-                whiteSpace: 'nowrap',
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
-                minWidth: 0,
-              }}
-            >
-              {item.title}
-            </Typography>
+              {item.icon}
+            </Box>
           </Stack>
           <Typography
+            sx={{
+              position: 'relative',
+              zIndex: 1,
+              fontWeight: 900,
+              fontSize: '1rem',
+              mb: 1,
+            }}
+          >
+            {item.title}
+          </Typography>
+          <Typography
             sx={(theme) => ({
+              position: 'relative',
+              zIndex: 1,
               color: alpha(theme.palette.text.primary, 0.6),
               fontSize: '0.78rem',
-              lineHeight: 1.55,
-              textWrap: 'balance',
+              lineHeight: 1.65,
+              mb: 2,
             })}
           >
             {item.body}
           </Typography>
+          <Stack
+            direction="row"
+            spacing={0.9}
+            alignItems="center"
+            sx={(theme) => ({
+              position: 'relative',
+              zIndex: 1,
+              mt: 'auto',
+              pt: 1.25,
+              borderTop: `1px solid ${theme.palette.border.light}`,
+            })}
+          >
+            <Box
+              sx={(theme) => ({
+                width: 6,
+                height: 6,
+                borderRadius: '50%',
+                backgroundColor: theme.palette.status.merged,
+                boxShadow: `0 0 0 4px ${alpha(theme.palette.status.merged, 0.1)}`,
+              })}
+            />
+            <Typography
+              sx={(theme) => ({
+                color: alpha(theme.palette.text.primary, 0.72),
+                fontSize: '0.68rem',
+                lineHeight: 1.3,
+              })}
+            >
+              {item.result}
+            </Typography>
+          </Stack>
         </Box>
       ))}
     </Box>
@@ -1700,8 +1971,8 @@ const OnboardingCard: React.FC<{ content: OnboardingCardContent }> = ({
       display: 'flex',
       flexDirection: 'column',
       justifyContent: 'space-between',
-      gap: 3,
-      p: { xs: 2, md: 2.5 },
+      gap: { xs: 2, xl: 3 },
+      p: { xs: 1.75, md: 2.15, xl: 2.5 },
       borderRadius: 2,
       backgroundColor: theme.palette.surface.subtle,
       color: theme.palette.text.primary,
@@ -1709,7 +1980,7 @@ const OnboardingCard: React.FC<{ content: OnboardingCardContent }> = ({
       borderTop: `3px solid ${theme.palette.status.merged}`,
       position: 'relative',
       overflow: 'hidden',
-      minHeight: 260,
+      minHeight: { xs: 220, md: 230, xl: 260 },
       ...fadeUp(700),
     })}
   >
@@ -1739,7 +2010,7 @@ const OnboardingCard: React.FC<{ content: OnboardingCardContent }> = ({
         sx={{
           fontFamily: 'var(--font-heading)',
           fontWeight: 900,
-          fontSize: { xs: '2rem', md: '2.45rem' },
+          fontSize: { xs: '1.75rem', md: '2rem', xl: '2.45rem' },
           lineHeight: 1,
         }}
       >
@@ -1756,9 +2027,15 @@ const OnboardingCard: React.FC<{ content: OnboardingCardContent }> = ({
       </Typography>
     </Stack>
     <Stack
-      direction={{ xs: 'column', sm: 'row', lg: 'column', xl: 'row' }}
+      direction={{ xs: 'column', sm: 'row' }}
       spacing={1}
-      sx={{ position: 'relative', zIndex: 1 }}
+      sx={{
+        position: 'relative',
+        zIndex: 1,
+        '@media (min-width: 1420px) and (max-width: 1535px)': {
+          flexDirection: 'column',
+        },
+      }}
     >
       <Button
         component="a"


### PR DESCRIPTION
## Summary

Polishes the landing page first-contact flow so new visitors can understand the Gittensor loop faster: miners join, work on tracked repositories, validators verify useful merged work, and reward estimates come from live contribution data.

## What changed

- Reworked the hero layout and proof stats for better large-screen fit, clearer spacing, and less overlap risk on shorter desktop viewports.
- Expanded the "How it works" section with clearer Join / Build / Reward steps, icons, result callouts, and stronger visual hierarchy.
- Improved live proof and top-miner presentation with animated reward bars, count-up reward values, loading skeletons, and calmer panel switching.
- Tuned maintainer/miner onboarding cards and tab placement so lower landing-page sections remain readable across responsive breakpoints.
- Added configurable Vite host/proxy support through `VITE_ALLOWED_HOSTS`, `VITE_DEV_ORIGIN`, and optional `VITE_USE_PROD_API_PROXY` for production API/mirror proxying in dev or preview.

## Testing

- Not run; PR description update only.

Closes #970