### PR TITLE
fix(dashboard): always send `since` on mirror `/issues` so the Resolved series populates

### DIFF
--- a/src/pages/dashboard/dashboardData.ts
+++ b/src/pages/dashboard/dashboardData.ts
@@ -170,12 +170,13 @@ export const getPreviousWindowBounds = (
   };
 };
 
-// Omitting `since` uses the mirror's default 35-day window and keeps the
-// cache key stable across 1d/7d/35d ranges.
-export const getMirrorSinceParam = (
-  range: TrendTimeRange,
-): string | undefined =>
-  range === 'all' ? new Date(GITTENSOR_START_MS).toISOString() : undefined;
+// Always send `since` — the mirror's `/issues` endpoint returns only currently
+// OPEN issues when `since` is omitted, which silently zeroes the resolved-issues
+// trend. Fetch the full subnet history once (back to GITTENSOR_START_MS) so the
+// cache key is stable across every range button: switching 1D/7D/35D/All
+// re-buckets the already-fetched data instead of re-firing the N mirror calls.
+export const getMirrorSinceParam = (): string =>
+  new Date(GITTENSOR_START_MS).toISOString();
 
 // Dedupe by (repo, number) so an issue surfaced under multiple miners is counted once.
 export const flattenMinerIssues = (

--- a/src/pages/dashboard/useDashboardData.ts
+++ b/src/pages/dashboard/useDashboardData.ts
@@ -65,7 +65,10 @@ export const useDashboardData = (range: TrendTimeRange) => {
     [minersQuery.data],
   );
 
-  const minerIssuesSince = getMirrorSinceParam(range);
+  // Pin the `since` cutoff once per component lifetime so the cache key never
+  // changes — range button clicks (1D/7D/35D/All) re-bucket the already-fetched
+  // data instead of re-firing the N mirror calls.
+  const minerIssuesSince = useMemo(() => getMirrorSinceParam(), []);
   const minerIssuesQueries = useMinersIssues(
     activeMinerGithubIds,
     activeMinerGithubIds.length > 0,


### PR DESCRIPTION
## Summary

The dashboard's **Issues Resolved** trend series was permanently zero. Root cause: the mirror's `/api/v1/miners/<id>/issues` endpoint returns only currently-open issues when `since` is omitted — it does *not* default to a 35-day window as the surrounding code assumed. The dashboard fired its N fan-out calls with no `since`, so it never saw a single closed issue and the resolved-issues filter never matched.

This PR makes the dashboard always send `since=<GITTENSOR_START_MS>` and pins that value across renders so the chart's range buttons (1D / 7D / 35D / All) re-bucket the cached data instead of re-firing the per-miner fan-out.

## Empirical proof

Direct probe of the mirror with the **same miner** the dashboard would query:

​```
GET /miners/65635253/issues
→ 2 issues, all OPEN
  state_reasons: {None: 2}
  with solving_pr: 0

GET /miners/65635253/issues?since=2026-01-01T00:00:00Z
→ 12 issues, 10 CLOSED
  state_reasons: {COMPLETED: 8, NOT_PLANNED: 2}
  with solving_pr: 8
​```

Without `since`, the mirror hides every closed issue. The predicate `isResolvedMinerIssue` (`state === 'CLOSED' && state_reason === 'COMPLETED'`) is correct — it just had no closed data to filter.

## Changes

### `src/pages/dashboard/dashboardData.ts`

​```diff
-// Omitting `since` uses the mirror's default 35-day window and keeps the
-// cache key stable across 1d/7d/35d ranges.
-export const getMirrorSinceParam = (
-  range: TrendTimeRange,
-): string | undefined =>
-  range === 'all' ? new Date(GITTENSOR_START_MS).toISOString() : undefined;
+// Always send `since` — the mirror's `/issues` endpoint returns only
+// currently-OPEN issues when `since` is omitted, which silently zeroes the
+// resolved-issues trend. Fetch the full subnet history once (back to
+// GITTENSOR_START_MS) so the cache key is stable across every range button:
+// switching 1D/7D/35D/All re-buckets the already-fetched data instead of
+// re-firing the N mirror calls.
+export const getMirrorSinceParam = (): string =>
+  new Date(GITTENSOR_START_MS).toISOString();
​```

- Drops the `range` parameter — `since` is no longer range-dependent.
- "All" range now actually shows all-time data (up to `GITTENSOR_START_MS`, the subnet inception).

### `src/pages/dashboard/useDashboardData.ts`

​```diff
-  const minerIssuesSince = getMirrorSinceParam(range);
+  // Pin the `since` cutoff once per component lifetime so the cache key never
+  // changes — range button clicks (1D/7D/35D/All) re-bucket the already-fetched
+  // data instead of re-firing the N mirror calls.
+  const minerIssuesSince = useMemo(() => getMirrorSinceParam(), []);
   const minerIssuesQueries = useMinersIssues(
     activeMinerGithubIds,
     activeMinerGithubIds.length > 0,
     minerIssuesSince,
   );
​```

- `useMemo([], …)` prevents `getMirrorSinceParam()` from recomputing per render (which would mutate the React Query cache key).

## Behavior after this PR

- **First dashboard mount:** N parallel mirror calls (one per active miner), each requesting all history since `GITTENSOR_START_MS`. Same N as before — just with a wider window per call.
- **User clicks 1D / 7D / 35D / All:** **zero new mirror calls.** The URL — and therefore the cache key — is identical for every range. `buildContributionTrends` simply re-buckets the cached `minerIssuesData` to the selected window.
- **Issues Resolved series:** now populates correctly because closed issues are actually in the response payload.

## Test plan

- [ ] Open `/dashboard`. The **Issues Resolved** trend line is non-zero on ranges where solved issues exist.
- [ ] DevTools → Network: on first mount, see N parallel requests to `mirror.gittensor.io/api/v1/miners/<id>/issues?since=2025-12-01T00:00:00.000Z`.
- [ ] Click **1D / 7D / 35D / All** in turn — **no new network requests fire** (verified in DevTools), the chart just re-buckets.
- [ ] **Issues Opened**, **Merged PRs**, **PRs Opened** series remain unchanged.
- [ ] No console errors / `npm run type-check` passes / `npm run lint` passes.

## Tradeoffs

- **Larger initial payload per miner.** Previously the no-`since` request returned only open issues; now each request returns the miner's full history since subnet inception. Acceptable: paid once per session, never again across range changes — exactly the inverse pattern of the previous behavior, which fetched a slim payload but re-fired on every range change.
- **No change to N.** The fan-out count (one request per active miner) is structural — the mirror has no `/miners/issues?ids=…` aggregate endpoint. Reducing N is a separate optimization (e.g. cap to top-N, persistent cache).

## Out of scope

- Adding `staleTime` / persistent cache to `useMinersIssues` for cross-session reuse. Separate optimization.
- Reducing N via a mirror-side aggregate endpoint or top-N capping. Separate optimization.

Fixes #1125 

Before
<img width="1764" height="853" alt="image" src="https://github.com/user-attachments/assets/2a3d2887-4548-4a47-9266-44b884ea1ec7" />

After
<img width="1830" height="759" alt="image" src="https://github.com/user-attachments/assets/2034a512-48ad-4e30-a8ea-e910b18fe57a" />
