### PR TITLE
fix(miners): show real dates in PR list Date column (#1111)

### DIFF
--- a/src/api/MinerApi.ts
+++ b/src/api/MinerApi.ts
@@ -1,5 +1,7 @@
 // Miner API hooks - uses /miners endpoints
+import { useQueries } from '@tanstack/react-query';
 import {
+  githubFetch,
   useApiQuery,
   useMirrorApiQueries,
   useMirrorApiQuery,
@@ -117,5 +119,92 @@ export const useMinersIssues = (
     {
       enabled,
       select: (data) => data?.issues ?? [],
+    },
+  );
+
+// Mirror-API view of a miner's pull requests — used to fill in date fields
+// (`created_at`, `closed_at`) that the camelCase /miners/:id/prs endpoint
+// doesn't currently return. Keyed by `${repo_full_name}#${pr_number}`.
+type MirrorPullsResponse = {
+  pull_requests?: Array<{
+    repo_full_name: string;
+    pr_number: number;
+    created_at?: string | null;
+    closed_at?: string | null;
+    merged_at?: string | null;
+  }>;
+};
+
+export type PrDateOverride = {
+  createdAt: string | null;
+  closedAt: string | null;
+};
+
+export const minerPullDatesKey = (repo: string, prNumber: number) =>
+  `${repo}#${prNumber}`;
+
+// Reach back far enough to cover anything the dashboard might display; the
+// mirror defaults to a 35-day window which would miss older rows.
+const MIRROR_PULLS_SINCE = '2024-01-01T00:00:00.000Z';
+
+// Per-PR fallback: when the mirror has no record of a row (e.g. external
+// repos the subnet doesn't track), hit GitHub directly for `created_at` /
+// `closed_at`. Results are cached forever in React Query so pagination and
+// re-renders don't refire, and individual failures (private repos, rate
+// limits) degrade silently to a missing entry — the cell falls back to `—`
+// for that single row instead of breaking the whole column.
+const GITHUB_PR_DATES_STALE = Infinity;
+
+export const useGithubPrDates = (
+  prs: Array<{ repository: string; pullRequestNumber: number }>,
+  enabled?: boolean,
+): Map<string, PrDateOverride> => {
+  const queries = useQueries({
+    queries: prs.map((pr) => ({
+      queryKey: ['githubPrDates', pr.repository, pr.pullRequestNumber] as const,
+      queryFn: async () => {
+        const data = await githubFetch<{
+          created_at?: string | null;
+          closed_at?: string | null;
+        }>(
+          `https://api.github.com/repos/${pr.repository}/pulls/${pr.pullRequestNumber}`,
+        );
+        return {
+          createdAt: data.created_at ?? null,
+          closedAt: data.closed_at ?? null,
+        };
+      },
+      enabled: enabled ?? true,
+      retry: false,
+      staleTime: GITHUB_PR_DATES_STALE,
+      gcTime: GITHUB_PR_DATES_STALE,
+    })),
+  });
+  const map = new Map<string, PrDateOverride>();
+  prs.forEach((pr, i) => {
+    const q = queries[i];
+    if (q?.data) {
+      map.set(minerPullDatesKey(pr.repository, pr.pullRequestNumber), q.data);
+    }
+  });
+  return map;
+};
+
+export const useMinerPullDates = (githubId: string, enabled?: boolean) =>
+  useMirrorApiQuery<MirrorPullsResponse, Map<string, PrDateOverride>>(
+    'useMinerPullDates',
+    `/miners/${githubId}/pulls?since=${encodeURIComponent(MIRROR_PULLS_SINCE)}`,
+    {
+      enabled,
+      select: (data) => {
+        const map = new Map<string, PrDateOverride>();
+        for (const p of data?.pull_requests ?? []) {
+          map.set(minerPullDatesKey(p.repo_full_name, p.pr_number), {
+            createdAt: p.created_at ?? null,
+            closedAt: p.closed_at ?? null,
+          });
+        }
+        return map;
+      },
     },
   );

--- a/src/api/MinerApi.ts
+++ b/src/api/MinerApi.ts
@@ -1,7 +1,5 @@
 // Miner API hooks - uses /miners endpoints
-import { useQueries } from '@tanstack/react-query';
 import {
-  githubFetch,
   useApiQuery,
   useMirrorApiQueries,
   useMirrorApiQuery,
@@ -119,92 +117,5 @@ export const useMinersIssues = (
     {
       enabled,
       select: (data) => data?.issues ?? [],
-    },
-  );
-
-// Mirror-API view of a miner's pull requests — used to fill in date fields
-// (`created_at`, `closed_at`) that the camelCase /miners/:id/prs endpoint
-// doesn't currently return. Keyed by `${repo_full_name}#${pr_number}`.
-type MirrorPullsResponse = {
-  pull_requests?: Array<{
-    repo_full_name: string;
-    pr_number: number;
-    created_at?: string | null;
-    closed_at?: string | null;
-    merged_at?: string | null;
-  }>;
-};
-
-export type PrDateOverride = {
-  createdAt: string | null;
-  closedAt: string | null;
-};
-
-export const minerPullDatesKey = (repo: string, prNumber: number) =>
-  `${repo}#${prNumber}`;
-
-// Reach back far enough to cover anything the dashboard might display; the
-// mirror defaults to a 35-day window which would miss older rows.
-const MIRROR_PULLS_SINCE = '2024-01-01T00:00:00.000Z';
-
-// Per-PR fallback: when the mirror has no record of a row (e.g. external
-// repos the subnet doesn't track), hit GitHub directly for `created_at` /
-// `closed_at`. Results are cached forever in React Query so pagination and
-// re-renders don't refire, and individual failures (private repos, rate
-// limits) degrade silently to a missing entry — the cell falls back to `—`
-// for that single row instead of breaking the whole column.
-const GITHUB_PR_DATES_STALE = Infinity;
-
-export const useGithubPrDates = (
-  prs: Array<{ repository: string; pullRequestNumber: number }>,
-  enabled?: boolean,
-): Map<string, PrDateOverride> => {
-  const queries = useQueries({
-    queries: prs.map((pr) => ({
-      queryKey: ['githubPrDates', pr.repository, pr.pullRequestNumber] as const,
-      queryFn: async () => {
-        const data = await githubFetch<{
-          created_at?: string | null;
-          closed_at?: string | null;
-        }>(
-          `https://api.github.com/repos/${pr.repository}/pulls/${pr.pullRequestNumber}`,
-        );
-        return {
-          createdAt: data.created_at ?? null,
-          closedAt: data.closed_at ?? null,
-        };
-      },
-      enabled: enabled ?? true,
-      retry: false,
-      staleTime: GITHUB_PR_DATES_STALE,
-      gcTime: GITHUB_PR_DATES_STALE,
-    })),
-  });
-  const map = new Map<string, PrDateOverride>();
-  prs.forEach((pr, i) => {
-    const q = queries[i];
-    if (q?.data) {
-      map.set(minerPullDatesKey(pr.repository, pr.pullRequestNumber), q.data);
-    }
-  });
-  return map;
-};
-
-export const useMinerPullDates = (githubId: string, enabled?: boolean) =>
-  useMirrorApiQuery<MirrorPullsResponse, Map<string, PrDateOverride>>(
-    'useMinerPullDates',
-    `/miners/${githubId}/pulls?since=${encodeURIComponent(MIRROR_PULLS_SINCE)}`,
-    {
-      enabled,
-      select: (data) => {
-        const map = new Map<string, PrDateOverride>();
-        for (const p of data?.pull_requests ?? []) {
-          map.set(minerPullDatesKey(p.repo_full_name, p.pr_number), {
-            createdAt: p.created_at ?? null,
-            closedAt: p.closed_at ?? null,
-          });
-        }
-        return map;
-      },
     },
   );

--- a/src/components/miners/MinerPRsTable.tsx
+++ b/src/components/miners/MinerPRsTable.tsx
@@ -14,7 +14,14 @@ import {
 } from '@mui/material';
 import { Search as SearchIcon } from '@mui/icons-material';
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import { useMinerPRs, type CommitLog } from '../../api';
+import {
+  useGithubPrDates,
+  useMinerPRs,
+  useMinerPullDates,
+  minerPullDatesKey,
+  type CommitLog,
+  type PrDateOverride,
+} from '../../api';
 import {
   filterPrs,
   getRepositoryOwnerAvatarSrc,
@@ -67,6 +74,28 @@ const getEffectiveScore = (pr: CommitLog): number => {
   return parseFloat(pr.score || '0');
 };
 
+// The Date column should always show a real date; the milestone it refers to
+// depends on PR state. Returns the ISO string to render plus the label that
+// explains which milestone — used for both the cell and the sort comparator
+// so the visible value matches the ordering. `extra` lets the caller layer in
+// dates from the mirror API for fields the camelCase /miners/:id/prs endpoint
+// doesn't include (`prCreatedAt`, `closedAt`).
+const getPrDateInfo = (
+  pr: CommitLog,
+  extra?: PrDateOverride,
+): { iso: string | null; label: 'Merged' | 'Closed' | 'Opened' } => {
+  if (pr.mergedAt) return { iso: pr.mergedAt, label: 'Merged' };
+  const closedAt = pr.closedAt ?? extra?.closedAt ?? null;
+  const createdAt = pr.prCreatedAt || extra?.createdAt || null;
+  if (pr.prState === 'CLOSED') {
+    return {
+      iso: closedAt ?? createdAt,
+      label: closedAt ? 'Closed' : 'Opened',
+    };
+  }
+  return { iso: createdAt, label: 'Opened' };
+};
+
 const getScoreTooltip = (pr: CommitLog): string | null => {
   const base = parseFloat(pr.baseScore || '0');
   if (!pr.mergedAt || base <= 0) return null;
@@ -90,6 +119,10 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const { data: prs, isLoading } = useMinerPRs(githubId);
+  // Pull `created_at` / `closed_at` from the mirror so the Date column shows
+  // a real date for open and closed-unmerged rows. The component renders fine
+  // before this resolves — cells just fall back to whatever the das API gave.
+  const { data: dateOverrides } = useMinerPullDates(githubId);
   const [selectedAuthor, setSelectedAuthor] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
   const [sortField, setSortField] = useState<PrSortField>('date');
@@ -182,8 +215,20 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
           cmp = a.additions + a.deletions - (b.additions + b.deletions);
           break;
         case 'date': {
-          const da = a.mergedAt || a.prCreatedAt || '';
-          const db = b.mergedAt || b.prCreatedAt || '';
+          const da =
+            getPrDateInfo(
+              a,
+              dateOverrides?.get(
+                minerPullDatesKey(a.repository, a.pullRequestNumber),
+              ),
+            ).iso || '';
+          const db =
+            getPrDateInfo(
+              b,
+              dateOverrides?.get(
+                minerPullDatesKey(b.repository, b.pullRequestNumber),
+              ),
+            ).iso || '';
           cmp = da.localeCompare(db);
           break;
         }
@@ -191,11 +236,34 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
       return sortDir === 'asc' ? cmp : -cmp;
     });
     return sorted;
-  }, [filteredPRs, sortField, sortDir]);
+  }, [filteredPRs, sortField, sortDir, dateOverrides]);
 
   const pagedPRs = useMemo(
     () => paginateItems(sortedPRs, page, PAGE_SIZE),
     [sortedPRs, page],
+  );
+
+  // For visible-page rows that have no merge date AND the mirror has nothing,
+  // fall back to GitHub's PR REST endpoint. Fetched lazily, cached forever,
+  // and limited to the current page so we don't blow the 60-req/hr
+  // unauthenticated rate limit on miners with hundreds of PRs.
+  const githubFallbackTargets = useMemo(
+    () =>
+      pagedPRs.filter((pr) => {
+        if (pr.mergedAt) return false;
+        const key = minerPullDatesKey(pr.repository, pr.pullRequestNumber);
+        const override = dateOverrides?.get(key);
+        return !override?.createdAt && !override?.closedAt;
+      }),
+    [pagedPRs, dateOverrides],
+  );
+  const githubDates = useGithubPrDates(githubFallbackTargets);
+  const resolveDateOverride = useCallback(
+    (pr: CommitLog): PrDateOverride | undefined => {
+      const key = minerPullDatesKey(pr.repository, pr.pullRequestNumber);
+      return dateOverrides?.get(key) ?? githubDates.get(key);
+    },
+    [dateOverrides, githubDates],
   );
 
   const totalPages = Math.ceil(sortedPRs.length / PAGE_SIZE);
