### PR TITLE
feat: add repository options sidebar

### DIFF
--- a/src/components/common/TabsOptionsPortal.tsx
+++ b/src/components/common/TabsOptionsPortal.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { Box, type SxProps, type Theme } from '@mui/material';
+
+export const TABS_OPTIONS_PORTAL_ID = 'tabs-options-portal';
+
+interface TabsOptionsPortalProps {
+  children?: React.ReactNode;
+  sx?: SxProps<Theme>;
+}
+
+export const TabsOptionsPortal: React.FC<TabsOptionsPortalProps> = ({
+  children,
+  sx,
+}) => (
+  <Box
+    id={TABS_OPTIONS_PORTAL_ID}
+    sx={[
+      {
+        display: 'none',
+        '@media (min-width: 1536px)': {
+          display: 'flex',
+          flexDirection: 'column',
+          p: 2,
+          borderRadius: 3,
+          border: '1px solid',
+          borderColor: 'border.light',
+          backgroundColor: 'background.default',
+        },
+      },
+      ...(Array.isArray(sx) ? sx : [sx]),
+    ]}
+  >
+    {children}
+  </Box>
+);

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -2,5 +2,6 @@ export * from './ClearSearchAdornment';
 export * from './linkBehavior';
 export * from './WatchlistButton';
 export * from './DataTable';
+export * from './TabsOptionsPortal';
 export { default as ConversationTimeline } from './ConversationTimeline';
 export * from './ConversationTimeline';

--- a/src/components/leaderboard/TopRepositoriesTable.tsx
+++ b/src/components/leaderboard/TopRepositoriesTable.tsx
@@ -17,10 +17,11 @@ import {
   Tooltip,
   IconButton,
   Collapse,
+  Popover,
+  Portal,
   TablePagination,
   Select,
   MenuItem,
-  FormControl,
   Button,
   Switch,
   FormControlLabel,
@@ -32,6 +33,7 @@ import {
 import SearchIcon from '@mui/icons-material/Search';
 import BarChartIcon from '@mui/icons-material/BarChart';
 import TableChartIcon from '@mui/icons-material/TableChart';
+import TuneOutlinedIcon from '@mui/icons-material/TuneOutlined';
 import ViewModuleIcon from '@mui/icons-material/ViewModule';
 import ViewListIcon from '@mui/icons-material/ViewList';
 import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
@@ -56,6 +58,7 @@ import type { TooltipComponentFormatterCallbackParams } from 'echarts';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { DataTable, type DataTableColumn } from '../common/DataTable';
 import { ClearSearchAdornment, WatchlistButton } from '../common';
+import { TABS_OPTIONS_PORTAL_ID } from '../common/TabsOptionsPortal';
 import { DebouncedSearchInput } from '../common/DebouncedSearchInput';
 import {
   compareByWatchlist,
@@ -151,7 +154,6 @@ const CARD_SORT_OPTIONS: Array<{ value: SortColumn; label: string }> = [
   { value: 'discoveryScore', label: 'Issue Score' },
   { value: 'discoveryIssues', label: 'Issues' },
   { value: 'discoveryContributors', label: 'Issue Contributors' },
-  { value: 'repository', label: 'Repository' },
 ];
 
 interface TopRepositoriesTableProps {
@@ -263,7 +265,16 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
     debouncedSearchTrim,
   );
   const isCompactChart = useMediaQuery(theme.breakpoints.down('sm'));
-  const isMobileControls = useMediaQuery(theme.breakpoints.down('md'));
+  const isLargeScreen = useMediaQuery(theme.breakpoints.up('xl'));
+  const [portalTarget, setPortalTarget] = useState<HTMLElement | null>(null);
+  const [optionsAnchorEl, setOptionsAnchorEl] = useState<HTMLElement | null>(
+    null,
+  );
+  const optionsOpen = Boolean(optionsAnchorEl);
+
+  useEffect(() => {
+    setPortalTarget(document.getElementById(TABS_OPTIONS_PORTAL_ID));
+  }, []);
 
   const cardSortSelectOptions = useMemo(() => {
     const opts = [...CARD_SORT_OPTIONS];
@@ -808,9 +819,7 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
               ),
             }}
             sx={{
-              width: { xs: '100%', sm: '200px' },
-              flexBasis: { xs: '100%', sm: 'auto' },
-              order: { xs: -1, sm: 'initial' },
+              width: '100%',
               ...searchFieldBaseSx,
             }}
           />
@@ -881,6 +890,162 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
         </IconButton>
       </Tooltip>
     </>
+  );
+
+  const setRepositoryStatusFilter = (
+    nextStatus: 'all' | 'active' | 'inactive',
+  ) => {
+    setStatusFilter(nextStatus);
+    setPage(0);
+    syncToUrl({ status: nextStatus, page: '0' });
+  };
+
+  const rowsSelect = (
+    <Select
+      size="small"
+      value={rowsPerPage}
+      onChange={(e) => {
+        const newRows = e.target.value as number;
+        setRowsPerPage(newRows);
+        setPage(0);
+        syncToUrl({ rows: String(newRows), page: '0' });
+      }}
+      sx={{
+        color: 'text.primary',
+        backgroundColor: 'background.default',
+        fontSize: '0.8rem',
+        height: '36px',
+        borderRadius: 2,
+        width: '100%',
+        '& fieldset': { borderColor: 'border.light' },
+        '&:hover fieldset': {
+          borderColor: 'border.medium',
+        },
+        '&.Mui-focused fieldset': { borderColor: 'primary.main' },
+        '& .MuiSelect-select': { py: 0.75 },
+      }}
+    >
+      {(viewMode === 'cards'
+        ? REPOSITORIES_CARD_ROWS
+        : REPOSITORIES_LIST_ROWS
+      ).map((n) => (
+        <MenuItem key={n} value={n}>
+          {n}
+        </MenuItem>
+      ))}
+    </Select>
+  );
+
+  const sortControls = (viewMode === 'cards' || showChart) && (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+      <OptionsLabel>Sort by</OptionsLabel>
+      <Box
+        sx={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(2, minmax(0, 1fr))',
+          gap: 0.75,
+        }}
+      >
+        {cardSortSelectOptions.map((option) => (
+          <FilterButton
+            key={option.value}
+            label={option.label}
+            color={STATUS_COLORS.info}
+            isActive={sortColumn === option.value}
+            fullWidth
+            onClick={() => {
+              if (sortColumn === option.value) return;
+              handleSort(option.value);
+            }}
+          />
+        ))}
+      </Box>
+      <Button
+        size="small"
+        variant="outlined"
+        startIcon={
+          sortDirection === 'asc' ? (
+            <ArrowUpwardIcon fontSize="small" />
+          ) : (
+            <ArrowDownwardIcon fontSize="small" />
+          )
+        }
+        onClick={() => handleSort(sortColumn)}
+        sx={{
+          justifyContent: 'flex-start',
+          textTransform: 'none',
+          borderColor: 'border.light',
+          color: 'text.secondary',
+        }}
+      >
+        {sortDirection === 'asc' ? 'Ascending' : 'Descending'}
+      </Button>
+    </Box>
+  );
+
+  const optionsPanelContent = (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+        <OptionsLabel>Search</OptionsLabel>
+        {searchInput}
+      </Box>
+
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+        <OptionsLabel>Status</OptionsLabel>
+        <Box
+          sx={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(3, minmax(0, 1fr))',
+            gap: 0.75,
+          }}
+        >
+          <FilterButton
+            label="All"
+            count={rankedRepositories.length}
+            color={STATUS_COLORS.neutral}
+            isActive={statusFilter === 'all'}
+            fullWidth
+            onClick={() => setRepositoryStatusFilter('all')}
+          />
+          <FilterButton
+            label="Active"
+            count={rankedRepositories.filter((r) => !r.inactiveAt).length}
+            color={STATUS_COLORS.success}
+            isActive={statusFilter === 'active'}
+            fullWidth
+            onClick={() => setRepositoryStatusFilter('active')}
+          />
+          <FilterButton
+            label="Inactive"
+            count={rankedRepositories.filter((r) => !!r.inactiveAt).length}
+            color={STATUS_COLORS.closed}
+            isActive={statusFilter === 'inactive'}
+            fullWidth
+            onClick={() => setRepositoryStatusFilter('inactive')}
+          />
+        </Box>
+      </Box>
+
+      {sortControls}
+
+      <Box sx={{ display: 'grid', gridTemplateColumns: '1fr auto', gap: 1.25 }}>
+        <Box sx={{ minWidth: 0 }}>
+          <OptionsLabel>Rows</OptionsLabel>
+          {rowsSelect}
+        </Box>
+        <Box>
+          <OptionsLabel>View</OptionsLabel>
+          <ViewModeToggle viewMode={viewMode} onChange={handleViewModeChange} />
+        </Box>
+      </Box>
+
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+        <OptionsLabel>Chart</OptionsLabel>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          {chartControls}
+        </Box>
+      </Box>
+    </Box>
   );
 
   const compactSortableHeaderSx = {
@@ -1160,249 +1325,59 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
       }}
       elevation={0}
     >
