### PR TITLE
fix(navigation): respect backLabel state in BackButton

### DIFF
--- a/src/components/BackButton.tsx
+++ b/src/components/BackButton.tsx
@@ -19,8 +19,10 @@ const BackButton: React.FC<BackButtonProps> = ({
 }) => {
   const navigate = useNavigate();
   const location = useLocation();
-  const state = (location.state as { backTo?: string }) || {};
+  const state =
+    (location.state as { backLabel?: string; backTo?: string }) || {};
   const canGoBack = typeof window !== 'undefined' && window.history.length > 1;
+  const displayLabel = state.backLabel ?? label;
 
   const handleClick = () => {
     if (canGoBack) {
@@ -43,7 +45,7 @@ const BackButton: React.FC<BackButtonProps> = ({
       onClick={handleClick}
       sx={{ mb, alignSelf: 'flex-start' }}
     >
-      {label}
+      {displayLabel}
     </Button>
   );
 };


### PR DESCRIPTION
## Summary

`BackButton` read navigation state with the key `backTo`, but every caller across the codebase passes `backLabel` (20+ sites: `MinerPRsTable`, `RepositoryPRsTable`, `HomePage`, `WatchlistPage`, `BountySidebar`, etc.). The key mismatch meant the rendered label always fell through to the destination page's hardcoded `label` prop, so every caller's intent was silently dropped.

**Visible symptom:** opening a PR from a miner's Pull Requests tab shows "Back to Repositories" in the top-left even though the user came from the miner page. Click behavior was already correct (`navigate(-1)`), so this was confusing rather than functionally broken.

**Fix:** `BackButton` now reads `state.backLabel` and uses it as the label when present, falling back to the `label` prop otherwise. All 20+ existing callers benefit without any changes on their side.


## Related Issues

None


## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)


## Screenshots
**Before:**
<img width="213" height="38" alt="image" src="https://github.com/user-attachments/assets/d94b909a-364f-4b03-b170-f18871a9b6ec" />

**After:**
<img width="184" height="52" alt="image" src="https://github.com/user-attachments/assets/4f3f8d75-f100-40a4-843c-eac2f31e22b4" />


## Additional Videos
**Before:**
https://github.com/user-attachments/assets/ec96b4be-9264-426d-855a-b7bf8262ab7a

**After:**
https://github.com/user-attachments/assets/a45a5a33-0e69-4478-9688-8e8a9ac79713


## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes