### PR TITLE
fix(miners): render PR lifecycle dates

### DIFF
--- a/src/api/models/Dashboard.ts
+++ b/src/api/models/Dashboard.ts
@@ -153,8 +153,8 @@ export type CommitLog = {
   commitCount: number;
   repository: string;
   mergedAt: string | null;
-  closedAt: string | null;
-  prCreatedAt: string;
+  closedAt?: string | null;
+  prCreatedAt?: string | null;
   prState: string;
   collateralScore?: string;
   author: string;

--- a/src/components/miners/MinerPRsTable.tsx
+++ b/src/components/miners/MinerPRsTable.tsx
@@ -21,6 +21,8 @@ import {
   getPrStatusCounts,
   isOutsideScoringWindow,
   paginateItems,
+  formatPrLifecycleDate,
+  getPrLifecycleDate,
   type PrStatusFilter,
 } from '../../utils';
 import {
@@ -182,8 +184,8 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
           cmp = a.additions + a.deletions - (b.additions + b.deletions);
           break;
         case 'date': {
-          const da = a.mergedAt || a.prCreatedAt || '';
-          const db = b.mergedAt || b.prCreatedAt || '';
+          const da = getPrLifecycleDate(a) || '';
+          const db = getPrLifecycleDate(b) || '';
           cmp = da.localeCompare(db);
           break;
         }
@@ -414,12 +416,7 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
         fontSize: { xs: '0.75rem', sm: '0.85rem' },
         color: (theme) => alpha(theme.palette.text.primary, 0.7),
       },
-      renderCell: (pr) =>
-        pr.mergedAt
-          ? new Date(pr.mergedAt).toLocaleDateString()
-          : pr.prState === 'CLOSED'
-            ? 'Closed'
-            : 'Open',
+      renderCell: (pr) => formatPrLifecycleDate(pr),
     },
     {
       key: 'watch',

--- a/src/components/repositories/RepositoryPrActivityChart.tsx
+++ b/src/components/repositories/RepositoryPrActivityChart.tsx
@@ -303,10 +303,10 @@ const RepositoryPrActivityChart: React.FC<RepositoryPrActivityChartProps> = ({
     const bucket = axis[0]?.bucket ?? bucketDayKey;
     const first = isIssueMode
       ? countByKey(issueRows, axisKeys, (issue) => issue.createdAt, bucket)
-      : countByKey(repoPrs, axisKeys, (pr) => pr.prCreatedAt, bucket);
+      : countByKey(repoPrs, axisKeys, (pr) => pr.prCreatedAt ?? null, bucket);
     const second = isIssueMode
       ? countByKey(issueRows, axisKeys, (issue) => issue.closedAt, bucket)
-      : countByKey(repoPrs, axisKeys, (pr) => pr.mergedAt, bucket);
+      : countByKey(repoPrs, axisKeys, (pr) => pr.mergedAt ?? null, bucket);
     const hasAnyLocal = first.some((n) => n > 0) || second.some((n) => n > 0);
     return {
       labels: labelsLocal,

--- a/src/pages/dashboard/dashboardData.ts
+++ b/src/pages/dashboard/dashboardData.ts
@@ -352,8 +352,6 @@ const getPrOverviewMetrics = (prs: CommitLog[], window: WindowBounds) => {
     const normalizedState = getPrStatusLabel(pr);
     const createdInWindow = isWithinWindow(toTimestamp(pr.prCreatedAt), window);
     const mergedInWindow = isWithinWindow(toTimestamp(pr.mergedAt), window);
-    // API does not currently return closedAt for PRs — fall back to
-    // prCreatedAt so closed PRs are still tracked within the window.
     const closedInWindow = isWithinWindow(
       toTimestamp(pr.closedAt ?? pr.prCreatedAt),
       window,

--- a/src/pages/dashboard/views/LiveCommitLog.tsx
+++ b/src/pages/dashboard/views/LiveCommitLog.tsx
@@ -61,7 +61,7 @@ interface CommitLogEntry {
   commitCount: number;
   repository: string;
   mergedAt: string | null;
-  prCreatedAt: string;
+  prCreatedAt?: string | null;
   prState?: string;
   author: string;
   score: string;

--- a/src/pages/search/searchData.ts
+++ b/src/pages/search/searchData.ts
@@ -10,7 +10,7 @@ import {
   type Repository,
 } from '../../api/models/Dashboard';
 import { useSearchDatasets } from '../../api/SearchApi';
-import { parseNumber } from '../../utils';
+import { getPrLifecycleDate, parseNumber } from '../../utils';
 
 export const MIN_SEARCH_QUERY_LENGTH = 2;
 
@@ -219,7 +219,10 @@ const getPrSearchResults = (
             pr.prState || '',
             String(pr.pullRequestNumber || ''),
           ],
-    (pr) => new Date(pr.mergedAt ?? pr.prCreatedAt).getTime(),
+    (pr) => {
+      const date = getPrLifecycleDate(pr);
+      return date ? new Date(date).getTime() : 0;
+    },
   );
 
   return limitResults(results, limit);

--- a/src/tests/prTable.test.ts
+++ b/src/tests/prTable.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import type { CommitLog } from '../api';
+import { formatPrLifecycleDate, getPrLifecycleDate } from '../utils';
+
+const pr = (overrides: Partial<CommitLog>): CommitLog =>
+  ({
+    pullRequestNumber: 1,
+    hotkey: 'hk',
+    pullRequestTitle: 'Title',
+    additions: 0,
+    deletions: 0,
+    commitCount: 1,
+    repository: 'owner/repo',
+    mergedAt: null,
+    closedAt: null,
+    prCreatedAt: '2026-05-01T12:00:00.000Z',
+    prState: 'OPEN',
+    author: 'alice',
+    score: '0',
+    ...overrides,
+  }) as CommitLog;
+
+describe('PR lifecycle dates', () => {
+  it('prefers mergedAt for merged PRs', () => {
+    const mergedAt = '2026-05-03T12:00:00.000Z';
+
+    expect(
+      getPrLifecycleDate(
+        pr({
+          mergedAt,
+          closedAt: '2026-05-04T12:00:00.000Z',
+          prState: 'MERGED',
+        }),
+      ),
+    ).toBe(mergedAt);
+  });
+
+  it('uses closedAt for closed unmerged PRs', () => {
+    const closedAt = '2026-05-02T12:00:00.000Z';
+
+    expect(getPrLifecycleDate(pr({ closedAt, prState: 'CLOSED' }))).toBe(
+      closedAt,
+    );
+  });
+
+  it('uses prCreatedAt for open PRs', () => {
+    const prCreatedAt = '2026-05-01T12:00:00.000Z';
+
+    expect(getPrLifecycleDate(pr({ prCreatedAt, prState: 'OPEN' }))).toBe(
+      prCreatedAt,
+    );
+  });
+
+  it('falls back to a dash when the API omits the expected date', () => {
+    expect(formatPrLifecycleDate(pr({ prCreatedAt: null }))).toBe('-');
+  });
+});

--- a/src/utils/prTable.ts
+++ b/src/utils/prTable.ts
@@ -3,6 +3,21 @@ import { isClosedUnmergedPr, isMergedPr, isOpenPr } from './prStatus';
 
 export type PrStatusFilter = 'all' | 'open' | 'merged' | 'closed';
 
+export const getPrLifecycleDate = (
+  pr: Pick<CommitLog, 'mergedAt' | 'closedAt' | 'prCreatedAt' | 'prState'>,
+) => {
+  if (isMergedPr(pr)) return pr.mergedAt;
+  if (isClosedUnmergedPr(pr)) return pr.closedAt;
+  return pr.prCreatedAt;
+};
+
+export const formatPrLifecycleDate = (
+  pr: Pick<CommitLog, 'mergedAt' | 'closedAt' | 'prCreatedAt' | 'prState'>,
+) => {
+  const date = getPrLifecycleDate(pr);
+  return date ? new Date(date).toLocaleDateString() : '-';
+};
+
 interface FilterPrsOptions {
   author?: string | null;
   includeNumber?: boolean;


### PR DESCRIPTION
## Summary

Related to #1120. This keeps the UI ready for the backend fields requested there by rendering the correct PR lifecycle date in `MinerPRsTable`:

- merged PRs render `mergedAt`
- closed unmerged PRs render `closedAt`
- open PRs render `prCreatedAt`
- missing API fields still fall back to `-`

It also normalizes the shared PR model and related consumers so optional `closedAt` / `prCreatedAt` values are handled consistently.

## Why

`GET /miners/:id/prs` currently exposes `mergedAt`, but #1120 tracks adding `closedAt` and `prCreatedAt`. Without this UI handling, non-merged rows cannot show their lifecycle date once those fields are available.

## Screenshots

Live before/after screenshots are not useful yet because the current test API still omits `closedAt` and `prCreatedAt` on `/miners/:id/prs`, so the UI correctly renders the fallback `-` for those missing values. The lifecycle selection is covered with unit tests until the backend fields are present on the wire.

## Validation

- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm test` (4 files, 31 tests)

Build completed successfully. Vite still reports the existing dynamic-import/chunk-size warnings.

## Notes

This replaces closed PR #1121 after the branch was rebased onto current `test` and kept as one clean commit.

Close: #1120 