-      <Box
-        sx={{
-          borderBottom: '1px solid',
-          borderColor: 'border.light',
-        }}
-      >
-        {/* Row 1: All Controls */}
+      {isLargeScreen && portalTarget ? (
+        <Portal container={portalTarget}>{optionsPanelContent}</Portal>
+      ) : (
         <Box
           sx={{
+            borderBottom: '1px solid',
+            borderColor: 'border.light',
             p: { xs: 1, sm: 1.5, md: 2 },
             display: 'flex',
-            flexDirection: { xs: 'column', md: 'row' },
-            alignItems: { xs: 'stretch', md: 'center' },
-            gap: { xs: 1, md: 2 },
+            justifyContent: 'flex-end',
           }}
         >
-          <Box
+          <Button
+            size="small"
+            variant="outlined"
+            startIcon={<TuneOutlinedIcon fontSize="small" />}
+            onClick={(event) => setOptionsAnchorEl(event.currentTarget)}
             sx={{
-              display: 'flex',
-              gap: { xs: 0.25, sm: 0.5 },
-              alignItems: 'center',
-              flexWrap: { xs: 'nowrap', sm: 'wrap' },
-              width: { xs: '100%', md: 'auto' },
-              '& > button': {
-                flex: { xs: 1, sm: 'initial' },
-                minWidth: 0,
-                px: { xs: 1, sm: 2 },
+              minHeight: 36,
+              textTransform: 'none',
+              borderColor: 'border.light',
+              color: 'text.primary',
+              '&:hover': {
+                borderColor: 'border.medium',
+                backgroundColor: 'surface.light',
               },
             }}
           >
-            <FilterButton
-              label="All"
-              count={rankedRepositories.length}
-              color={STATUS_COLORS.neutral}
-              isActive={statusFilter === 'all'}
-              onClick={() => {
-                setStatusFilter('all');
-                setPage(0);
-                syncToUrl({ status: 'all', page: '0' });
-              }}
-            />
-            <FilterButton
-              label="Active"
-              count={rankedRepositories.filter((r) => !r.inactiveAt).length}
-              color={STATUS_COLORS.success}
-              isActive={statusFilter === 'active'}
-              onClick={() => {
-                setStatusFilter('active');
-                setPage(0);
-                syncToUrl({ status: 'active', page: '0' });
-              }}
-            />
-            <FilterButton
-              label="Inactive"
-              count={rankedRepositories.filter((r) => !!r.inactiveAt).length}
-              color={STATUS_COLORS.closed}
-              isActive={statusFilter === 'inactive'}
-              onClick={() => {
-                setStatusFilter('inactive');
-                setPage(0);
-                syncToUrl({ status: 'inactive', page: '0' });
-              }}
-            />
-          </Box>
-
-          <Box
-            sx={{
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: { xs: 'flex-start', md: 'flex-end' },
-              gap: { xs: 0.75, sm: 1 },
-              flexWrap: 'wrap',
-              width: { xs: '100%', md: 'auto' },
+            Options
+          </Button>
+          <Popover
+            open={optionsOpen}
+            anchorEl={optionsAnchorEl}
+            onClose={() => setOptionsAnchorEl(null)}
+            anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+            transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+            slotProps={{
+              paper: {
+                sx: (theme) => ({
+                  mt: 1,
+                  width: 'min(420px, calc(100vw - 24px))',
+                  p: 2,
+                  borderRadius: 3,
+                  border: `1px solid ${theme.palette.border.light}`,
+                  backgroundColor: theme.palette.background.default,
+                }),
+              },
             }}
           >
-            {!isMobileControls && (
-              <Box
-                sx={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: 1,
-                }}
-              >
-                {chartControls}
-              </Box>
-            )}
-
-            <FormControl size="small">
-              <Box
-                sx={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: { xs: 0.75, sm: 1 },
-                }}
-              >
-                <Typography
-                  variant="body2"
-                  sx={{
-                    color: 'text.secondary',
-                    fontSize: '0.8rem',
-                    minWidth: { xs: 36, md: 'auto' },
-                    flexShrink: 0,
-                  }}
-                >
-                  Rows:
-                </Typography>
-                <Select
-                  value={rowsPerPage}
-                  onChange={(e) => {
-                    const newRows = e.target.value as number;
-                    setRowsPerPage(newRows);
-                    setPage(0);
-                    syncToUrl({ rows: String(newRows), page: '0' });
-                  }}
-                  sx={{
-                    color: 'text.primary',
-                    backgroundColor: 'background.default',
-                    fontSize: '0.8rem',
-                    height: '36px',
-                    borderRadius: 2,
-                    minWidth: '140px',
-                    '& fieldset': { borderColor: 'border.light' },
-                    '&:hover fieldset': {
-                      borderColor: 'border.medium',
-                    },
-                    '&.Mui-focused fieldset': { borderColor: 'primary.main' },
-                    '& .MuiSelect-select': { py: 0.75 },
-                  }}
-                >
-                  {(viewMode === 'cards'
-                    ? REPOSITORIES_CARD_ROWS
-                    : REPOSITORIES_LIST_ROWS
-                  ).map((n) => (
-                    <MenuItem key={n} value={n}>
-                      {n}
-                    </MenuItem>
-                  ))}
-                </Select>
-              </Box>
-            </FormControl>
-
-            {searchInput}
-
-            <Box sx={{ ml: 'auto' }}>
-              <ViewModeToggle
-                viewMode={viewMode}
-                onChange={handleViewModeChange}
-              />
-            </Box>
-          </Box>
+            {optionsPanelContent}
+          </Popover>
         </Box>
-
-        {(viewMode === 'cards' || showChart) && (
-          <Box
-            sx={{
-              px: { xs: 1, sm: 1.5, md: 2 },
-              pb: { xs: 1, sm: 1.5, md: 2 },
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: { xs: 'flex-start', md: 'flex-end' },
-              gap: { xs: 0.75, sm: 1 },
-            }}
-          >
-            <Typography
-              variant="body2"
-              sx={{
-                color: 'text.secondary',
-                fontSize: '0.8rem',
-                minWidth: { xs: 36, md: 'auto' },
-                flexShrink: 0,
-              }}
-            >
-              Sort:
-            </Typography>
-            <Select
-              size="small"
-              value={sortColumn}
-              onChange={(e) => handleSort(e.target.value as SortColumn)}
-              sx={{
-                color: 'text.primary',
-                backgroundColor: 'background.default',
-                fontSize: '0.8rem',
-                height: '36px',
-                borderRadius: 2,
-                minWidth: '140px',
-                '& fieldset': { borderColor: 'border.light' },
-                '&:hover fieldset': { borderColor: 'border.medium' },
-                '&.Mui-focused fieldset': { borderColor: 'primary.main' },
-                '& .MuiSelect-select': { py: 0.75 },
-              }}
-            >
-              {cardSortSelectOptions.map((opt) => (
-                <MenuItem key={opt.value} value={opt.value}>
-                  {opt.label}
-                </MenuItem>
-              ))}
-            </Select>
-            <Tooltip
-              title={sortDirection === 'asc' ? 'Ascending' : 'Descending'}
-            >
-              <IconButton
-                onClick={() => handleSort(sortColumn)}
-                size="small"
-                aria-label={
-                  sortDirection === 'asc' ? 'Sort descending' : 'Sort ascending'
-                }
-                sx={{
-                  color: 'text.primary',
-                  border: '1px solid',
-                  borderColor: 'border.light',
-                  borderRadius: 2,
-                  padding: '6px',
-                  ml: { xs: 'auto', md: 0 },
-                  '&:hover': {
-                    backgroundColor: 'surface.light',
-                    borderColor: 'border.medium',
-                  },
-                }}
-              >
-                {sortDirection === 'asc' ? (
-                  <ArrowUpwardIcon fontSize="small" />
-                ) : (
-                  <ArrowDownwardIcon fontSize="small" />
-                )}
-              </IconButton>
-            </Tooltip>
-          </Box>
-        )}
-
-        {isMobileControls && (
-          <Box
-            sx={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: 1,
-              px: { xs: 1, sm: 1.5 },
-              pb: { xs: 1, sm: 1.5 },
-            }}
-          >
-            {chartControls}
-          </Box>
-        )}
-      </Box>
+      )}
 
       <Collapse in={showChart}>
         <Box
