### PR TITLE
Pluralize bounty chart issue count

### DIFF
--- a/src/components/issues/IssuesList.tsx
+++ b/src/components/issues/IssuesList.tsx
@@ -110,6 +110,9 @@ const parseBountyAmount = (value: string | null | undefined): number => {
   return Number.isFinite(parsed) ? parsed : 0;
 };
 
+const formatIssueCount = (count: number): string =>
+  `${count} ${count === 1 ? 'issue' : 'issues'}`;
+
 interface IssuesListProps {
   issues: IssueBounty[];
   isLoading?: boolean;
@@ -460,7 +463,7 @@ const IssuesList: React.FC<IssuesListProps> = ({
       backgroundColor: 'transparent',
       title: {
         text: 'Bounty Pool by Repository',
-        subtext: `${filteredIssues.length} issues`,
+        subtext: formatIssueCount(filteredIssues.length),
         left: 'center',
         top: 20,
         textStyle: {


### PR DESCRIPTION
## Summary
- Adds a small formatter for issue count labels.
- Uses singular `issue` when the filtered count is 1 and plural `issues` otherwise.

## Validation
- `npm ci --ignore-scripts`
- `npm run build`
- `npm run lint`
- `git diff --check`

## Disclosure
Prepared by an AI automation bot under human operator supervision.

Fixes #1153

Bounty payout address, if applicable: `0x7D9536A1042894AEE0717519c72b572893fC21D1`