### PR TITLE
fix: use shared formatDate helper instead of toLocaleDateString for consistent locale-independent dates

### DIFF
--- a/src/components/miners/MinerOpenDiscoveryIssuesByRepo.tsx
+++ b/src/components/miners/MinerOpenDiscoveryIssuesByRepo.tsx
@@ -35,6 +35,7 @@ import {
 } from '../../hooks/useMinerRepositoriesOpenIssues';
 import { useSessionStoredState } from '../../hooks/useSessionStoredState';
 import { type RepositoryIssue } from '../../api/models/Miner';
+import { formatDate } from '../../utils/format';
 
 type IssueFilter = 'all' | 'open' | 'solved' | 'closed';
 
@@ -592,7 +593,7 @@ const MinerOpenDiscoveryIssuesByRepo: React.FC<
           renderCell: (issue) =>
             issue.createdAt ? (
               <Tooltip
-                title={new Date(issue.createdAt).toLocaleDateString()}
+                title={formatDate(issue.createdAt)}
                 placement="bottom"
                 arrow
               >
@@ -785,7 +786,7 @@ const MinerOpenDiscoveryIssuesByRepo: React.FC<
           renderCell: (issue) =>
             issue.createdAt ? (
               <Tooltip
-                title={new Date(issue.createdAt).toLocaleDateString()}
+                title={formatDate(issue.createdAt)}
                 placement="bottom"
                 arrow
               >

--- a/src/components/miners/MinerPRsTable.tsx
+++ b/src/components/miners/MinerPRsTable.tsx
@@ -32,6 +32,7 @@ import { ClearSearchAdornment } from '../common/ClearSearchAdornment';
 import { WatchlistButton } from '../../components/common';
 import { serializePRKey } from '../../hooks/useWatchlist';
 import TablePagination from '../common/TablePagination';
+import { formatDate } from '../../utils/format';
 import { tooltipSlotProps } from '../../theme';
 
 type PrSortField = 'number' | 'repository' | 'score' | 'lines' | 'date';
@@ -416,7 +417,7 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
       },
       renderCell: (pr) =>
         pr.mergedAt
-          ? new Date(pr.mergedAt).toLocaleDateString()
+          ? formatDate(pr.mergedAt)
           : pr.prState === 'CLOSED'
             ? 'Closed'
             : 'Open',

--- a/src/components/repositories/RepositoryIssuesTable.tsx
+++ b/src/components/repositories/RepositoryIssuesTable.tsx
@@ -24,6 +24,7 @@ import {
   type DataTableColumn,
 } from '../../components/common/DataTable';
 import { formatTokenAmount, getLowerText, type SortOrder } from '../../utils';
+import { formatDate } from '../../utils/format';
 import { ScrollAwareTooltip } from '../../components/common/ScrollAwareTooltip';
 import {
   getIssueStatusMeta,
@@ -266,16 +267,14 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
       header: 'Created',
       align: 'right',
       sortKey: 'created',
-      renderCell: (issue) =>
-        issue.createdAt ? new Date(issue.createdAt).toLocaleDateString() : '-',
+      renderCell: (issue) => formatDate(issue.createdAt),
     },
     {
       key: 'closed',
       header: 'Closed',
       align: 'right',
       sortKey: 'closed',
-      renderCell: (issue) =>
-        issue.closedAt ? new Date(issue.closedAt).toLocaleDateString() : '-',
+      renderCell: (issue) => formatDate(issue.closedAt),
     },
   ];
 

--- a/src/components/repositories/RepositoryPRsTable.tsx
+++ b/src/components/repositories/RepositoryPRsTable.tsx
@@ -22,6 +22,7 @@ import { serializePRKey } from '../../hooks/useWatchlist';
 import theme, { TEXT_OPACITY, scrollbarSx } from '../../theme';
 import { filterPrs, getPrStatusCounts, type PrStatusFilter } from '../../utils';
 import { getRepositoryOwnerAvatarSrc } from '../../utils/avatar';