@@ -1605,6 +1580,23 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
     </Card>
   );
 };
+
+const OptionsLabel: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => (
+  <Typography
+    sx={{
+      fontFamily: '"JetBrains Mono", monospace',
+      fontSize: '0.7rem',
+      fontWeight: 700,
+      color: 'text.secondary',
+      textTransform: 'uppercase',
+      mb: 0.75,
+    }}
+  >
+    {children}
+  </Typography>
+);
 
 interface ViewModeToggleProps {
   viewMode: ViewMode;

--- a/src/pages/RepositoriesPage.tsx
+++ b/src/pages/RepositoriesPage.tsx
@@ -1,17 +1,32 @@
 import React, { useMemo } from 'react';
 
-import { Avatar, Box, Button, Card, Tooltip, Typography } from '@mui/material';
+import {
+  Avatar,
+  Box,
+  Button,
+  Card,
+  Stack,
+  Tooltip,
+  Typography,
+  useMediaQuery,
+} from '@mui/material';
 import { alpha, type Theme } from '@mui/material/styles';
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
 
 import { LinkBox, useLinkBehavior } from '../components/common/linkBehavior';
+import { TabsOptionsPortal } from '../components/common/TabsOptionsPortal';
 import { Page } from '../components/layout';
 import { TopRepositoriesTable, SEO } from '../components';
+import { ActivitySidebarCards } from '../components/leaderboard/ActivitySidebarCards';
+import { SectionCard } from '../components/leaderboard/SectionCard';
 import { useAllPrs, useAllMiners, useReposAndWeights } from '../api';
 import { type CommitLog } from '../api/models/Dashboard';
+import { useTwitterStickySidebar } from '../hooks/useTwitterStickySidebar';
 import { getRepositoryOwnerAvatarSrc } from '../utils/avatar';
 import { buildRepoDiscoveryRollupFromMiners } from '../utils/ExplorerUtils';
+import { mapAllMinersToStats } from '../utils/minerMapper';
 import { isMergedPr } from '../utils/prStatus';
+import theme, { scrollbarSx, STATUS_COLORS } from '../theme';
 
 const FONTS = { mono: '"JetBrains Mono", monospace' } as const;
 
@@ -127,6 +142,63 @@ const cardSx = (theme: Theme) => ({
   },
 });
 
