### PR TITLE
fix: `validateDOMNesting(...)` while keeping middle-click supports and _blank supports with `a` 

### DIFF
--- a/src/components/common/DataTable.tsx
+++ b/src/components/common/DataTable.tsx
@@ -56,10 +56,10 @@ export type DataTableProps<T, SortKey extends string = never> = {
   emptyState?: React.ReactNode;
   minWidth?: number | string;
   /**
-   * When set, each row renders as an `<a href>` (native new-tab / middle-click
-   * support). NOTE: because the row becomes `<a>`, cells must not contain
-   * nested `<a>` elements (invalid HTML). For tables with nested anchors,
-   * use `onRowClick` instead.
+   * When set, each row stays a valid `<tr>` and each cell gets a stretched
+   * `<a href>` so the browser status URL, middle-click, and link context menu
+   * behave like a normal anchor. Cells must not contain nested `<a>` elements.
+   * For tables with nested anchors, use `onRowClick` instead.
    */
   getRowHref?: (item: T) => string;
   linkState?: Record<string, unknown>;

--- a/src/components/common/linkBehavior.tsx
+++ b/src/components/common/linkBehavior.tsx
@@ -1,9 +1,18 @@
-import { forwardRef, useCallback } from 'react';
+import {
+  Children,
+  cloneElement,
+  forwardRef,
+  isValidElement,
+  useCallback,
+  type ReactElement,
+} from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
   Box,
+  TableCell,
   TableRow,
   type BoxProps,
+  type TableCellProps,
   type TableRowProps,
 } from '@mui/material';
 import type { SxProps, Theme } from '@mui/material/styles';
@@ -93,25 +102,78 @@ export const LinkBox = forwardRef<HTMLAnchorElement, BoxProps & LinkProps>(
 );
 LinkBox.displayName = 'LinkBox';
 
+const cellLinkOverlaySx: SxProps<Theme> = {
+  position: 'absolute',
+  inset: 0,
+  zIndex: 1,
+  ...linkResetSx,
+};
+
+/** Content above the stretch `<a>`; pointer hits pass through to the anchor except on controls. */
+const cellLinkContentSx: SxProps<Theme> = {
+  position: 'relative',
+  zIndex: 2,
+  display: 'block',
+  height: '100%',
+  pointerEvents: 'none',
+  '& a, & button, & input, & select, & textarea, & [role="button"]': {
+    pointerEvents: 'auto',
+  },
+};
+
 /**
- * A `TableRow` that renders as `<a href>`. Drop-in replacement for any
- * `<TableRow onClick={() => navigate(...)}>` row.
+ * A normal `<tr>` with a real `<a href>` stretched over each cell. That keeps
+ * the table DOM valid, restores the browser status URL on hover, and keeps
+ * native middle-click / context-menu link behavior. Cells must not nest
+ * another `<a>` when this row is used.
  */
 export const LinkTableRow = forwardRef<
-  HTMLAnchorElement,
+  HTMLTableRowElement,
   TableRowProps & LinkProps
->(({ href, linkState, sx, ...rest }, ref) => {
+>(({ href, linkState, replace, sx, children, ...rest }, ref) => {
   const linkProps = useLinkBehavior<HTMLAnchorElement>(href, {
     state: linkState,
+    replace,
   });
+
+  const enhancedCells = Children.map(children, (child, index) => {
+    if (!isValidElement(child) || child.type !== TableCell) {
+      return child;
+    }
+    const cell = child as ReactElement<TableCellProps>;
+    const prevSx = cell.props.sx;
+    const mergedCellSx: SxProps<Theme> = [
+      { position: 'relative' },
+      ...(prevSx === undefined
+        ? []
+        : Array.isArray(prevSx)
+          ? prevSx
+          : [prevSx]),
+    ];
+
+    return cloneElement(cell, {
+      sx: mergedCellSx,
+      children: (
+        <>
+          <Box
+            component="a"
+            {...linkProps}
+            tabIndex={index === 0 ? 0 : -1}
+            aria-hidden={index === 0 ? undefined : true}
+            sx={cellLinkOverlaySx}
+          />
+          <Box component="span" sx={cellLinkContentSx}>
+            {cell.props.children}
+          </Box>
+        </>
+      ),
+    });
+  });
+
   return (
-    <TableRow
-      component="a"
-      ref={ref}
-      {...linkProps}
-      sx={mergeSx(linkResetSx, sx)}
-      {...rest}
-    />
+    <TableRow ref={ref} {...rest} sx={sx}>
+      {enhancedCells}
+    </TableRow>
   );
 });
 LinkTableRow.displayName = 'LinkTableRow';


### PR DESCRIPTION
## Summary

Fixes invalid table DOM and restores native link UX for `DataTable` rows when `getRowHref` is set.

Previously, linked rows used `TableRow` with `component="a"`, which produced an `<a>` as a direct child of `<tbody>` and triggered React’s `validateDOMNesting` warning. That pattern also could not show the real URL in the browser status bar the way a normal link does.

`LinkTableRow` now renders a standard `<tr>` and clones each `TableCell` child to inject a stretched `<a href>` (via `useLinkBehavior`, same as `LinkBox`) plus a `pointer-events` layer so hover and primary clicks hit a real anchor while nested controls (`button`, `input`, inner links with `role="button"`, etc.) stay interactive. Secondary cell anchors are `aria-hidden` / `tabIndex={-1}` so keyboard focus stays sensible; only the first cell’s anchor is in the tab order by default.

`DataTable`’s `getRowHref` JSDoc is updated to describe the valid DOM and the requirement that cells must not nest another `<a>` when row links are enabled.

## Related Issues

fixes #1127 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

Before:

<img width="1661" height="643" alt="image" src="https://github.com/user-attachments/assets/2b355144-cbc4-4388-b763-8e5e7ac1b238" />


After:

<img width="1645" height="657" alt="image" src="https://github.com/user-attachments/assets/1ead1224-a44b-4b6e-920d-a60dc441fa78" />



## Checklist

- [ ] New components are modularized/separated where sensible
- [ ] Uses predefined theme (e.g. no hardcoded colors)
- [ ] Responsive/mobile checked
- [ ] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