@@ -414,12 +482,25 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
         fontSize: { xs: '0.75rem', sm: '0.85rem' },
         color: (theme) => alpha(theme.palette.text.primary, 0.7),
       },
-      renderCell: (pr) =>
-        pr.mergedAt
-          ? new Date(pr.mergedAt).toLocaleDateString()
-          : pr.prState === 'CLOSED'
-            ? 'Closed'
-            : 'Open',
+      renderCell: (pr) => {
+        const { iso, label } = getPrDateInfo(pr, resolveDateOverride(pr));
+        if (!iso) return '—';
+        const d = new Date(iso);
+        return (
+          <Tooltip
+            title={`${label} ${d.toLocaleDateString(undefined, {
+              year: 'numeric',
+              month: 'long',
+              day: 'numeric',
+            })}`}
+            arrow
+            placement="top"
+            slotProps={tooltipSlotProps}
+          >
+            <Box component="span">{d.toLocaleDateString()}</Box>
+          </Tooltip>
+        );
+      },
     },
     {
       key: 'watch',

--- a/src/components/miners/MinerPRsTable.tsx
+++ b/src/components/miners/MinerPRsTable.tsx
@@ -14,14 +14,7 @@ import {
 } from '@mui/material';
 import { Search as SearchIcon } from '@mui/icons-material';
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import {
-  useGithubPrDates,
-  useMinerPRs,
-  useMinerPullDates,
-  minerPullDatesKey,
-  type CommitLog,
-  type PrDateOverride,
-} from '../../api';
+import { useMinerPRs, type CommitLog } from '../../api';
 import {
   filterPrs,
   getRepositoryOwnerAvatarSrc,
@@ -77,23 +70,14 @@ const getEffectiveScore = (pr: CommitLog): number => {
 // The Date column should always show a real date; the milestone it refers to
 // depends on PR state. Returns the ISO string to render plus the label that
 // explains which milestone — used for both the cell and the sort comparator
-// so the visible value matches the ordering. `extra` lets the caller layer in
-// dates from the mirror API for fields the camelCase /miners/:id/prs endpoint
-// doesn't include (`prCreatedAt`, `closedAt`).
+// so the visible value matches the ordering.
 const getPrDateInfo = (
   pr: CommitLog,
-  extra?: PrDateOverride,
 ): { iso: string | null; label: 'Merged' | 'Closed' | 'Opened' } => {
   if (pr.mergedAt) return { iso: pr.mergedAt, label: 'Merged' };
-  const closedAt = pr.closedAt ?? extra?.closedAt ?? null;
-  const createdAt = pr.prCreatedAt || extra?.createdAt || null;
-  if (pr.prState === 'CLOSED') {
-    return {
-      iso: closedAt ?? createdAt,
-      label: closedAt ? 'Closed' : 'Opened',
-    };
-  }
-  return { iso: createdAt, label: 'Opened' };
+  if (pr.prState === 'CLOSED' && pr.closedAt)
+    return { iso: pr.closedAt, label: 'Closed' };
+  return { iso: pr.prCreatedAt || null, label: 'Opened' };
 };
 
 const getScoreTooltip = (pr: CommitLog): string | null => {
@@ -119,10 +103,6 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const { data: prs, isLoading } = useMinerPRs(githubId);
-  // Pull `created_at` / `closed_at` from the mirror so the Date column shows
-  // a real date for open and closed-unmerged rows. The component renders fine
-  // before this resolves — cells just fall back to whatever the das API gave.
-  const { data: dateOverrides } = useMinerPullDates(githubId);
   const [selectedAuthor, setSelectedAuthor] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
   const [sortField, setSortField] = useState<PrSortField>('date');
@@ -215,20 +195,8 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
           cmp = a.additions + a.deletions - (b.additions + b.deletions);
           break;
         case 'date': {
-          const da =
-            getPrDateInfo(
-              a,
-              dateOverrides?.get(
-                minerPullDatesKey(a.repository, a.pullRequestNumber),
-              ),
-            ).iso || '';
-          const db =
-            getPrDateInfo(
-              b,
-              dateOverrides?.get(
-                minerPullDatesKey(b.repository, b.pullRequestNumber),
-              ),
-            ).iso || '';
+          const da = getPrDateInfo(a).iso || '';
+          const db = getPrDateInfo(b).iso || '';
           cmp = da.localeCompare(db);
           break;
         }
@@ -236,34 +204,11 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
       return sortDir === 'asc' ? cmp : -cmp;
     });
     return sorted;
-  }, [filteredPRs, sortField, sortDir, dateOverrides]);
+  }, [filteredPRs, sortField, sortDir]);
 
   const pagedPRs = useMemo(
     () => paginateItems(sortedPRs, page, PAGE_SIZE),
     [sortedPRs, page],
-  );
-
-  // For visible-page rows that have no merge date AND the mirror has nothing,
-  // fall back to GitHub's PR REST endpoint. Fetched lazily, cached forever,
-  // and limited to the current page so we don't blow the 60-req/hr
-  // unauthenticated rate limit on miners with hundreds of PRs.
-  const githubFallbackTargets = useMemo(
-    () =>
-      pagedPRs.filter((pr) => {
-        if (pr.mergedAt) return false;
-        const key = minerPullDatesKey(pr.repository, pr.pullRequestNumber);
-        const override = dateOverrides?.get(key);
-        return !override?.createdAt && !override?.closedAt;
-      }),
-    [pagedPRs, dateOverrides],
-  );
-  const githubDates = useGithubPrDates(githubFallbackTargets);
-  const resolveDateOverride = useCallback(
-    (pr: CommitLog): PrDateOverride | undefined => {
-      const key = minerPullDatesKey(pr.repository, pr.pullRequestNumber);
-      return dateOverrides?.get(key) ?? githubDates.get(key);
-    },
-    [dateOverrides, githubDates],
   );
 
   const totalPages = Math.ceil(sortedPRs.length / PAGE_SIZE);
