### PR TITLE
fix: `selectMinerIssueScanRepos` admits blank repository names

### DIFF
--- a/src/hooks/useMinerRepositoriesOpenIssues.ts
+++ b/src/hooks/useMinerRepositoriesOpenIssues.ts
@@ -27,10 +27,12 @@ export const selectMinerIssueScanRepos = (prs: CommitLog[] | undefined) => {
   if (!prs?.length) return [];
   const latest = new Map<string, number>();
   prs.forEach((pr) => {
+    const repo = typeof pr.repository === 'string' ? pr.repository.trim() : '';
+    if (!repo) return;
     const raw = pr.mergedAt || pr.prCreatedAt;
     const t = raw ? new Date(raw).getTime() : 0;
-    const prev = latest.get(pr.repository) ?? 0;
-    if (t >= prev) latest.set(pr.repository, t);
+    const prev = latest.get(repo) ?? 0;
+    if (t >= prev) latest.set(repo, t);
   });
   return [...latest.entries()]
     .sort((a, b) => b[1] - a[1])
@@ -47,7 +49,13 @@ export const useMinerRepositoriesOpenIssues = (
   enabled: boolean,
 ) => {
   const stableRepos = useMemo(
-    () => [...new Set(repos)].filter(Boolean),
+    () => [
+      ...new Set(
+        repos
+          .map((r) => (typeof r === 'string' ? r.trim() : ''))
+          .filter((r) => r.length > 0),
+      ),
+    ],
     [repos],
   );
 


### PR DESCRIPTION
## Summary

`selectMinerIssueScanRepos` keyed a `Map` by `pr.repository` without normalizing or skipping invalid values. Blank or whitespace-only names could appear in the returned repo list and consume `REPO_FETCH_LIMIT` budget ahead of valid repositories. `useMinerRepositoriesOpenIssues` only used `filter(Boolean)`, which does not treat whitespace-only strings as empty.

## Related Issues

Closes #1096

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Checklist

- [ ] New components are modularized/separated where sensible
- [ ] Uses predefined theme (e.g. no hardcoded colors)
- [ ] Responsive/mobile checked
- [ ] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [ ] Screenshots included for any UI/visual changes

## Solution

1. **`selectMinerIssueScanRepos`** — For each PR, derive `repo` as a trimmed string; skip when empty after trim. Keeps map keys valid for API paths and for `reposForGrouping` in `MinerOpenDiscoveryIssuesByRepo`.

2. **`useMinerRepositoriesOpenIssues`** — Build `stableRepos` by trimming each entry, dropping empty strings, then deduping with `Set` (defense in depth for any caller of the hook).