### PR TITLE
fix: close gap between sticky search bar and tab row on Bounties page

### DIFF
--- a/src/pages/IssuesPage.tsx
+++ b/src/pages/IssuesPage.tsx
@@ -115,8 +115,8 @@ const IssuesPage: React.FC = () => {
               position: 'sticky',
               top: 64,
               zIndex: 50,
-              backgroundColor: (t) => alpha(t.palette.background.default, 0.85),
-              backdropFilter: 'blur(12px)',
+              backgroundColor: 'background.default',
+              mt: '-1px',
             }}
           >
             <Tabs


### PR DESCRIPTION
Fixes #1112

The Bounties page had a visible gap between the sticky global search bar and the sticky tab row (All/Available/Pending/History) where scrolling content could peek through. This was caused by the tab row using semi-transparent background and not overlapping the search bar border-bottom.

- Changed tab row background from semi-transparent to fully opaque
- Added -1px margin-top to overlap with search bar border
- Removed unnecessary backdrop-filter