### PR TITLE
chore(pr-breakdown): drop repoWeightMultiplier per gittensor#1215

### DIFF
--- a/src/api/models/Dashboard.ts
+++ b/src/api/models/Dashboard.ts
@@ -163,7 +163,6 @@ export type CommitLog = {
   baseScore?: string; // Backend returns as string
 
   // Score multiplier fields (from /miners/{id}/prs endpoint)
-  repoWeightMultiplier?: string;
   issueMultiplier?: string;
   openPrSpamMultiplier?: string;
   pioneerDividend?: number;
@@ -287,7 +286,6 @@ export type PullRequestDetails = {
   mergedAt: string | null;
   prCreatedAt: string;
   prState: string;
-  repoWeightMultiplier: string; // float returned as string
   baseScore: string; // float returned as string
   issueMultiplier: string; // float returned as string
   openPrSpamMultiplier: string; // float returned as string

--- a/src/utils/multiplierDefs.ts
+++ b/src/utils/multiplierDefs.ts
@@ -61,13 +61,6 @@ const PILL_CONFIGS: PillConfig[] = [
     desc: 'Based on your PR success rate, scaled to reward consistency.',
   },
   {
-    key: 'repoWt',
-    label: 'repo wt',
-    field: 'repoWeightMultiplier',
-    title: 'Repo Weight',
-    desc: 'Based on repository weight and activity.',
-  },
-  {
     key: 'issue',
     label: 'issue',
     field: 'issueMultiplier',
@@ -165,12 +158,10 @@ function buildDensityEntry(pr: PullRequestDetails): MultiplierGridEntry | null {
 }
 
 const OPEN_GRID: GridConfig[] = [
-  { label: 'Repo Weight', field: 'repoWeightMultiplier' },
   { label: 'Issue Bonus', field: 'issueMultiplier' },
 ];
 
 const MERGED_GRID: GridConfig[] = [
-  { label: 'Repo Weight', field: 'repoWeightMultiplier' },
   { label: 'Issue Bonus', field: 'issueMultiplier' },
   { label: 'Credibility', field: 'credibilityMultiplier', isCredibility: true },
   { label: 'Review Quality', field: 'reviewQualityMultiplier' },


### PR DESCRIPTION
## Summary

Drops the now-defunct `repoWeightMultiplier` field from the PR multiplier-breakdown surface. Aligns the UI with [gittensor#1215](https://github.com/entrius/gittensor/issues/1215), which removed `repo_weight_multiplier` from the per-PR scoring chain in favor of a per-repo `emission_share` allocation at aggregation time.

This is the UI portion of **deliverable #4**:

> The per-PR `repo_weight_multiplier` factor is removed from base-score and downstream score computation. Every PR is scored as if its repo's contribution to the multiplier chain were 1.0; no code path multiplies by a per-repo weight at PR granularity. **The multiplier-breakdown surface drops the field accordingly.**

## Changes

5 sites in 2 files.

### `src/api/models/Dashboard.ts` (PR + Issue types)

- Drops `repoWeightMultiplier?: string` from the `CommitLog`-style type (`/miners/{id}/prs` payload — line 166)
- Drops `repoWeightMultiplier: string` from `PullRequestDetails` (the per-PR detail type — line 290)

### `src/utils/multiplierDefs.ts` (3 render sites)

- Drops the `repoWt` pill from `PILL_CONFIGS` (chip row on the score-breakdown card)
- Drops `{ label: 'Repo Weight', field: 'repoWeightMultiplier' }` from `OPEN_GRID` (open-PR multiplier grid in PRDetailsCard)
- Drops the same entry from `MERGED_GRID` (merged-PR multiplier grid)

## What the UI looks like after this

The user-visible change is "one fewer item in three places":

| Surface | Before | After |
|---|---|---|
| Score breakdown pill row (`MinerScoreBreakdown.tsx` → `buildMergedPillDefs`) | `cred · repo wt · issue · decay · spam · review · label · density` | `cred · issue · decay · spam · review · label · density` |
| Open PR multiplier grid (`PRDetailsCard.tsx` → `buildMultiplierGrid(pr, true)`) | `Repo Weight \| Issue Bonus` (+ collateral row) | `Issue Bonus` (+ collateral row) |
| Merged PR multiplier grid (`PRDetailsCard.tsx` → `buildMultiplierGrid(pr, false)`) | `Repo Weight \| Issue Bonus \| Credibility \| Review Quality \| Time Decay` | `Issue Bonus \| Credibility \| Review Quality \| Time Decay` |

## Verified against backend

Cross-checked the surviving multipliers in `PILL_CONFIGS` against the authoritative chain in `gittensor/validator/oss_contributions/mirror/scored_pr.py:89-98`:

```python
multipliers = {
    'issue':  self.issue_multiplier,
    'label':  self.label_multiplier,
    'spam':   self.open_pr_spam_multiplier,
    'decay':  self.time_decay_multiplier,
    'cred':   self.credibility_multiplier,
    'review': self.review_quality_multiplier,
}
```
Before
<img width="1374" height="775" alt="image" src="https://github.com/user-attachments/assets/2f601f27-f29b-44e2-a025-79d93c5f3df0" />
After
<img width="1381" height="704" alt="image" src="https://github.com/user-attachments/assets/fc91cba8-1d28-4d30-b1c8-2312b56ab3af" />
