### PR TITLE
fix: handle filters toolbar's status using query search params

### DIFF
--- a/src/components/issues/BountySidebar.tsx
+++ b/src/components/issues/BountySidebar.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useMemo } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import {
   Avatar,
@@ -29,6 +29,7 @@ import { CHART_COLORS, CREDIBILITY_COLORS, STATUS_COLORS } from '../../theme';
 import { getGithubAvatarSrc, parseNumber } from '../../utils';
 import { formatAlphaToUsd, formatTokenAmount } from '../../utils/format';
 import { usePrices } from '../../hooks/usePrices';
+import { useFiltersPanelOpenInUrl } from '../../hooks/useFiltersPanelUrlState';
 
 type FilterType = 'all' | 'available' | 'pending' | 'history';
 
@@ -156,7 +157,7 @@ const useTopBountyHunters = (
 
 const FilterSection: React.FC = () => {
   const [searchParams] = useSearchParams();
-  const [open, setOpen] = useState(false);
+  const [open, setOpen] = useFiltersPanelOpenInUrl();
 
   const filterType = useMemo<FilterType>(() => {
     const f = searchParams.get('filter');
@@ -181,7 +182,7 @@ const FilterSection: React.FC = () => {
       <Box
         component="button"
         type="button"
-        onClick={() => setOpen((v) => !v)}
+        onClick={() => setOpen(!open)}
         sx={(t) => ({
           display: 'flex',
           alignItems: 'center',

--- a/src/components/leaderboard/TopMinersTable.tsx
+++ b/src/components/leaderboard/TopMinersTable.tsx
@@ -26,6 +26,11 @@ import { MinerCard } from './MinerCard';
 import { MinersList } from './MinersList';
 import theme, { STATUS_COLORS } from '../../theme';
 import { useDataTableParams } from '../../hooks/useDataTableParams';
+import {
+  FILTERS_PANEL_QUERY_PARAM,
+  parseFiltersPanelOpen,
+  serializeFiltersPanelOpen,
+} from '../../hooks/useFiltersPanelUrlState';
 import { useWatchlist } from '../../hooks/useWatchlist';
 import { type SortOrder } from '../../utils/ExplorerUtils';
 import { compareByWatchlist } from '../../utils/watchlistSort';
@@ -49,7 +54,6 @@ const DISC_ELIGIBLE_QUERY_PARAM = 'discElig';
 const VIEW_QUERY_PARAM = 'view';
 const SEARCH_QUERY_PARAM = 'search';
 const VISIBLE_QUERY_PARAM = 'visible';
-const FILTERS_PANEL_QUERY_PARAM = 'filters';
 const VIEW_STORAGE_KEY_LEADERBOARD = 'leaderboard:viewMode';
 const VIEW_STORAGE_KEY_WATCHLIST = 'watchlist:viewMode';
 
@@ -245,9 +249,8 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
       },
       filtersOpen: {
         paramKey: FILTERS_PANEL_QUERY_PARAM,
-        parse: (raw: string | null): boolean =>
-          raw === 'open' || raw === 'true',
-        serialize: (value: boolean): string | null => (value ? 'open' : null),
+        parse: parseFiltersPanelOpen,
+        serialize: serializeFiltersPanelOpen,
         resetPageOnChange: false,
       },
       eligible:

--- a/src/hooks/useFiltersPanelUrlState.ts
+++ b/src/hooks/useFiltersPanelUrlState.ts
@@ -1,0 +1,45 @@
+import { useCallback, useMemo } from 'react';
+import { useSearchParams } from 'react-router-dom';
+
+/**
+ * Query key for collapsible filter toolbars in sidebars (leaderboard miners,
+ * bounties page, watchlist tabs). Matches `useDataTableParams` filtersOpen in
+ * TopMinersTable.
+ */
+export const FILTERS_PANEL_QUERY_PARAM = 'filters';
+
+export const parseFiltersPanelOpen = (raw: string | null): boolean =>
+  raw === 'open' || raw === 'true';
+
+export const serializeFiltersPanelOpen = (value: boolean): string | null =>
+  value ? 'open' : null;
+
+export function useFiltersPanelOpenInUrl(): readonly [
+  open: boolean,
+  setOpen: (next: boolean) => void,
+] {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const open = useMemo(
+    () => parseFiltersPanelOpen(searchParams.get(FILTERS_PANEL_QUERY_PARAM)),
+    [searchParams],
+  );
+  const setOpen = useCallback(
+    (next: boolean) => {
+      setSearchParams(
+        (prev) => {
+          const p = new URLSearchParams(prev);
+          const serialized = serializeFiltersPanelOpen(next);
+          if (serialized != null) {
+            p.set(FILTERS_PANEL_QUERY_PARAM, serialized);
+          } else {
+            p.delete(FILTERS_PANEL_QUERY_PARAM);
+          }
+          return p;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
+  );
+  return [open, setOpen] as const;
+}

--- a/src/pages/WatchlistPage.tsx
+++ b/src/pages/WatchlistPage.tsx
@@ -67,6 +67,7 @@ import {
   useAllPrs,
   useMinersIssues,
 } from '../api';
+import { useFiltersPanelOpenInUrl } from '../hooks/useFiltersPanelUrlState';
 import type {
   CommitLog,
   MinerIssue,
@@ -604,14 +605,14 @@ const WatchlistOptionsSidebarPanel: React.FC<
     hasActiveFilter: boolean;
   }
 > = (props) => {
-  const [open, setOpen] = useState(false);
+  const [open, setOpen] = useFiltersPanelOpenInUrl();
 
   return (
     <Box>
       <Box
         component="button"
         type="button"
-        onClick={() => setOpen((v) => !v)}
+        onClick={() => setOpen(!open)}
         sx={(t) => ({
           display: 'flex',
           alignItems: 'center',


### PR DESCRIPTION
## Summary

This PR addresses the remaining issues not covered in #1082. While #1082 fixed the filter toolbar’s status handling on the Leaderboard page, the same issue persisted on other pages such as Watchlist and Bounties. This PR resolves those inconsistencies across the affected pages.


## Related Issues

closes #1106 
closes #1081 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

Before:

Please check video in #1106 

After:

[after.webm](https://github.com/user-attachments/assets/66b841f1-9cd7-43b4-a2f1-62503f10b19f)


## Checklist

- [x] New components are modularized/separated where sensible
- [ ] Uses predefined theme (e.g. no hardcoded colors)
- [ ] Responsive/mobile checked
- [ ] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
