### PR TITLE
feat(miner-activity): add 7D/35D/All range selector to contribution heatmap

### DIFF
--- a/src/components/ContributionHeatmap.tsx
+++ b/src/components/ContributionHeatmap.tsx
@@ -15,7 +15,7 @@ interface ContributionData {
 
 interface ContributionHeatmapProps {
   data: ContributionData[];
-  contributionsLast30Days: number;
+  contributionsCount: number;
   totalDaysShown: number;
   subtitle?: string;
   footerText?: string;
@@ -24,11 +24,12 @@ interface ContributionHeatmapProps {
   bare?: boolean;
   selectedDate?: string;
   onDayClick?: (date: string) => void;
+  headerRight?: React.ReactNode;
 }
 
 const ContributionHeatmap: React.FC<ContributionHeatmapProps> = ({
   data,
-  contributionsLast30Days,
+  contributionsCount,
   totalDaysShown,
   subtitle = 'network contribution(s) in the last 30 days',
   footerText,
@@ -37,6 +38,7 @@ const ContributionHeatmap: React.FC<ContributionHeatmapProps> = ({
   bare = false,
   selectedDate,
   onDayClick,
+  headerRight,
 }) => {
   const theme = useTheme();
   const heatmapLevels = [...CONTRIBUTION_HEATMAP_SCALE];
@@ -46,27 +48,38 @@ const ContributionHeatmap: React.FC<ContributionHeatmapProps> = ({
 
   const content = (
     <>
-      <Box sx={{ mb: 2.5 }}>
-        <Typography
-          sx={{
-            color: 'text.primary',
-            fontWeight: 700,
-            fontSize: '2.5rem',
-            lineHeight: 1,
-          }}
-        >
-          {contributionsLast30Days.toLocaleString()}
-        </Typography>
-        <Typography
-          variant="body2"
-          sx={{
-            color: alpha(theme.palette.common.white, TEXT_OPACITY.faint),
-            fontSize: '0.85rem',
-            mt: 0.5,
-          }}
-        >
-          {subtitle}
-        </Typography>
+      <Box
+        sx={{
+          mb: 2.5,
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'flex-start',
+          gap: 2,
+        }}
+      >
+        <Box>
+          <Typography
+            sx={{
+              color: 'text.primary',
+              fontWeight: 700,
+              fontSize: '2.5rem',
+              lineHeight: 1,
+            }}
+          >
+            {contributionsCount.toLocaleString()}
+          </Typography>
+          <Typography
+            variant="body2"
+            sx={{
+              color: alpha(theme.palette.common.white, TEXT_OPACITY.faint),
+              fontSize: '0.85rem',
+              mt: 0.5,
+            }}
+          >
+            {subtitle}
+          </Typography>
+        </Box>
+        {headerRight}
       </Box>
 
       <Box sx={{ width: '100%', overflowX: 'auto', mb: 1, ...scrollbarSx }}>

--- a/src/components/miners/MinerActivity.tsx
+++ b/src/components/miners/MinerActivity.tsx
@@ -5,6 +5,9 @@ import {
   Typography,
   Grid,
   CircularProgress,
+  FormControl,
+  MenuItem,
+  Select,
   alpha,
   useTheme,
 } from '@mui/material';
@@ -36,6 +39,14 @@ import CredibilityChart from './CredibilityChart';
 import PerformanceRadar from './PerformanceRadar';
 
 type ViewMode = 'prs' | 'issues';
+
+type ActivityRange = '7d' | '35d' | 'all';
+
+const RANGE_OPTIONS: { value: ActivityRange; label: string }[] = [
+  { value: '7d', label: '7D' },
+  { value: '35d', label: '35D' },
+  { value: 'all', label: 'All' },
+];
 
 interface MinerActivityProps {
   githubId: string;
@@ -305,6 +316,7 @@ const MinerActivity: React.FC<MinerActivityProps> = ({
   githubId,
   viewMode = 'prs',
 }) => {
+  const theme = useTheme();
   const isIssueMode = viewMode === 'issues';
   const { data: minerStats } = useMinerStats(githubId);
   const { data: prs, isLoading: isLoadingPRs } = useMinerPRs(githubId);
@@ -313,6 +325,7 @@ const MinerActivity: React.FC<MinerActivityProps> = ({
   const { data: allMinerStats } = useAllMiners();
   const todayStr = format(new Date(), 'yyyy-MM-dd');
   const [selectedDate, setSelectedDate] = useState<string>(todayStr);
+  const [activityRange, setActivityRange] = useState<ActivityRange>('35d');
 
   useEffect(() => {
     setSelectedDate(todayStr);
@@ -323,19 +336,20 @@ const MinerActivity: React.FC<MinerActivityProps> = ({
   };
 
   // Calculate contribution heatmap data
-  const { contributionData, contributionsLast30Days, totalDaysShown } =
+  const { contributionData, contributionsCount, totalDaysShown, rangeLabel } =
     useMemo(() => {
+      const today = new Date();
+
       if (!prs || prs.length === 0) {
         return {
           contributionData: [],
-          contributionsLast30Days: 0,
+          contributionsCount: 0,
           totalDaysShown: 0,
+          rangeLabel: 'all time',
         };
       }
 
-      const today = new Date();
       let earliestDate = today;
-
       prs.forEach((pr) => {
         if (pr.mergedAt) {
           const d = new Date(pr.mergedAt);
@@ -343,18 +357,27 @@ const MinerActivity: React.FC<MinerActivityProps> = ({
         }
       });
 
-      const diffTime = Math.abs(today.getTime() - earliestDate.getTime());
-      const daysDiff = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
-      const daysToShow = Math.max(daysDiff, 1);
+      let windowDays: number;
+      let label: string;
+      if (activityRange === '7d') {
+        windowDays = 7;
+        label = 'last 7 days';
+      } else if (activityRange === '35d') {
+        windowDays = 35;
+        label = 'last 35 days';
+      } else {
+        const diffMs = Math.abs(today.getTime() - earliestDate.getTime());
+        const span = Math.ceil(diffMs / (1000 * 60 * 60 * 24)) + 1;
+        windowDays = Math.max(span, 1);
+        label = 'all time';
+      }
 
       const dataMap = new Map<string, number>();
-      for (let i = daysToShow; i >= 0; i--) {
+      for (let i = windowDays - 1; i >= 0; i--) {
         dataMap.set(format(subDays(today, i), 'yyyy-MM-dd'), 0);
       }
 
-      let last30Count = 0;
-      const thirtyDaysAgo = subDays(today, 30);
-
+      let count = 0;
       prs.forEach((pr) => {
         if (!pr.mergedAt) return;
         const date = new Date(pr.mergedAt);
@@ -363,27 +386,28 @@ const MinerActivity: React.FC<MinerActivityProps> = ({
         const dateStr = format(date, 'yyyy-MM-dd');
         if (dataMap.has(dateStr)) {
           dataMap.set(dateStr, (dataMap.get(dateStr) || 0) + 1);
+          count++;
         }
-        if (date >= thirtyDaysAgo) last30Count++;
       });
 
       const data = Array.from(dataMap.entries())
-        .map(([date, count]) => {
+        .map(([date, c]) => {
           let level: 0 | 1 | 2 | 3 | 4 = 0;
-          if (count > 0) level = 1;
-          if (count >= 2) level = 2;
-          if (count >= 3) level = 3;
-          if (count >= 5) level = 4;
-          return { date, count, level };
+          if (c > 0) level = 1;
+          if (c >= 2) level = 2;
+          if (c >= 3) level = 3;
+          if (c >= 5) level = 4;
+          return { date, count: c, level };
         })
         .sort((a, b) => a.date.localeCompare(b.date));
 
       return {
         contributionData: data,
-        contributionsLast30Days: last30Count,
-        totalDaysShown: daysToShow,
+        contributionsCount: count,
+        totalDaysShown: windowDays,
+        rangeLabel: label,
       };
-    }, [prs]);
+    }, [prs, activityRange]);
 
   // PR-mode radar chart values (normalized to 100)
   const prRadarValues = useMemo(() => {
@@ -617,13 +641,39 @@ const MinerActivity: React.FC<MinerActivityProps> = ({
             >
               <ContributionHeatmap
                 data={contributionData}
-                contributionsLast30Days={contributionsLast30Days}
+                contributionsCount={contributionsCount}
                 totalDaysShown={totalDaysShown}
-                subtitle="contribution(s) in the last 30 days"
+                subtitle={`contribution(s) in the ${rangeLabel}`}
                 footerText="* Activity based on merged PRs in Gittensor-tracked repositories"
                 bare
                 selectedDate={selectedDate}
                 onDayClick={handleDayClick}
+                headerRight={
+                  <FormControl
+                    size="small"
+                    sx={{ minWidth: 78, flexShrink: 0 }}
+                  >
+                    <Select
+                      value={activityRange}
+                      onChange={(e) =>
+                        setActivityRange(e.target.value as ActivityRange)
+                      }
+                      sx={{
+                        height: 28,
+                        fontSize: '0.75rem',
+                        '& .MuiOutlinedInput-notchedOutline': {
+                          borderColor: alpha(theme.palette.text.primary, 0.2),
+                        },
+                      }}
+                    >
+                      {RANGE_OPTIONS.map((opt) => (
+                        <MenuItem key={opt.value} value={opt.value} dense>
+                          {opt.label}
+                        </MenuItem>
+                      ))}
+                    </Select>
+                  </FormControl>
+                }
               />
             </Grid>
 


### PR DESCRIPTION
## Summary

The Developer Activity heatmap on every miner profile currently hardcodes a "last 30 days" window for its prominent count, while the dashboard's repository activity chart already supports a **7D / 35D / All** range selector ([`RepositoryPrActivityChart.tsx`](src/components/repositories/RepositoryPrActivityChart.tsx)). This PR brings the miner heatmap in line with that pattern — same option set, same `<Select>` styling, same `ActivityRange = '7d' | '35d' | 'all'` shape — so users can switch between recent and historical activity views without leaving the page.

## What changed

- Added a `7D / 35D / All` `<Select>` in the heatmap card header (matches dashboard styling exactly).
- Heatmap data + count are now driven by the selected range:
  - **7D** → 7-day window
  - **35D** → 35-day window (new default)
  - **All** → full window from earliest merged PR to today
- The prominent number's subtitle is now dynamic: `contribution(s) in the last 7 days` / `in the last 35 days` / `all time`.
- Window count is now consistent with the rendered cells (the previous "last 30 days" label counted 31 days due to an off-by-one — fixed as a side effect of replacing the magic constant).
- Renamed `ContributionHeatmap`'s `contributionsLast30Days` prop to the more honest `contributionsCount`, and added an optional `headerRight` slot so the dashboard's existing usage stays untouched.

## Why this approach

- Reuses an interaction pattern reviewers have already approved on the dashboard — no new design surface.
- Keeps the change scoped to two files (`MinerActivity.tsx` + `ContributionHeatmap.tsx`); no new shared utilities or routes.
- The default stays close to the old behavior (35D is the closest matching dashboard option to the old hardcoded 30) so existing users see a familiar view on first load.

## Verification

1. Open a miner profile → **Activity** tab.
2. Toggle the new selector through `7D`, `35D`, `All` and confirm:
   - The big number, subtitle, and heatmap cell count all stay consistent with the selected range.
   - The heatmap library's footer caption (`X contribution(s) in the last Y day(s)`) also matches.
3. Open a brand-new miner with very little history and select `All` — confirm the heatmap collapses to just the days they've been active.
4. Open the dashboard and confirm the repository activity chart's `<Select>` is visually identical to the new one on the miner page.


https://github.com/user-attachments/assets/88bec3e2-91bf-4d0a-a3fb-648ed04a75c5


Fixes #1152