### PR TITLE
fix: eliminate tab switch flicker on Watchlist page

### DIFF
--- a/src/pages/WatchlistPage.tsx
+++ b/src/pages/WatchlistPage.tsx
@@ -371,16 +371,24 @@ export const WatchlistContent: React.FC = () => {
             Go to {discovery.label}
           </Button>
         </Box>
-      ) : activeTab === 'miners' ? (
-        <MinersList itemKeys={ids} />
-      ) : activeTab === 'repos' ? (
-        <ReposList itemKeys={ids} />
-      ) : activeTab === 'bounties' ? (
-        <BountiesList itemKeys={ids} />
-      ) : activeTab === 'issues' ? (
-        <IssuesList minerIds={minerIds} />
       ) : (
-        <PRsList itemKeys={ids} />
+        <>
+          <Box sx={{ display: activeTab === 'miners' ? 'block' : 'none' }}>
+            <MinersList itemKeys={ids} />
+          </Box>
+          <Box sx={{ display: activeTab === 'repos' ? 'block' : 'none' }}>
+            <ReposList itemKeys={ids} />
+          </Box>
+          <Box sx={{ display: activeTab === 'bounties' ? 'block' : 'none' }}>
+            <BountiesList itemKeys={ids} />
+          </Box>
+          <Box sx={{ display: activeTab === 'issues' ? 'block' : 'none' }}>
+            <IssuesList minerIds={minerIds} />
+          </Box>
+          <Box sx={{ display: activeTab === 'prs' ? 'block' : 'none' }}>
+            <PRsList itemKeys={ids} />
+          </Box>
+        </>
       )}
 
       <Dialog


### PR DESCRIPTION
Fixes #1165 (Watchlist part)

Switching between Miners/Repos/Bounties/PRs/Issues tabs caused a visible flicker because ternary chaining unmounts and remounts each tab's component tree on every switch.

**Fix:** Changed to CSS display-based hiding so all tab contents stay mounted in the DOM. Switching tabs only toggles visibility, avoiding the mount/unmount flash.