### PR TITLE
fix: add ClearSearchAdornment to MinerScoreBreakdown search (#1054)

### DIFF
--- a/src/components/miners/MinerScoreBreakdown.tsx
+++ b/src/components/miners/MinerScoreBreakdown.tsx
@@ -36,6 +36,7 @@ import {
 } from '@mui/icons-material';
 import { useSearchParams } from 'react-router-dom';
 import { DebouncedSearchInput } from '../common/DebouncedSearchInput';
+import { ClearSearchAdornment } from '../common/ClearSearchAdornment';
 import { linkResetSx, useLinkBehavior } from '../common/linkBehavior';
 import {
   useMinerStats,
@@ -1148,6 +1149,12 @@ const PrBreakdownView: React.FC<{ githubId: string }> = ({ githubId }) => {
                     }}
                   />
                 </InputAdornment>
+              ),
+              endAdornment: (
+                <ClearSearchAdornment
+                  visible={Boolean(draftValue)}
+                  onClear={() => setDraftValue('')}
+                />
               ),
             }}
             sx={textFieldSx}


### PR DESCRIPTION
## Summary
Add ClearSearchAdornment (clear button) to the Score Breakdown search field on the Miner Overview tab. Uses the existing shared component pattern already present in 7 other search inputs across the app.

## Root Cause
The DebouncedSearchInput in MinerScoreBreakdown renders a TextField with startAdornment but no endAdornment. All other searchable views already include ClearSearchAdornment for one-click clear.

## Impact
Score Breakdown search was the only search field without a clear control — a UX inconsistency.

## Related Issues
Fixes #1054

## Test plan
### How to verify
- Open miner profile → Score Breakdown
- Type in search → clear button appears
- Click clear → search text cleared, results reset

### Edge cases
- Empty search: button hidden by `visible={Boolean(draftValue)}`
- Mobile: same behavior as desktop

### Post-merge
- All search fields in the app now have consistent clear behavior