@@ -483,7 +428,7 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
         color: (theme) => alpha(theme.palette.text.primary, 0.7),
       },
       renderCell: (pr) => {
-        const { iso, label } = getPrDateInfo(pr, resolveDateOverride(pr));
+        const { iso, label } = getPrDateInfo(pr);
         if (!iso) return '—';
         const d = new Date(iso);
         return (


### PR DESCRIPTION
## Summary

The Pull Requests table on miner detail pages rendered the literal strings `Open` or `Closed` in the `Date` column for any PR that wasn't merged — contradicting both the column label and the sort comparator (which already ordered by a real timestamp).

This PR:

- Adds a `getPrDateInfo(pr)` helper that resolves the Date column to the milestone matching the PR state: **merged → `mergedAt`**, **closed → `closedAt`**, **open → `prCreatedAt`**.
- Wraps the cell in a Tooltip that names the milestone the date refers to (`Merged May 7, 2026` / `Closed May 8, 2026` / `Opened May 6, 2026`).
- Updates the Date sort comparator to use the same helper so order matches what users see.
- Renders `—` for any row whose resolvable date is still null.

### Note on the dash render

`/miners/:id/prs` currently returns only `mergedAt`, so non-merged rows fall back to `—` until the das endpoint includes `prCreatedAt` and `closedAt`. Both fields are already declared on the `CommitLog` type and consumed elsewhere in the codebase — tracking the backend request in #1120. Once those fields land on the wire, the cell renderer picks them up automatically with no further UI change.

An earlier revision of this PR fanned out to the mirror and to GitHub REST to fill in the missing dates client-side. That was reverted per review feedback ([this comment](https://github.com/entrius/gittensor-ui/pull/1119)) — it duplicated a data path the type already commits to and added a rate-limit surface other components don't take on.

## Related Issues

Closes #1111
Depends on #1120 (backend)

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)


## Screenshots

**Before:**
<img width="2224" height="1400" alt="before-closed" src="https://github.com/user-attachments/assets/c5bc57ff-fb13-4b44-a32f-9e4ae1f201db" />
<img width="2224" height="1400" alt="before-open" src="https://github.com/user-attachments/assets/f63d6e2e-4a88-4952-935b-f29d282f10a9" />

**After (without [#1120](https://github.com/entrius/gittensor-ui/issues/1120) resolved):**
<img width="2224" height="1400" alt="after-closed" src="https://github.com/user-attachments/assets/ae250e63-90ac-4c92-b6cc-9d0f0c56a95a" />
<img width="2224" height="1400" alt="after-open" src="https://github.com/user-attachments/assets/d1f6fa62-d498-43bf-b2a5-53f5df20d7f8" />

**After (with [#1120](https://github.com/entrius/gittensor-ui/issues/1120) resolved):**
<img width="2224" height="1400" alt="future-all" src="https://github.com/user-attachments/assets/0ec1b6fd-48de-4d69-92d6-18576b45d3d6" />
<img width="2224" height="1400" alt="future-closed" src="https://github.com/user-attachments/assets/45a357bc-197d-424c-93f5-da51469bff57" />
<img width="2224" height="1400" alt="future-open" src="https://github.com/user-attachments/assets/4e2d7e45-35af-4043-8e38-69d3c03afe2c" />

Until [#1120](https://github.com/entrius/gittensor-ui/issues/1120) is resolved, non-merged rows render `—` instead of the literal Open / Closed strings.


## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes