### PR TITLE
Keep miner score controls visible without PRs

### DIFF
--- a/src/components/miners/MinerScoreBreakdown.tsx
+++ b/src/components/miners/MinerScoreBreakdown.tsx
@@ -1187,7 +1187,7 @@ const PrBreakdownView: React.FC<{ githubId: string }> = ({ githubId }) => {
     </DebouncedSearchInput>
   );
 
-  if (isLoading || !prs || prs.length === 0) return null;
+  if (isLoading || !prs) return null;
 
   return (
     <Card sx={{ p: 0, overflow: 'hidden' }} elevation={0}>


### PR DESCRIPTION
## Summary
- keep the miner score breakdown card rendered when a miner has zero PRs
- preserve the existing filter buttons, rows selector, search field, and empty-state copy instead of returning null

Fixes #1133

## Verification
- npm run lint
- npm run build
- in-app browser: opened `http://localhost:8080/miners/details?githubId=94741984&mode=prs&tab=overview` with test API data where `/miners/94741984/prs` returns an empty array; observed Score Breakdown, All/Open/Merged/Closed filters, Rows selector, search input, and `No PRs to show.`