### PR TITLE
fix(404): fall back to /dashboard when Go back has no in-app history

### DIFF
--- a/src/pages/NotFoundPage.tsx
+++ b/src/pages/NotFoundPage.tsx
@@ -9,6 +9,15 @@ import { useNavigate, useLocation } from 'react-router-dom';
 const NotFoundPage: React.FC = () => {
   const navigate = useNavigate();
   const location = useLocation();
+  const canGoBack = typeof window !== 'undefined' && window.history.length > 1;
+
+  const handleGoBack = () => {
+    if (canGoBack) {
+      navigate(-1);
+    } else {
+      navigate('/dashboard');
+    }
+  };
 
   return (
     <Box
@@ -83,7 +92,7 @@ const NotFoundPage: React.FC = () => {
           <Button
             variant="outlined"
             startIcon={<ArrowBackIcon />}
-            onClick={() => navigate(-1)}
+            onClick={handleGoBack}
             sx={{
               textTransform: 'none',
               color: 'text.secondary',

--- a/src/pages/NotFoundPage.tsx
+++ b/src/pages/NotFoundPage.tsx
@@ -9,15 +9,17 @@ import { useNavigate, useLocation } from 'react-router-dom';
 const NotFoundPage: React.FC = () => {
   const navigate = useNavigate();
   const location = useLocation();
-  const canGoBack = typeof window !== 'undefined' && window.history.length > 1;
-
-  const handleGoBack = () => {
-    if (canGoBack) {
-      navigate(-1);
-    } else {
-      navigate('/dashboard');
+  const canGoBack = (() => {
+    if (typeof window === 'undefined') return false;
+    if (window.history.length <= 1) return false;
+    const ref = document.referrer;
+    if (!ref) return false;
+    try {
+      return new URL(ref).origin === window.location.origin;
+    } catch {
+      return false;
     }
-  };
+  })();
 
   return (
     <Box
@@ -89,18 +91,20 @@ const NotFoundPage: React.FC = () => {
           >
             Go to Dashboard
           </Button>
-          <Button
-            variant="outlined"
-            startIcon={<ArrowBackIcon />}
-            onClick={handleGoBack}
-            sx={{
-              textTransform: 'none',
-              color: 'text.secondary',
-              borderColor: 'border.medium',
-            }}
-          >
-            Go back
-          </Button>
+          {canGoBack && (
+            <Button
+              variant="outlined"
+              startIcon={<ArrowBackIcon />}
+              onClick={() => navigate(-1)}
+              sx={{
+                textTransform: 'none',
+                color: 'text.secondary',
+                borderColor: 'border.medium',
+              }}
+            >
+              Go back
+            </Button>
+          )}
         </Stack>
       </Stack>
     </Box>


### PR DESCRIPTION
Closes #1146 

## Summary
Fixes the "Go back" button on the 404 page so it never silently leaves the app or lands on a blank browser screen.

## What changed
`src/pages/NotFoundPage.tsx` — the "Go back" button is now **conditionally rendered**. It only appears when we can be confident `navigate(-1)` will stay inside the app:

```ts
const canGoBack = (() => {
  if (typeof window === 'undefined') return false;
  if (window.history.length <= 1) return false;
  const ref = document.referrer;
  if (!ref) return false;
  try {
    return new URL(ref).origin === window.location.origin;
  } catch {
    return false;
  }
})();
```

When `canGoBack` is false the button is hidden, leaving only **"Go to Dashboard"** — which always works.

## Why this approach (instead of falling through to `/dashboard`)
The first iteration just gated on `window.history.length > 1`. That isn't enough:

- In a fresh **incognito** tab, the browser's own new-tab page counts as a history entry. `length === 2` → check passes → `navigate(-1)` actually takes the user to the chrome new-tab page. Reproduced and confirmed.
- On a reused tab where the previous site was outside the app (`google.com` → typed 404), `length === 2` again — and clicking "Go back" would still leave the app.

Adding the same-origin `document.referrer` check fixes both cases: if there was no same-origin page in this tab's history before the 404, we hide the button entirely. The "Go to Dashboard" button covers the recovery path.

## Behavior matrix

| Scenario | Before | After |
|---|---|---|
| Direct URL paste, fresh tab | did nothing | button hidden |
| Direct URL paste, incognito new-tab | leaked to chrome new-tab | button hidden |
| Linked from another site | leaked to that site | button hidden |
| Stale link from inside the app | back into the app ✓ | back into the app ✓ (unchanged) |

## Type of Change
- [x] Bug fix

## Testing
- [ ] `npm run build`
- [ ] `npm run lint:fix`
- [ ] Manual — open a **fresh incognito tab**, paste `/not-a-real-route`, load → only "Go to Dashboard" is visible. (Previously: clicking "Go back" leaked to the chrome new-tab page.)
- [ ] Manual — from inside the app, follow any stale link to a 404 → both buttons visible → "Go back" returns to the previous in-app page (unchanged behaviour).

## Checklist
- [x] No new dependencies
- [x] Single file touched
- [x] Targets `test` branch
- [x] No control silently does the wrong thing — buttons only render when they will work

## Recordings

https://github.com/user-attachments/assets/86557b2d-4a3a-494f-a2ab-68ef6f2415e9

