### PR TITLE
fix(dashboard): replace per-miner mirror fan-out with single bulk call

### DIFF
--- a/src/api/MirrorDashboardApi.ts
+++ b/src/api/MirrorDashboardApi.ts
@@ -1,0 +1,27 @@
+// Mirror dashboard API — single-call replacements for the dashboard's
+// per-miner fan-out against `/miners/<id>/issues`. The mirror endpoints
+// return roster-blind data; callers blend with the gittensor miner roster
+// client-side to filter to subnet authors.
+import { useMirrorApiQuery } from './ApiUtils';
+import {
+  type MirrorDashboardIssue,
+  type MirrorDashboardIssuesResponse,
+} from './models';
+
+/**
+ * Slim issue rows for dashboard trend aggregation.
+ *
+ * One bulk call replaces the N per-miner calls previously fanned out via
+ * `useMinersIssues`. Returns every issue created on or after `since`, plus
+ * every CLOSED issue closed on or after `since`. Authorship is preserved
+ * via `author_github_id` so the dashboard can filter to subnet miners.
+ */
+export const useMirrorDashboardIssues = (since: string, enabled?: boolean) =>
+  useMirrorApiQuery<MirrorDashboardIssuesResponse, MirrorDashboardIssue[]>(
+    'useMirrorDashboardIssues',
+    `/dashboard/issues?since=${encodeURIComponent(since)}`,
+    {
+      enabled,
+      select: (data) => data?.issues ?? [],
+    },
+  );

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -4,6 +4,7 @@ export * from './DashboardApi';
 export * from './IssuesApi';
 export * from './MinerApi';
 export * from './MirrorApi';
+export * from './MirrorDashboardApi';
 export * from './PrsApi';
 export * from './ReposApi';
 export * from './SearchApi';

--- a/src/api/models/MirrorDashboard.ts
+++ b/src/api/models/MirrorDashboard.ts
@@ -1,0 +1,21 @@
+// Mirror API (snake_case) — slim issue rows returned by
+// `/api/v1/dashboard/issues`. The mirror is intentionally roster-blind: every
+// row is returned regardless of author. The dashboard blends with the
+// gittensor miner roster client-side to filter to subnet authors.
+
+export interface MirrorDashboardIssue {
+  repo_full_name: string;
+  issue_number: number;
+  author_github_id: string | null;
+  created_at: string;
+  closed_at: string | null;
+  state: 'OPEN' | 'CLOSED' | string;
+  state_reason: string | null;
+  solving_pr: { merged_at: string } | null;
+}
+
+export interface MirrorDashboardIssuesResponse {
+  since: string;
+  generated_at: string;
+  issues: MirrorDashboardIssue[];
+}

--- a/src/api/models/index.ts
+++ b/src/api/models/index.ts
@@ -2,4 +2,5 @@ export * from './Dashboard';
 export * from './DatasetState';
 export * from './Issues';
 export * from './Miner';
+export * from './MirrorDashboard';
 export * from './Configurations';

