### PR TITLE
fixed alignment issue in tooltip in PR time decay

### DIFF
--- a/src/components/prs/PRTimeDecayChart.tsx
+++ b/src/components/prs/PRTimeDecayChart.tsx
@@ -113,11 +113,20 @@ function formatTooltipBody(
   mutedHex: string,
 ): string {
   const header = `<div style="font-weight:600;margin-bottom:2px">Day ${day.toFixed(1)}</div>`;
-  const multiplierLine = `<div><span style="color:${mutedHex}">Multiplier</span> <b>${multiplier.toFixed(2)}×</b></div>`;
-  if (preDecayScore == null) return header + multiplierLine;
-  const score = preDecayScore * multiplier;
-  const scoreLine = `<div style="margin-top:2px"><span style="color:${mutedHex}">Score</span> <b>${score.toFixed(2)}</b></div>`;
-  return header + multiplierLine + scoreLine;
+  const multVal = `${multiplier.toFixed(2)}×`;
+  const metricRow = (label: string, value: string, topPad: boolean) =>
+    '<tr>' +
+    `<td style="color:${mutedHex};padding:${topPad ? '4px' : '0'} 10px 0 0;vertical-align:baseline;white-space:nowrap">${label}</td>` +
+    `<td style="text-align:right;font-weight:600;padding:${topPad ? '4px' : '0'} 0 0 0;vertical-align:baseline;white-space:nowrap">${value}</td>` +
+    '</tr>';
+  const table =
+    '<table style="border-collapse:collapse;margin-top:2px;width:100%">' +
+    metricRow('Multiplier', multVal, false) +
+    (preDecayScore == null
+      ? ''
+      : metricRow('Score', (preDecayScore * multiplier).toFixed(2), true)) +
+    '</table>';
+  return header + table;
 }
 
 function buildTooltipFormatter(preDecayScore: number | null, mutedHex: string) {


### PR DESCRIPTION
## Summary

On the miner PR Overview view, the Time Decay line chart tooltip rendered Multiplier and Score as plain “label + space + value” lines. Because “Multiplier” is longer than “Score”, the numbers did not line up in a single column and looked inconsistent next to other, more structured tooltips in the app.
This change builds those rows with a small HTML table: muted labels in the first column and right-aligned bold values in the second, so the two metrics read clearly and values stack vertically. When preDecayScore is missing, the tooltip still shows only the multiplier row in the same layout.

## Related Issues

Fixes #1140 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots
###before
<img width="1873" height="953" alt="image" src="https://github.com/user-attachments/assets/0767427b-f70b-484a-b2fb-bc9bf8dbdeae" />
###after
<img width="1876" height="887" alt="image" src="https://github.com/user-attachments/assets/2e1be012-caa0-42b8-9eb0-a33d58667ef8" />


## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
