### PR TITLE
fix(watchlist): populate Resolved and Closed filters on Issues tab

### DIFF
--- a/src/api/MinerApi.ts
+++ b/src/api/MinerApi.ts
@@ -95,13 +95,14 @@ export const useMinerIssues = (githubId: string, enabled?: boolean) =>
     },
   );
 
+/** Subnet-launch `since` (2025-12-01 UTC). Module-level keeps the cache key stable. */
+export const MINER_ISSUES_FULL_HISTORY_SINCE_ISO = new Date(
+  Date.UTC(2025, 11, 1, 0, 0, 0),
+).toISOString();
+
 /**
- * Fan-out variant: one mirror-API call per miner, useful for the watchlist
- * and the dashboard issues-trend aggregation.
- *
- * `since` (ISO timestamp) is forwarded to the mirror as a query param. Omit
- * for the mirror's default 35-day window — this also keeps the cache key
- * stable across callers that don't need a custom range.
+ * One mirror call per miner. ⚠️ Omitting `since` returns OPEN-only rows —
+ * pass `MINER_ISSUES_FULL_HISTORY_SINCE_ISO` to include closed/resolved.
  */
 export const useMinersIssues = (
   githubIds: string[],

--- a/src/pages/WatchlistPage.tsx
+++ b/src/pages/WatchlistPage.tsx
@@ -70,6 +70,7 @@ import {
   useIssues,
   useAllPrs,
   useMinersIssues,
+  MINER_ISSUES_FULL_HISTORY_SINCE_ISO,
 } from '../api';
 import type {
   CommitLog,
@@ -4234,7 +4235,11 @@ const IssueCard: React.FC<{
 };
 
 const IssuesList: React.FC<{ minerIds: string[] }> = ({ minerIds }) => {
-  const issueQueries = useMinersIssues(minerIds, minerIds.length > 0);
+  const issueQueries = useMinersIssues(
+    minerIds,
+    minerIds.length > 0,
+    MINER_ISSUES_FULL_HISTORY_SINCE_ISO,
+  );
   const sidebarFixedRight = useWatchlistSidebarFixedRight();
 
   const { ids: starredIssueIds } = useWatchlist('issues');


### PR DESCRIPTION
## Summary

The Watchlist Issues tab kept rendering an empty list under the Resolved and Closed filters, with both chip counts pinned at zero. Root cause is the same gotcha #1126 documented for the dashboard: `WatchlistPage.tsx` was calling `useMinersIssues(minerIds, minerIds.length > 0)` without a `since` argument, and the mirror's `/miners/<id>/issues` endpoint returns only currently OPEN rows when `since` is omitted (it does not default to a recent window, despite what the hook's JSDoc previously claimed). With no closed rows reaching `issueState()`, the Resolved and Closed buckets stayed empty for every watched miner.

The fix passes a pinned subnet-launch cutoff to `useMinersIssues`. Co-locating the constant with the hook in `MinerApi.ts` keeps the gotcha and its workaround in one place, and module-level pinning keeps the React Query cache key stable across renders without a `useMemo`. The misleading JSDoc on `useMinersIssues` is corrected to flag the OPEN-only behaviour.

Scope is intentionally narrow: two files touched, one new exported constant, no behavioural changes outside the Issues tab.

## Open question

After this fix, the filter chips and the “Issue Activity” sidebar show different counts.
The chips display: Solved 70 / Open 5 / Closed 16, while the sidebar shows: Solved 55 / Open 15 / Closed 15.
From what I can see, the chip counts are based directly on the table rows, while the sidebar totals are calculated from the scoring stats returned by /miners. I also noticed the same discrepancy on the dashboard after #1134.

Do you think it’s worth reconciling these two data sources so the numbers stay consistent, or is it acceptable to leave them as they are?

## Related Issues

Fixes #1176

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

Before: Resolved and Closed chips read `0` for every watched miner; clicking either filter shows an empty list.
<img width="1907" height="850" alt="before1" src="https://github.com/user-attachments/assets/2cfcac47-6adf-472b-a1ba-1ad7938d0b22" />

After: chip counts reflect real state distribution, and the Resolved view matches what the per-miner Issue Discovery surface already shows.
<img width="1893" height="858" alt="after1" src="https://github.com/user-attachments/assets/9bde4c07-401f-4aec-99ad-e9131f95c495" />

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
