### PR TITLE
feat(dashboard): source Total Lines Committed

### DIFF
--- a/src/api/DashboardApi.ts
+++ b/src/api/DashboardApi.ts
@@ -6,7 +6,6 @@ import {
   type Repository,
   type LanguageWeight,
   type CommitLog,
-  type CommitsTrend,
 } from './models/Dashboard';
 
 const useDashboardQuery = <TResponse = void, TSelect = TResponse>(
@@ -36,8 +35,11 @@ export const useReposAndWeights = () =>
 export const useLanguagesAndWeights = () =>
   useDashboardQuery<LanguageWeight[]>('useLanguagesAndWeights', '/languages');
 
-export const useLinesHistTrend = () =>
-  useDashboardQuery<CommitsTrend[]>('useLinesHistTrend', '/lines/hist-trend');
+export const useLinesTotal = (params: { from: string; to: string }) =>
+  useDashboardQuery<number>('useLinesTotal', '/lines/total', undefined, {
+    from: params.from,
+    to: params.to,
+  });
 
 export const useInfiniteCommitLog = (options?: {
   refetchInterval?: number;

--- a/src/api/DashboardApi.ts
+++ b/src/api/DashboardApi.ts
@@ -6,6 +6,7 @@ import {
   type Repository,
   type LanguageWeight,
   type CommitLog,
+  type CommitsTrend,
 } from './models/Dashboard';
 
 const useDashboardQuery = <TResponse = void, TSelect = TResponse>(
@@ -34,6 +35,9 @@ export const useReposAndWeights = () =>
 
 export const useLanguagesAndWeights = () =>
   useDashboardQuery<LanguageWeight[]>('useLanguagesAndWeights', '/languages');
+
+export const useLinesHistTrend = () =>
+  useDashboardQuery<CommitsTrend[]>('useLinesHistTrend', '/lines/hist-trend');
 
 export const useInfiniteCommitLog = (options?: {
   refetchInterval?: number;

--- a/src/api/models/Dashboard.ts
+++ b/src/api/models/Dashboard.ts
@@ -35,11 +35,6 @@ export type LanguageWeight = {
   language: string | null; // Canonical language name (e.g., "python" for .py, .pyi)
 };
 
-export type CommitsTrend = {
-  date: string;
-  linesCommitted: number | string; // API returns string, needs conversion
-};
-
 /**
  * Dashboard statistics
  *

--- a/src/pages/dashboard/dashboardData.ts
+++ b/src/pages/dashboard/dashboardData.ts
@@ -9,7 +9,6 @@
  */
 import {
   type CommitLog,
-  type CommitsTrend,
   type MinerEvaluation,
   type MirrorDashboardIssue,
   type Repository,
@@ -636,7 +635,7 @@ export const buildDashboardOverview = (
 export const buildDashboardKpis = (
   prs: CommitLog[],
   issues: MirrorDashboardIssue[],
-  linesHistTrend: CommitsTrend[],
+  totalLinesCommitted: number,
   range: TrendTimeRange,
   now = new Date(),
 ): DashboardKpi[] => {
@@ -653,9 +652,6 @@ export const buildDashboardKpis = (
     0,
   );
   const totalIssuesSolved = solvedIssues.length;
-  const totalLinesCommitted = linesHistTrend
-    .filter((entry) => isWithinWindow(toTimestamp(entry.date), window))
-    .reduce((sum, entry) => sum + parseNumber(entry.linesCommitted), 0);
   const totalRepositories = new Set(
     mergedWindowPrs.map((pr) => pr.repository).filter(Boolean),
   ).size;

--- a/src/pages/dashboard/dashboardData.ts
+++ b/src/pages/dashboard/dashboardData.ts
@@ -9,6 +9,7 @@
  */
 import {
   type CommitLog,
+  type CommitsTrend,
   type MinerEvaluation,
   type MirrorDashboardIssue,
   type Repository,
@@ -635,6 +636,7 @@ export const buildDashboardOverview = (
 export const buildDashboardKpis = (
   prs: CommitLog[],
   issues: MirrorDashboardIssue[],
+  linesHistTrend: CommitsTrend[],
   range: TrendTimeRange,
   now = new Date(),
 ): DashboardKpi[] => {
@@ -651,10 +653,9 @@ export const buildDashboardKpis = (
     0,
   );
   const totalIssuesSolved = solvedIssues.length;
-  const totalLinesCommitted = mergedWindowPrs.reduce(
-    (sum, pr) => sum + parseNumber(pr.additions) + parseNumber(pr.deletions),
-    0,
-  );
+  const totalLinesCommitted = linesHistTrend
+    .filter((entry) => isWithinWindow(toTimestamp(entry.date), window))
+    .reduce((sum, entry) => sum + parseNumber(entry.linesCommitted), 0);
   const totalRepositories = new Set(
     mergedWindowPrs.map((pr) => pr.repository).filter(Boolean),
   ).size;

--- a/src/pages/dashboard/useDashboardData.ts
+++ b/src/pages/dashboard/useDashboardData.ts
@@ -12,6 +12,7 @@ import {
   useAllMiners,
   useAllPrs,
   useIssues,
+  useLinesHistTrend,
   useMirrorDashboardIssues,
   useReposAndWeights,
 } from '../../api';
@@ -51,6 +52,7 @@ export const useDashboardData = (range: TrendTimeRange) => {
   const minersQuery = useAllMiners();
   const issuesQuery = useIssues();
   const reposQuery = useReposAndWeights();
+  const linesHistTrendQuery = useLinesHistTrend();
 
   // Single bulk mirror call replaces the previous per-miner fan-out.
   // The mirror is roster-blind; we filter to subnet authors below using the
@@ -142,10 +144,20 @@ export const useDashboardData = (range: TrendTimeRange) => {
     [datasets.prs.data, datasets.repos.data],
   );
 
+  const linesHistTrendData = useMemo(
+    () => linesHistTrendQuery.data ?? [],
+    [linesHistTrendQuery.data],
+  );
+
   const kpis = useMemo(
     () =>
-      buildDashboardKpis(datasets.prs.data, datasets.minerIssues.data, range),
-    [datasets.minerIssues.data, datasets.prs.data, range],
+      buildDashboardKpis(
+        datasets.prs.data,
+        datasets.minerIssues.data,
+        linesHistTrendData,
+        range,
+      ),
+    [datasets.minerIssues.data, datasets.prs.data, linesHistTrendData, range],
   );
 
   const isFeaturedWorkLoading =

--- a/src/pages/dashboard/useDashboardData.ts
+++ b/src/pages/dashboard/useDashboardData.ts
@@ -12,7 +12,7 @@ import {
   useAllMiners,
   useAllPrs,
   useIssues,
-  useLinesHistTrend,
+  useLinesTotal,
   useMirrorDashboardIssues,
   useReposAndWeights,
 } from '../../api';
@@ -31,6 +31,7 @@ import {
   buildFeaturedContributors,
   buildFeaturedWork,
   buildFeaturedDiscoveryContributors,
+  getWindowBounds,
   GITTENSOR_START_MS,
   type TrendTimeRange,
 } from './dashboardData';
@@ -52,7 +53,15 @@ export const useDashboardData = (range: TrendTimeRange) => {
   const minersQuery = useAllMiners();
   const issuesQuery = useIssues();
   const reposQuery = useReposAndWeights();
-  const linesHistTrendQuery = useLinesHistTrend();
+
+  const { from, to } = useMemo(() => {
+    const bounds = getWindowBounds(range);
+    return {
+      from: new Date(bounds.startMs).toISOString(),
+      to: new Date(bounds.endMs).toISOString(),
+    };
+  }, [range]);
+  const linesTotalQuery = useLinesTotal({ from, to });
 
   // Single bulk mirror call replaces the previous per-miner fan-out.
   // The mirror is roster-blind; we filter to subnet authors below using the
@@ -144,20 +153,17 @@ export const useDashboardData = (range: TrendTimeRange) => {
     [datasets.prs.data, datasets.repos.data],
   );
 
-  const linesHistTrendData = useMemo(
-    () => linesHistTrendQuery.data ?? [],
-    [linesHistTrendQuery.data],
-  );
+  const totalLinesCommitted = linesTotalQuery.data ?? 0;
 
   const kpis = useMemo(
     () =>
       buildDashboardKpis(
         datasets.prs.data,
         datasets.minerIssues.data,
-        linesHistTrendData,
+        totalLinesCommitted,
         range,
       ),
-    [datasets.minerIssues.data, datasets.prs.data, linesHistTrendData, range],
+    [datasets.minerIssues.data, datasets.prs.data, totalLinesCommitted, range],
   );
 
   const isFeaturedWorkLoading =


### PR DESCRIPTION
## Summary

Replaces the client-side sum of `additions + deletions` over `mergedWindowPrs`
with the pre-aggregated `/dash/lines/hist-trend` time series from the dashboard
backend.

## Why

- **Single source of truth.** The dashboard backend already owns the canonical
  daily total. Computing the same value client-side risked drift if the
  backend's definition ever changed (e.g., excluding bot commits, filtering
  merge commits).
- **Less client work.** The KPI no longer requires materializing every PR's
  `additions + deletions` just to read one number.
- **Faster perceived load.** Hist-trend is a tiny payload (~one row per day)
  compared to walking the full PR set.

## Changes

- New `useLinesHistTrend()` hook in `DashboardApi.ts` consuming the existing
  `CommitsTrend` type (previously declared but unused).
- `buildDashboardKpis(prs, issues, linesHistTrend, range)` now accepts the
  trend array and sums only buckets inside the active window.
- `useDashboardData` calls the new hook and passes the data through.
- Other KPIs (Total Commits, Issues Solved, Total Repositories) still derive
  client-side — those have no equivalent backend endpoint.

## Test plan

- [ ] Compare displayed `Total Lines Committed` against the previous value for
  each preset window (1d / 7d / 35d / all) — should match.
- [ ] Verify the KPI updates when the time-range selector changes.
- [ ] Verify graceful fallback when the endpoint is empty / errors (KPI shows
  `0` instead of crashing).
- [ ] Confirm no regression in the other three KPI tiles.


<img width="1772" height="697" alt="image" src="https://github.com/user-attachments/assets/f7e2fb3d-70bc-41a2-9af9-356d07e7263a" />
