### PR TITLE
fix: populate Resolved/Closed filters on Watchlist Issues tab

### DIFF
--- a/src/pages/WatchlistPage.tsx
+++ b/src/pages/WatchlistPage.tsx
@@ -4150,7 +4150,14 @@ const IssueCard: React.FC<{
 };
 
 const IssuesList: React.FC<{ minerIds: string[] }> = ({ minerIds }) => {
-  const issueQueries = useMinersIssues(minerIds, minerIds.length > 0);
+  // Include a `since` param so the mirror returns issues across all states
+  // (open, resolved, closed), not just open. See #1176.
+  const since = useMemo(() => {
+    const d = new Date();
+    d.setDate(d.getDate() - 35);
+    return d.toISOString();
+  }, []);
+  const issueQueries = useMinersIssues(minerIds, minerIds.length > 0, since);
   const sidebarFixedRight = useWatchlistSidebarFixedRight();
 
   const { ids: starredIssueIds } = useWatchlist('issues');


### PR DESCRIPTION
Fixes #1176

The Watchlist Issues tab was calling useMinersIssues without a since parameter. The mirror API returns only OPEN issues when since is omitted, so Resolved and Closed filters always showed 0.

**Fix:** Added a stable since timestamp (35 days back, memoized with useMemo([])) so the mirror returns issues across all states.

Same pattern used by the dashboard fix referenced in the issue.