### PR TITLE
issue(s) plural issue in chart view in bounties

### DIFF
--- a/src/components/issues/IssuesList.tsx
+++ b/src/components/issues/IssuesList.tsx
@@ -460,7 +460,7 @@ const IssuesList: React.FC<IssuesListProps> = ({
       backgroundColor: 'transparent',
       title: {
         text: 'Bounty Pool by Repository',
-        subtext: `${filteredIssues.length} issues`,
+        subtext: `${filteredIssues.length} issue(s)`,
         left: 'center',
         top: 20,
         textStyle: {


### PR DESCRIPTION
## Summary

On /bounties, the “Bounty Pool by Repository” chart title subtext always used the word “issues”, so when filters left exactly one row the UI read “1 issues”. The subtitle now picks issue vs issues from filteredIssues.length, matching the N issue(s) behavior

## Related Issues

Fixes #1153 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

<img width="1878" height="870" alt="image" src="https://github.com/user-attachments/assets/74ecc8d5-b5ac-479c-a2fc-cb1b9005f69f" />


## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
