### PR TITLE
fix: clarify leaderboard rank gaps

### DIFF
--- a/src/components/leaderboard/MinersList.tsx
+++ b/src/components/leaderboard/MinersList.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Avatar, Box, Card, Tooltip, Typography } from '@mui/material';
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import { useMinerGithubData, useMinerPRs } from '../../api';
 import { CHART_COLORS } from '../../theme';
 import { getGithubAvatarSrc, type SortOrder } from '../../utils/ExplorerUtils';
@@ -50,6 +51,10 @@ interface MinersListProps {
   getHref: (miner: MinerStats) => string;
   linkState?: Record<string, unknown>;
   pagination?: React.ReactNode;
+  rankContext?: {
+    filteredCount: number;
+    totalCount: number;
+  };
 }
 
 export const MinersList: React.FC<MinersListProps> = ({
@@ -61,6 +66,7 @@ export const MinersList: React.FC<MinersListProps> = ({
   getHref,
   linkState,
   pagination,
+  rankContext,
 }) => {
   const isWatchlist = variant === 'watchlist';
   const isDiscoveries = variant === 'discoveries';
@@ -69,6 +75,9 @@ export const MinersList: React.FC<MinersListProps> = ({
   const singleActivitySortKey: SortOption = isDiscoveries
     ? 'totalIssues'
     : 'totalPRs';
+  const showRankContext = Boolean(
+    rankContext && rankContext.filteredCount < rankContext.totalCount,
+  );
 
   const activityColumns: DataTableColumn<MinerStats, SortOption>[] = isWatchlist
     ? [
@@ -117,7 +126,7 @@ export const MinersList: React.FC<MinersListProps> = ({
   const columns: DataTableColumn<MinerStats, SortOption>[] = [
     {
       key: 'rank',
-      header: 'Rank',
+      header: <RankHeader />,
       width: '60px',
       cellSx: { pr: 0 },
       renderCell: (miner) => <RankIcon rank={miner.rank ?? 0} />,
@@ -257,6 +266,14 @@ export const MinersList: React.FC<MinersListProps> = ({
           transition: 'opacity 0.2s, background-color 0.2s',
         })}
         minWidth="1020px"
+        header={
+          showRankContext ? (
+            <RankContextNotice
+              filteredCount={rankContext?.filteredCount ?? miners.length}
+              totalCount={rankContext?.totalCount ?? miners.length}
+            />
+          ) : undefined
+        }
         stickyHeader
         sort={{
           field: sortOption,
@@ -268,6 +285,58 @@ export const MinersList: React.FC<MinersListProps> = ({
     </Card>
   );
 };
+
+const RankHeader: React.FC = () => (
+  <Tooltip
+    title="Rank is global across all miners before filters are applied."
+    arrow
+    placement="top"
+  >
+    <Box
+      component="span"
+      sx={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 0.5,
+        verticalAlign: 'middle',
+      }}
+    >
+      Rank
+      <InfoOutlinedIcon sx={{ fontSize: 14, color: 'text.secondary' }} />
+    </Box>
+  </Tooltip>
+);
+
+interface RankContextNoticeProps {
+  filteredCount: number;
+  totalCount: number;
+}
+
+const RankContextNotice: React.FC<RankContextNoticeProps> = ({
+  filteredCount,
+  totalCount,
+}) => (
+  <Box
+    sx={{
+      px: 2,
+      py: 1,
+      borderBottom: '1px solid',
+      borderColor: 'border.light',
+    }}
+  >
+    <Typography
+      sx={{
+        color: 'text.secondary',
+        fontSize: '0.72rem',
+        lineHeight: 1.5,
+      }}
+    >
+      Rank shows global position across all {totalCount.toLocaleString()}{' '}
+      miners. Gaps indicate miners hidden by the current filters;{' '}
+      {filteredCount.toLocaleString()} match.
+    </Typography>
+  </Box>
+);
 
 interface MinerIdentityCellProps {
   miner: MinerStats;

--- a/src/components/leaderboard/TopMinersTable.tsx
+++ b/src/components/leaderboard/TopMinersTable.tsx
@@ -558,6 +558,10 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
             onSort={handleSortChange}
             getHref={getMinerHref}
             linkState={linkState}
+            rankContext={{
+              filteredCount: filteredMiners.length,
+              totalCount: rankedMiners.length,
+            }}
             pagination={stackedPaginationControls ?? undefined}
           />
         )}


### PR DESCRIPTION
## Summary

Clarify that miner ranks in list view are global ranks, even when filters hide rows. The Rank header now has a tooltip, and the table shows a compact context note whenever the current filters reduce the visible leaderboard subset.

This keeps existing ranking, sorting, and filtering behavior intact while making gaps such as `16 → 19 → 23` discoverable.

## Related Issues

Fixes #1102

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

before:

<img width="1429" height="878" alt="origin" src="https://github.com/user-attachments/assets/447d7568-5c8f-4e77-b07b-65c7b09dbb2c" />

after:

<img width="1126" height="204" alt="after (2)" src="https://github.com/user-attachments/assets/dbe4a118-f2d6-43f8-830b-68d6a00e2c96" />

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [ ] Tested against the test API (local live page hit existing `miners.map is not a function` before table render)
- [ ] `npm run format` and `npm run lint:fix` have been run (focused Prettier plus lint-staged ESLint/Prettier ran on changed files)
- [x] `npm run build` passes
- [ ] Screenshots included for any UI/visual changes (attempted, blocked by the local live data error above)

Validation run: `npx prettier --write src/components/leaderboard/MinersList.tsx src/components/leaderboard/TopMinersTable.tsx`, `npm run lint`, `npm test`, `npm run build`, `git diff --check`, and a local dev-server smoke attempt at `/top-miners?view=list&eligible=true`.