### PR TITLE
fix plural issue in follower display

### DIFF
--- a/src/components/miners/MinerScoreCard.tsx
+++ b/src/components/miners/MinerScoreCard.tsx
@@ -60,6 +60,11 @@ const formatTimeAgo = (date: Date): string => {
   return `${diffDays} days ago`;
 };
 
+function formatFollowersCount(count: number): string {
+  const noun = count === 1 ? 'follower' : 'followers';
+  return `${count} ${noun}`;
+}
+
 const openPrColor = (open: number, threshold: number) => {
   if (open >= threshold) return RISK_COLORS.exceeded;
   if (open >= threshold - 1) return RISK_COLORS.critical;
@@ -596,7 +601,7 @@ const MinerScoreCard: React.FC<MinerScoreCardProps> = ({
               <Chip
                 variant="info"
                 icon={<FollowersIcon />}
-                label={`${githubData.followers} followers`}
+                label={formatFollowersCount(githubData.followers)}
                 size="small"
                 sx={{ display: { xs: 'none', sm: 'inline-flex' } }}
               />
@@ -615,7 +620,7 @@ const MinerScoreCard: React.FC<MinerScoreCardProps> = ({
           color: (t) => alpha(t.palette.text.primary, 0.5),
         }}
       >
-        {githubData?.followers ?? 0} followers
+        {formatFollowersCount(githubData?.followers ?? 0)}
         {minerStats.updatedAt
           ? ` • Updated ${formatTimeAgo(new Date(minerStats.updatedAt))}`
           : ''}

--- a/src/components/miners/MinerScoreCard.tsx
+++ b/src/components/miners/MinerScoreCard.tsx
@@ -60,11 +60,6 @@ const formatTimeAgo = (date: Date): string => {
   return `${diffDays} days ago`;
 };
 
-function formatFollowersCount(count: number): string {
-  const noun = count === 1 ? 'follower' : 'followers';
-  return `${count} ${noun}`;
-}
-
 const openPrColor = (open: number, threshold: number) => {
   if (open >= threshold) return RISK_COLORS.exceeded;
   if (open >= threshold - 1) return RISK_COLORS.critical;
@@ -601,7 +596,7 @@ const MinerScoreCard: React.FC<MinerScoreCardProps> = ({
               <Chip
                 variant="info"
                 icon={<FollowersIcon />}
-                label={formatFollowersCount(githubData.followers)}
+                label={`${githubData.followers} followers`}
                 size="small"
                 sx={{ display: { xs: 'none', sm: 'inline-flex' } }}
               />
@@ -620,7 +615,7 @@ const MinerScoreCard: React.FC<MinerScoreCardProps> = ({
           color: (t) => alpha(t.palette.text.primary, 0.5),
         }}
       >
-        {formatFollowersCount(githubData?.followers ?? 0)}
+        {githubData?.followers ?? 0} follower(s)
         {minerStats.updatedAt
           ? ` • Updated ${formatTimeAgo(new Date(minerStats.updatedAt))}`
           : ''}


### PR DESCRIPTION
## Summary

On /miners/details, the GitHub followers line and chip always used the word “followers”, so accounts with exactly one follower showed “1 followers”. English copy should use “1 follower” when the count is 1, and “N followers” otherwise (including 0).
This updates MinerScoreCard by introducing a small formatFollowersCount helper and using it for both the desktop chip (from sm up) and the mobile-only metadata line under the header, so behavior stays consistent across breakpoints.

## Related Issues

Fixes #1142

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

<img width="1891" height="949" alt="image" src="https://github.com/user-attachments/assets/33cb67b8-ab53-4fd9-8dc9-fc1ed0c27d09" />


## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