+import { formatDate } from '../../utils/format';
 import FilterButton from '../FilterButton';
 import { AUTHOR_FILTER_ALL, AuthorFilter } from './AuthorFilter';
 
@@ -353,8 +354,7 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
       header: 'Merged',
       align: 'right',
       sortKey: 'mergedAt',
-      renderCell: (pr) =>
-        pr.mergedAt ? new Date(pr.mergedAt).toLocaleDateString() : '-',
+      renderCell: (pr) => formatDate(pr.mergedAt),
     },
     {
       key: 'watch',

--- a/src/pages/WatchlistPage.tsx
+++ b/src/pages/WatchlistPage.tsx
@@ -4026,7 +4026,7 @@ const buildIssueColumns = (
             color: (t) => alpha(t.palette.text.primary, 0.6),
           }}
         >
-          {d ? new Date(d).toLocaleDateString() : '-'}
+          {formatDate(d)}
         </Typography>
       );
     },

--- a/src/pages/search/PullRequestsTab.tsx
+++ b/src/pages/search/PullRequestsTab.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Box } from '@mui/material';
 import { type CommitLog } from '../../api/models/Dashboard';
 import { getGithubAvatarSrc } from '../../utils';
+import { formatDate } from '../../utils/format';
 import { type DataTableColumn } from '../../components/common/DataTable';
 import SearchResultsCard from './SearchResultsCard';
 import {
@@ -17,7 +18,7 @@ const formatPrScore = (pr: CommitLog) => {
 };
 
 const formatPrDateOrStatus = (pr: CommitLog) => {
-  if (pr.mergedAt) return new Date(pr.mergedAt).toLocaleDateString();
+  if (pr.mergedAt) return formatDate(pr.mergedAt);
   if (pr.prState === 'CLOSED') return 'Closed';
   return 'Open';
 };


### PR DESCRIPTION
## Summary

Several tables and tooltips across the app were rendering dates with `new Date(x).toLocaleDateString()`, which produces different output depending on the viewer's locale (e.g. `11/14/2025` for `en-US` vs `14/11/2025` for `en-GB` vs `2025/11/14` for `ja-JP`). The rest of the app uses a shared `formatDate` helper in `src/utils/format.ts` that renders as `MMM d, yyyy` (e.g. `Nov 14, 2025`) — a locale-independent, unambiguous format.

This PR replaces every remaining `toLocaleDateString()` call site with the shared `formatDate` helper so dates render consistently across the UI regardless of the user's browser locale.

## Changes

- `src/components/miners/MinerOpenDiscoveryIssuesByRepo.tsx` — 2 tooltip dates
- `src/components/miners/MinerPRsTable.tsx` — merged date in the PR row (Open/Closed fallback preserved)
- `src/components/repositories/RepositoryPRsTable.tsx` — merged date column
- `src/components/repositories/RepositoryIssuesTable.tsx` — created and closed date columns
- `src/pages/search/PullRequestsTab.tsx` — merged date in search results
- `src/pages/WatchlistPage.tsx` — date column in the watchlist tables

No behavior change for users with `en-US`; consistent output for all other locales.

## Verification

1. Open a repo detail page, a miner page, the global search results, and the watchlist.
2. In DevTools, emulate a non-`en-US` locale (e.g. `en-GB`, `ja-JP`, `de-DE`) and reload.
3. Confirm all date cells/tooltips render as `Mon D, YYYY` (e.g. `Nov 14, 2025`) and match the format used elsewhere on the page.

## Screenshots
### Bounties
<img width="1857" height="792" alt="image" src="https://github.com/user-attachments/assets/fd9917b9-5514-4aec-b130-7736f3c3c546" />

### Miner Page
<img width="1844" height="815" alt="image" src="https://github.com/user-attachments/assets/4424145a-8d15-4c78-a4d3-e8dd571baa46" />

### Repositories Detail Page
<img width="1848" height="905" alt="image" src="https://github.com/user-attachments/assets/592f3d5e-e8cf-4650-b88a-81d24105c215" />

Closes #1149