### PR TITLE
chore: drop pioneerDividend/pioneerRank from Dashboard API types

### DIFF
--- a/src/api/models/Dashboard.ts
+++ b/src/api/models/Dashboard.ts
@@ -4,7 +4,7 @@ export type RepoChanges = {
   additions: number;
   deletions: number;
   linesChanged: number;
-  weight: string; // bc float
+  emissionShare: string; // bc float
   inactiveAt: string | null;
 };
 
@@ -12,7 +12,8 @@ export type RepoChanges = {
 // gittensor's master_repositories.json with shallow camelCase keys; nested
 // object values (e.g. labelMultipliers) keep their inner keys verbatim.
 export type RepositoryConfig = {
-  weight?: number | string;
+  emissionShare?: number | string;
+  issueDiscoveryShare?: number | string;
   additionalAcceptableBranches?: string[] | null;
   inactiveAt?: string | null;
   mirrorEnabled?: boolean;

--- a/src/api/models/Dashboard.ts
+++ b/src/api/models/Dashboard.ts
@@ -5,7 +5,6 @@ export type RepoChanges = {
   deletions: number;
   linesChanged: number;
   emissionShare: string; // bc float
-  inactiveAt: string | null;
 };
 
 // Raw config blob from das-gittensor /dash/repos and /repos/:repo. Mirrors
@@ -15,7 +14,6 @@ export type RepositoryConfig = {
   emissionShare?: number | string;
   issueDiscoveryShare?: number | string;
   additionalAcceptableBranches?: string[] | null;
-  inactiveAt?: string | null;
   mirrorEnabled?: boolean;
   trustedLabelPipeline?: boolean;
   labelMultipliers?: Record<string, number>;

--- a/src/api/models/Dashboard.ts
+++ b/src/api/models/Dashboard.ts
@@ -166,8 +166,6 @@ export type CommitLog = {
   repoWeightMultiplier?: string;
   issueMultiplier?: string;
   openPrSpamMultiplier?: string;
-  pioneerDividend?: number;
-  pioneerRank?: number;
   timeDecayMultiplier?: string;
   credibilityMultiplier?: string;
 
@@ -291,8 +289,6 @@ export type PullRequestDetails = {
   baseScore: string; // float returned as string
   issueMultiplier: string; // float returned as string
   openPrSpamMultiplier: string; // float returned as string
-  pioneerDividend: number;
-  pioneerRank: number;
   timeDecayMultiplier: string; // float returned as string
   credibilityMultiplier: string; // float returned as string
   reviewQualityMultiplier?: string; // float returned as string

--- a/src/components/leaderboard/RepositoryCard.tsx
+++ b/src/components/leaderboard/RepositoryCard.tsx
@@ -19,8 +19,6 @@ interface RepositoryCardProps {
   linkState?: Record<string, unknown>;
 }
 
-const INACTIVE_OPACITY = 0.5;
-
 interface ConfigBarProps {
   label: string;
   value: number;
@@ -100,47 +98,26 @@ interface LabelChipProps {
 
 const LabelChip: React.FC<LabelChipProps> = ({ label, multiplier }) => (
   <Box
-    sx={(theme) => {
-      const direction =
-        multiplier > 1 ? 'boost' : multiplier < 1 ? 'penalty' : 'neutral';
-      const color =
-        direction === 'boost'
-          ? theme.palette.status.success
-          : direction === 'penalty'
-            ? theme.palette.status.closed
-            : theme.palette.text.secondary;
-      return {
-        display: 'inline-flex',
-        alignItems: 'baseline',
-        gap: 0.5,
-        px: 0.75,
-        py: 0.25,
-        borderRadius: '4px',
-        border: '1px solid',
-        borderColor: alpha(color, 0.35),
-        backgroundColor: alpha(color, 0.08),
-        fontFamily: FONTS.mono,
-        fontSize: '0.7rem',
-        lineHeight: 1.2,
-        whiteSpace: 'nowrap',
-      };
-    }}
+    sx={(theme) => ({
+      display: 'inline-flex',
+      alignItems: 'baseline',
+      gap: 0.5,
+      px: 0.75,
+      py: 0.25,
+      borderRadius: '4px',
+      border: '1px solid',
+      borderColor: theme.palette.border.light,
+      backgroundColor: alpha(theme.palette.text.primary, 0.04),
+      fontFamily: FONTS.mono,
+      fontSize: '0.7rem',
+      lineHeight: 1.2,
+      whiteSpace: 'nowrap',
+    })}
   >
-    <Box component="span" sx={{ color: 'text.primary', fontWeight: 500 }}>
+    <Box component="span" sx={{ color: 'text.secondary', fontWeight: 500 }}>
       {label}
     </Box>
-    <Box
-      component="span"
-      sx={(theme) => ({
-        color:
-          multiplier > 1
-            ? theme.palette.status.success
-            : multiplier < 1
-              ? theme.palette.status.closed
-              : theme.palette.text.tertiary,
-        fontWeight: 600,
-      })}
-    >
+    <Box component="span" sx={{ color: 'text.tertiary', fontWeight: 600 }}>
       ×{multiplier.toFixed(2)}
     </Box>
   </Box>
@@ -153,7 +130,6 @@ export const RepositoryCard: React.FC<RepositoryCardProps> = ({
   linkState,
 }) => {
   const owner = (repo.repository || '').split('/')[0] || '';
-  const isInactive = !!repo.inactiveAt;
   const weightPct =
     maxWeight > 0
       ? Math.max(0, Math.min(100, (repo.weight / maxWeight) * 100))
@@ -180,7 +156,6 @@ export const RepositoryCard: React.FC<RepositoryCardProps> = ({
         gap: { xs: 1.25, sm: 1.5 },
         cursor: 'pointer',
         transition: 'all 0.2s',
-        opacity: isInactive ? INACTIVE_OPACITY : 1,
         '&:hover': {
           backgroundColor: theme.palette.surface.light,
           borderColor: theme.palette.border.medium,
@@ -233,29 +208,6 @@ export const RepositoryCard: React.FC<RepositoryCardProps> = ({
             {repo.repository}
           </Typography>
         </Tooltip>
-        <Typography
-          component="span"
-          sx={(theme) => ({
-            fontFamily: FONTS.mono,
-            fontSize: { xs: '0.6rem', sm: '0.65rem' },
-            fontWeight: 600,
-            textTransform: 'uppercase',
-            letterSpacing: '0.04em',
-            px: { xs: 0.5, sm: 0.75 },
-            py: 0.25,
-            borderRadius: '4px',
-            flexShrink: 0,
-            whiteSpace: 'nowrap',
-            color: isInactive
-              ? theme.palette.status.closed
-              : theme.palette.status.success,
-            backgroundColor: isInactive
-              ? alpha(theme.palette.status.closed, 0.12)
-              : alpha(theme.palette.status.success, 0.12),
-          })}
-        >
-          {isInactive ? 'Inactive' : 'Active'}
-        </Typography>
         {repo.repository && (
           <WatchlistButton
             category="repos"

--- a/src/components/leaderboard/RepositoryCard.tsx
+++ b/src/components/leaderboard/RepositoryCard.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import { Avatar, Box, Card, Divider, Tooltip, Typography } from '@mui/material';
 import { alpha } from '@mui/material/styles';
 import { linkResetSx, useLinkBehavior } from '../common/linkBehavior';
@@ -20,46 +21,128 @@ interface RepositoryCardProps {
 
 const INACTIVE_OPACITY = 0.5;
 
-const formatMetric = (value: number, decimals = 0): string =>
-  value > 0 ? (decimals > 0 ? value.toFixed(decimals) : String(value)) : '-';
-
-interface MetricCellProps {
+interface ConfigBarProps {
   label: string;
-  value: string;
+  value: number;
+  display: string;
+  pct: number;
+  accent: 'primary' | 'discovery';
 }
 
-const MetricCell: React.FC<MetricCellProps> = ({ label, value }) => (
-  <Box
-    sx={{
-      display: 'flex',
-      flexDirection: 'column',
-      alignItems: 'flex-start',
-      minWidth: 0,
-    }}
-  >
-    <Typography
-      sx={(theme) => ({
-        fontFamily: FONTS.mono,
-        fontSize: { xs: '0.62rem', sm: '0.65rem' },
-        color: theme.palette.text.tertiary,
-        textTransform: 'uppercase',
-        letterSpacing: '0.04em',
-        whiteSpace: 'nowrap',
-      })}
-    >
-      {label}
-    </Typography>
-    <Typography
+const ConfigBar: React.FC<ConfigBarProps> = ({
+  label,
+  display,
+  pct,
+  accent,
+}) => (
+  <Box>
+    <Box
       sx={{
-        fontFamily: FONTS.mono,
-        fontSize: { xs: '0.85rem', sm: '0.9rem' },
-        fontWeight: 600,
-        color: value === '-' ? 'text.secondary' : 'text.primary',
-        lineHeight: 1.2,
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        mb: 0.5,
       }}
     >
-      {value}
-    </Typography>
+      <Typography
+        sx={(theme) => ({
+          fontFamily: FONTS.mono,
+          fontSize: '0.65rem',
+          color: theme.palette.text.tertiary,
+          textTransform: 'uppercase',
+          letterSpacing: '0.04em',
+        })}
+      >
+        {label}
+      </Typography>
+      <Typography
+        sx={{
+          fontFamily: FONTS.mono,
+          fontSize: '0.75rem',
+          fontWeight: 600,
+          color: 'text.primary',
+        }}
+      >
+        {display}
+      </Typography>
+    </Box>
+    <Box
+      aria-hidden="true"
+      sx={(theme) => ({
+        position: 'relative',
+        height: 4,
+        borderRadius: 2,
+        backgroundColor: alpha(theme.palette.text.primary, 0.08),
+        overflow: 'hidden',
+      })}
+    >
+      <Box
+        sx={(theme) => ({
+          position: 'absolute',
+          inset: 0,
+          width: `${pct}%`,
+          backgroundColor:
+            accent === 'primary'
+              ? theme.palette.primary.main
+              : theme.palette.status.success,
+          borderRadius: 2,
+          transition: 'width 0.3s ease',
+        })}
+      />
+    </Box>
+  </Box>
+);
+
+interface LabelChipProps {
+  label: string;
+  multiplier: number;
+}
+
+const LabelChip: React.FC<LabelChipProps> = ({ label, multiplier }) => (
+  <Box
+    sx={(theme) => {
+      const direction =
+        multiplier > 1 ? 'boost' : multiplier < 1 ? 'penalty' : 'neutral';
+      const color =
+        direction === 'boost'
+          ? theme.palette.status.success
+          : direction === 'penalty'
+            ? theme.palette.status.closed
+            : theme.palette.text.secondary;
+      return {
+        display: 'inline-flex',
+        alignItems: 'baseline',
+        gap: 0.5,
+        px: 0.75,
+        py: 0.25,
+        borderRadius: '4px',
+        border: '1px solid',
+        borderColor: alpha(color, 0.35),
+        backgroundColor: alpha(color, 0.08),
+        fontFamily: FONTS.mono,
+        fontSize: '0.7rem',
+        lineHeight: 1.2,
+        whiteSpace: 'nowrap',
+      };
+    }}
+  >
+    <Box component="span" sx={{ color: 'text.primary', fontWeight: 500 }}>
+      {label}
+    </Box>
+    <Box
+      component="span"
+      sx={(theme) => ({
+        color:
+          multiplier > 1
+            ? theme.palette.status.success
+            : multiplier < 1
+              ? theme.palette.status.closed
+              : theme.palette.text.tertiary,
+        fontWeight: 600,
+      })}
+    >
+      ×{multiplier.toFixed(2)}
+    </Box>
   </Box>
 );
 
@@ -182,104 +265,81 @@ export const RepositoryCard: React.FC<RepositoryCardProps> = ({
         )}
       </Box>
 
-      <Box>
-        <Box
-          sx={{
-            display: 'flex',
-            justifyContent: 'space-between',
-            alignItems: 'center',
-            mb: 0.5,
-          }}
+      <ConfigBar
+        label="Weight"
+        value={repo.weight}
+        display={repo.weight.toFixed(2)}
+        pct={weightPct}
+        accent="primary"
+      />
+
+      <ConfigBar
+        label="Issue Discovery"
+        value={repo.issueDiscoveryShare ?? 0}
+        display={(repo.issueDiscoveryShare ?? 0).toFixed(2)}
+        pct={Math.max(0, Math.min(100, (repo.issueDiscoveryShare ?? 0) * 100))}
+        accent="discovery"
+      />
+
+      <Divider sx={{ borderColor: 'border.light', opacity: 0.85 }} />
+
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.75 }}>
+        <Typography
+          sx={(theme) => ({
+            fontFamily: FONTS.mono,
+            fontSize: '0.65rem',
+            color: theme.palette.text.tertiary,
+            textTransform: 'uppercase',
+            letterSpacing: '0.04em',
+          })}
         >
-          <Typography
-            sx={(theme) => ({
-              fontFamily: FONTS.mono,
-              fontSize: '0.65rem',
-              color: theme.palette.text.tertiary,
-              textTransform: 'uppercase',
-              letterSpacing: '0.04em',
-            })}
-          >
-            Weight
-          </Typography>
+          Label multipliers
+        </Typography>
+        {repo.labelMultipliers &&
+        Object.keys(repo.labelMultipliers).length > 0 ? (
+          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
+            {Object.entries(repo.labelMultipliers).map(([label, mult]) => (
+              <LabelChip key={label} label={label} multiplier={mult} />
+            ))}
+          </Box>
+        ) : (
           <Typography
             sx={{
               fontFamily: FONTS.mono,
-              fontSize: '0.75rem',
-              fontWeight: 600,
-              color: 'text.primary',
+              fontSize: '0.7rem',
+              color: 'text.tertiary',
+              fontStyle: 'italic',
             }}
           >
-            {repo.weight.toFixed(2)}
+            Default scoring (×1.00)
           </Typography>
-        </Box>
-        <Box
-          aria-hidden="true"
-          sx={(theme) => ({
-            position: 'relative',
-            height: 4,
-            borderRadius: 2,
-            backgroundColor: alpha(theme.palette.text.primary, 0.08),
-            overflow: 'hidden',
-          })}
+        )}
+      </Box>
+
+      {repo.trustedLabelPipeline && (
+        <Tooltip
+          title="Maintainer-applied labels are trusted as scoring input, including those from GitHub Apps."
+          placement="top"
+          arrow
         >
           <Box
             sx={(theme) => ({
-              position: 'absolute',
-              inset: 0,
-              width: `${weightPct}%`,
-              backgroundColor: theme.palette.primary.main,
-              borderRadius: 2,
-              transition: 'width 0.3s ease',
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 0.5,
+              alignSelf: 'flex-start',
+              fontFamily: FONTS.mono,
+              fontSize: '0.65rem',
+              letterSpacing: '0.04em',
+              textTransform: 'uppercase',
+              color: theme.palette.status.success,
             })}
-          />
-        </Box>
-      </Box>
-
-      <Box
-        sx={{ display: 'flex', flexDirection: 'column', gap: 1.25, pt: 0.5 }}
-      >
-        <Box
-          sx={{
-            display: 'grid',
-            gridTemplateColumns: '1.4fr 0.6fr 1fr',
-            gap: 1.5,
-          }}
-        >
-          <MetricCell
-            label="OSS Score"
-            value={formatMetric(repo.totalScore, 2)}
-          />
-          <MetricCell label="PRs" value={formatMetric(repo.totalPRs)} />
-          <MetricCell
-            label="Contributors"
-            value={formatMetric(repo.uniqueMiners?.size ?? 0)}
-          />
-        </Box>
-
-        <Divider sx={{ borderColor: 'border.light', opacity: 0.85 }} />
-
-        <Box
-          sx={{
-            display: 'grid',
-            gridTemplateColumns: '1.4fr 0.6fr 1fr',
-            gap: 1.5,
-          }}
-        >
-          <MetricCell
-            label="Issue score"
-            value={formatMetric(repo.discoveryScore, 2)}
-          />
-          <MetricCell
-            label="Issues"
-            value={formatMetric(repo.discoveryIssues)}
-          />
-          <MetricCell
-            label="Contributors"
-            value={formatMetric(repo.discoveryContributors?.size ?? 0)}
-          />
-        </Box>
-      </Box>
+          >
+            <CheckCircleIcon sx={{ fontSize: '0.85rem' }} />
+            Trusted label pipeline
+          </Box>
+        </Tooltip>
+      )}
     </Card>
   );
 };

--- a/src/components/leaderboard/TopRepositoriesTable.tsx
+++ b/src/components/leaderboard/TopRepositoriesTable.tsx
@@ -36,7 +36,6 @@ import ViewModuleIcon from '@mui/icons-material/ViewModule';
 import ViewListIcon from '@mui/icons-material/ViewList';
 import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
 import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
-import FilterButton from '../FilterButton';
 import { RepositoryCard } from './RepositoryCard';
 import {
   REPOSITORIES_CARD_ROWS,
@@ -205,20 +204,8 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
   const urlSort = searchParams.get('sort') as SortColumn;
   const urlDir = searchParams.get('dir') as SortDirection;
   const urlSearch = searchParams.get('search') || '';
-  const urlStatusFilter = searchParams.get('status') as
-    | 'all'
-    | 'active'
-    | 'inactive'
-    | null;
 
   const [searchQuery, setSearchQuery] = useState(urlSearch);
-  const [statusFilter, setStatusFilter] = useState<
-    'all' | 'active' | 'inactive'
-  >(
-    urlStatusFilter === 'active' || urlStatusFilter === 'inactive'
-      ? urlStatusFilter
-      : 'all',
-  );
   const [showChart, setShowChart] = useState(false);
   const [page, setPage] = useState(urlPage >= 0 ? urlPage : 0);
   const [rowsPerPage, setRowsPerPage] = useState(() => {
@@ -294,7 +281,6 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
       const sort = overrides?.sort ?? sortColumn;
       const dir = overrides?.dir ?? sortDirection;
       const search = overrides?.search ?? searchQuery;
-      const active = overrides?.status ?? statusFilter;
       const view = overrides?.view ?? viewMode;
 
       if (rows !== '10') params.rows = rows;
@@ -302,7 +288,6 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
       if (sort !== 'weight') params.sort = sort;
       if (dir !== 'desc') params.dir = dir;
       if (search) params.search = search;
-      if (active !== 'all') params.status = active;
       if (view === 'cards') params.view = view;
 
       setSearchParams(params, { replace: true });
@@ -313,7 +298,6 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
       sortColumn,
       sortDirection,
       searchQuery,
-      statusFilter,
       viewMode,
       setSearchParams,
     ],
@@ -388,12 +372,6 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
   const filteredRepositories = useMemo(() => {
     let filtered = rankedRepositories;
 
-    if (statusFilter === 'active') {
-      filtered = filtered.filter((repo) => !repo.inactiveAt);
-    } else if (statusFilter === 'inactive') {
-      filtered = filtered.filter((repo) => !!repo.inactiveAt);
-    }
-
     // Apply search filter
     if (searchQuery) {
       const lowerQuery = searchQuery.toLowerCase();
@@ -403,7 +381,7 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
     }
 
     return filtered;
-  }, [rankedRepositories, statusFilter, searchQuery]);
+  }, [rankedRepositories, searchQuery]);
 
   const maxWeight = useMemo(
     () => rankedRepositories.reduce((m, r) => (r.weight > m ? r.weight : m), 0),
@@ -1179,55 +1157,6 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
           <Box
             sx={{
               display: 'flex',
-              gap: { xs: 0.25, sm: 0.5 },
-              alignItems: 'center',
-              flexWrap: { xs: 'nowrap', sm: 'wrap' },
-              width: { xs: '100%', md: 'auto' },
-              '& > button': {
-                flex: { xs: 1, sm: 'initial' },
-                minWidth: 0,
-                px: { xs: 1, sm: 2 },
-              },
-            }}
-          >
-            <FilterButton
-              label="All"
-              count={rankedRepositories.length}
-              color={STATUS_COLORS.neutral}
-              isActive={statusFilter === 'all'}
-              onClick={() => {
-                setStatusFilter('all');
-                setPage(0);
-                syncToUrl({ status: 'all', page: '0' });
-              }}
-            />
-            <FilterButton
-              label="Active"
-              count={rankedRepositories.filter((r) => !r.inactiveAt).length}
-              color={STATUS_COLORS.success}
-              isActive={statusFilter === 'active'}
-              onClick={() => {
-                setStatusFilter('active');
-                setPage(0);
-                syncToUrl({ status: 'active', page: '0' });
-              }}
-            />
-            <FilterButton
-              label="Inactive"
-              count={rankedRepositories.filter((r) => !!r.inactiveAt).length}
-              color={STATUS_COLORS.closed}
-              isActive={statusFilter === 'inactive'}
-              onClick={() => {
-                setStatusFilter('inactive');
-                setPage(0);
-                syncToUrl({ status: 'inactive', page: '0' });
-              }}
-            />
-          </Box>
-
-          <Box
-            sx={{
-              display: 'flex',
               alignItems: 'center',
               justifyContent: { xs: 'flex-start', md: 'flex-end' },
               gap: { xs: 0.75, sm: 1 },
@@ -1514,8 +1443,7 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
             getRowKey={(repo) => repo.repository || ''}
             getRowHref={(repo) => getRepositoryHref(repo.repository || '')}
             linkState={linkState}
-            getRowSx={(repo) => ({
-              opacity: repo.inactiveAt ? 0.5 : 1,
+            getRowSx={() => ({
               '&:hover': { backgroundColor: 'border.subtle' },
               transition: 'all 0.2s',
               borderBottom: '1px solid',

--- a/src/components/leaderboard/types.ts
+++ b/src/components/leaderboard/types.ts
@@ -59,6 +59,12 @@ export interface RepoStats {
   discoveryIssues: number;
   /** Identities with non-zero pro-rated discovery score/issues in this repo. */
   discoveryContributors: Set<string>;
+  /** Fraction of the repo allocation reserved for issue discovery (0-1). */
+  issueDiscoveryShare?: number;
+  /** Labels-as-scoring trust opt-in; surfaced on the card as a badge. */
+  trustedLabelPipeline?: boolean;
+  /** Per-label scoring multipliers, e.g. `{ bug: 1.25, refactor: 0.25 }`. */
+  labelMultipliers?: Record<string, number>;
 }
 
 export type LeaderboardVariant = 'oss' | 'discoveries' | 'watchlist';

--- a/src/components/leaderboard/types.ts
+++ b/src/components/leaderboard/types.ts
@@ -48,7 +48,6 @@ export interface RepoStats {
   uniqueMiners: Set<string>;
   weight: number;
   rank?: number;
-  inactiveAt?: string | null;
   mirrorEnabled?: boolean;
   /** Issue discovery track score (UI: "Issue score"; miner stats + merged multiplier PRs). */
   discoveryScore: number;

--- a/src/components/miners/MinerRepositoriesTable.tsx
+++ b/src/components/miners/MinerRepositoriesTable.tsx
@@ -47,7 +47,7 @@ import { scrollbarSx } from '../../theme';
 
 type ViewMode = 'prs' | 'issues';
 
-type RepoStatusFilter = 'all' | 'active' | 'inactive' | 'recent' | 'stale';
+type RepoStatusFilter = 'all' | 'recent' | 'stale';
 
 interface MinerRepositoriesTableProps {
   githubId: string;
@@ -56,16 +56,16 @@ interface MinerRepositoriesTableProps {
 
 const PAGE_SIZE = 20;
 
-/** Active on subnet + latest merged PR within the rolling scoring window. */
+/** Latest merged PR is within the rolling scoring window. */
 const isRecentRepoStats = (r: RepoStats): boolean =>
-  !r.inactiveAt && !isOutsideScoringWindow(r.latestPrDate);
+  !isOutsideScoringWindow(r.latestPrDate);
 
 /** Latest merged PR is older than the rolling scoring window. */
 const isStaleRepoStats = (r: RepoStats): boolean =>
   isOutsideScoringWindow(r.latestPrDate);
 
 const isRecentIssueRepoStats = (r: IssueRepoStats): boolean =>
-  !r.inactiveAt && !isOutsideScoringWindow(r.latestActivityDate);
+  !isOutsideScoringWindow(r.latestActivityDate);
 
 const isStaleIssueRepoStats = (r: IssueRepoStats): boolean =>
   isOutsideScoringWindow(r.latestActivityDate);
@@ -92,46 +92,22 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
     setPage(0);
   }, [viewMode, statusFilter, searchQuery]);
 
-  const inactiveAtByRepo = useMemo(() => {
-    const m = new Map<string, string | null>();
-    for (const r of repos || []) {
-      if (r?.fullName) {
-        m.set(r.fullName.toLowerCase(), r.config?.inactiveAt ?? null);
-      }
-    }
-    return m;
-  }, [repos]);
-
   const repoWeights = useMemo(() => buildRepoWeightsMap(repos), [repos]);
 
-  const repoStats = useMemo(() => {
-    const base = aggregatePRsByRepository(prs || [], repoWeights);
-    return base.map((row) => ({
-      ...row,
-      inactiveAt: inactiveAtByRepo.get(row.repository.toLowerCase()) ?? null,
-    }));
-  }, [prs, repoWeights, inactiveAtByRepo]);
+  const repoStats = useMemo(
+    () => aggregatePRsByRepository(prs || [], repoWeights),
+    [prs, repoWeights],
+  );
 
-  const issueRepoStats = useMemo(() => {
-    const base = aggregateIssueDiscoveryByRepository(
-      prs || [],
-      issues,
-      repoWeights,
-    );
-    return base.map((row) => ({
-      ...row,
-      inactiveAt: inactiveAtByRepo.get(row.repository.toLowerCase()) ?? null,
-    }));
-  }, [prs, issues, repoWeights, inactiveAtByRepo]);
+  const issueRepoStats = useMemo(
+    () => aggregateIssueDiscoveryByRepository(prs || [], issues, repoWeights),
+    [prs, issues, repoWeights],
+  );
 
   const statusFilteredRepoStats = useMemo(() => {
     switch (statusFilter) {
       case 'all':
         return repoStats;
-      case 'active':
-        return repoStats.filter((r) => !r.inactiveAt);
-      case 'inactive':
-        return repoStats.filter((r) => !!r.inactiveAt);
       case 'recent':
         return repoStats.filter(isRecentRepoStats);
       case 'stale':
@@ -145,10 +121,6 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
     switch (statusFilter) {
       case 'all':
         return issueRepoStats;
-      case 'active':
-        return issueRepoStats.filter((r) => !r.inactiveAt);
-      case 'inactive':
-        return issueRepoStats.filter((r) => !!r.inactiveAt);
       case 'recent':
         return issueRepoStats.filter(isRecentIssueRepoStats);
       case 'stale':
@@ -161,8 +133,6 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
   const repoStatusCounts = useMemo(
     () => ({
       all: repoStats.length,
-      active: repoStats.filter((r) => !r.inactiveAt).length,
-      inactive: repoStats.filter((r) => !!r.inactiveAt).length,
       recent: repoStats.filter(isRecentRepoStats).length,
       stale: repoStats.filter(isStaleRepoStats).length,
     }),
@@ -172,8 +142,6 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
   const issueRepoStatusCounts = useMemo(
     () => ({
       all: issueRepoStats.length,
-      active: issueRepoStats.filter((r) => !r.inactiveAt).length,
-      inactive: issueRepoStats.filter((r) => !!r.inactiveAt).length,
       recent: issueRepoStats.filter(isRecentIssueRepoStats).length,
       stale: issueRepoStats.filter(isStaleIssueRepoStats).length,
     }),
@@ -560,20 +528,6 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
               onClick={() => setStatusFilter('all')}
             />
             <FilterButton
-              label="Active"
-              count={statusCounts.active}
-              color={theme.palette.status.success}
-              isActive={statusFilter === 'active'}
-              onClick={() => setStatusFilter('active')}
-            />
-            <FilterButton
-              label="Inactive"
-              count={statusCounts.inactive}
-              color={theme.palette.status.closed}
-              isActive={statusFilter === 'inactive'}
-              onClick={() => setStatusFilter('inactive')}
-            />
-            <FilterButton
               label="Recent"
               count={statusCounts.recent}
               color={theme.palette.status.merged}
@@ -669,11 +623,7 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
             onChange: handleIssueSort,
           }}
           getRowSx={(repo) => ({
-            opacity: repo.inactiveAt
-              ? 0.5
-              : isOutsideScoringWindow(repo.latestActivityDate)
-                ? 0.4
-                : 1,
+            opacity: isOutsideScoringWindow(repo.latestActivityDate) ? 0.4 : 1,
             transition: 'opacity 0.2s',
           })}
           pagination={
@@ -702,11 +652,7 @@ const MinerRepositoriesTable: React.FC<MinerRepositoriesTableProps> = ({
             onChange: handlePrSort,
           }}
           getRowSx={(repo) => ({
-            opacity: repo.inactiveAt
-              ? 0.5
-              : isOutsideScoringWindow(repo.latestPrDate)
-                ? 0.4
-                : 1,
+            opacity: isOutsideScoringWindow(repo.latestPrDate) ? 0.4 : 1,
             transition: 'opacity 0.2s',
           })}
           pagination={

--- a/src/components/repositories/RepositoryStats.tsx
+++ b/src/components/repositories/RepositoryStats.tsx
@@ -127,7 +127,7 @@ const RepositoryStats: React.FC<RepositoryStatsProps> = ({
               fontSize: '13px',
             }}
           >
-            {String(repository.config?.weight ?? '')}
+            {String(repository.config?.emissionShare ?? '')}
           </Typography>
         </Box>
 

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -8,12 +8,7 @@ import NetworkCanvas from '../components/landing/NetworkCanvas';
 import useCountUp from '../hooks/useCountUp';
 import { SEO } from '../components';
 import { LinkBox, useLinkBehavior } from '../components/common/linkBehavior';
-import {
-  type CommitLog,
-  type MinerEvaluation,
-  type Repository,
-  useStats,
-} from '../api';
+import { type CommitLog, type MinerEvaluation, useStats } from '../api';
 import { useMonthlyRewards } from '../hooks/useMonthlyRewards';
 import {
   getGithubAvatarSrc,
@@ -175,9 +170,9 @@ const buildTopMinerRows = (miners: MinerEvaluation[]): LandingMinerRow[] => {
 const getActivityRowId = (pr: CommitLog) =>
   `${pr.repository}-${pr.pullRequestNumber}`;
 
-const pickLandingActivityPrs = (prs: CommitLog[], repos: Repository[]) => {
+const pickLandingActivityPrs = (prs: CommitLog[]) => {
   const validPrs = prs.filter((pr) => pr.repository && pr.pullRequestNumber);
-  const featuredRepos = buildFeaturedWork(validPrs, repos);
+  const featuredRepos = buildFeaturedWork(validPrs);
 
   const selected: CommitLog[] = [];
   const selectedIds = new Set<string>();
@@ -236,11 +231,8 @@ const pickLandingActivityPrs = (prs: CommitLog[], repos: Repository[]) => {
   return selected.slice(0, 4);
 };
 
-const buildActivityRows = (
-  prs: CommitLog[],
-  repos: Repository[],
-): LandingActivityRow[] =>
-  pickLandingActivityPrs(prs, repos).map((pr) => {
+const buildActivityRows = (prs: CommitLog[]): LandingActivityRow[] =>
+  pickLandingActivityPrs(prs).map((pr) => {
     const status = getPrStatusLabel(pr);
     const statusLabel =
       status === 'Merged'
@@ -307,8 +299,8 @@ const HomePage: React.FC = () => {
     [datasets.miners.data],
   );
   const activityRows = useMemo(
-    () => buildActivityRows(datasets.prs.data, datasets.repos.data),
-    [datasets.prs.data, datasets.repos.data],
+    () => buildActivityRows(datasets.prs.data),
+    [datasets.prs.data],
   );
 
   const mergedPrs35d = useMemo(

--- a/src/pages/RepositoriesPage.tsx
+++ b/src/pages/RepositoriesPage.tsx
@@ -203,12 +203,16 @@ const RepositoriesPage: React.FC = () => {
           totalScore: s?.totalScore || 0,
           totalPRs: s?.totalPRs || 0,
           uniqueMiners: s?.uniqueMiners || new Set<string>(),
-          weight: parseFloat(String(repo.config?.weight ?? 0)) || 0,
+          weight: parseFloat(String(repo.config?.emissionShare ?? 0)) || 0,
           inactiveAt: repo.config?.inactiveAt ?? null,
           mirrorEnabled: repo.config?.mirrorEnabled ?? false,
           discoveryScore: d?.discoveryScore ?? 0,
           discoveryIssues: d?.discoveryIssues ?? 0,
           discoveryContributors: d?.discoveryContributors ?? new Set<string>(),
+          issueDiscoveryShare:
+            parseFloat(String(repo.config?.issueDiscoveryShare ?? 0)) || 0,
+          trustedLabelPipeline: repo.config?.trustedLabelPipeline ?? false,
+          labelMultipliers: repo.config?.labelMultipliers,
         };
       })
       .sort((a, b) => b.totalScore - a.totalScore);
@@ -333,12 +337,14 @@ const RepositoriesPage: React.FC = () => {
         // Tiebreak by repo weight
         const weightA = parseFloat(
           String(
-            repoMap.get(a.repository?.toLowerCase() ?? '')?.config?.weight ?? 0,
+            repoMap.get(a.repository?.toLowerCase() ?? '')?.config
+              ?.emissionShare ?? 0,
           ),
         );
         const weightB = parseFloat(
           String(
-            repoMap.get(b.repository?.toLowerCase() ?? '')?.config?.weight ?? 0,
+            repoMap.get(b.repository?.toLowerCase() ?? '')?.config
+              ?.emissionShare ?? 0,
           ),
         );
         return weightB - weightA;

--- a/src/pages/RepositoriesPage.tsx
+++ b/src/pages/RepositoriesPage.tsx
@@ -204,7 +204,6 @@ const RepositoriesPage: React.FC = () => {
           totalPRs: s?.totalPRs || 0,
           uniqueMiners: s?.uniqueMiners || new Set<string>(),
           weight: parseFloat(String(repo.config?.emissionShare ?? 0)) || 0,
-          inactiveAt: repo.config?.inactiveAt ?? null,
           mirrorEnabled: repo.config?.mirrorEnabled ?? false,
           discoveryScore: d?.discoveryScore ?? 0,
           discoveryIssues: d?.discoveryIssues ?? 0,

--- a/src/pages/RepositoryDetailsPage.tsx
+++ b/src/pages/RepositoryDetailsPage.tsx
@@ -7,7 +7,6 @@ import React, {
   useState,
 } from 'react';
 import { useSearchParams, useNavigate } from 'react-router-dom';
-import { formatDate } from '../utils/format';
 import { getRepositoryOwnerAvatarSrc } from '../utils/avatar';
 import {
   Alert,
@@ -240,13 +239,8 @@ const RepositoryDetailsPage: React.FC = () => {
     [repo, setSearchParams],
   );
 
-  const statusChips = useMemo(() => {
-    const inactiveAt = trackedRepo?.config?.inactiveAt ?? null;
-    const inactiveLabel = inactiveAt
-      ? `Inactive since ${formatDate(inactiveAt)}`
-      : null;
-
-    return (
+  const statusChips = useMemo(
+    () => (
       <>
         <Chip variant="info" label="Public" />
         <Chip
@@ -260,22 +254,10 @@ const RepositoryDetailsPage: React.FC = () => {
             fontWeight: 600,
           }}
         />
-        {inactiveLabel ? (
-          <Chip
-            label={inactiveLabel}
-            sx={{
-              backgroundColor: alpha(STATUS_COLORS.error, 0.1),
-              color: 'status.error',
-              border: `1px solid ${alpha(STATUS_COLORS.error, 0.3)}`,
-              fontSize: '0.75rem',
-              height: '24px',
-              fontWeight: 600,
-            }}
-          />
-        ) : null}
       </>
-    );
-  }, [trackedRepo?.config?.inactiveAt]);
+    ),
+    [],
+  );
 
   const issuesTabLabel = useMemo(() => {
     const openBounties =

--- a/src/pages/WatchlistPage.tsx
+++ b/src/pages/WatchlistPage.tsx
@@ -1144,7 +1144,7 @@ const repoColumns: DataTableColumn<WatchedRepoStats, RepoSortKey>[] = [
     cellSx: repoCellSx,
     renderCell: (repo) => (
       <Typography sx={{ fontSize: '0.75rem', fontWeight: 600 }}>
-        {parseFloat(String(repo.config?.weight ?? 0)).toFixed(2)}
+        {parseFloat(String(repo.config?.emissionShare ?? 0)).toFixed(2)}
       </Typography>
     ),
   },
@@ -1414,7 +1414,7 @@ const RepoCard: React.FC<{ repo: WatchedRepoStats; maxWeight: number }> = ({
 }) => {
   const { label, color } = repoStatusMeta(repo);
   const owner = repo.fullName.split('/')[0] || '';
-  const weight = parseFloat(String(repo.config?.weight ?? 0));
+  const weight = parseFloat(String(repo.config?.emissionShare ?? 0));
   const isInactive = !!repo.config?.inactiveAt;
   const weightPct =
     maxWeight > 0 ? Math.max(0, Math.min(100, (weight / maxWeight) * 100)) : 0;
@@ -1718,7 +1718,7 @@ const ReposList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
         const d = discoveryByRepo.get(key);
         return {
           ...r,
-          weight: r.config?.weight ?? 0,
+          weight: r.config?.emissionShare ?? 0,
           inactiveAt: r.config?.inactiveAt ?? null,
           totalScore: s?.totalScore || 0,
           totalPRs: s?.totalPRs || 0,
@@ -1763,8 +1763,8 @@ const ReposList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
           return cmpStr(a.fullName, b.fullName);
         case 'weight':
           return cmpNum(
-            parseFloat(String(a.config?.weight ?? 0)),
-            parseFloat(String(b.config?.weight ?? 0)),
+            parseFloat(String(a.config?.emissionShare ?? 0)),
+            parseFloat(String(b.config?.emissionShare ?? 0)),
           );
         case 'totalScore':
           return cmpNum(a.totalScore, b.totalScore);
@@ -1827,7 +1827,7 @@ const ReposList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
   const maxWeight = useMemo(
     () =>
       items.reduce(
-        (m, r) => Math.max(m, parseFloat(String(r.config?.weight ?? 0))),
+        (m, r) => Math.max(m, parseFloat(String(r.config?.emissionShare ?? 0))),
         0,
       ),
     [items],
@@ -1844,7 +1844,7 @@ const ReposList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
     const chartData = paged.map((repo) => ({
       name: repo.fullName.split('/')[1] || repo.fullName,
       repository: repo.fullName,
-      value: parseFloat(String(repo.config?.weight ?? 0)),
+      value: parseFloat(String(repo.config?.emissionShare ?? 0)),
     }));
 
     const barGradient = {

--- a/src/pages/WatchlistPage.tsx
+++ b/src/pages/WatchlistPage.tsx
@@ -953,7 +953,6 @@ type WatchedRepoStats = Repository & {
   // Hoisted from `config` for downstream sort/render code; populated when
   // constructing each row from the API Repository.
   weight: number | string;
-  inactiveAt: string | null | undefined;
   totalScore: number;
   totalPRs: number;
   uniqueMiners: Set<string>;
@@ -961,13 +960,6 @@ type WatchedRepoStats = Repository & {
   discoveryIssues: number;
   discoveryContributors: Set<string>;
 };
-
-const isRepoActive = (repo: Repository): boolean => !repo.config?.inactiveAt;
-
-type RepoStatusFilter = 'all' | 'active' | 'inactive';
-
-const isRepoStatusFilter = (v: unknown): v is RepoStatusFilter =>
-  v === 'all' || v === 'active' || v === 'inactive';
 
 const isPrStatusFilterStored = (v: unknown): v is PrStatusFilter =>
   v === 'all' || v === 'open' || v === 'merged' || v === 'closed';
@@ -1088,14 +1080,6 @@ const repoHeaderStack = (
     <Box component="span">{lines[1]}</Box>
   </Box>
 );
-
-const repoStatusMeta = (repo: Repository) => {
-  const active = isRepoActive(repo);
-  return {
-    label: active ? 'ACTIVE' : 'INACTIVE',
-    color: active ? STATUS_COLORS.success : STATUS_COLORS.closed,
-  };
-};
 
 const getRepoHref = (repo: Repository) =>
   `/miners/repository?name=${encodeURIComponent(repo.fullName)}`;
@@ -1412,10 +1396,8 @@ const RepoCard: React.FC<{ repo: WatchedRepoStats; maxWeight: number }> = ({
   repo,
   maxWeight,
 }) => {
-  const { label, color } = repoStatusMeta(repo);
   const owner = repo.fullName.split('/')[0] || '';
   const weight = parseFloat(String(repo.config?.emissionShare ?? 0));
-  const isInactive = !!repo.config?.inactiveAt;
   const weightPct =
     maxWeight > 0 ? Math.max(0, Math.min(100, (weight / maxWeight) * 100)) : 0;
 
@@ -1434,7 +1416,6 @@ const RepoCard: React.FC<{ repo: WatchedRepoStats; maxWeight: number }> = ({
         gap: 1.5,
         cursor: 'pointer',
         transition: 'all 0.2s',
-        opacity: isInactive ? 0.5 : 1,
         '&:hover': {
           backgroundColor: theme.palette.surface.light,
           borderColor: theme.palette.border.medium,
@@ -1476,29 +1457,6 @@ const RepoCard: React.FC<{ repo: WatchedRepoStats; maxWeight: number }> = ({
             </Typography>
           </Tooltip>
         </LinkBox>
-        <Typography
-          component="span"
-          sx={(theme) => ({
-            fontFamily: '"JetBrains Mono", monospace',
-            fontSize: '0.65rem',
-            fontWeight: 600,
-            textTransform: 'uppercase',
-            letterSpacing: '0.04em',
-            px: 0.75,
-            py: 0.25,
-            borderRadius: '4px',
-            flexShrink: 0,
-            color,
-            backgroundColor: alpha(
-              isInactive
-                ? theme.palette.status.closed
-                : theme.palette.status.success,
-              0.12,
-            ),
-          })}
-        >
-          {label === 'ACTIVE' ? 'Active' : 'Inactive'}
-        </Typography>
         <WatchlistButton
           category="repos"
           itemKey={repo.fullName}
@@ -1647,12 +1605,6 @@ const ReposList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
   const { data: allMiners } = useAllMiners();
   const sidebarFixedRight = useWatchlistSidebarFixedRight();
   const [searchQuery, setSearchQuery] = useState('');
-  const [statusFilter, setStatusFilter] =
-    useSessionStoredState<RepoStatusFilter>(
-      'watchlist:repos:statusFilter',
-      'all',
-      isRepoStatusFilter,
-    );
   const [viewMode, setViewMode] = useWatchlistViewMode();
   const [showChart, setShowChart] = useState(false);
   const [useLogScale, setUseLogScale] = useState(false);
@@ -1669,7 +1621,7 @@ const ReposList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
 
   useEffect(() => {
     setPage(0);
-  }, [statusFilter, searchQuery, sortField, sortOrder, viewMode]);
+  }, [searchQuery, sortField, sortOrder, viewMode]);
 
   const handleSort = (field: RepoSortKey) => {
     if (sortField === field) {
@@ -1719,7 +1671,6 @@ const ReposList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
         return {
           ...r,
           weight: r.config?.emissionShare ?? 0,
-          inactiveAt: r.config?.inactiveAt ?? null,
           totalScore: s?.totalScore || 0,
           totalPRs: s?.totalPRs || 0,
           uniqueMiners: s?.uniqueMiners || new Set<string>(),
@@ -1730,28 +1681,14 @@ const ReposList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
       });
   }, [repos, allPrs, allMiners, itemKeys]);
 
-  const counts = useMemo(() => {
-    let active = 0;
-    let inactive = 0;
-    for (const r of items) {
-      if (isRepoActive(r)) active++;
-      else inactive++;
-    }
-    return { all: items.length, active, inactive };
-  }, [items]);
+  const counts = useMemo(() => ({ all: items.length }), [items]);
 
   const filtered = useMemo(() => {
     let result = items;
-    if (statusFilter === 'active')
-      result = result.filter((r) => isRepoActive(r));
-    else if (statusFilter === 'inactive')
-      result = result.filter((r) => !isRepoActive(r));
-
     const q = searchQuery.trim().toLowerCase();
     if (q) result = result.filter((r) => r.fullName.toLowerCase().includes(q));
-
     return result;
-  }, [items, statusFilter, searchQuery]);
+  }, [items, searchQuery]);
 
   const sorted = useMemo(() => {
     const dir = sortOrder === 'asc' ? 1 : -1;
@@ -1985,22 +1922,8 @@ const ReposList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
                   label="All"
                   count={counts.all}
                   color={STATUS_COLORS.neutral}
-                  isActive={statusFilter === 'all'}
-                  onClick={() => setStatusFilter('all')}
-                />
-                <FilterButton
-                  label="Active"
-                  count={counts.active}
-                  color={STATUS_COLORS.success}
-                  isActive={statusFilter === 'active'}
-                  onClick={() => setStatusFilter('active')}
-                />
-                <FilterButton
-                  label="Inactive"
-                  count={counts.inactive}
-                  color={STATUS_COLORS.closed}
-                  isActive={statusFilter === 'inactive'}
-                  onClick={() => setStatusFilter('inactive')}
+                  isActive
+                  onClick={() => {}}
                 />
               </Box>
             }
@@ -2080,7 +2003,7 @@ const ReposList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
             viewModeToggle={
               <ReposViewModeToggle viewMode={viewMode} onChange={setViewMode} />
             }
-            hasActiveFilter={statusFilter !== 'all'}
+            hasActiveFilter={false}
           />
         )}
       </DebouncedSearchInput>
@@ -2113,13 +2036,6 @@ const ReposList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
           getRowKey={(repo) => repo.fullName}
           getRowHref={getRepoHref}
           linkState={{ backLabel: 'Back to Watchlist' }}
-          getRowSx={(repo) =>
-            isRepoActive(repo)
-              ? {}
-              : {
-                  opacity: 0.5,
-                }
-          }
           minWidth="1180px"
           stickyHeader
           emptyLabel="No watched repositories found."

--- a/src/pages/dashboard/dashboardData.ts
+++ b/src/pages/dashboard/dashboardData.ts
@@ -11,7 +11,6 @@ import {
   type CommitLog,
   type MinerEvaluation,
   type MirrorDashboardIssue,
-  type Repository,
 } from '../../api';
 import {
   getPrStatusLabel,
@@ -905,27 +904,13 @@ interface RepoAccumulator {
   totalScore: number;
 }
 
-type InactiveRepoSet = Set<string>;
-
-const buildInactiveRepoSet = (repos: Repository[]): InactiveRepoSet =>
-  new Set(
-    repos
-      .filter((r: Repository): boolean => !!r.config?.inactiveAt)
-      .map((r: Repository): string => r.fullName.toLowerCase()),
-  );
-
-const isMergedInWindow = (
-  pr: CommitLog,
-  cutoff: number,
-  inactiveRepos: InactiveRepoSet,
-): boolean => {
+const isMergedInWindow = (pr: CommitLog, cutoff: number): boolean => {
   const merged: number | null = toTimestamp(pr.mergedAt);
   return (
     merged !== null &&
     merged >= cutoff &&
     getPrStatusLabel(pr) === 'Merged' &&
-    Boolean(pr.repository) &&
-    !inactiveRepos.has(pr.repository.toLowerCase())
+    Boolean(pr.repository)
   );
 };
 
@@ -991,18 +976,13 @@ const buildRepoEntry = (
   };
 };
 
-export const buildFeaturedWork = (
-  prs: CommitLog[],
-  repos: Repository[],
-): FeaturedWorkRepo[] => {
+export const buildFeaturedWork = (prs: CommitLog[]): FeaturedWorkRepo[] => {
   const config: FeaturedWorkConfig = FEATURED_WORK_CONFIG;
   const now: number = Date.now();
   const cutoff: number = now - config.windowHours * HOUR_MS;
 
-  const inactiveRepos: InactiveRepoSet = buildInactiveRepoSet(repos);
-
   const windowPrs: CommitLog[] = prs.filter((pr: CommitLog): boolean =>
-    isMergedInWindow(pr, cutoff, inactiveRepos),
+    isMergedInWindow(pr, cutoff),
   );
 
   const repoMap: Map<string, RepoAccumulator> = groupPrsByRepo(windowPrs);

--- a/src/pages/dashboard/useDashboardData.ts
+++ b/src/pages/dashboard/useDashboardData.ts
@@ -138,8 +138,8 @@ export const useDashboardData = (range: TrendTimeRange) => {
   );
 
   const featuredWork = useMemo(
-    () => buildFeaturedWork(datasets.prs.data, datasets.repos.data),
-    [datasets.prs.data, datasets.repos.data],
+    () => buildFeaturedWork(datasets.prs.data),
+    [datasets.prs.data],
   );
 
   const kpis = useMemo(

--- a/src/pages/search/searchData.ts
+++ b/src/pages/search/searchData.ts
@@ -165,7 +165,7 @@ const buildRepoSearchData = (
       return {
         fullName: repo.fullName,
         owner: repo.owner,
-        weight: parseNumber(repo.config?.weight),
+        weight: parseNumber(repo.config?.emissionShare),
         totalScore: stats?.totalScore || 0,
         totalPRs: stats?.totalPRs || 0,
         contributors: stats?.uniqueAuthors.size || 0,

--- a/src/utils/ExplorerUtils.ts
+++ b/src/utils/ExplorerUtils.ts
@@ -123,8 +123,6 @@ export interface RepoStats {
   tokenScore: number;
   weight: number;
   latestPrDate?: string | null;
-  /** Set when subnet repo list marks the repository inactive (miners / enrich layer). */
-  inactiveAt?: string | null;
 }
 
 /** Per-repository stats for Issue Discovery (miner solved bounties via winning PRs). */
@@ -136,7 +134,6 @@ export interface IssueRepoStats {
   bountyEarned: number;
   weight: number;
   latestActivityDate: string | null;
-  inactiveAt?: string | null;
 }
 
 export type RepoSortField =

--- a/src/utils/ExplorerUtils.ts
+++ b/src/utils/ExplorerUtils.ts
@@ -261,7 +261,7 @@ export const buildRepoWeightsMap = (
     if (repo && repo.fullName) {
       map.set(
         repo.fullName.toLowerCase(),
-        parseFloat(String(repo.config?.weight ?? 0)),
+        parseFloat(String(repo.config?.emissionShare ?? 0)),
       );
     }
   }


### PR DESCRIPTION
## Summary
- Remove the two unused `pioneerDividend` / `pioneerRank` declarations from `src/api/models/Dashboard.ts` (4 lines, two type definitions)

The fields are not rendered anywhere in `src/` (grep clean) — purely type-level passthrough that mirrored what das-gittensor returned. Pairs with:
- entrius/gittensor PR #1285 (stops writing the columns)
- entrius/das-gittensor PR #73 (stops selecting them)
- entrius/gittensor-db PR #43 (drops the columns)

## Test plan
- [x] `npx tsc -b --noEmit` clean
- [x] `npm run format:check` clean
- [x] `npm run lint` clean