### PR TITLE
fix: align Bounties sticky filter tabs with global search offset

### DIFF
--- a/src/pages/IssuesPage.tsx
+++ b/src/pages/IssuesPage.tsx
@@ -113,7 +113,7 @@ const IssuesPage: React.FC = () => {
               borderBottom: '1px solid',
               borderColor: 'border.light',
               position: 'sticky',
-              top: 64,
+              top: 60,
               zIndex: 50,
               backgroundColor: (t) => alpha(t.palette.background.default, 0.85),
               backdropFilter: 'blur(12px)',


### PR DESCRIPTION
## Summary

Set the Bounties page sticky filter tabs `top` offset from `64px` to `60px` so it matches other pages that stack a sticky global search bar with a sticky tab row (e.g. Top Miners, Watchlist).

## Related Issues

Closes #1112


## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

### Before
<img width="2141" height="456" alt="image" src="https://github.com/user-attachments/assets/139e961b-1972-4223-88f2-7d434726af58" />

### After
<img width="2135" height="642" alt="image" src="https://github.com/user-attachments/assets/227933a3-6254-40ba-b950-7ea99aca576b" />

## Checklist

- [ ] New components are modularized/separated where sensible
- [ ] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [ ] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
