### PR TITLE
fix hardcoded plural issue in dashboard top agent by earnings

### DIFF
--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1361,8 +1361,8 @@ const TopMinersPanel: React.FC<{
                     }}
                   >
                     {shortIdentity(miner.githubId)} -{' '}
-                    {miner.totalMergedPrs || 0} PRs,{' '}
-                    {miner.totalSolvedIssues || 0} issues
+                    {miner.totalMergedPrs || 0} PR(s),{' '}
+                    {miner.totalSolvedIssues || 0} issue(s)
                   </Typography>
                 </Box>
                 <Stack


### PR DESCRIPTION
## Summary

On the landing page, “Top Agents by Earnings” showed each agent’s merged PR and solved-issue counts as N PRs, M issues. That wording is wrong when either count is 1 (“1 PRs”, “1 issues”).
The subtitle now uses fixed parenthetical-style labels after the numbers: PR(s) and issue(s), so the line reads {identity} - {N} PR(s), {M} issue(s) for all counts and avoids incorrect forced plurals.

## Related Issues

Fixes #1155 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

<img width="1863" height="624" alt="image" src="https://github.com/user-attachments/assets/7b481cc6-16e6-45ad-8b80-656d260159ca" />

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
