### PR TITLE
fix(sidebar): add visible keyboard focus state on nav items

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -356,9 +356,13 @@ const SidebarNavLink: React.FC<{
           display: 'block',
           flexShrink: 0,
         },
-        '&:hover': {
+        '&:hover, &:focus-visible': {
           backgroundColor: 'rgba(255, 255, 255, 0.05)',
           color: 'primary.main',
+        },
+        '&:focus-visible': {
+          outline: 'none',
+          boxShadow: (theme) => `0 0 0 2px ${theme.palette.primary.main}`,
         },
       }}
     >


### PR DESCRIPTION
## Summary

Sidebar nav items previously had no visible focus indicator, so keyboard and switch users could not tell which item was focused while tabbing through the menu. This change adds a focus-visible treatment so the active focus position is always obvious.

The new state combines the existing hover background and label color shift with a 2px outer ring in `primary.main`, applied via `box-shadow` so the ring follows each button's `border-radius` (rounded in collapsed mode, square when expanded). The ring sits outside the button rather than inset, which keeps it distinct from the white left border used on the active route and satisfies WCAG 2.4.7 and 2.4.11 minimums (2px thickness, non-text contrast).

Focus styling is gated on `:focus-visible` so mouse clicks do not leave a lingering ring; only keyboard, switch, and screen magnifier users see the indicator.

## Related Issues

Fixes #526

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

Before:
[before.webm](https://github.com/user-attachments/assets/3e379cbc-fd41-4be9-9367-c0749e8a05d6)

After:
[after.webm](https://github.com/user-attachments/assets/0526f794-d7a7-431f-b1ce-1f02b4558c2f)
<img width="1920" height="878" alt="after" src="https://github.com/user-attachments/assets/a879a4d0-0f93-489f-83b8-9ed4fc786143" />

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
