### PR TITLE
fix(miners): debounce search in MinerPRsTable and MinerOpenDiscoveryIssuesByRepo

### DIFF
--- a/src/components/miners/MinerOpenDiscoveryIssuesByRepo.tsx
+++ b/src/components/miners/MinerOpenDiscoveryIssuesByRepo.tsx
@@ -27,6 +27,7 @@ import { getRepositoryOwnerAvatarSrc, paginateItems } from '../../utils';
 import { DataTable, type DataTableColumn } from '../common/DataTable';
 import FilterButton from '../FilterButton';
 import { ClearSearchAdornment } from '../common/ClearSearchAdornment';
+import { DebouncedSearchInput } from '../common/DebouncedSearchInput';
 import { WatchlistButton } from '../common';
 import TablePagination from '../common/TablePagination';
 import {
@@ -870,44 +871,51 @@ const MinerOpenDiscoveryIssuesByRepo: React.FC<
           flexWrap: 'wrap',
         }}
       >
-        <TextField
-          size="small"
-          placeholder="Search by title, repo, or issue #..."
-          value={search}
-          onChange={(e) => onSearchChange(e.target.value)}
-          InputProps={{
-            startAdornment: (
-              <InputAdornment position="start">
-                <SearchIcon
-                  sx={{
-                    color: (t) => alpha(t.palette.text.primary, 0.3),
-                    fontSize: '1rem',
-                  }}
-                />
-              </InputAdornment>
-            ),
-            endAdornment: (
-              <ClearSearchAdornment
-                visible={Boolean(search)}
-                onClear={() => onSearchChange('')}
-              />
-            ),
-          }}
-          sx={{
-            width: { xs: '100%', sm: 'auto' },
-            maxWidth: { xs: '100%', sm: 400 },
-            minWidth: { xs: 0, sm: 350 },
-            '& .MuiOutlinedInput-root': {
-              fontSize: '0.8rem',
-              color: 'text.primary',
-              backgroundColor: 'surface.subtle',
-              borderRadius: 2,
-              '& fieldset': { borderColor: 'border.light' },
-              '&:hover fieldset': { borderColor: 'border.medium' },
-              '&.Mui-focused fieldset': { borderColor: 'primary.main' },
-            },
-          }}
-        />
+        <DebouncedSearchInput
+          initialDraft={search}
+          onDebouncedChange={onSearchChange}
+        >
+          {({ draftValue, setDraftValue }) => (
+            <TextField
+              size="small"
+              placeholder="Search by title, repo, or issue #..."
+              value={draftValue}
+              onChange={(e) => setDraftValue(e.target.value)}
+              InputProps={{
+                startAdornment: (
+                  <InputAdornment position="start">
+                    <SearchIcon
+                      sx={{
+                        color: (t) => alpha(t.palette.text.primary, 0.3),
+                        fontSize: '1rem',
+                      }}
+                    />
+                  </InputAdornment>
+                ),
+                endAdornment: (
+                  <ClearSearchAdornment
+                    visible={Boolean(draftValue)}
+                    onClear={() => setDraftValue('')}
+                  />
+                ),
+              }}
+              sx={{
+                width: { xs: '100%', sm: 'auto' },
+                maxWidth: { xs: '100%', sm: 400 },
+                minWidth: { xs: 0, sm: 350 },
+                '& .MuiOutlinedInput-root': {
+                  fontSize: '0.8rem',
+                  color: 'text.primary',
+                  backgroundColor: 'surface.subtle',
+                  borderRadius: 2,
+                  '& fieldset': { borderColor: 'border.light' },
+                  '&:hover fieldset': { borderColor: 'border.medium' },
+                  '&.Mui-focused fieldset': { borderColor: 'primary.main' },
+                },
+              }}
+            />
+          )}
+        </DebouncedSearchInput>
 
         <Box
           sx={{

--- a/src/components/miners/MinerPRsTable.tsx
+++ b/src/components/miners/MinerPRsTable.tsx
@@ -1,4 +1,10 @@
-import React, { useState, useMemo, useCallback, useEffect } from 'react';
+import React, {
+  useState,
+  useMemo,
+  useCallback,
+  useEffect,
+  useRef,
+} from 'react';
 import {
   Avatar,
   Box,
@@ -29,6 +35,7 @@ import {
 } from '../../components/common/DataTable';
 import FilterButton from '../FilterButton';
 import { ClearSearchAdornment } from '../common/ClearSearchAdornment';
+import { DebouncedSearchInput } from '../common/DebouncedSearchInput';
 import { WatchlistButton } from '../../components/common';
 import { serializePRKey } from '../../hooks/useWatchlist';
 import TablePagination from '../common/TablePagination';
@@ -121,6 +128,24 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
       );
     },
     [page, setSearchParams],
+  );
+
+  // Ref lets the callback read the latest searchQuery without closing over
+  // it (which would re-fire the wrapper's debounce effect on every commit).
+  const searchQueryRef = useRef(searchQuery);
+  useEffect(() => {
+    searchQueryRef.current = searchQuery;
+  });
+
+  // Skip when the wrapper fires with the already-committed value (mount + the
+  // [githubId] reset above) so a deep-linked `?prPage=N` survives.
+  const handleDebouncedSearch = useCallback(
+    (next: string) => {
+      if (next === searchQueryRef.current) return;
+      setSearchQuery(next);
+      setPage(0);
+    },
+    [setPage],
   );
 
   const setStatusFilter = useCallback(
@@ -547,51 +572,52 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
         </Box>
       </Box>
 
-      <TextField
-        size="small"
-        placeholder="Search by title, repo, or PR number..."
-        value={searchQuery}
-        onChange={(e) => {
-          setSearchQuery(e.target.value);
-          setPage(0);
-        }}
-        InputProps={{
-          startAdornment: (
-            <InputAdornment position="start">
-              <SearchIcon
-                sx={{
-                  color: (t) => alpha(t.palette.text.primary, 0.3),
-                  fontSize: '1rem',
-                }}
-              />
-            </InputAdornment>
-          ),
-          endAdornment: (
-            <ClearSearchAdornment
-              visible={Boolean(searchQuery)}
-              onClear={() => {
-                setSearchQuery('');
-                setPage(0);
-              }}
-            />
-          ),
-        }}
-        sx={{
-          mt: 2,
-          width: { xs: '100%', sm: 'auto' },
-          maxWidth: { xs: '100%', sm: 400 },
-          minWidth: { xs: 0, sm: 350 },
-          '& .MuiOutlinedInput-root': {
-            fontSize: '0.8rem',
-            color: 'text.primary',
-            backgroundColor: 'surface.subtle',
-            borderRadius: 2,
-            '& fieldset': { borderColor: 'border.light' },
-            '&:hover fieldset': { borderColor: 'border.medium' },
-            '&.Mui-focused fieldset': { borderColor: 'primary.main' },
-          },
-        }}
-      />
+      <DebouncedSearchInput
+        initialDraft={searchQuery}
+        onDebouncedChange={handleDebouncedSearch}
+      >
+        {({ draftValue, setDraftValue }) => (
+          <TextField
+            size="small"
+            placeholder="Search by title, repo, or PR number..."
+            value={draftValue}
+            onChange={(e) => setDraftValue(e.target.value)}
+            InputProps={{
+              startAdornment: (
+                <InputAdornment position="start">
+                  <SearchIcon
+                    sx={{
+                      color: (t) => alpha(t.palette.text.primary, 0.3),
+                      fontSize: '1rem',
+                    }}
+                  />
+                </InputAdornment>
+              ),
+              endAdornment: (
+                <ClearSearchAdornment
+                  visible={Boolean(draftValue)}
+                  onClear={() => setDraftValue('')}
+                />
+              ),
+            }}
+            sx={{
+              mt: 2,
+              width: { xs: '100%', sm: 'auto' },
+              maxWidth: { xs: '100%', sm: 400 },
+              minWidth: { xs: 0, sm: 350 },
+              '& .MuiOutlinedInput-root': {
+                fontSize: '0.8rem',
+                color: 'text.primary',
+                backgroundColor: 'surface.subtle',
+                borderRadius: 2,
+                '& fieldset': { borderColor: 'border.light' },
+                '&:hover fieldset': { borderColor: 'border.medium' },
+                '&.Mui-focused fieldset': { borderColor: 'primary.main' },
+              },
+            }}
+          />
+        )}
+      </DebouncedSearchInput>
     </Box>
   );
 


