### PR TITLE
fix: render insight description body in MinerInsightsCard

### DIFF
--- a/src/components/miners/MinerInsightsCard.tsx
+++ b/src/components/miners/MinerInsightsCard.tsx
@@ -444,7 +444,9 @@ const MinerInsightsCard: React.FC<MinerInsightsCardProps> = ({
                     lineHeight: 1.45,
                     wordBreak: 'break-word',
                   }}
-                />
+                >
+                  {insight.description}
+                </Typography>
               </Box>
             </Box>
           );


### PR DESCRIPTION
Fixes #1182

The <Typography> element for the insight description body was self-closing (/>) instead of wrapping {insight.description}. Every insight row showed only the title and type chip, with empty space where the description text should appear.

**Fix:** Changed self-closing <Typography /> to <Typography>{insight.description}</Typography>.