### PR TITLE
fix: show in-view rank indicator when leaderboard filters are active (#1102)

### DIFF
--- a/src/components/leaderboard/MinerCard.tsx
+++ b/src/components/leaderboard/MinerCard.tsx
@@ -219,11 +219,26 @@ export const MinerCard: React.FC<MinerCardProps> = ({
                   opacity: isEligible ? 1 : INACTIVE_OPACITY,
                   lineHeight: 1,
                   flexShrink: 0,
-                })}
-              >
-                #{miner.rank}
-              </Typography>
-            </Box>
+                 })}
+               >
+                 #{miner.rank}
+               </Typography>
+               {miner.viewRank != null && miner.viewRank !== miner.rank && (
+                 <Typography
+                   component="span"
+                   sx={(theme) => ({
+                     fontFamily: FONTS.mono,
+                     fontSize: '0.58rem',
+                     fontWeight: 500,
+                     color: theme.palette.text.tertiary,
+                     lineHeight: 1,
+                     flexShrink: 0,
+                   })}
+                 >
+                   ·{miner.viewRank} in view
+                 </Typography>
+               )}
+             </Box>
             {/* Badges under the name */}
             <Box
               sx={{

--- a/src/components/leaderboard/MinersList.tsx
+++ b/src/components/leaderboard/MinersList.tsx
@@ -120,7 +120,24 @@ export const MinersList: React.FC<MinersListProps> = ({
       header: 'Rank',
       width: '60px',
       cellSx: { pr: 0 },
-      renderCell: (miner) => <RankIcon rank={miner.rank ?? 0} />,
+      renderCell: (miner) => (
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
+          <RankIcon rank={miner.rank ?? 0} />
+          {miner.viewRank != null && miner.viewRank !== miner.rank && (
+            <Typography
+              component="span"
+              sx={{
+                fontSize: '0.6rem',
+                color: 'text.tertiary',
+                fontWeight: 500,
+                lineHeight: 1,
+              }}
+            >
+              ·{miner.viewRank}
+            </Typography>
+          )}
+        </Box>
+      ),
     },
     {
       key: 'miner',

--- a/src/components/leaderboard/TopMinersTable.tsx
+++ b/src/components/leaderboard/TopMinersTable.tsx
@@ -363,6 +363,16 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
       return passesSingleProgramEligibility(m, eligibleOssFilter);
     });
 
+    // Tag each miner with its position in the filtered subset so the UI
+    // can show a "· N in view" indicator when filters are active.
+    const hasActiveFilter =
+      searchQuery !== '' ||
+      eligibleOssFilter !== 'all' ||
+      eligibleDiscoveryFilter !== 'all';
+    if (hasActiveFilter) {
+      result = result.map((miner, index) => ({ ...miner, viewRank: index + 1 }));
+    }
+
     return result;
   }, [
     rankedMiners,

--- a/src/components/leaderboard/types.ts
+++ b/src/components/leaderboard/types.ts
@@ -17,6 +17,10 @@ export interface MinerStats {
   linesDeleted: number;
   hotkey: string;
   rank?: number;
+  /** Position in the current filtered subset (1-indexed). Only populated
+   *  when a search or eligibility filter is active, so the UI layer can
+   *  show a "· N in view" indicator beside the global rank. */
+  viewRank?: number;
   uniqueReposCount?: number;
   credibility?: number;
   isEligible?: boolean;


### PR DESCRIPTION
## Summary

The Rank column on Top Miners / Discoveries leaderboards always shows the global rank. When a filter is active, consecutive rows show gaps (16, 19, 23, 48, 94) with no UI indication that the gaps are caused by filtered-out miners. Users reasonably interpret this as a bug.

Fix (Option A): add a subtle "·N in view" indicator next to the global rank when filters are active and the two ranks diverge.

## Changes

- **types.ts**: add `viewRank` to `MinerStats` — 1-indexed position in filtered subset
- **TopMinersTable.tsx**: compute `viewRank` only when a search/eligibility filter is active
- **MinersList.tsx**: show `·{viewRank}` beside the RankIcon in list view
- **MinerCard.tsx**: show `·{viewRank} in view` next to the global rank on cards

## Edge cases

- No filter active → no indicator shown
- First row (rank=viewRank=1) → no indicator shown
- Pure search filter → indicator shown for mismatched rows
- Both search + eligibility → indicator shown correctly
- No backend changes — computed entirely in frontend

## Validation

- [x] 4 files, +52/−6, no new dependencies
- [x] Null-guarded: `viewRank != null` before comparison
- [x] Both card view and list view covered

Closes #1102