### PR DESCRIPTION
## Summary

Two miner views were missed by the `DebouncedSearchInput` migration in #1084 and still committed `searchQuery` on every keystroke, forcing the parent and its filter/sort/paginate `useMemo` chains to rerun per character.

* `MinerPRsTable.tsx`: wrap the PR search field in `DebouncedSearchInput`. The `setPage(0)` reset that used to ride along with the keystroke handler now lives in the debounced commit path, gated by a `searchQueryRef` comparison so the wrapper's mount fire and the existing `[githubId]` reset do not clobber a deep-linked `?prPage=N` URL.
* `MinerOpenDiscoveryIssuesByRepo.tsx`: wrap the search field inside `renderToolbar`, so the "Your open discovery issues" and "Other open discovery issues" sections each get an independent debounced draft. Typing in one section no longer rerenders the other.

Both files now match the existing pattern used by `MinerRepositoriesTable`, `IssuesList`, `TopRepositoriesTable`, `MinerScoreBreakdown`, `LanguageWeightsTable`, and `WatchlistPage`.

## Related Issues

Fixes #1107

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Refactor
* [ ] Documentation
* [ ] Other (describe below)

## Screenshots

Before:
[before.webm](https://github.com/user-attachments/assets/d5bad137-c2b7-491b-93c8-547793bb7541)

After:
[after.webm](https://github.com/user-attachments/assets/d69e5fbd-e838-4a0c-90d7-cae41fc011fe)

## Checklist

* [x] New components are modularized/separated where sensible
* [x] Uses predefined theme (e.g. no hardcoded colors)
* [x] Responsive/mobile checked
* [x] Tested against the test API
* [x] `npm run format` and `npm run lint:fix` have been run
* [x] `npm run build` passes
* [x] Screenshots included for any UI/visual changes