+const RepoOverviewCard: React.FC<{
+  repositories: { inactiveAt?: string | null }[];
+}> = ({ repositories }) => {
+  const total = repositories.length;
+  const inactive = repositories.filter((repo) => repo.inactiveAt).length;
+  const active = Math.max(0, total - inactive);
+  const rows = [
+    { label: 'Total', value: total, color: STATUS_COLORS.neutral },
+    { label: 'Active', value: active, color: STATUS_COLORS.success },
+    { label: 'Inactive', value: inactive, color: STATUS_COLORS.closed },
+  ];
+
+  return (
+    <SectionCard title="Tracked Repositories" sx={{ flexShrink: 0 }}>
+      <Stack spacing={1.25} sx={{ px: 2, pb: 2 }}>
+        {rows.map((row) => (
+          <Box
+            key={row.label}
+            sx={(theme) => ({
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              gap: 1,
+              p: 1.25,
+              borderRadius: 1.5,
+              border: `1px solid ${theme.palette.border.subtle}`,
+              backgroundColor: alpha(row.color, 0.08),
+            })}
+          >
+            <Typography
+              sx={{
+                fontFamily: FONTS.mono,
+                fontSize: '0.75rem',
+                color: 'text.secondary',
+                textTransform: 'uppercase',
+              }}
+            >
+              {row.label}
+            </Typography>
+            <Typography
+              sx={{
+                fontFamily: FONTS.mono,
+                fontSize: '1rem',
+                fontWeight: 700,
+                color: row.color,
+                fontVariantNumeric: 'tabular-nums',
+              }}
+            >
+              {row.value.toLocaleString()}
+            </Typography>
+          </Box>
+        ))}
+      </Stack>
+    </SectionCard>
+  );
+};
+
 // ── Page ────────────────────────────────────────────────────────────────────
 const REPO_LINK_STATE = { backLabel: 'Back to Repositories' } as const;
 const getRepoHref = (name: string) =>
