### PR TITLE
fix: reserve space for sort indicator to prevent header layout shift (#995)

### DIFF
--- a/src/components/common/DataTable.tsx
+++ b/src/components/common/DataTable.tsx
@@ -56,9 +56,9 @@ export type DataTableProps<T, SortKey extends string = never> = {
   emptyState?: React.ReactNode;
   minWidth?: number | string;
   /**
-   * When set, each row renders as an `<a href>` (native new-tab / middle-click
-   * support). NOTE: because the row becomes `<a>`, cells must not contain
-   * nested `<a>` elements (invalid HTML). For tables with nested anchors,
+   * When set, each row navigates via React Router on click (native new-tab /
+   * middle-click support). Cells may contain `<a>` elements without nesting
+   * issues because the row itself is a valid `<tr>`.
    * use `onRowClick` instead.
    */
   getRowHref?: (item: T) => string;

--- a/src/components/common/DataTable.tsx
+++ b/src/components/common/DataTable.tsx
@@ -56,9 +56,9 @@ export type DataTableProps<T, SortKey extends string = never> = {
   emptyState?: React.ReactNode;
   minWidth?: number | string;
   /**
-   * When set, each row navigates via React Router on click (native new-tab /
-   * middle-click support). Cells may contain `<a>` elements without nesting
-   * issues because the row itself is a valid `<tr>`.
+   * When set, each row renders as an `<a href>` (native new-tab / middle-click
+   * support). NOTE: because the row becomes `<a>`, cells must not contain
+   * nested `<a>` elements (invalid HTML). For tables with nested anchors,
    * use `onRowClick` instead.
    */
   getRowHref?: (item: T) => string;

--- a/src/components/common/DataTable.tsx
+++ b/src/components/common/DataTable.tsx
@@ -205,6 +205,7 @@ export const DataTable = <T, SortKey extends string = never>({
                             ? [{ width: column.width }]
                             : []),
                           ...(column.headerSx ? [column.headerSx] : []),
+                          { whiteSpace: 'nowrap' },
                         ]}
                       >
                         {sortKey && sort ? (
@@ -212,6 +213,12 @@ export const DataTable = <T, SortKey extends string = never>({
                             active={isActive}
                             direction={isActive ? sort.order : 'desc'}
                             onClick={() => sort.onChange(sortKey)}
+                            sx={{
+                              '& .MuiTableSortLabel-icon': {
+                                opacity: isActive ? 1 : 0,
+                                width: 18,
+                              },
+                            }}
                           >
                             {column.header}
                           </TableSortLabel>

--- a/src/components/common/linkBehavior.tsx
+++ b/src/components/common/linkBehavior.tsx
@@ -94,35 +94,22 @@ export const LinkBox = forwardRef<HTMLAnchorElement, BoxProps & LinkProps>(
 LinkBox.displayName = 'LinkBox';
 
 /**
- * A `TableRow` that navigates via React Router on click. Renders as a native
- * `<tr>` (valid HTML inside `<tbody>`), with ``role="link"`` and keyboard
- * support for accessibility. Drop-in replacement for any
+ * A `TableRow` that renders as `<a href>`. Drop-in replacement for any
  * `<TableRow onClick={() => navigate(...)}>` row.
  */
 export const LinkTableRow = forwardRef<
-  HTMLTableRowElement,
+  HTMLAnchorElement,
   TableRowProps & LinkProps
 >(({ href, linkState, sx, ...rest }, ref) => {
-  const navigate = useNavigate();
-  const handleClick = useCallback(
-    (e: React.MouseEvent<HTMLTableRowElement>) => {
-      if (isModifiedEvent(e)) return;
-      e.preventDefault();
-      navigate(href, { state: linkState });
-    },
-    [href, linkState, navigate],
-  );
-
+  const linkProps = useLinkBehavior<HTMLAnchorElement>(href, {
+    state: linkState,
+  });
   return (
     <TableRow
+      component="a"
       ref={ref}
-      onClick={handleClick}
-      sx={mergeSx(
-        { cursor: 'pointer', textDecoration: 'none', color: 'inherit' },
-        sx,
-      )}
-      tabIndex={0}
-      role="link"
+      {...linkProps}
+      sx={mergeSx(linkResetSx, sx)}
       {...rest}
     />
   );

--- a/src/components/common/linkBehavior.tsx
+++ b/src/components/common/linkBehavior.tsx
@@ -94,22 +94,35 @@ export const LinkBox = forwardRef<HTMLAnchorElement, BoxProps & LinkProps>(
 LinkBox.displayName = 'LinkBox';
 
 /**
- * A `TableRow` that renders as `<a href>`. Drop-in replacement for any
+ * A `TableRow` that navigates via React Router on click. Renders as a native
+ * `<tr>` (valid HTML inside `<tbody>`), with ``role="link"`` and keyboard
+ * support for accessibility. Drop-in replacement for any
  * `<TableRow onClick={() => navigate(...)}>` row.
  */
 export const LinkTableRow = forwardRef<
-  HTMLAnchorElement,
+  HTMLTableRowElement,
   TableRowProps & LinkProps
 >(({ href, linkState, sx, ...rest }, ref) => {
-  const linkProps = useLinkBehavior<HTMLAnchorElement>(href, {
-    state: linkState,
-  });
+  const navigate = useNavigate();
+  const handleClick = useCallback(
+    (e: React.MouseEvent<HTMLTableRowElement>) => {
+      if (isModifiedEvent(e)) return;
+      e.preventDefault();
+      navigate(href, { state: linkState });
+    },
+    [href, linkState, navigate],
+  );
+
   return (
     <TableRow
-      component="a"
       ref={ref}
-      {...linkProps}
-      sx={mergeSx(linkResetSx, sx)}
+      onClick={handleClick}
+      sx={mergeSx(
+        { cursor: 'pointer', textDecoration: 'none', color: 'inherit' },
+        sx,
+      )}
+      tabIndex={0}
+      role="link"
       {...rest}
     />
   );


### PR DESCRIPTION
## Summary

Clicking a sortable column header causes the header row to reflow because the `TableSortLabel` icon appears/disappears dynamically, pushing cell content and triggering width recalculation.

Add `white-space: nowrap` on the header cell to prevent text reflow, and reserve `width: 18px` for the sort icon (opacity 0 when inactive) so the space is always accounted for in the layout.

## Validation

- `npm run lint` — clean
- `npm run test` — 27 passed

Closes #995