### PR TITLE
fix(leaderboard): make rank column reflect active sort column and dir…

### DIFF
--- a/src/components/leaderboard/TopMinersTable.tsx
+++ b/src/components/leaderboard/TopMinersTable.tsx
@@ -330,15 +330,17 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
     [setFilter],
   );
 
-  // Rank is computed on the full sorted leaderboard so each miner keeps their
-  // true position regardless of filters. Filtering (search / eligibility) then
-  // only hides rows without renumbering the ones that remain. Sort direction
-  // is included so the list view's asc/desc toggle ranks consistently.
+  // Rank is column-specific: it's the position when sorted by the active
+  // metric, descending. Switching ASC just reverses the list (so the last-
+  // place miner ends up at the top with their actual last-place rank, not
+  // "1"). Filters apply downstream and never renumber the rows they keep.
   const rankedMiners = useMemo(() => {
-    const dir = sortDirection === 'asc' ? 1 : -1;
-    return [...miners]
-      .sort((a, b) => compareMiners(a, b, sortOption, isWatched) * dir)
+    const canonicalDesc = [...miners]
+      .sort((a, b) => -compareMiners(a, b, sortOption, isWatched))
       .map((miner, index) => ({ ...miner, rank: index + 1 }));
+    return sortDirection === 'desc'
+      ? canonicalDesc
+      : canonicalDesc.slice().reverse();
   }, [miners, sortOption, sortDirection, isWatched]);
 
   const filteredMiners = useMemo(() => {


### PR DESCRIPTION
## Summary

In the list view of the leaderboards (`/top-miners`, `/discoveries`, `/watchlist`), the Rank column was just "row number in the current sort" — re-numbered starting at `1` from the top regardless of direction. Two visible symptoms came out of that:

1. **The gold/silver/bronze "1/2/3" badges landed on the worst miners in any ascending sort.** Sort Credibility ascending (ASC) and the miner with the *lowest* credibility shows up at the top of the list with the gold "# 1" badge. Same for Score ASC, Earnings ASC, etc.

2. **ASC and descending (DESC) of the same column didn't mirror each other.** Because rank was always re-numbered from the top, flipping direction reshuffled the rank values across miners instead of just turning the list upside-down. The same miner could be rank "1" in ASC and rank "N" in DESC, even though their actual standing hadn't moved.

### Fix

`rankedMiners` in `TopMinersTable.tsx` now derives rank from the active column in its *descending* (canonical) direction, then reverses the list for ASC. Rank "1" / the gold badge consistently means "best by the column you're viewing," and ASC of any column is `N, N-1, … 1` top-to-bottom — so the last-place miner shows up at the top with their actual last-place rank. Filters still apply downstream and never renumber.


## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)


## Screenshots

**Before:**
<img width="1919" height="1079" alt="Before - Credibility" src="https://github.com/user-attachments/assets/c6b9da44-b570-4b68-8af8-0256758fb9db" />
<img width="1919" height="1079" alt="Before - Earnings" src="https://github.com/user-attachments/assets/b3afaff7-bbbc-4d26-8cc5-d6659d85fbe3" />

**After:**
<img width="1919" height="1079" alt="After - Credibility" src="https://github.com/user-attachments/assets/6c7ad3d3-ae0c-4e58-807d-fc8a8c9ace1b" />
<img width="1919" height="1079" alt="After - Earnings" src="https://github.com/user-attachments/assets/40e7f3e6-e07a-43e8-af84-c98bdcbcc3f9" />


## Additional Video

https://github.com/user-attachments/assets/968cb108-0e72-4772-a374-415b37e68fd9


## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes