### PR TITLE
Add bounty pool chart to watchlist

### DIFF
--- a/src/components/issues/IssuesList.tsx
+++ b/src/components/issues/IssuesList.tsx
@@ -39,6 +39,7 @@ import ReactECharts from 'echarts-for-react';
 import { format } from 'date-fns';
 import { IssueBounty } from '../../api/models/Issues';
 import { usePrices } from '../../hooks/usePrices';
+import { parseBountyAmount } from '../../utils/bountyAmount';
 import {
   formatAlphaToUsd,
   formatDate,
@@ -103,11 +104,6 @@ const SORT_LABELS: Record<SortKey, string> = {
   funding: 'Funding',
   solver: 'Solver',
   date: 'Date',
-};
-
-const parseBountyAmount = (value: string | null | undefined): number => {
-  const parsed = Number.parseFloat(value ?? '0');
-  return Number.isFinite(parsed) ? parsed : 0;
 };
 
 interface IssuesListProps {

--- a/src/pages/WatchlistPage.tsx
+++ b/src/pages/WatchlistPage.tsx
@@ -101,6 +101,7 @@ import { filterPrs, type PrStatusFilter } from '../utils/prTable';
 import { getIssueStatusMeta } from '../utils/issueStatus';
 import { formatDate, formatTokenAmount } from '../utils/format';
 import { compareByWatchlist } from '../utils/watchlistSort';
+import { parseBountyAmount } from '../utils/bountyAmount';
 import { buildBountyPoolByRepositoryRows } from '../utils/bountyPoolByRepository';
 import { getRepositoryOwnerAvatarSrc } from '../utils/avatar';
 import theme, {
@@ -2257,11 +2258,6 @@ const bountyVisibleSortKeysForFilter = (
   return [...common, 'bounty', 'status'];
 };
 
-const parseBountyAmount = (value: string | null | undefined): number => {
-  const parsed = Number.parseFloat(value ?? '0');
-  return Number.isFinite(parsed) ? parsed : 0;
-};
-
 const getBountySortValue = (
   issue: IssueBounty,
   key: BountySortKey,
@@ -2888,36 +2884,40 @@ const BountiesList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
       </DebouncedSearchInput>
 
       <Collapse in={showChart}>
-        <Box
-          sx={{
-            p: 2,
-            borderBottom: '1px solid',
-            borderColor: 'border.light',
-            height: '500px',
-            backgroundColor: 'surface.subtle',
-          }}
-        >
-          {showChart && filtered.length > 0 ? (
-            <ReactECharts
-              option={chartOption}
-              style={{ height: '100%', width: '100%' }}
-              notMerge
-            />
-          ) : (
-            <Box
-              sx={{
-                height: '100%',
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-              }}
-            >
-              <Typography sx={{ color: 'text.secondary', fontSize: '0.85rem' }}>
-                No watched bounties found.
-              </Typography>
-            </Box>
-          )}
-        </Box>
+        {showChart ? (
+          <Box
+            sx={{
+              p: 2,
+              borderBottom: '1px solid',
+              borderColor: 'border.light',
+              height: '500px',
+              backgroundColor: 'surface.subtle',
+            }}
+          >
+            {filtered.length > 0 ? (
+              <ReactECharts
+                option={chartOption}
+                style={{ height: '100%', width: '100%' }}
+                notMerge
+              />
+            ) : (
+              <Box
+                sx={{
+                  height: '100%',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                }}
+              >
+                <Typography
+                  sx={{ color: 'text.secondary', fontSize: '0.85rem' }}
+                >
+                  No watched bounties found.
+                </Typography>
+              </Box>
+            )}
+          </Box>
+        ) : null}
       </Collapse>
 
       {viewMode === 'list' ? (

--- a/src/pages/WatchlistPage.tsx
+++ b/src/pages/WatchlistPage.tsx
@@ -101,6 +101,7 @@ import { filterPrs, type PrStatusFilter } from '../utils/prTable';
 import { getIssueStatusMeta } from '../utils/issueStatus';
 import { formatDate, formatTokenAmount } from '../utils/format';
 import { compareByWatchlist } from '../utils/watchlistSort';
+import { buildBountyPoolByRepositoryRows } from '../utils/bountyPoolByRepository';
 import { getRepositoryOwnerAvatarSrc } from '../utils/avatar';
 import theme, {
   CHART_COLORS,
@@ -2532,6 +2533,7 @@ const BountiesList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
 
   const [sortField, setSortField] = useState<BountySortKey>('id');
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc');
+  const [showChart, setShowChart] = useState(false);
 
   const bountyVisibleSortKeys = useMemo(
     () => bountyVisibleSortKeysForFilter(statusFilter),
@@ -2600,6 +2602,93 @@ const BountiesList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
     });
     return decorated.map((d) => d.row);
   }, [filtered, sortField, sortOrder]);
+
+  const chartOption = useMemo(() => {
+    const rows = buildBountyPoolByRepositoryRows(filtered);
+    const textColor = alpha(theme.palette.common.white, 0.85);
+    const gridColor = theme.palette.border.subtle;
+
+    return {
+      backgroundColor: 'transparent',
+      title: {
+        text: 'Bounty Pool by Repository',
+        subtext: `${filtered.length} watched issues`,
+        left: 'center',
+        top: 20,
+        textStyle: {
+          color: theme.palette.text.primary,
+          fontFamily: 'JetBrains Mono',
+          fontSize: 16,
+          fontWeight: 600,
+        },
+        subtextStyle: {
+          color: alpha(theme.palette.common.white, TEXT_OPACITY.tertiary),
+          fontFamily: 'JetBrains Mono',
+          fontSize: 12,
+        },
+      },
+      tooltip: {
+        trigger: 'axis',
+        axisPointer: { type: 'shadow' },
+        backgroundColor: alpha(theme.palette.background.default, 0.95),
+        borderColor: alpha(theme.palette.common.white, 0.15),
+        borderWidth: 1,
+        textStyle: {
+          color: theme.palette.text.primary,
+          fontFamily: 'JetBrains Mono',
+        },
+        formatter: (params: { name: string; value: number }[]) => {
+          const p = params[0];
+          return `${p.name}: ${p.value.toFixed(4)} ل`;
+        },
+      },
+      grid: {
+        left: '3%',
+        right: '3%',
+        bottom: '15%',
+        top: '20%',
+        containLabel: true,
+      },
+      xAxis: {
+        type: 'category',
+        data: rows.map((row) => row.label),
+        axisLabel: {
+          color: textColor,
+          fontFamily: 'JetBrains Mono',
+          rotate: 45,
+          interval: 0,
+        },
+        axisLine: { lineStyle: { color: gridColor } },
+      },
+      yAxis: {
+        type: 'value',
+        name: 'Bounty (ل)',
+        nameTextStyle: { color: textColor, fontFamily: 'JetBrains Mono' },
+        axisLabel: { color: textColor, fontFamily: 'JetBrains Mono' },
+        splitLine: { lineStyle: { color: gridColor, type: 'dashed' } },
+      },
+      series: [
+        {
+          data: rows.map((row) => row.value),
+          type: 'bar',
+          itemStyle: {
+            color: {
+              type: 'linear',
+              x: 0,
+              y: 0,
+              x2: 0,
+              y2: 1,
+              colorStops: [
+                { offset: 0, color: theme.palette.primary.main },
+                { offset: 1, color: theme.palette.status.info },
+              ],
+            },
+            borderRadius: [4, 4, 0, 0],
+          },
+        },
+      ],
+    };
+  }, [filtered]);
 
   const totalBountyPages = Math.max(
     1,
@@ -2748,6 +2837,34 @@ const BountiesList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
                 </Tooltip>
               </Box>
             }
+            extraContent={
+              <Box>
+                <OptionsLabel>Chart</OptionsLabel>
+                <Tooltip title={showChart ? 'Hide Chart' : 'Show Chart'} arrow>
+                  <IconButton
+                    onClick={() => setShowChart((v) => !v)}
+                    size="small"
+                    sx={{
+                      color: showChart ? 'text.primary' : 'text.tertiary',
+                      border: '1px solid',
+                      borderColor: 'border.light',
+                      borderRadius: 2,
+                      padding: '6px',
+                      '&:hover': {
+                        backgroundColor: 'surface.light',
+                        borderColor: 'border.medium',
+                      },
+                    }}
+                  >
+                    {showChart ? (
+                      <TableChartIcon fontSize="small" />
+                    ) : (
+                      <BarChartIcon fontSize="small" />
+                    )}
+                  </IconButton>
+                </Tooltip>
+              </Box>
+            }
             searchValue={draftValue}
             searchPlaceholder="Search bounties..."
             onSearchChange={setDraftValue}
@@ -2769,6 +2886,39 @@ const BountiesList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
           />
         )}
       </DebouncedSearchInput>
+
+      <Collapse in={showChart}>
+        <Box
+          sx={{
+            p: 2,
+            borderBottom: '1px solid',
+            borderColor: 'border.light',
+            height: '500px',
+            backgroundColor: 'surface.subtle',
+          }}
+        >
+          {showChart && filtered.length > 0 ? (
+            <ReactECharts
+              option={chartOption}
+              style={{ height: '100%', width: '100%' }}
+              notMerge
+            />
+          ) : (
+            <Box
+              sx={{
+                height: '100%',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+              }}
+            >
+              <Typography sx={{ color: 'text.secondary', fontSize: '0.85rem' }}>
+                No watched bounties found.
+              </Typography>
+            </Box>
+          )}
+        </Box>
+      </Collapse>
 
       {viewMode === 'list' ? (
         <DataTable<IssueBounty, BountySortKey>

--- a/src/tests/bountyPoolByRepository.test.ts
+++ b/src/tests/bountyPoolByRepository.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import type { IssueBounty } from '../api/models/Issues';
+import { buildBountyPoolByRepositoryRows } from '../utils/bountyPoolByRepository';
+
+const issue = (
+  id: number,
+  repositoryFullName: string,
+  targetBounty: string,
+): IssueBounty => ({
+  id,
+  repositoryFullName,
+  targetBounty,
+  githubUrl: `https://github.com/${repositoryFullName}/issues/${id}`,
+  issueNumber: id,
+  bountyAmount: targetBounty,
+  status: 'active',
+  solverHotkey: null,
+  winningPrNumber: null,
+  registeredAtBlock: 1,
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-01T00:00:00Z',
+  closedAt: null,
+  completedAt: null,
+  title: `Issue ${id}`,
+});
+
+describe('buildBountyPoolByRepositoryRows', () => {
+  it('aggregates bounty pool by repository and sorts descending', () => {
+    const rows = buildBountyPoolByRepositoryRows([
+      issue(1, 'owner/a', '1.5'),
+      issue(2, 'owner/b', '4'),
+      issue(3, 'owner/a', '2.25'),
+    ]);
+
+    expect(rows).toEqual([
+      { repository: 'owner/b', label: 'b', value: 4 },
+      { repository: 'owner/a', label: 'a', value: 3.75 },
+    ]);
+  });
+
+  it('limits rows and treats invalid amounts as zero', () => {
+    const rows = buildBountyPoolByRepositoryRows(
+      [
+        issue(1, 'owner/a', 'not-a-number'),
+        issue(2, 'owner/b', '2'),
+        issue(3, 'owner/c', '1'),
+      ],
+      2,
+    );
+
+    expect(rows).toEqual([
+      { repository: 'owner/b', label: 'b', value: 2 },
+      { repository: 'owner/c', label: 'c', value: 1 },
+    ]);
+  });
+});

--- a/src/utils/bountyAmount.ts
+++ b/src/utils/bountyAmount.ts
@@ -1,0 +1,4 @@
+export const parseBountyAmount = (value: string | null | undefined): number => {
+  const parsed = Number.parseFloat(value ?? '0');
+  return Number.isFinite(parsed) ? parsed : 0;
+};

--- a/src/utils/bountyPoolByRepository.ts
+++ b/src/utils/bountyPoolByRepository.ts
@@ -1,0 +1,36 @@
+import type { IssueBounty } from '../api/models/Issues';
+
+export interface BountyPoolByRepositoryRow {
+  repository: string;
+  label: string;
+  value: number;
+}
+
+const parseBountyAmount = (value: string | null | undefined): number => {
+  const parsed = Number.parseFloat(value ?? '0');
+  return Number.isFinite(parsed) ? parsed : 0;
+};
+
+export const buildBountyPoolByRepositoryRows = (
+  issues: IssueBounty[],
+  limit = 20,
+): BountyPoolByRepositoryRow[] => {
+  const repoTotals = new Map<string, number>();
+
+  issues.forEach((issue) => {
+    const amount = parseBountyAmount(issue.targetBounty);
+    repoTotals.set(
+      issue.repositoryFullName,
+      (repoTotals.get(issue.repositoryFullName) || 0) + amount,
+    );
+  });
+
+  return [...repoTotals.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, limit)
+    .map(([repository, value]) => ({
+      repository,
+      label: repository.split('/')[1] || repository,
+      value,
+    }));
+};

--- a/src/utils/bountyPoolByRepository.ts
+++ b/src/utils/bountyPoolByRepository.ts
@@ -1,15 +1,11 @@
 import type { IssueBounty } from '../api/models/Issues';
+import { parseBountyAmount } from './bountyAmount';
 
 export interface BountyPoolByRepositoryRow {
   repository: string;
   label: string;
   value: number;
 }
-
-const parseBountyAmount = (value: string | null | undefined): number => {
-  const parsed = Number.parseFloat(value ?? '0');
-  return Number.isFinite(parsed) ? parsed : 0;
-};
 
 export const buildBountyPoolByRepositoryRows = (
   issues: IssueBounty[],


### PR DESCRIPTION
## Summary

- Add a Watchlist > Bounties Chart control in Options.
- Render a Bounty Pool by Repository bar chart from the currently filtered watched bounties.
- Add a focused aggregation utility and unit tests for totals, sorting, limits, and invalid amounts.

## Related Issues

Fixes #1018

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

Before screenshots are in #1018. After verification was completed in the in-app browser with real test API data: added 3 bounties to Watchlist > Bounties, opened Options > Chart, observed the toggle switch to Hide Chart, and confirmed a visible ECharts canvas was mounted. The local browser screenshot command timed out during capture, so I am leaving the verification details here rather than attaching a stale/generated image.

## Verification

- [x] `npm test -- --run src/tests/bountyPoolByRepository.test.ts`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run build`
- [x] Tested against the test API via local CORS proxy to `https://test-api.gittensor.io`

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked via constrained chart container and existing Watchlist layout controls
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run where applicable by the commit hook; `npm run format:check` and `npm run lint` pass
- [x] `npm run build` passes
- [ ] Screenshots included for any UI/visual changes — screenshot capture timed out; see verification notes above