### PR TITLE
Add watchlist bounty chart toggle

### DIFF
--- a/src/pages/WatchlistPage.tsx
+++ b/src/pages/WatchlistPage.tsx
@@ -986,11 +986,17 @@ const WATCHLIST_REPO_CARD_SORT_OPTIONS: Array<{
   { value: 'discoveryContributors', label: 'Issue contributors' },
 ];
 
-const WatchlistRepoCardSortPills: React.FC<{
-  sortField: RepoSortKey;
+const SortPills = <T extends string>({
+  options,
+  sortField,
+  sortOrder,
+  onSortChange,
+}: {
+  options: Array<{ value: T; label: string }>;
+  sortField: T;
   sortOrder: 'asc' | 'desc';
-  onSortChange: (key: RepoSortKey) => void;
-}> = ({ sortField, sortOrder, onSortChange }) => (
+  onSortChange: (key: T) => void;
+}) => (
   <Box
     sx={{
       display: 'flex',
@@ -999,7 +1005,7 @@ const WatchlistRepoCardSortPills: React.FC<{
       justifyContent: 'flex-start',
     }}
   >
-    {WATCHLIST_REPO_CARD_SORT_OPTIONS.map((opt) => {
+    {options.map((opt) => {
       const isActive = sortField === opt.value;
       return (
         <Box
@@ -1054,6 +1060,14 @@ const WatchlistRepoCardSortPills: React.FC<{
       );
     })}
   </Box>
+);
+
+const WatchlistRepoCardSortPills: React.FC<{
+  sortField: RepoSortKey;
+  sortOrder: 'asc' | 'desc';
+  onSortChange: (key: RepoSortKey) => void;
+}> = (props) => (
+  <SortPills options={WATCHLIST_REPO_CARD_SORT_OPTIONS} {...props} />
 );
 
 const repoCellSx = { py: 1.5 } as const;
@@ -2217,6 +2231,25 @@ const BOUNTY_STATUS_FILTERS: readonly BountyStatusFilter[] = [
   'history',
 ];
 
+const WATCHLIST_BOUNTY_CARD_SORT_OPTIONS: Array<{
+  value: BountySortKey;
+  label: string;
+}> = [
+  { value: 'bounty', label: 'Bounty' },
+  { value: 'date', label: 'Updated' },
+  { value: 'repo', label: 'Repository' },
+  { value: 'issue', label: 'Issue' },
+  { value: 'status', label: 'Status' },
+];
+
+const WatchlistBountyCardSortPills: React.FC<{
+  sortField: BountySortKey;
+  sortOrder: 'asc' | 'desc';
+  onSortChange: (key: BountySortKey) => void;
+}> = (props) => (
+  <SortPills options={WATCHLIST_BOUNTY_CARD_SORT_OPTIONS} {...props} />
+);
+
 const bountyKey = (issue: IssueBounty) => String(issue.id);
 
 const getBountyHref = (issue: IssueBounty) =>
@@ -2558,6 +2591,15 @@ const BountiesList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
                   />
                 ))}
               </Box>
+            }
+            sortContent={
+              viewMode === 'cards' ? (
+                <WatchlistBountyCardSortPills
+                  sortField={sortField}
+                  sortOrder={sortOrder}
+                  onSortChange={handleSort}
+                />
+              ) : undefined
             }
             searchValue={draftValue}
             searchPlaceholder="Search bounties..."

--- a/src/pages/WatchlistPage.tsx
+++ b/src/pages/WatchlistPage.tsx
@@ -2445,6 +2445,11 @@ const buildBountyColumns = (): DataTableColumn<
   },
 ];
 
+const parseBountyAmount = (value: string | null | undefined): number => {
+  const parsed = Number.parseFloat(value ?? '0');
+  return Number.isFinite(parsed) ? parsed : 0;
+};
+
 const BountiesList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
   const { data: allIssues, isLoading } = useIssues();
   const { taoPrice, alphaPrice } = usePrices();
@@ -2462,6 +2467,7 @@ const BountiesList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
   const [searchQuery, setSearchQuery] = useState('');
   const [statusFilter, setStatusFilter] = useState<BountyStatusFilter>('all');
   const [viewMode, setViewMode] = useWatchlistViewMode();
+  const [showChart, setShowChart] = useState(false);
   const [page, setPage] = useState(0);
   const observerTarget = useRef<HTMLDivElement>(null);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
@@ -2518,6 +2524,105 @@ const BountiesList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
       }
     });
   }, [filtered, sortField, sortOrder]);
