### PR TITLE
fix: use PR(s)/issue(s) in Top Agents subtitle

### DIFF
--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1353,8 +1353,8 @@ const TopMinersPanel: React.FC<{
                     }}
                   >
                     {shortIdentity(miner.githubId)} -{' '}
-                    {miner.totalMergedPrs || 0} PRs,{' '}
-                    {miner.totalSolvedIssues || 0} issues
+                    {miner.totalMergedPrs || 0} PR(s),{' '}
+                    {miner.totalSolvedIssues || 0} issue(s)
                   </Typography>
                 </Box>
                 <Stack


### PR DESCRIPTION
Fixes #1155

Changed hardcoded plurals 'PRs' and 'issues' to 'PR(s)' and 'issue(s)' in the Top Agents by Earnings panel subtitle, matching the parenthetical plural convention so counts of 1 read correctly (e.g. '1 PR(s), 0 issue(s)').