### PR TITLE
fix(leaderboard): floor credibility in list view instead of rounding

### DIFF
--- a/src/components/leaderboard/MinersList.tsx
+++ b/src/components/leaderboard/MinersList.tsx
@@ -160,7 +160,7 @@ export const MinersList: React.FC<MinersListProps> = ({
       sortKey: 'credibility',
       renderCell: (miner) => (
         <Typography sx={{ ...cellTypographySx, color: 'text.primary' }}>
-          {((miner.credibility ?? 0) * 100).toFixed(0)}%
+          {Math.floor((miner.credibility ?? 0) * 100)}%
         </Typography>
       ),
     },


### PR DESCRIPTION
## Summary

The Credibility column in the miner leaderboard list view (`MinersList.tsx`) rounds half-up via `toFixed(0)`, which can over-state a miner's credibility. A miner with `credibility = 0.967` is displayed as **`97%`** even though they haven't crossed that threshold. This PR switches to integer truncation so values floor toward the displayed integer — `96.7%` now displays as **`96%`**.

## Why

`toFixed(0)` rounds half-up — values in `[0.965, 0.974]` all become `97%`. For credibility (which gates eligibility at 80%), displaying a higher value than the miner has actually earned is misleading. Truncation via `Math.floor` is the conservative choice: the displayed integer is always ≤ the true value, so the user never sees a percentage they don't yet have.

## Behavior

| Raw credibility | Before (`toFixed(0)`) | After (`Math.floor`) |
|---|---|---|
| 0.7949 | 79% | 79% |
| 0.7950 | 80% | 79% |
| 0.8499 | 85% | 84% |
| 0.8500 | 85% | 85% |
| 0.967  | 97% | 96% |
| 1.000  | 100% | 100% |

Sort behavior is unchanged: ordering is still done on the raw fraction (`(a.credibility ?? 0) - (b.credibility ?? 0)` in `TopMinersTable.tsx:197-198`), so two miners at `0.847` and `0.852` still resolve order correctly even though both render as `84%` and `85%` respectively.

## Test plan

- [ ] Open `/leaderboard` (or any view that mounts `MinersList`).
- [ ] Switch to list view.
- [ ] Find a miner whose card-view donut shows ≥ X.5% — confirm the list-view Credibility column now reads `X%` (truncated) instead of `X+1%`.
- [ ] Sort by Credibility ascending and descending — order is unchanged.
- [ ] `npm run type-check` and `npm run lint` pass.

## Out of scope

- Card-view `MinerCard.tsx` uses the unrounded percent directly in a donut visualization — no rounding change needed there.
- The `Credibility` cell in `MinerScoreBreakdown.tsx` and any miner-stats KPI tiles are unchanged. If we want a globally consistent truncation policy, that's a follow-up.

Before
<img width="1163" height="838" alt="image" src="https://github.com/user-attachments/assets/82d3f871-e214-4064-a40f-90670c229fc2" />

After
<img width="1198" height="721" alt="image" src="https://github.com/user-attachments/assets/64911eb2-76d2-4958-afc2-4652d0c659ee" />