+
+  const chartOption = useMemo(() => {
+    const repoTotals = new Map<string, number>();
+    filtered.forEach((issue) => {
+      const amount = parseBountyAmount(
+        issue.targetBounty || issue.bountyAmount,
+      );
+      repoTotals.set(
+        issue.repositoryFullName,
+        (repoTotals.get(issue.repositoryFullName) || 0) + amount,
+      );
+    });
+    const chartData = [...repoTotals.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 20);
+    const textColor = alpha(theme.palette.common.white, 0.85);
+    const gridColor = theme.palette.border.subtle;
+
+    return {
+      backgroundColor: 'transparent',
+      title: {
+        text: 'Bounty Pool by Repository',
+        subtext: `${filtered.length} watched issues`,
+        left: 'center',
+        top: 20,
+        textStyle: {
+          color: theme.palette.text.primary,
+          fontFamily: 'JetBrains Mono',
+          fontSize: 16,
+          fontWeight: 600,
+        },
+        subtextStyle: {
+          color: alpha(theme.palette.common.white, TEXT_OPACITY.tertiary),
+          fontFamily: 'JetBrains Mono',
+          fontSize: 12,
+        },
+      },
+      tooltip: {
+        trigger: 'axis',
+        axisPointer: { type: 'shadow' },
+        backgroundColor: alpha(theme.palette.background.default, 0.95),
+        borderColor: alpha(theme.palette.common.white, 0.15),
+        borderWidth: 1,
+        textStyle: {
+          color: theme.palette.text.primary,
+          fontFamily: 'JetBrains Mono',
+        },
+        formatter: (params: { name: string; value: number }[]) => {
+          const p = params[0];
+          return `${p.name}: ${p.value.toFixed(4)} ل`;
+        },
+      },
+      grid: {
+        left: '3%',
+        right: '3%',
+        bottom: '15%',
+        top: '20%',
+        containLabel: true,
+      },
+      xAxis: {
+        type: 'category',
+        data: chartData.map(([repo]) => repo.split('/')[1] || repo),
+        axisLabel: {
+          color: textColor,
+          fontFamily: 'JetBrains Mono',
+          rotate: 45,
+          interval: 0,
+        },
+        axisLine: { lineStyle: { color: gridColor } },
+      },
+      yAxis: {
+        type: 'value',
+        name: 'Bounty (ل)',
+        nameTextStyle: { color: textColor, fontFamily: 'JetBrains Mono' },
+        axisLabel: { color: textColor, fontFamily: 'JetBrains Mono' },
+        splitLine: { lineStyle: { color: gridColor, type: 'dashed' } },
+      },
+      series: [
+        {
+          data: chartData.map(([, value]) => value),
+          type: 'bar',
+          itemStyle: {
+            color: {
+              type: 'linear',
+              x: 0,
+              y: 0,
+              x2: 0,
+              y2: 1,
+              colorStops: [
+                { offset: 0, color: theme.palette.primary.main },
+                { offset: 1, color: theme.palette.status.info },
+              ],
+            },
+            borderRadius: [4, 4, 0, 0],
+          },
+        },
+      ],
+    };
+  }, [filtered]);
 
   const totalBountyPages = Math.max(
     1,
@@ -2601,6 +2706,34 @@ const BountiesList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
                 />
               ) : undefined
             }
+            extraContent={
+              <Box>
+                <OptionsLabel>Chart</OptionsLabel>
+                <Tooltip title={showChart ? 'Hide Chart' : 'Show Chart'}>
+                  <IconButton
+                    onClick={() => setShowChart((v) => !v)}
+                    size="small"
+                    sx={{
+                      color: showChart ? 'text.primary' : 'text.tertiary',
+                      border: '1px solid',
+                      borderColor: 'border.light',
+                      borderRadius: 2,
+                      padding: '6px',
+                      '&:hover': {
+                        backgroundColor: 'surface.light',
+                        borderColor: 'border.medium',
+                      },
+                    }}
+                  >
+                    {showChart ? (
+                      <TableChartIcon fontSize="small" />
+                    ) : (
+                      <BarChartIcon fontSize="small" />
+                    )}
+                  </IconButton>
+                </Tooltip>
+              </Box>
+            }
             searchValue={draftValue}
             searchPlaceholder="Search bounties..."
             onSearchChange={setDraftValue}
@@ -2622,6 +2755,26 @@ const BountiesList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
           />
         )}
       </DebouncedSearchInput>
+
+      <Collapse in={showChart}>
+        <Box
+          sx={{
+            p: 2,
+            borderBottom: '1px solid',
+            borderColor: 'border.light',
+            height: '500px',
+            backgroundColor: 'surface.subtle',
+          }}
+        >
+          {showChart && filtered.length > 0 && (
+            <ReactECharts
+              option={chartOption}
+              style={{ height: '100%', width: '100%' }}
+              notMerge
+            />
+          )}
+        </Box>
+      </Collapse>
 
       {viewMode === 'list' ? (
         <DataTable<IssueBounty, BountySortKey>


### PR DESCRIPTION
## Summary
- add the missing Watchlist → Bounties chart toggle
- aggregate watched bounty pool by repository from the filtered bounty set
- render the same “Bounty Pool by Repository” chart pattern used on /bounties

Fixes #1018

## Verification
- npm run lint -- --quiet
- npm run build