### PR TITLE
fix(dashboard): correct double count in OSS Contributions and Issue Discoveries pools

### DIFF
--- a/src/pages/dashboard/dashboardData.ts
+++ b/src/pages/dashboard/dashboardData.ts
@@ -340,46 +340,36 @@ export const buildDashboardTrendData = (
   };
 };
 
+// Each PR contributes to exactly one bucket, keyed by its terminal state and
+// the timestamp that produced that state. API does not currently return
+// closedAt for PRs — fall back to prCreatedAt so closed PRs are still windowed.
+const getPrTerminalTimestamp = (
+  pr: CommitLog,
+  status: ReturnType<typeof getPrStatusLabel>,
+): string | null | undefined => {
+  if (status === 'Merged') return pr.mergedAt;
+  if (status === 'Closed') return pr.closedAt ?? pr.prCreatedAt;
+  return pr.prCreatedAt;
+};
+
 const getPrOverviewMetrics = (prs: CommitLog[], window: WindowBounds) => {
-  const statusCounts = {
-    total: 0,
-    merged: 0,
-    open: 0,
-    closed: 0,
-  };
+  const counts = { merged: 0, open: 0, closed: 0 };
 
   prs.forEach((pr) => {
-    const normalizedState = getPrStatusLabel(pr);
-    const createdInWindow = isWithinWindow(toTimestamp(pr.prCreatedAt), window);
-    const mergedInWindow = isWithinWindow(toTimestamp(pr.mergedAt), window);
-    // API does not currently return closedAt for PRs — fall back to
-    // prCreatedAt so closed PRs are still tracked within the window.
-    const closedInWindow = isWithinWindow(
-      toTimestamp(pr.closedAt ?? pr.prCreatedAt),
-      window,
-    );
+    const status = getPrStatusLabel(pr);
+    if (
+      !isWithinWindow(toTimestamp(getPrTerminalTimestamp(pr, status)), window)
+    )
+      return;
 
-    if (createdInWindow) {
-      statusCounts.open += 1;
-      statusCounts.total += 1;
-    }
-
-    if (mergedInWindow) {
-      statusCounts.merged += 1;
-      statusCounts.total += 1;
-    }
-
-    if (normalizedState === 'Closed' && closedInWindow) {
-      statusCounts.closed += 1;
-      statusCounts.total += 1;
-    }
+    if (status === 'Merged') counts.merged += 1;
+    else if (status === 'Closed') counts.closed += 1;
+    else counts.open += 1;
   });
 
   return {
-    total: statusCounts.total,
-    merged: statusCounts.merged,
-    open: statusCounts.open,
-    closed: statusCounts.closed,
+    total: counts.merged + counts.open + counts.closed,
+    ...counts,
   };
 };
 


### PR DESCRIPTION
## Summary

The OSS Contributions and Issue Discoveries overview cards on the dashboard were double counting PRs. `getPrOverviewMetrics` in [src/pages/dashboard/dashboardData.ts](src/pages/dashboard/dashboardData.ts) ran three independent `if` branches against the created, merged, and closed timestamps, incrementing separate counters in each branch. A PR created and merged in the same window therefore contributed +1 to Open, +1 to Merged, and +2 to Total. The Open tile also incremented for every PR created in the window regardless of its terminal state, so merged or closed PRs inflated the Open count too.

The fix classifies each PR once via `getPrStatusLabel`, pairs it with the timestamp that produced its terminal state (`mergedAt` for Merged, `closedAt ?? prCreatedAt` for Closed, `prCreatedAt` for Open), and increments exactly one bucket. Total becomes the sum of the three buckets by construction, so the donut segments partition the window relevant PRs cleanly and `Total === Merged + Open + Closed` is structurally enforced.

The `closedAt ?? prCreatedAt` fallback (carried over from the previous logic) is preserved so closed PRs are still tracked while the API does not return `closedAt`. The return shape is unchanged, so the chart center label (`Merged / (Merged + Closed)`) and the delta arrows on both pools continue to work without modification.

## Related Issues

Fixes #1180

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

Not applicable. No rendering code changed, only the counts feeding the existing tiles and donut chart.

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [ ] Screenshots included for any UI/visual changes (N/A, data layer only)
