### PR TITLE
fix: forward scoring window 'since' param to Watchlist Issues queries

### DIFF
--- a/src/pages/WatchlistPage.tsx
+++ b/src/pages/WatchlistPage.tsx
@@ -83,6 +83,7 @@ import { BountyCard } from '../components/issues/BountyCard';
 import { mapAllMinersToStats } from '../utils/minerMapper';
 import {
   buildRepoDiscoveryRollupFromMiners,
+  getScoringWindowStartIso,
   isOutsideScoringWindow,
 } from '../utils/ExplorerUtils';
 import {
@@ -4150,7 +4151,8 @@ const IssueCard: React.FC<{
 };
 
 const IssuesList: React.FC<{ minerIds: string[] }> = ({ minerIds }) => {
-  const issueQueries = useMinersIssues(minerIds, minerIds.length > 0);
+  const since = useMemo(() => getScoringWindowStartIso(), []);
+  const issueQueries = useMinersIssues(minerIds, minerIds.length > 0, since);
   const sidebarFixedRight = useWatchlistSidebarFixedRight();
 
   const { ids: starredIssueIds } = useWatchlist('issues');

--- a/src/utils/ExplorerUtils.ts
+++ b/src/utils/ExplorerUtils.ts
@@ -245,6 +245,13 @@ export const isOutsideScoringWindow = (
   return new Date(date) < cutoff;
 };
 
+/** Return an ISO-8601 timestamp for the start of the scoring window (now - SCORING_WINDOW_DAYS). */
+export const getScoringWindowStartIso = (): string => {
+  const cutoff = new Date();
+  cutoff.setDate(cutoff.getDate() - SCORING_WINDOW_DAYS);
+  return cutoff.toISOString();
+};
+
 // ---------------------------------------------------------------------------
 // Map builders – extract lookup maps from API data
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #1176

The Watchlist Issues tab was silently hiding all closed/resolved issues because useMinersIssues was called without a 'since' parameter. The mirror API only returns OPEN issues when 'since' is omitted.

- Added getScoringWindowStartIso() to ExplorerUtils
- Forward the 35-day scoring window start as the 'since' param
- Resolved/Closed filters now populate correctly