### PR TITLE
fix(miner-insights): render insight description body in Insights & Next Actions card

### DIFF
--- a/src/components/miners/MinerInsightsCard.tsx
+++ b/src/components/miners/MinerInsightsCard.tsx
@@ -444,7 +444,9 @@ const MinerInsightsCard: React.FC<MinerInsightsCardProps> = ({
                     lineHeight: 1.45,
                     wordBreak: 'break-word',
                   }}
-                />
+                >
+                  {insight.description}
+                </Typography>
               </Box>
             </Box>
           );


### PR DESCRIPTION
## Summary

The **Insights & Next Actions** card on every miner detail page silently dropped the description body under each insight. Each row rendered only the title + colored type chip (`WARNING` / `TIP` / `ACHIEVEMENT`) with empty space below it, removing all the actionable context users rely on.

Root cause: `MinerInsightsCard.tsx` had a **self-closing** `<Typography sx={{...}} />` where `{insight.description}` was supposed to be rendered. The `InsightItem` interface declared `description: string` and all 8 insight builders (PR-mode + issue-mode) populated it correctly, but the JSX never emitted a child for it — so the styled `<p>` sat empty in the DOM on every row.

The fix is a one-line render change. The remaining diff extracts the pure insight-builder logic out of the JSX file into `src/components/miners/minerInsights.ts` so each builder can be unit-tested without standing up React DOM testing infrastructure (matching the existing `src/tests/*.test.ts` pure-logic convention). The new test file pins every builder's description-populating behavior so this regression cannot silently come back.


## Changes

- **`src/components/miners/MinerInsightsCard.tsx`** — adds `{insight.description}` as a child of the previously self-closing `Typography`. Removes the inlined insight builders/assemblers (now imported from `./minerInsights`).
- **`src/components/miners/minerInsights.ts`** *(new)* — pure module exporting `InsightItem`, `InsightType`, the 8 builders (`getOpenPrInsight`, `getCredibilityInsight`, `getEligibilityInsight`, `getCollateralInsight`, `getOpenIssueRiskInsight`, `getIssueEligibilityInsight`, `getIssueCredibilityInsight`, `getIssueSolvedInsight`), and `assemblePrInsights` / `assembleIssueInsights`. Behavior is identical to the previous inlined implementation — code was moved verbatim.
- **`src/tests/minerInsights.test.ts`** *(new)* — 10 Vitest cases following the pure-logic pattern of the existing tests in `src/tests/`. Covers every builder and asserts both assemble-level outputs contain only insights with non-empty descriptions.


## Related Issues

Closes #1182


## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)


## Screenshots

**Before:**
<img width="1279" height="647" alt="Screenshot 2026-05-14 155955" src="https://github.com/user-attachments/assets/73560d6f-d506-4c6a-8742-ddde1d196c68" />

**After:**
<img width="1276" height="632" alt="Screenshot 2026-05-14 155927" src="https://github.com/user-attachments/assets/19b62cba-625a-41f0-9e54-cfd6f7059c9a" />


## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors) — no styling changes; existing `STATUS_COLORS` + `alpha()` only
- [x] Responsive/mobile checked — render-only fix, no layout impact
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