@@ -138,6 +210,13 @@ const RepositoriesPage: React.FC = () => {
   const registerRepoLink = useLinkBehavior<HTMLAnchorElement>(
     '/repository-registration',
   );
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+  const isTablet = useMediaQuery(theme.breakpoints.between('sm', 'md'));
+  const isLargeScreen = useMediaQuery(theme.breakpoints.up('xl'));
+  const showSidebarRight = useMediaQuery(theme.breakpoints.up('xl'));
+  const stickySidebarRef = useTwitterStickySidebar();
+  const sidebarWidth =
+    isMobile || isTablet ? '100%' : isLargeScreen ? '340px' : '300px';
 
   const formatRelativeTime = (date: Date) => {
     const now = new Date();
@@ -160,6 +239,10 @@ const RepositoriesPage: React.FC = () => {
     useReposAndWeights();
 
   const isLoading = isLoadingPRs || isLoadingRepos || isLoadingMiners;
+  const minerStats = useMemo(
+    () => (Array.isArray(allMiners) ? mapAllMinersToStats(allMiners) : []),
+    [allMiners],
+  );
 
   // ── Main table stats ────────────────────────────────────────────────────
   const repoStats = useMemo(() => {
@@ -190,7 +273,7 @@ const RepositoriesPage: React.FC = () => {
 
     const discoveryByRepo = buildRepoDiscoveryRollupFromMiners(
       allPRs,
-      allMiners,
+      Array.isArray(allMiners) ? allMiners : [],
     );
 
     return reposWithWeights
@@ -362,354 +445,391 @@ const RepositoriesPage: React.FC = () => {
       <Box
         sx={{
           width: '100%',
-          maxWidth: 1440,
-          mx: 'auto',
-          py: { xs: 1.5, sm: 3 },
-          px: { xs: 1.25, sm: 3 },
+          display: 'flex',
+          flexDirection: showSidebarRight ? 'row' : 'column',
+          alignItems: showSidebarRight ? 'flex-start' : 'stretch',
+          gap: { xs: 2, sm: 2, md: 2.5, lg: 3 },
+          py: { xs: 1.5, sm: 2, md: 2.5, lg: 3 },
+          px: { xs: 1.25, sm: 2, md: 2.5, lg: 3 },
         }}
       >
-        {/* ── Highlight Sections ─────────────────────────────────────── */}
         <Box
           sx={{
-            display: 'grid',
-            gridTemplateColumns: { xs: '1fr', lg: '1fr 1fr 1fr' },
-            gap: { xs: 1.25, sm: 2 },
-            mb: { xs: 2, sm: 3 },
-            alignItems: 'stretch',
+            flex: 1,
+            minWidth: 0,
+            pr: showSidebarRight ? 1 : 0,
+            minHeight: showSidebarRight ? 'calc(100vh - 88px)' : 'auto',
           }}
         >
-          {/* Trending This Week */}
-          <Card sx={cardSx}>
-            {isLoading || trendingRepos.length > 0 ? (
-              <>
-                <SectionHeader>Trending This Week</SectionHeader>
-                <Box sx={{ display: 'flex', flexDirection: 'column' }}>
-                  {trendingRepos.length === 0 && !isLoading ? (
-                    <Typography
-                      sx={(theme) => ({
-                        color: alpha(theme.palette.text.primary, 0.3),
-                        fontSize: '0.8rem',
-                        fontStyle: 'italic',
-                        p: 1,
-                      })}
-                    >
-                      No data available
-                    </Typography>
-                  ) : (
-                    trendingRepos.map((repo) => (
-                      <HighlightRow
-                        key={repo.name}
-                        href={getRepoHref(repo.name)}
-                        linkState={REPO_LINK_STATE}
-                        avatar={getRepositoryOwnerAvatarSrc(
-                          repo.name.split('/')[0],
-                        )}
-                        avatarAlt={repo.name}
-                        avatarBg={getAvatarBg(repo.name)}
-                        label={
-                          <Tooltip title={repo.name} arrow placement="top">
-                            <Typography
-                              sx={{
-                                fontFamily: FONTS.mono,
-                                fontSize: '0.82rem',
-                                color: 'text.primary',
-                                overflow: 'hidden',
-                                textOverflow: 'ellipsis',
-                                whiteSpace: 'nowrap',
-                              }}
-                            >
-                              {repo.name}
-                            </Typography>
-                          </Tooltip>
-                        }
-                        right={
-                          <Typography
-                            sx={(theme) => ({
-                              fontFamily: FONTS.mono,
-                              fontSize: '0.75rem',
-                              fontWeight: 600,
-                              color: theme.palette.status.success,
-                              flexShrink: 0,
-                              backgroundColor: alpha(
-                                theme.palette.status.success,
-                                0.1,
-                              ),
-                              px: 0.75,
-                              py: 0.25,
-                              borderRadius: '4px',
-                            })}
-                          >
-                            +{repo.pctIncrease.toFixed(0)}%
-                          </Typography>
-                        }
-                      />
-                    ))
-                  )}
-                </Box>
-              </>
-            ) : null}
-          </Card>
-
-          {/* Most Collateral Staked */}
-          <Card sx={cardSx}>
-            {isLoading || topCollateralRepos.length > 0 ? (
-              <>
-                <SectionHeader>Most Collateral Staked</SectionHeader>
-                <Box sx={{ display: 'flex', flexDirection: 'column' }}>
-                  {topCollateralRepos.length === 0 && !isLoading ? (
-                    <Typography
-                      sx={(theme) => ({
-                        color: alpha(theme.palette.text.primary, 0.3),
-                        fontSize: '0.8rem',
-                        fontStyle: 'italic',
-                        p: 1,
-                      })}
-                    >
-                      No collateral data available
-                    </Typography>
-                  ) : (
-                    topCollateralRepos.map((repo) => (
-                      <HighlightRow
-                        key={repo.name}
-                        href={getRepoHref(repo.name)}
-                        linkState={REPO_LINK_STATE}
-                        avatar={getRepositoryOwnerAvatarSrc(
-                          repo.name.split('/')[0],
-                        )}
-                        avatarAlt={repo.name}
-                        avatarBg={getAvatarBg(repo.name)}
-                        label={
-                          <Tooltip title={repo.name} arrow placement="top">
-                            <Typography
-                              sx={{
-                                fontFamily: FONTS.mono,
-                                fontSize: '0.82rem',
-                                color: 'text.primary',
-                                overflow: 'hidden',
-                                textOverflow: 'ellipsis',
-                                whiteSpace: 'nowrap',
-                              }}
-                            >
-                              {repo.name}
-                            </Typography>
-                          </Tooltip>
-                        }
-                        right={
-                          <Typography
-                            sx={{
-                              fontFamily: FONTS.mono,
-                              fontSize: '0.72rem',
-                              color: 'text.secondary',
-                              flexShrink: 0,
-                              whiteSpace: 'nowrap',
-                            }}
-                          >
-                            {repo.collateral.toFixed(1)} ({repo.openPRs} PR
-                            {repo.openPRs !== 1 ? 's' : ''})
-                          </Typography>
-                        }
-                      />
-                    ))
-                  )}
-                </Box>
-              </>
-            ) : null}
-          </Card>
-
-          {/* Recent PRs */}
-          <Card sx={cardSx}>
-            {isLoading || recentPrs.length > 0 ? (
-              <>
-                <SectionHeader>Recent Pull Requests</SectionHeader>
-                <Box sx={{ display: 'flex', flexDirection: 'column' }}>
-                  {recentPrs.length === 0 && !isLoading ? (
-                    <Typography
-                      sx={(theme) => ({
-                        color: alpha(theme.palette.text.primary, 0.3),
-                        fontSize: '0.8rem',
-                        fontStyle: 'italic',
-                        p: 1,
-                      })}
-                    >
-                      No data available
-                    </Typography>
-                  ) : (
-                    recentPrs.map((pr) => (
-                      <HighlightRow
-                        key={`${pr.name}-${pr.number}`}
-                        href={getPrHref(pr.name, pr.number)}
-                        linkState={REPO_LINK_STATE}
-                        avatar={getRepositoryOwnerAvatarSrc(
-                          pr.name.split('/')[0],
-                        )}
-                        avatarAlt={pr.name}
-                        avatarBg={getAvatarBg(pr.name)}
-                        label={
-                          <Box
-                            sx={{
-                              minWidth: 0,
-                              display: 'flex',
-                              flexDirection: 'column',
-                              justifyContent: 'center',
-                            }}
-                          >
-                            <Tooltip title={pr.name} arrow placement="top">
+          {/* ── Highlight Sections ─────────────────────────────────────── */}
+          <Box
+            sx={{
+              display: 'grid',
+              gridTemplateColumns: { xs: '1fr', lg: '1fr 1fr 1fr' },
+              gap: { xs: 1.25, sm: 2 },
+              mb: { xs: 2, sm: 3 },
+              alignItems: 'stretch',
+            }}
+          >
+            {/* Trending This Week */}
+            <Card sx={cardSx}>
+              {isLoading || trendingRepos.length > 0 ? (
+                <>
+                  <SectionHeader>Trending This Week</SectionHeader>
+                  <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+                    {trendingRepos.length === 0 && !isLoading ? (
+                      <Typography
+                        sx={(theme) => ({
+                          color: alpha(theme.palette.text.primary, 0.3),
+                          fontSize: '0.8rem',
+                          fontStyle: 'italic',
+                          p: 1,
+                        })}
+                      >
+                        No data available
+                      </Typography>
+                    ) : (
+                      trendingRepos.map((repo) => (
+                        <HighlightRow
+                          key={repo.name}
+                          href={getRepoHref(repo.name)}
+                          linkState={REPO_LINK_STATE}
+                          avatar={getRepositoryOwnerAvatarSrc(
+                            repo.name.split('/')[0],
+                          )}
+                          avatarAlt={repo.name}
+                          avatarBg={getAvatarBg(repo.name)}
+                          label={
+                            <Tooltip title={repo.name} arrow placement="top">
                               <Typography
                                 sx={{
                                   fontFamily: FONTS.mono,
-                                  fontSize: '0.68rem',
-                                  color: 'text.tertiary',
-                                  overflow: 'hidden',
-                                  textOverflow: 'ellipsis',
-                                  whiteSpace: 'nowrap',
-                                  lineHeight: 1.2,
-                                }}
-                              >
-                                {pr.name}
-                              </Typography>
-                            </Tooltip>
-                            <Tooltip title={pr.title} arrow placement="top">
-                              <Typography
-                                sx={{
-                                  fontFamily: FONTS.mono,
-                                  fontSize: '0.78rem',
+                                  fontSize: '0.82rem',
                                   color: 'text.primary',
                                   overflow: 'hidden',
                                   textOverflow: 'ellipsis',
                                   whiteSpace: 'nowrap',
-                                  lineHeight: 1.3,
                                 }}
                               >
-                                {pr.title}
+                                {repo.name}
                               </Typography>
                             </Tooltip>
-                          </Box>
-                        }
-                        right={
-                          <Typography
-                            sx={(theme) => ({
-                              fontFamily: FONTS.mono,
-                              fontSize: '0.68rem',
-                              color: alpha(theme.palette.text.primary, 0.35),
-                              flexShrink: 0,
-                              whiteSpace: 'nowrap',
-                              ml: 1,
-                            })}
-                          >
-                            {formatRelativeTime(pr.createdAt)}
-                          </Typography>
-                        }
-                      />
-                    ))
-                  )}
-                </Box>
-              </>
-            ) : null}
-            {!isLoading && recentPrs.length === 0 ? (
-              <>
-                <SectionHeader>Recent Pull Requests</SectionHeader>
-                <Box
-                  sx={{
-                    flex: 1,
-                    minHeight: ROW_HEIGHT * 5,
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                  }}
-                >
-                  <Typography
-                    sx={(theme) => ({
-                      color: alpha(theme.palette.text.primary, 0.3),
-                      fontSize: '0.8rem',
-                      p: 1,
-                      textAlign: 'center',
-                    })}
+                          }
+                          right={
+                            <Typography
+                              sx={(theme) => ({
+                                fontFamily: FONTS.mono,
+                                fontSize: '0.75rem',
+                                fontWeight: 600,
+                                color: theme.palette.status.success,
+                                flexShrink: 0,
+                                backgroundColor: alpha(
+                                  theme.palette.status.success,
+                                  0.1,
+                                ),
+                                px: 0.75,
+                                py: 0.25,
+                                borderRadius: '4px',
+                              })}
+                            >
+                              +{repo.pctIncrease.toFixed(0)}%
+                            </Typography>
+                          }
+                        />
+                      ))
+                    )}
+                  </Box>
+                </>
+              ) : null}
+            </Card>
+
+            {/* Most Collateral Staked */}
+            <Card sx={cardSx}>
+              {isLoading || topCollateralRepos.length > 0 ? (
+                <>
+                  <SectionHeader>Most Collateral Staked</SectionHeader>
+                  <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+                    {topCollateralRepos.length === 0 && !isLoading ? (
+                      <Typography
+                        sx={(theme) => ({
+                          color: alpha(theme.palette.text.primary, 0.3),
+                          fontSize: '0.8rem',
+                          fontStyle: 'italic',
+                          p: 1,
+                        })}
+                      >
+                        No collateral data available
+                      </Typography>
+                    ) : (
+                      topCollateralRepos.map((repo) => (
+                        <HighlightRow
+                          key={repo.name}
+                          href={getRepoHref(repo.name)}
+                          linkState={REPO_LINK_STATE}
+                          avatar={getRepositoryOwnerAvatarSrc(
+                            repo.name.split('/')[0],
+                          )}
+                          avatarAlt={repo.name}
+                          avatarBg={getAvatarBg(repo.name)}
+                          label={
+                            <Tooltip title={repo.name} arrow placement="top">
+                              <Typography
+                                sx={{
+                                  fontFamily: FONTS.mono,
+                                  fontSize: '0.82rem',
+                                  color: 'text.primary',
+                                  overflow: 'hidden',
+                                  textOverflow: 'ellipsis',
+                                  whiteSpace: 'nowrap',
+                                }}
+                              >
+                                {repo.name}
+                              </Typography>
+                            </Tooltip>
+                          }
+                          right={
+                            <Typography
+                              sx={{
+                                fontFamily: FONTS.mono,
+                                fontSize: '0.72rem',
+                                color: 'text.secondary',
+                                flexShrink: 0,
+                                whiteSpace: 'nowrap',
+                              }}
+                            >
+                              {repo.collateral.toFixed(1)} ({repo.openPRs} PR
+                              {repo.openPRs !== 1 ? 's' : ''})
+                            </Typography>
+                          }
+                        />
+                      ))
+                    )}
+                  </Box>
+                </>
+              ) : null}
+            </Card>
+
+            {/* Recent PRs */}
+            <Card sx={cardSx}>
+              {isLoading || recentPrs.length > 0 ? (
+                <>
+                  <SectionHeader>Recent Pull Requests</SectionHeader>
+                  <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+                    {recentPrs.length === 0 && !isLoading ? (
+                      <Typography
+                        sx={(theme) => ({
+                          color: alpha(theme.palette.text.primary, 0.3),
+                          fontSize: '0.8rem',
+                          fontStyle: 'italic',
+                          p: 1,
+                        })}
+                      >
+                        No data available
+                      </Typography>
+                    ) : (
+                      recentPrs.map((pr) => (
+                        <HighlightRow
+                          key={`${pr.name}-${pr.number}`}
+                          href={getPrHref(pr.name, pr.number)}
+                          linkState={REPO_LINK_STATE}
+                          avatar={getRepositoryOwnerAvatarSrc(
+                            pr.name.split('/')[0],
+                          )}
+                          avatarAlt={pr.name}
+                          avatarBg={getAvatarBg(pr.name)}
+                          label={
+                            <Box
+                              sx={{
+                                minWidth: 0,
+                                display: 'flex',
+                                flexDirection: 'column',
+                                justifyContent: 'center',
+                              }}
+                            >
+                              <Tooltip title={pr.name} arrow placement="top">
+                                <Typography
+                                  sx={{
+                                    fontFamily: FONTS.mono,
+                                    fontSize: '0.68rem',
+                                    color: 'text.tertiary',
+                                    overflow: 'hidden',
+                                    textOverflow: 'ellipsis',
+                                    whiteSpace: 'nowrap',
+                                    lineHeight: 1.2,
+                                  }}
+                                >
+                                  {pr.name}
+                                </Typography>
+                              </Tooltip>
+                              <Tooltip title={pr.title} arrow placement="top">
+                                <Typography
+                                  sx={{
+                                    fontFamily: FONTS.mono,
+                                    fontSize: '0.78rem',
+                                    color: 'text.primary',
+                                    overflow: 'hidden',
+                                    textOverflow: 'ellipsis',
+                                    whiteSpace: 'nowrap',
+                                    lineHeight: 1.3,
+                                  }}
+                                >
+                                  {pr.title}
+                                </Typography>
+                              </Tooltip>
+                            </Box>
+                          }
+                          right={
+                            <Typography
+                              sx={(theme) => ({
+                                fontFamily: FONTS.mono,
+                                fontSize: '0.68rem',
+                                color: alpha(theme.palette.text.primary, 0.35),
+                                flexShrink: 0,
+                                whiteSpace: 'nowrap',
+                                ml: 1,
+                              })}
+                            >
+                              {formatRelativeTime(pr.createdAt)}
+                            </Typography>
+                          }
+                        />
+                      ))
+                    )}
+                  </Box>
+                </>
+              ) : null}
+              {!isLoading && recentPrs.length === 0 ? (
+                <>
+                  <SectionHeader>Recent Pull Requests</SectionHeader>
+                  <Box
+                    sx={{
+                      flex: 1,
+                      minHeight: ROW_HEIGHT * 5,
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                    }}
                   >
-                    No merged PRs today
-                  </Typography>
-                </Box>
-              </>
-            ) : null}
+                    <Typography
+                      sx={(theme) => ({
+                        color: alpha(theme.palette.text.primary, 0.3),
+                        fontSize: '0.8rem',
+                        p: 1,
+                        textAlign: 'center',
+                      })}
+                    >
+                      No merged PRs today
+                    </Typography>
+                  </Box>
+                </>
+              ) : null}
+            </Card>
+          </Box>
+
+          {/* ── Register-a-repo CTA ───────────────────────────────────── */}
+          <Box
+            sx={(theme) => ({
+              mb: 3,
+              p: { xs: 2, sm: 2.5 },
+              borderRadius: 2,
+              border: `1px solid ${theme.palette.border.light}`,
+              backgroundColor: theme.palette.surface.transparent,
+              display: 'flex',
+              flexDirection: { xs: 'column', sm: 'row' },
+              alignItems: { xs: 'flex-start', sm: 'center' },
+              justifyContent: 'space-between',
+              gap: 2,
+            })}
+          >
+            <Box sx={{ minWidth: 0 }}>
+              <Typography
+                sx={(theme) => ({
+                  fontFamily: FONTS.mono,
+                  fontSize: '0.85rem',
+                  fontWeight: 600,
+                  color: theme.palette.text.primary,
+                  mb: 0.5,
+                })}
+              >
+                Don&apos;t see your repository?
+              </Typography>
+              <Typography
+                sx={(theme) => ({
+                  fontSize: '0.78rem',
+                  color: theme.palette.text.secondary,
+                  lineHeight: 1.5,
+                })}
+              >
+                Maintainers can register a repo to be added to the network.
+              </Typography>
+            </Box>
+            <Button
+              component="a"
+              {...registerRepoLink}
+              variant="contained"
+              endIcon={<ArrowForwardIcon />}
+              sx={(theme) => ({
+                flexShrink: 0,
+                minHeight: 40,
+                borderRadius: 1.5,
+                backgroundColor: theme.palette.status.merged,
+                color: theme.palette.common.black,
+                textTransform: 'none',
+                fontWeight: 800,
+                '&:hover': {
+                  backgroundColor: alpha(theme.palette.status.merged, 0.9),
+                },
+              })}
+            >
+              Register a repo
+            </Button>
+          </Box>
+
+          {/* ── Main Table ────────────────────────────────────────────── */}
+          <Card
+            sx={(theme) => ({
+              borderRadius: { xs: 2, sm: 3 },
+              border: '1px solid',
+              borderColor: theme.palette.border.light,
+              backgroundColor: theme.palette.surface.transparent,
+              overflow: 'hidden',
+            })}
+            elevation={0}
+          >
+            <TopRepositoriesTable
+              repositories={repoStats}
+              isLoading={isLoading}
+              getRepositoryHref={getRepoHref}
+              linkState={REPO_LINK_STATE}
+            />
           </Card>
         </Box>
 
-        {/* ── Register-a-repo CTA ───────────────────────────────────── */}
         <Box
-          sx={(theme) => ({
-            mb: 3,
-            p: { xs: 2, sm: 2.5 },
-            borderRadius: 2,
-            border: `1px solid ${theme.palette.border.light}`,
-            backgroundColor: theme.palette.surface.transparent,
+          ref={showSidebarRight ? stickySidebarRef : undefined}
+          sx={{
+            width: showSidebarRight ? sidebarWidth : '100%',
+            flexShrink: 0,
             display: 'flex',
-            flexDirection: { xs: 'column', sm: 'row' },
-            alignItems: { xs: 'flex-start', sm: 'center' },
-            justifyContent: 'space-between',
+            flexDirection: 'column',
             gap: 2,
-          })}
+            position: showSidebarRight ? 'sticky' : 'static',
+            top: showSidebarRight ? 88 : 'auto',
+            ...(showSidebarRight && {
+              maxHeight: 'calc(100vh - 88px)',
+              overflowY: 'auto',
+              scrollbarWidth: 'none',
+              ...scrollbarSx,
+            }),
+          }}
         >
-          <Box sx={{ minWidth: 0 }}>
-            <Typography
-              sx={(theme) => ({
-                fontFamily: FONTS.mono,
-                fontSize: '0.85rem',
-                fontWeight: 600,
-                color: theme.palette.text.primary,
-                mb: 0.5,
-              })}
-            >
-              Don&apos;t see your repository?
-            </Typography>
-            <Typography
-              sx={(theme) => ({
-                fontSize: '0.78rem',
-                color: theme.palette.text.secondary,
-                lineHeight: 1.5,
-              })}
-            >
-              Maintainers can register a repo to be added to the network.
-            </Typography>
-          </Box>
-          <Button
-            component="a"
-            {...registerRepoLink}
-            variant="contained"
-            endIcon={<ArrowForwardIcon />}
-            sx={(theme) => ({
-              flexShrink: 0,
-              minHeight: 40,
-              borderRadius: 1.5,
-              backgroundColor: theme.palette.status.merged,
-              color: theme.palette.common.black,
-              textTransform: 'none',
-              fontWeight: 800,
-              '&:hover': {
-                backgroundColor: alpha(theme.palette.status.merged, 0.9),
-              },
-            })}
-          >
-            Register a repo
-          </Button>
-        </Box>
-
-        {/* ── Main Table ────────────────────────────────────────────── */}
-        <Card
-          sx={(theme) => ({
-            borderRadius: { xs: 2, sm: 3 },
-            border: '1px solid',
-            borderColor: theme.palette.border.light,
-            backgroundColor: theme.palette.surface.transparent,
-            overflow: 'hidden',
-          })}
-          elevation={0}
-        >
-          <TopRepositoriesTable
-            repositories={repoStats}
-            isLoading={isLoading}
-            getRepositoryHref={getRepoHref}
-            linkState={REPO_LINK_STATE}
+          <ActivitySidebarCards
+            miners={minerStats}
+            defaultFilter="all"
+            insertAfterFirstCard={<TabsOptionsPortal />}
           />
-        </Card>
+          <RepoOverviewCard repositories={repoStats} />
+        </Box>
       </Box>
     </Page>
   );


### PR DESCRIPTION
## Summary

- Adds a shared `TabsOptionsPortal` slot for tab/page option controls.
- Moves repository search, status filters, rows, view, sort, and chart controls into the right sidebar on `xl`, with an Options popover below `xl`.
- Updates `/repositories` to use a two-column large-screen layout with sticky sidebar activity cards and a tracked repositories overview.
- Narrows the effective PR diff back to the repository options/sidebar work, avoiding unrelated Watchlist/Issues/pagination churn.

## Related Issues

Fixes #947

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

Before (`upstream/test`, 1800px desktop):

![Before repositories inline controls](https://raw.githubusercontent.com/Desel72/gittensor-ui/screenshots/pr-1091/before-xl.png)

After (`feat/repositories-options-sidebar`, 1800px desktop):

![After repositories right sidebar controls](https://raw.githubusercontent.com/Desel72/gittensor-ui/screenshots/pr-1091/after-xl.png)

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes

Validation:

- `npm run lint`
- `npm test`
- `npm run build`