--- a/src/pages/dashboard/dashboardData.ts
+++ b/src/pages/dashboard/dashboardData.ts
@@ -10,7 +10,7 @@
 import {
   type CommitLog,
   type MinerEvaluation,
-  type MinerIssue,
+  type MirrorDashboardIssue,
   type Repository,
 } from '../../api';
 import {
@@ -106,7 +106,7 @@ interface FeaturedWorkConfig {
 const HOUR_MS = 60 * 60 * 1000;
 const DAY_MS = 24 * HOUR_MS;
 const WEEK_MS = 7 * DAY_MS;
-const GITTENSOR_START_MS = Date.UTC(2025, 11, 1, 0, 0, 0);
+export const GITTENSOR_START_MS = Date.UTC(2025, 11, 1, 0, 0, 0);
 
 const RANGE_CONFIG: Record<
   PresetTimeRange,
@@ -170,39 +170,21 @@ export const getPreviousWindowBounds = (
   };
 };
 
-// Omitting `since` uses the mirror's default 35-day window and keeps the
-// cache key stable across 1d/7d/35d ranges.
-export const getMirrorSinceParam = (
-  range: TrendTimeRange,
-): string | undefined =>
-  range === 'all' ? new Date(GITTENSOR_START_MS).toISOString() : undefined;
-
-// Dedupe by (repo, number) so an issue surfaced under multiple miners is counted once.
-export const flattenMinerIssues = (
-  responses: ReadonlyArray<ReadonlyArray<MinerIssue>>,
-): MinerIssue[] => {
-  const seen = new Set<string>();
-  const flattened: MinerIssue[] = [];
-  responses.forEach((batch) => {
-    batch.forEach((issue) => {
-      const key = `${issue.repo_full_name}#${issue.issue_number}`;
-      if (seen.has(key)) return;
-      seen.add(key);
-      flattened.push(issue);
-    });
-  });
-  return flattened;
-};
-
-export const isResolvedMinerIssue = (issue: MinerIssue): boolean =>
-  issue.state === 'CLOSED' && issue.state_reason === 'COMPLETED';
+// A "truly resolved" issue: closed as completed AND the linked PR is merged.
+// The conjunction matters — state_reason alone misses cases where GitHub
+// doesn't set 'completed', and solving_pr.merged_at alone counts not-planned
+// closures with stray PR links.
+export const isResolvedMinerIssue = (issue: MirrorDashboardIssue): boolean =>
+  issue.state === 'CLOSED' &&
+  issue.state_reason === 'COMPLETED' &&
+  !!issue.solving_pr?.merged_at;
 
 export const isResolvedInWindow = (
-  issue: MinerIssue,
+  issue: MirrorDashboardIssue,
   window: WindowBounds,
 ): boolean =>
   isResolvedMinerIssue(issue) &&
-  isWithinWindow(toTimestamp(issue.closed_at), window);
+  isWithinWindow(toTimestamp(issue.solving_pr?.merged_at), window);
 
 const getUtcWeekStart = (timestamp: number) => {
   const date = new Date(timestamp);
@@ -312,7 +294,7 @@ const formatDelta = (
 
 export const buildDashboardTrendData = (
   prs: CommitLog[],
-  issues: MinerIssue[],
+  issues: MirrorDashboardIssue[],
   range: TrendTimeRange,
   now = new Date(),
 ): { labels: string[]; series: DashboardTrendSeries[] } => {
@@ -323,7 +305,7 @@ export const buildDashboardTrendData = (
   );
   const resolvedIssueTimestamps = issues
     .filter(isResolvedMinerIssue)
-    .map((issue) => toTimestamp(issue.closed_at));
+    .map((issue) => toTimestamp(issue.solving_pr?.merged_at));
   const buckets = buildTrendBuckets(
     [
       ...mergedPrTimestamps,
@@ -652,7 +634,7 @@ export const buildDashboardOverview = (
 
 export const buildDashboardKpis = (
   prs: CommitLog[],
-  issues: MinerIssue[],
+  issues: MirrorDashboardIssue[],
   range: TrendTimeRange,
   now = new Date(),
 ): DashboardKpi[] => {

--- a/src/pages/dashboard/useDashboardData.ts
+++ b/src/pages/dashboard/useDashboardData.ts
@@ -12,7 +12,7 @@ import {
   useAllMiners,
   useAllPrs,
   useIssues,
-  useMinersIssues,
+  useMirrorDashboardIssues,
   useReposAndWeights,
 } from '../../api';
 import {
@@ -20,7 +20,7 @@ import {
   type DatasetState,
   type IssueBounty,
   type MinerEvaluation,
-  type MinerIssue,
+  type MirrorDashboardIssue,
   type Repository,
 } from '../../api/models';
 import {
@@ -30,8 +30,7 @@ import {
   buildFeaturedContributors,
   buildFeaturedWork,
   buildFeaturedDiscoveryContributors,
-  flattenMinerIssues,
-  getMirrorSinceParam,
+  GITTENSOR_START_MS,
   type TrendTimeRange,
 } from './dashboardData';
 
@@ -40,14 +39,12 @@ type DashboardDatasets = {
   miners: DatasetState<MinerEvaluation>;
   issues: DatasetState<IssueBounty>;
   repos: DatasetState<Repository>;
-  minerIssues: DatasetState<MinerIssue>;
+  minerIssues: DatasetState<MirrorDashboardIssue>;
 };
 
-const hasIssueActivity = (miner: MinerEvaluation): boolean =>
-  (miner.totalSolvedIssues ?? 0) +
-    (miner.totalOpenIssues ?? 0) +
-    (miner.totalClosedIssues ?? 0) >
-  0;
+// Pinned once per module load — same `since` for every dashboard mount keeps
+// the React Query cache key stable across renders and route remounts.
+const DASHBOARD_ISSUES_SINCE_ISO = new Date(GITTENSOR_START_MS).toISOString();
 
 export const useDashboardData = (range: TrendTimeRange) => {
   const prsQuery = useAllPrs();
@@ -55,31 +52,32 @@ export const useDashboardData = (range: TrendTimeRange) => {
   const issuesQuery = useIssues();
   const reposQuery = useReposAndWeights();
 
-  // Fan-out per-miner mirror calls; gate on issue activity to bound parallel requests.
-  const activeMinerGithubIds = useMemo(
+  // Single bulk mirror call replaces the previous per-miner fan-out.
+  // The mirror is roster-blind; we filter to subnet authors below using the
+  // gittensor miner roster.
+  const dashboardIssuesQuery = useMirrorDashboardIssues(
+    DASHBOARD_ISSUES_SINCE_ISO,
+  );
+
+  const minerGithubIdSet = useMemo(() => {
+    const set = new Set<string>();
+    (minersQuery.data ?? []).forEach((m) => {
+      if (m.githubId) set.add(m.githubId);
+    });
+    return set;
+  }, [minersQuery.data]);
+
+  const minerIssuesData = useMemo<MirrorDashboardIssue[]>(
     () =>
-      (minersQuery.data ?? [])
-        .filter(hasIssueActivity)
-        .map((m) => m.githubId)
-        .filter((id): id is string => Boolean(id)),
-    [minersQuery.data],
+      (dashboardIssuesQuery.data ?? []).filter(
+        (issue) =>
+          !!issue.author_github_id &&
+          minerGithubIdSet.has(issue.author_github_id),
+      ),
+    [dashboardIssuesQuery.data, minerGithubIdSet],
   );
-
-  const minerIssuesSince = getMirrorSinceParam(range);
-  const minerIssuesQueries = useMinersIssues(
-    activeMinerGithubIds,
-    activeMinerGithubIds.length > 0,
-    minerIssuesSince,
-  );
-
-  const minerIssuesData = useMemo<MinerIssue[]>(
-    () => flattenMinerIssues(minerIssuesQueries.map((q) => q.data ?? [])),
-    [minerIssuesQueries],
-  );
-  const isMinerIssuesLoading =
-    activeMinerGithubIds.length > 0 &&
-    minerIssuesQueries.some((q) => q.isLoading);
-  const isMinerIssuesError = minerIssuesQueries.some((q) => q.isError);
+  const isMinerIssuesLoading = dashboardIssuesQuery.isLoading;
+  const isMinerIssuesError = dashboardIssuesQuery.isError;
 
   const datasets: DashboardDatasets = {
     prs: {


### PR DESCRIPTION
## Summary

Replaces the dashboard's N parallel `mirror.gittensor.io/api/v1/miners/<id>/issues` calls (one per active miner, ~25+ on a typical mount) with a **single** call to the new `/api/v1/dashboard/issues` endpoint. Eliminates the rate-limit pressure visible as a cascade of 304s in DevTools on `/dashboard`. Also fixes #1125 (Issues Resolved trend always 0) by switching the resolved-issue predicate to the correct conjunction.

Depends on entrius/das-github-mirror#93 — must be merged + deployed first.

## Architectural shape

| Layer | Knows about |
|---|---|
| Mirror (`das-github-mirror`) | GitHub state only — issues, PRs. Roster-blind. |
| gittensor backend (`api.gittensor.io`) | Subnet roster, miner evaluations, scoring outputs. |
| Frontend (this repo) | Blends both — calls `useAllMiners()` for the roster, calls `useMirrorDashboardIssues()` for raw GitHub trend data, filters/buckets client-side. |

## Resolved predicate fix (#1125)

Old: `state === 'CLOSED' && state_reason === 'COMPLETED'` — missed every issue that was closed by a merged PR but not flagged COMPLETED. Trend series rendered as flat 0.

New: `state === 'CLOSED' && state_reason === 'COMPLETED' && !!solving_pr?.merged_at` — the conjunction matches the "Solved" definition used elsewhere in the app. Bucketing also moves from `closed_at` to `solving_pr.merged_at` so the bar reflects when the PR landed.

## Changes

### New files
- `src/api/models/MirrorDashboard.ts` — `MirrorDashboardIssue`, `MirrorDashboardIssuesResponse`
- `src/api/MirrorDashboardApi.ts` — `useMirrorDashboardIssues(since, enabled?)` hook (single-call via `useMirrorApiQuery`)

### Edits
- `src/api/index.ts` and `src/api/models/index.ts` — barrel exports
- `src/pages/dashboard/dashboardData.ts`:
  - `isResolvedMinerIssue` predicate: now the conjunction (#1125 fix)
  - Resolved bucketing uses `solving_pr.merged_at` instead of `closed_at`
  - Builders typed against `MirrorDashboardIssue[]` instead of `MinerIssue[]`
  - Removed unused `flattenMinerIssues` (no dedupe needed for single-call source) and `getMirrorSinceParam` (no range-dependent since)
  - Exported `GITTENSOR_START_MS`
- `src/pages/dashboard/useDashboardData.ts`:
  - Replaced `useMinersIssues` fan-out with single `useMirrorDashboardIssues` call, `since` pinned at module load to keep the React Query cache key stable across renders/remounts
  - Dropped `hasIssueActivity` + `activeMinerGithubIds`
  - Added `minerGithubIdSet` memo built from `minersQuery.data`
  - Added blend step: `dashboardIssues.filter(i => minerGithubIdSet.has(i.author_github_id))`

## Related Issues

Fixes #1125

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Other

## Screenshots

Before — DevTools Network tab on `/dashboard`:
<!-- N parallel mirror.gittensor.io/...issues requests -->

After:
<!-- single mirror.gittensor.io/api/v1/dashboard/issues request -->

## Test plan

- [ ] `/dashboard` mounts and the Contribution Trends chart renders all four series.
- [ ] DevTools → Network: only **one** `mirror.gittensor.io/api/v1/dashboard/issues?since=...` request fires per dashboard mount (no `/miners/<id>/issues` requests from the dashboard route).
- [ ] Switching range buttons (1D / 7D / 35D / All) fires **zero** new mirror requests.
- [ ] **Issues Resolved** trend line is non-zero on ranges where solved issues exist (#1125 fixed).
- [ ] **Issues Solved** KPI card matches the Issues Resolved series total for the active range.
- [ ] **Issues Opened**, **Merged PRs**, **PRs Opened** series unchanged.
- [ ] Watchlist and Miner Details pages still work — they continue to use the per-miner endpoint and are not affected by this change.

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors) — N/A, pure data layer
- [ ] Responsive/mobile checked — no UI changes
- [ ] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [ ] `npm run build` passes
- [ ] Screenshots included for any UI/visual changes — added once mirror PR is deployed and Network tab is verifiable

## Out of scope

- 1D range still uses day-granularity bucketing from a daily series — works visually but loses the 3-hour resolution. If we need it back we can either add `bucket=hour` to the mirror endpoint or compute hourly buckets client-side from the same dataset.
- Watchlist and Miner Details continue to use `useMinersIssues` per-miner — N is small there, no rate-limit pressure.