### PR TITLE
fix: show actual dates instead of Open/Closed in PR Date column (#1111)

### DIFF
--- a/src/components/miners/MinerPRsTable.tsx
+++ b/src/components/miners/MinerPRsTable.tsx
@@ -182,8 +182,8 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
           cmp = a.additions + a.deletions - (b.additions + b.deletions);
           break;
         case 'date': {
-          const da = a.mergedAt || a.prCreatedAt || '';
-          const db = b.mergedAt || b.prCreatedAt || '';
+          const da = a.mergedAt || a.closedAt || a.prCreatedAt || '';
+          const db = b.mergedAt || b.closedAt || b.prCreatedAt || '';
           cmp = da.localeCompare(db);
           break;
         }

--- a/src/components/miners/MinerPRsTable.tsx
+++ b/src/components/miners/MinerPRsTable.tsx
@@ -414,12 +414,10 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
         fontSize: { xs: '0.75rem', sm: '0.85rem' },
         color: (theme) => alpha(theme.palette.text.primary, 0.7),
       },
-      renderCell: (pr) =>
-        pr.mergedAt
-          ? new Date(pr.mergedAt).toLocaleDateString()
-          : pr.prState === 'CLOSED'
-            ? 'Closed'
-            : 'Open',
+      renderCell: (pr) => {
+        const dateStr = pr.mergedAt || pr.closedAt || pr.prCreatedAt;
+        return dateStr ? new Date(dateStr).toLocaleDateString() : null;
+      },
     },
     {
       key: 'watch',

--- a/src/pages/search/PullRequestsTab.tsx
+++ b/src/pages/search/PullRequestsTab.tsx
@@ -17,9 +17,8 @@ const formatPrScore = (pr: CommitLog) => {
 };
 
 const formatPrDateOrStatus = (pr: CommitLog) => {
-  if (pr.mergedAt) return new Date(pr.mergedAt).toLocaleDateString();
-  if (pr.prState === 'CLOSED') return 'Closed';
-  return 'Open';
+  const dateStr = pr.mergedAt || pr.closedAt || pr.prCreatedAt;
+  return dateStr ? new Date(dateStr).toLocaleDateString() : '';
 };
 
 const prColumns: DataTableColumn<CommitLog>[] = [


### PR DESCRIPTION
## Summary

The PR table Date column rendered literal strings `Open`/`Closed` for non-merged PRs instead of actual dates, duplicating status info already shown in the Status column and tabs while hiding the real date.

Fix: use `pr.closedAt || pr.prCreatedAt` fallback instead of hardcoded `Open`/`Closed` strings in `MinerPRsTable` and search `PullRequestsTab`.

## Validation

- [x] `npm run build` — no regressions
- [x] Merged PRs still show `mergedAt`
- [x] Closed PRs show `closedAt` (or `prCreatedAt` fallback)
- [x] Open PRs show `prCreatedAt`

Closes #1111