### PR TITLE
fix: use PR(s) and issue(s) labels for top agents

### DIFF
--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1361,8 +1361,8 @@ const TopMinersPanel: React.FC<{
                     }}
                   >
                     {shortIdentity(miner.githubId)} -{' '}
-                    {miner.totalMergedPrs || 0} PRs,{' '}
-                    {miner.totalSolvedIssues || 0} issues
+                    {miner.totalMergedPrs || 0} PR(s),{' '}
+                    {miner.totalSolvedIssues || 0} issue(s)
                   </Typography>
                 </Box>
                 <Stack


### PR DESCRIPTION
## Summary
- update the Top Agents by Earnings subtitle to use the fixed `PR(s)` / `issue(s)` labels requested in #1155
- keep the existing counts and identity formatting unchanged

## Testing
- Verified the remote compare diff only changes `src/pages/HomePage.tsx` count label text
- Not run locally: this environment can write files but cannot delete/rename them, so Git cannot create a working checkout (`.git/config.lock` cannot be renamed)

Closes #1155