### PR TITLE
fix: repository table responsiveness

### DIFF
--- a/src/components/repositories/RepositoryIssuesTable.tsx
+++ b/src/components/repositories/RepositoryIssuesTable.tsx
@@ -161,6 +161,7 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
     {
       key: 'number',
       header: 'Issue #',
+      width: 112,
       sortKey: 'number',
       renderCell: (issue) => (
         <a
@@ -181,6 +182,7 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
     {
       key: 'title',
       header: 'Title',
+      width: 360,
       sortKey: 'title',
       renderCell: (issue) => (
         <ScrollAwareTooltip
@@ -191,7 +193,7 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
         >
           <Box
             sx={{
-              maxWidth: '400px',
+              maxWidth: '100%',
               overflow: 'hidden',
               textOverflow: 'ellipsis',
               whiteSpace: 'nowrap',
@@ -205,6 +207,7 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
     {
       key: 'status',
       header: 'Status',
+      width: 128,
       sortKey: 'status',
       renderCell: (issue) => {
         const isOpen = !issue.closedAt;
@@ -225,6 +228,7 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
     {
       key: 'linkedPr',
       header: 'Linked PR',
+      width: 128,
       sortKey: 'linkedPr',
       renderCell: (issue) =>
         issue.prNumber ? (
@@ -254,6 +258,7 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
     {
       key: 'created',
       header: 'Created',
+      width: 128,
       align: 'right',
       sortKey: 'created',
       renderCell: (issue) =>
@@ -262,6 +267,7 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
     {
       key: 'closed',
       header: 'Closed',
+      width: 128,
       align: 'right',
       sortKey: 'closed',
       renderCell: (issue) =>
@@ -287,7 +293,13 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
       >
         Issues ({sortedIssues.length})
       </Typography>
-      <Stack direction="row" spacing={1}>
+      <Stack
+        direction="row"
+        spacing={1}
+        flexWrap="wrap"
+        useFlexGap
+        sx={{ rowGap: 1 }}
+      >
         <FilterButton
           label="All"
           isActive={filter === 'all'}
@@ -468,37 +480,6 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
           display: 'flex',
           flexDirection: 'column',
           overflow: 'hidden',
-          // Restructure so only the body scrolls — the header sits above the
-          // scroll area, so the scrollbar never appears next to the header row.
-          '& .MuiTableContainer-root': {
-            overflow: 'visible',
-          },
-          '& .MuiTable-root': {
-            display: 'block',
-          },
-          '& .MuiTableHead-root': {
-            display: 'block',
-            // Reserve space matching the body's scrollbar gutter so columns line up.
-            paddingRight: '8px',
-            backgroundColor: theme.palette.surface.tooltip,
-          },
-          '& .MuiTableHead-root .MuiTableRow-root': {
-            display: 'table',
-            tableLayout: 'fixed',
-            width: '100%',
-          },
-          '& .MuiTableBody-root': {
-            display: 'block',
-            maxHeight: '500px',
-            overflowY: 'auto',
-            scrollbarGutter: 'stable',
-            ...scrollbarSx,
-          },
-          '& .MuiTableBody-root .MuiTableRow-root': {
-            display: 'table',
-            tableLayout: 'fixed',
-            width: '100%',
-          },
         }}
         elevation={0}
       >
@@ -508,7 +489,14 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
           getRowKey={(issue) =>
             `${issue.number}-${issue.prNumber}-${issue.repositoryFullName}`
           }
+          minWidth="984px"
           stickyHeader
+          tableContainerSx={{
+            maxHeight: 500,
+            overflow: 'auto',
+            scrollbarGutter: 'stable',
+            ...scrollbarSx,
+          }}
           size="medium"
           header={headerToolbar}
           emptyState={

--- a/src/components/repositories/RepositoryPRsTable.tsx
+++ b/src/components/repositories/RepositoryPRsTable.tsx
@@ -221,6 +221,7 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
     {
       key: 'pullRequestNumber',
       header: 'PR #',
+      width: 88,
       sortKey: 'pullRequestNumber',
       renderCell: (pr) => (
         // Native <a> to GitHub — `onRowClick` (no row-as-anchor) keeps this valid HTML.
@@ -242,6 +243,7 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
     {
       key: 'pullRequestTitle',
       header: 'Title',
+      width: 320,
       sortKey: 'pullRequestTitle',
       renderCell: (pr) => (
         <ScrollAwareTooltip
@@ -252,7 +254,7 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
         >
           <Box
             sx={{
-              maxWidth: '300px',
+              maxWidth: '100%',
               overflow: 'hidden',
               textOverflow: 'ellipsis',
               whiteSpace: 'nowrap',
@@ -266,9 +268,12 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
     {
       key: 'author',
       header: 'Author',
+      width: 180,
       sortKey: 'author',
       renderCell: (pr) => (
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+        <Box
+          sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 0 }}
+        >
           <Avatar
             src={getRepositoryOwnerAvatarSrc(pr.author)}
             alt={pr.author}
@@ -276,7 +281,13 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
           />
           <Box
             component="span"
-            sx={{ whiteSpace: 'nowrap', wordBreak: 'keep-all' }}
+            sx={{
+              minWidth: 0,
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+              wordBreak: 'keep-all',
+            }}
           >
             {pr.author}
           </Box>
@@ -286,6 +297,7 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
     {
       key: 'commitCount',
       header: 'Commits',
+      width: 104,
       align: 'right',
       sortKey: 'commitCount',
       renderCell: (pr) => pr.commitCount,
@@ -293,10 +305,11 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
     {
       key: 'lines',
       header: '+/-',
+      width: 120,
       align: 'right',
       sortKey: 'lines',
       renderCell: (pr) => (
-        <>
+        <Box component="span" sx={{ whiteSpace: 'nowrap' }}>
           <Box
             component="span"
             sx={{ color: theme.palette.diff.additions, mr: 1 }}
@@ -306,12 +319,13 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
           <Box component="span" sx={{ color: theme.palette.diff.deletions }}>
             -{pr.deletions}
           </Box>
-        </>
+        </Box>
       ),
     },
     {
       key: 'score',
       header: 'Score',
+      width: 112,
       align: 'right',
       sortKey: 'score',
       renderCell: (pr) => (
@@ -323,6 +337,7 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
     {
       key: 'status',
       header: 'Status',
+      width: 112,
       sortKey: 'status',
       renderCell: (pr) => {
         const state =
@@ -343,6 +358,7 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
     {
       key: 'mergedAt',
       header: 'Merged',
+      width: 120,
       align: 'right',
       sortKey: 'mergedAt',
       renderCell: (pr) =>
@@ -351,6 +367,7 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
     {
       key: 'watch',
       header: '★',
+      width: 64,
       align: 'center',
       renderCell: (pr) => (
         <WatchlistButton
@@ -394,37 +411,6 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
         display: 'flex',
         flexDirection: 'column',
         overflow: 'hidden',
-        // Restructure so only the body scrolls — the header sits above the
-        // scroll area, so the scrollbar never appears next to the header row.
-        '& .MuiTableContainer-root': {
-          overflow: 'visible',
-        },
-        '& .MuiTable-root': {
-          display: 'block',
-        },
-        '& .MuiTableHead-root': {
-          display: 'block',
-          // Reserve space matching the body's scrollbar gutter so columns line up.
-          paddingRight: '8px',
-          backgroundColor: theme.palette.surface.tooltip,
-        },
-        '& .MuiTableHead-root .MuiTableRow-root': {
-          display: 'table',
-          tableLayout: 'fixed',
-          width: '100%',
-        },
-        '& .MuiTableBody-root': {
-          display: 'block',
-          maxHeight: '500px',
-          overflowY: 'auto',
-          scrollbarGutter: 'stable',
-          ...scrollbarSx,
-        },
-        '& .MuiTableBody-root .MuiTableRow-root': {
-          display: 'table',
-          tableLayout: 'fixed',
-          width: '100%',
-        },
       }}
       elevation={0}
     >
@@ -432,7 +418,14 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
         columns={columns}
         rows={sortedPRs}
         getRowKey={(pr) => `${pr.repository}-${pr.pullRequestNumber}`}
+        minWidth="1120px"
         stickyHeader
+        tableContainerSx={{
+          maxHeight: 500,
+          overflow: 'auto',
+          scrollbarGutter: 'stable',
+          ...scrollbarSx,
+        }}
         size="medium"
         header={headerToolbar}
         emptyState={


### PR DESCRIPTION
## Summary

Fixes repository detail page table responsiveness for the Issues and Pull Requests tabs.

## Changes

- Restores horizontal scrolling for narrow screens
- Adds stable minimum table widths and column widths
- Keeps sticky headers inside the table scroll container
- Allows Issues filter buttons to wrap on small screens

## Validation

- npm run lint
- npm run build

Fixes #787

## ScreenShot

### Before


https://github.com/user-attachments/assets/fae9a7ae-5ba8-4912-9c02-d5c197df9018


### After

https://github.com/user-attachments/assets/9ca7642d-46d4-4751-bf16-cb992ec43059


