### PR TITLE
fix(watchlist): prevent phantom miners from leaking into watchlist via /miners/details with an unknown id

### DIFF
--- a/src/pages/MinerDetailsPage.tsx
+++ b/src/pages/MinerDetailsPage.tsx
@@ -15,6 +15,7 @@ import {
   SEO,
 } from '../components';
 import { WatchlistButton } from '../components/common';
+import { useMinerStats } from '../api';
 
 type ViewMode = 'prs' | 'issues';
 
@@ -84,6 +85,13 @@ const MinerDetailsPage: React.FC = () => {
     setSearchParams(p, { replace: true });
   };
 
+  const { data: minerStats, isLoading: isLoadingMinerStats } = useMinerStats(
+    githubId ?? '',
+  );
+  // Only show the star once we've confirmed the miner exists — otherwise
+  // users can pin phantom entries via /miners/details?githubId=<anything>.
+  const minerExists = !isLoadingMinerStats && !!minerStats;
+
   if (!githubId) {
     return <Navigate to="/top-miners" replace />;
   }
@@ -131,11 +139,13 @@ const MinerDetailsPage: React.FC = () => {
               }}
             >
               <BackButton to="/top-miners" mb={0} />
-              <WatchlistButton
-                category="miners"
-                itemKey={githubId}
-                size="medium"
-              />
+              {minerExists && (
+                <WatchlistButton
+                  category="miners"
+                  itemKey={githubId}
+                  size="medium"
+                />
+              )}
             </Box>
             <Box
               sx={{

--- a/src/pages/WatchlistPage.tsx
+++ b/src/pages/WatchlistPage.tsx
@@ -919,6 +919,7 @@ const WatchlistOptionsButton: React.FC<WatchlistOptionsButtonProps> = ({
 
 const MinersList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
   const { data: allMinersStats, isLoading } = useAllMiners();
+  const { remove } = useWatchlist('miners');
   const watchedSet = useMemo(() => new Set(itemKeys), [itemKeys]);
 
   const minerStats = useMemo(() => {
@@ -933,8 +934,50 @@ const MinersList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
       }));
   }, [allMinersStats, watchedSet]);
 
+  const unresolvedIds = useMemo(() => {
+    if (isLoading || !allMinersStats) return [];
+    const known = new Set(allMinersStats.map((m) => m.githubId));
+    return itemKeys.filter((id) => !known.has(id));
+  }, [allMinersStats, isLoading, itemKeys]);
+
+  const handleRemoveUnresolved = useCallback(() => {
+    unresolvedIds.forEach((id) => remove(id));
+  }, [unresolvedIds, remove]);
+
   return (
-    <Box sx={{ width: '100%' }}>
+    <Box
+      sx={{ width: '100%', display: 'flex', flexDirection: 'column', gap: 2 }}
+    >
+      {unresolvedIds.length > 0 && (
+        <Card
+          sx={(theme) => ({
+            p: 1.5,
+            display: 'flex',
+            alignItems: { xs: 'flex-start', sm: 'center' },
+            justifyContent: 'space-between',
+            gap: 1.5,
+            flexDirection: { xs: 'column', sm: 'row' },
+            backgroundColor: alpha(theme.palette.status.warningOrange, 0.08),
+            border: `1px solid ${alpha(theme.palette.status.warningOrange, 0.3)}`,
+          })}
+          elevation={0}
+        >
+          <Typography sx={{ fontSize: '0.85rem', color: 'text.secondary' }}>
+            {unresolvedIds.length} watched{' '}
+            {unresolvedIds.length === 1 ? 'miner' : 'miners'} could not be
+            loaded (the account may not be tracked by Gittensor).
+          </Typography>
+          <Button
+            size="small"
+            variant="outlined"
+            color="warning"
+            onClick={handleRemoveUnresolved}
+            sx={{ textTransform: 'none', flexShrink: 0 }}
+          >
+            Remove unresolved
+          </Button>
+        </Card>
+      )}
       <TopMinersTable
         miners={minerStats}
         isLoading={isLoading}


### PR DESCRIPTION
Closes #1159

## Summary

The Miner Details page renders the "add to watchlist" star button as soon as a `githubId` is present in the URL - before the underlying miner data has been fetched. This makes it possible to pin a miner that doesn't actually exist (e.g. by manually visiting `/miners/details?githubId=123456789`), which leaks a phantom entry into the watchlist that can never be opened to anything but a "No data found" error page.

It also produces a visible inconsistency in the watchlist itself: the sidebar/category badge counts every id in storage, but the miners table inner-joins against `useAllMiners()` and silently drops anything that doesn't resolve - so the badge can read "Watchlist 2" while the visible list shows zero or one miner, with no way for the user to clean up the difference.

The repository and PR/issue detail pages already gate their watchlist buttons behind a successful data fetch - only the miner details page was missing this guard.

## Changes

- [`src/pages/MinerDetailsPage.tsx`](src/pages/MinerDetailsPage.tsx) - call `useMinerStats(githubId)` at the page level and render `<WatchlistButton>` only after the fetch resolves with a real record. While loading, or when the miner is unknown, the star is hidden. (TanStack Query dedupes against the existing call inside `MinerScoreCard`, so this adds no extra network traffic.)
- [`src/pages/WatchlistPage.tsx`](src/pages/WatchlistPage.tsx) - `MinersList` now detects unresolved watched ids (entries that aren't in the all-miners cache once it's loaded) and surfaces them as a warning card with a one-click **Remove unresolved** action. The visible list is unchanged for resolved miners.

## Verification

1. Open `/miners/details?githubId=123456789` in an incognito window. While the request is in flight the star is absent; once the API responds with no record the star stays hidden and the page collapses to the existing "No data found" card. The star can no longer be clicked.
2. Open a real miner profile (e.g. via the leaderboard). The star renders as before after the page data loads, and toggling it adds/removes the miner from the watchlist exactly as it did previously.
3. Pre-seed a phantom watchlist entry from DevTools - `localStorage.setItem('gittensor.watchlist.v2', JSON.stringify({ miners: ['999999'], repos: [], bounties: [], prs: [], issues: [] }))` - then reload `/watchlist`. The sidebar badge reads "1", and the miners tab now shows a warning card explaining the entry couldn't be loaded with a **Remove unresolved** button that clears it. Clicking it removes the entry from localStorage and the badge updates to "0".
4. The unresolved card only appears once `useAllMiners()` has finished loading, so a slow network won't cause a false positive on first paint.

## Recording


https://github.com/user-attachments/assets/819e8c7b-c48e-4654-8898-3122b8107195

