### PR TITLE
feat(leaderboard): add alphabetical (name) sort to miners

### DIFF
--- a/src/components/leaderboard/MinersList.tsx
+++ b/src/components/leaderboard/MinersList.tsx
@@ -126,6 +126,7 @@ export const MinersList: React.FC<MinersListProps> = ({
       key: 'miner',
       header: 'Miner',
       width: '25%',
+      sortKey: 'username',
       cellSx: { pl: 1.5 },
       renderCell: (miner) => <MinerIdentityCell miner={miner} />,
     },

--- a/src/components/leaderboard/TopMinersTable.tsx
+++ b/src/components/leaderboard/TopMinersTable.tsx
@@ -34,6 +34,7 @@ import {
   type SortOption,
   type LeaderboardVariant,
   FONTS,
+  minerSortName,
 } from './types';
 
 type ViewMode = 'cards' | 'list';
@@ -95,7 +96,14 @@ interface TopMinersTableProps {
 
 const getAllowedSortOptions = (variant: LeaderboardVariant): SortOption[] => {
   if (variant === 'discoveries')
-    return ['totalScore', 'usdPerDay', 'totalIssues', 'credibility', 'watch'];
+    return [
+      'totalScore',
+      'usdPerDay',
+      'totalIssues',
+      'credibility',
+      'username',
+      'watch',
+    ];
   if (variant === 'watchlist')
     return [
       'totalScore',
@@ -104,9 +112,17 @@ const getAllowedSortOptions = (variant: LeaderboardVariant): SortOption[] => {
       'totalIssues',
       'issueDiscoveryScore',
       'credibility',
+      'username',
       'watch',
     ];
-  return ['totalScore', 'usdPerDay', 'totalPRs', 'credibility', 'watch'];
+  return [
+    'totalScore',
+    'usdPerDay',
+    'totalPRs',
+    'credibility',
+    'username',
+    'watch',
+  ];
 };
 
 type EligibilityFilter = 'all' | 'eligible' | 'ineligible';
@@ -196,6 +212,8 @@ const compareMiners = (
       );
     case 'credibility':
       return (a.credibility ?? 0) - (b.credibility ?? 0);
+    case 'username':
+      return minerSortName(a).localeCompare(minerSortName(b));
     case 'watch':
       return compareByWatchlist(a, b, (m) => m.githubId, isWatched);
     default:
@@ -277,6 +295,8 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
   } = useDataTableParams<SortOption, TopMinersUrlFilters>({
     sortKeys: allowedSortKeys,
     defaultSortKey: 'totalScore',
+    // Alphabetical sort feels natural ascending; numeric metrics stay descending.
+    defaultOrderOverrides: { username: 'asc' },
     // Reuse the hook's `page` slot for our "show more" count — setSort and
     // filter changes reset it, which is the behavior we want.
     paramKeys: { page: VISIBLE_QUERY_PARAM },
@@ -606,14 +626,15 @@ const getSortButtonOptions = (
   };
   const credibility = { label: 'Credibility', value: 'credibility' as const };
   const score = { label: scoreLabel, value: 'totalScore' as const };
+  const name = { label: 'Name', value: 'username' as const };
 
   if (variant === 'watchlist') {
-    return [score, discovery, earnings, prs, issues, credibility];
+    return [score, discovery, earnings, prs, issues, credibility, name];
   }
   if (variant === 'discoveries') {
-    return [score, earnings, issues, credibility];
+    return [score, earnings, issues, credibility, name];
   }
-  return [score, earnings, prs, credibility];
+  return [score, earnings, prs, credibility, name];
 };
 
 const SortButtons: React.FC<SortButtonsProps> = ({

--- a/src/components/leaderboard/types.ts
+++ b/src/components/leaderboard/types.ts
@@ -70,7 +70,18 @@ export type SortOption =
   | 'totalIssues'
   | 'issueDiscoveryScore'
   | 'credibility'
+  | 'username'
   | 'watch';
+
+const NUMERIC_ID = /^\d+$/;
+
+// Resolves the user-visible name used for alphabetical sort & search filters.
+// Mirrors the fallback chain in MinerIdentityCell: prefer a non-numeric
+// `author` (the GitHub login), otherwise fall back to `githubId`.
+export const minerSortName = (m: Pick<MinerStats, 'author' | 'githubId'>) => {
+  if (m.author && !NUMERIC_ID.test(m.author)) return m.author.toLowerCase();
+  return (m.githubId ?? '').toLowerCase();
+};
 
 export const FONTS = {
   mono: '"JetBrains Mono", monospace',


### PR DESCRIPTION
## Summary

Adds a `username` SortOption to the miners leaderboard so miners can be sorted alphabetically by GitHub login. The pattern mirrors the Repository column on `TopRepositoriesTable` — same `localeCompare`, same ascending default, same toolbar treatment — so the leaderboard's two list-style tables behave consistently.

Visible in three places:
- **Card view** (`/top-miners`, `/discoveries`, `/watchlist`): "Name" chip appended to the Sort By row in the Options popover.
- **List view** (`?view=list`): the Miner column header is now clickable for asc/desc toggle.
- **URL state**: `?sort=username` and `?sort=username&dir=desc`.

Sort key resolution mirrors what `MinerIdentityCell` displays and what the existing search filter matches: prefer `miner.author` when it's a non-numeric GitHub login, fall back to `miner.githubId`. Lower-cased before compare so casing doesn't break alphabetical order. Helper `minerSortName` lives in `types.ts` next to the `SortOption` union.


## Related Issues

None


## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)


## Screenshots

(for `/watchlist` and `/top-miners`, tabs, same idea in `/discoveries`)
**Before:**
<img width="1919" height="1079" alt="Unsortable Miners" src="https://github.com/user-attachments/assets/e8975eb4-2693-41e0-8496-5bde9296023e" />
<img width="1919" height="1079" alt="Unsortable Watchlist" src="https://github.com/user-attachments/assets/0c79a457-5400-4e4b-9b84-9193705acc63" />

**After:**
<img width="1919" height="1079" alt="Ascending Miner Sort" src="https://github.com/user-attachments/assets/5d423366-4de5-4e7d-a4b8-f09ce32f6a79" />
<img width="1919" height="1079" alt="Ascending Watchlist Sort" src="https://github.com/user-attachments/assets/d277c4e6-1e59-4301-9e78-0c18dd91fc76" />
<img width="1919" height="1079" alt="Descending Miner Sort" src="https://github.com/user-attachments/assets/c4627245-9569-47ca-af03-bb82569659a8" />
<img width="1919" height="1079" alt="Descending Watchlist sort" src="https://github.com/user-attachments/assets/0a2519a3-04dc-479f-aab5-5cf45007a871" />



## Checklist

- [x] New components are modularized/separated where sensible — `minerSortName` helper lives in `types.ts` alongside `SortOption`, so the leaderboard family shares one definition.
- [x] Uses predefined theme — no new colors, sizes, or hardcoded styles introduced.
- [x] Responsive/mobile checked — the new "Name" chip flows with the existing Sort By group; both popover (small viewport) and sidebar (≥xl) variants render it.
- [x] Tested against the test API — `VITE_REACT_APP_BASE_URL=https://test-api.gittensor.io`. A→Z and Z→A confirmed on `/top-miners` (card view), `/top-miners?view=list` (column header), and `/discoveries`. URL state (`?sort=username[&dir=desc]`) round-trips.
- [x] `npm run format` and `npm run lint:fix` have been run on the changed files. Running them across the whole repo touches ~170 unrelated files due to pre-existing prettier drift; I left those out so the diff stays scoped to the feature.
- [x] `npm run build` passes — TypeScript + Vite build clean locally. The 2.97MB chunk-size warning is pre-existing and not from this change.
- [x] Screenshots included for any UI/visual changes — to add before submitting.


## Caveat

`miner.author` is sometimes a numeric GitHub ID rather than the resolved login (the displayed name in `MinerIdentityCell` comes from a separate `useMinerGithubData` fetch that isn't on the row at sort time). The sort falls back to `githubId` in that case — same fallback the search filter already uses — so a miner whose author hasn't been populated will sort by their numeric ID rather than their visible login. Fully resolving this would mean threading a `displayName` field through the API mapper, which felt out of scope for a small sort PR. Happy to expand if preferred.