### PR TITLE
fix: miner details activity title

### DIFF
--- a/src/components/miners/MinerActivity.tsx
+++ b/src/components/miners/MinerActivity.tsx
@@ -41,6 +41,12 @@ import {
 
 type ViewMode = 'prs' | 'issues';
 
+/** Matches miner details mode labels: OSS Contributions / Issue Discovery. */
+const ACTIVITY_SECTION_TITLE: Record<ViewMode, string> = {
+  prs: 'OSS Contributions Activity',
+  issues: 'Issue Discovery Activity',
+};
+
 interface MinerActivityProps {
   githubId: string;
   viewMode?: ViewMode;
@@ -578,7 +584,7 @@ const MinerActivity: React.FC<MinerActivityProps> = ({
           }}
         >
           <Typography variant="sectionTitle">
-            {isIssueMode ? 'Issue Discovery Activity' : 'Developer Activity'}
+            {ACTIVITY_SECTION_TITLE[isIssueMode ? 'issues' : 'prs']}
           </Typography>
           <Box sx={{ alignSelf: { xs: 'stretch', sm: 'auto' }, minWidth: 0 }}>
             <TrustBadge


### PR DESCRIPTION
## Summary

On **Miner details**, the **Activity** tab section header in `MinerActivity` used **Developer Activity** in OSS mode but **Issue Discovery Activity** in discovery mode. The page mode toggle already labels programs **OSS Contributions** and **Issue Discovery**; only the discovery side followed that vocabulary in the Activity card title.

## Related Issues

Closes #1219

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

<!-- Include before/after screenshots for every UI/visual change. Remove this section if not applicable. -->

## Checklist

- [ ] New components are modularized/separated where sensible
- [ ] Uses predefined theme (e.g. no hardcoded colors)
- [ ] Responsive/mobile checked
- [ ] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes


## Solution

Introduce a small map keyed by `viewMode` so both modes use the same **`{Program} Activity`** pattern:

| `viewMode` | Section title |
|------------|----------------|
| `prs` (OSS Contributions) | **OSS Contributions Activity** |
| `issues` (Issue Discovery) | **Issue Discovery Activity** |

The JSX ternary is replaced with `ACTIVITY_SECTION_TITLE[isIssueMode ? 'issues' : 'prs']` for a single source of truth next to the `ViewMode` type.
