### PR TITLE
feat(dashboard): add contribution calendar and dashboard activity insights

### DIFF
--- a/src/components/ContributionHeatmap.tsx
+++ b/src/components/ContributionHeatmap.tsx
@@ -1,19 +1,41 @@
 import React from 'react';
-import { Box, Card, Typography, Tooltip, alpha, useTheme } from '@mui/material';
+import {
+  Box,
+  Card,
+  Typography,
+  Tooltip,
+  alpha,
+  useTheme,
+  type SxProps,
+  type Theme,
+} from '@mui/material';
 import { ActivityCalendar } from 'react-activity-calendar';
+
 import {
   CONTRIBUTION_HEATMAP_SCALE,
   TEXT_OPACITY,
   scrollbarSx,
 } from '../theme';
 
-interface ContributionData {
+export interface ContributionData {
   date: string;
   count: number;
   level: 0 | 1 | 2 | 3 | 4;
 }
 
-interface ContributionHeatmapProps {
+type DayIndex = 0 | 1 | 2 | 3 | 4 | 5 | 6;
+type WeekdayLabel = 'sun' | 'mon' | 'tue' | 'wed' | 'thu' | 'fri' | 'sat';
+
+const formatActivityDateLabel = (dateKey: string) => {
+  const [year, month, day] = dateKey.split('-').map(Number);
+  return new Date(year, month - 1, day).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+};
+
+export interface ContributionHeatmapProps {
   data: ContributionData[];
   contributionsLast30Days: number;
   totalDaysShown: number;
@@ -22,8 +44,18 @@ interface ContributionHeatmapProps {
   emptyTitle?: string;
   emptySubtitle?: string;
   bare?: boolean;
+  showHeader?: boolean;
   selectedDate?: string;
   onDayClick?: (date: string) => void;
+  blockSize?: number;
+  blockMargin?: number;
+  fontSize?: number;
+  weekStart?: DayIndex;
+  showWeekdayLabels?: boolean | WeekdayLabel[];
+  showTotalCount?: boolean;
+  showColorLegend?: boolean;
+  scrollContainerRef?: React.RefObject<HTMLDivElement | null>;
+  scrollContainerSx?: SxProps<Theme>;
 }
 
 const ContributionHeatmap: React.FC<ContributionHeatmapProps> = ({
@@ -35,8 +67,18 @@ const ContributionHeatmap: React.FC<ContributionHeatmapProps> = ({
   emptyTitle = 'No contributions yet',
   emptySubtitle = 'Activity will appear here once PRs are merged',
   bare = false,
+  showHeader = true,
   selectedDate,
   onDayClick,
+  blockSize = 11,
+  blockMargin = 3,
+  fontSize = 11,
+  weekStart,
+  showWeekdayLabels = false,
+  showTotalCount,
+  showColorLegend,
+  scrollContainerRef,
+  scrollContainerSx,
 }) => {
   const theme = useTheme();
   const heatmapLevels = [...CONTRIBUTION_HEATMAP_SCALE];
@@ -44,139 +86,160 @@ const ContributionHeatmap: React.FC<ContributionHeatmapProps> = ({
   const isEmpty = data.length === 0;
   const interactive = !!onDayClick;
 
-  const content = (
-    <>
-      <Box sx={{ mb: 2.5 }}>
-        <Typography
+  const heatmapScroll = (
+    <Box
+      ref={scrollContainerRef}
+      sx={{
+        width: '100%',
+        maxWidth: '100%',
+        overflowX: 'auto',
+        overflowY: 'hidden',
+        mb: showHeader || footerText ? 1 : 0,
+        ...scrollbarSx,
+        ...scrollContainerSx,
+      }}
+    >
+      {isEmpty ? (
+        <Box
           sx={{
-            color: 'text.primary',
-            fontWeight: 700,
-            fontSize: '2.5rem',
-            lineHeight: 1,
+            py: 4,
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            minHeight: 100,
+            width: '100%',
           }}
         >
-          {contributionsLast30Days.toLocaleString()}
-        </Typography>
-        <Typography
-          variant="body2"
-          sx={{
-            color: alpha(theme.palette.common.white, TEXT_OPACITY.faint),
-            fontSize: '0.85rem',
-            mt: 0.5,
-          }}
-        >
-          {subtitle}
-        </Typography>
-      </Box>
-
-      <Box sx={{ width: '100%', overflowX: 'auto', mb: 1, ...scrollbarSx }}>
-        {isEmpty ? (
-          <Box
+          <Typography
             sx={{
-              py: 4,
-              display: 'flex',
-              flexDirection: 'column',
-              alignItems: 'center',
-              justifyContent: 'center',
-              minHeight: 100,
+              color: alpha(theme.palette.common.white, TEXT_OPACITY.muted),
+              fontSize: '0.85rem',
+              textAlign: 'center',
             }}
           >
+            {emptyTitle}
+          </Typography>
+          {emptySubtitle && (
             <Typography
               sx={{
-                color: alpha(theme.palette.common.white, TEXT_OPACITY.muted),
-                fontSize: '0.85rem',
+                color: alpha(theme.palette.common.white, TEXT_OPACITY.ghost),
+                fontSize: '0.75rem',
                 textAlign: 'center',
+                mt: 0.5,
               }}
             >
-              {emptyTitle}
+              {emptySubtitle}
             </Typography>
-            {emptySubtitle && (
-              <Typography
-                sx={{
-                  color: alpha(theme.palette.common.white, TEXT_OPACITY.ghost),
-                  fontSize: '0.75rem',
-                  textAlign: 'center',
-                  mt: 0.5,
+          )}
+        </Box>
+      ) : (
+        <ActivityCalendar
+          data={data}
+          theme={heatmapTheme}
+          labels={{
+            legend: { less: 'Less', more: 'More' },
+            months: [
+              'Jan',
+              'Feb',
+              'Mar',
+              'Apr',
+              'May',
+              'Jun',
+              'Jul',
+              'Aug',
+              'Sep',
+              'Oct',
+              'Nov',
+              'Dec',
+            ],
+            totalCount: `{{count}} contribution(s) in the last ${totalDaysShown} day(s)`,
+            weekdays: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
+          }}
+          blockSize={blockSize}
+          blockMargin={blockMargin}
+          fontSize={fontSize}
+          style={{ color: theme.palette.text.primary }}
+          weekStart={weekStart}
+          showWeekdayLabels={showWeekdayLabels}
+          showTotalCount={showTotalCount}
+          showColorLegend={showColorLegend}
+          renderBlock={(block, activity) => {
+            const clickable = interactive;
+            const isSelected = selectedDate === activity.date;
+            const highlighted =
+              clickable && isSelected
+                ? React.cloneElement(block as React.ReactElement, {
+                    stroke: theme.palette.text.primary,
+                    strokeWidth: 1.5,
+                  })
+                : block;
+            const wrapped = clickable ? (
+              <g
+                onClick={() => onDayClick?.(activity.date)}
+                style={{ cursor: 'pointer' }}
+                role="button"
+                aria-label={`View ${activity.count} contribution${activity.count !== 1 ? 's' : ''} on ${activity.date}`}
+              >
+                {highlighted}
+              </g>
+            ) : (
+              highlighted
+            );
+            return (
+              <Tooltip
+                title={`${activity.count} contribution${activity.count !== 1 ? 's' : ''} on ${formatActivityDateLabel(activity.date)}${clickable ? ' — click to view PRs' : ''}`}
+                arrow
+                placement="top"
+                enterDelay={0}
+                enterNextDelay={0}
+                leaveDelay={0}
+                disableInteractive
+                slotProps={{
+                  popper: {
+                    sx: {
+                      zIndex: theme.zIndex.tooltip,
+                    },
+                  },
                 }}
               >
-                {emptySubtitle}
-              </Typography>
-            )}
-          </Box>
-        ) : (
-          <ActivityCalendar
-            data={data}
-            theme={heatmapTheme}
-            labels={{
-              legend: { less: 'Less', more: 'More' },
-              months: [
-                'Jan',
-                'Feb',
-                'Mar',
-                'Apr',
-                'May',
-                'Jun',
-                'Jul',
-                'Aug',
-                'Sep',
-                'Oct',
-                'Nov',
-                'Dec',
-              ],
-              totalCount: `{{count}} contribution(s) in the last ${totalDaysShown} day(s)`,
-              weekdays: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
+                {wrapped}
+              </Tooltip>
+            );
+          }}
+        />
+      )}
+    </Box>
+  );
+
+  const content = (
+    <>
+      {showHeader && (
+        <Box sx={{ mb: 2.5 }}>
+          <Typography
+            sx={{
+              color: 'text.primary',
+              fontWeight: 700,
+              fontSize: '2.5rem',
+              lineHeight: 1,
             }}
-            blockSize={11}
-            blockMargin={3}
-            fontSize={11}
-            style={{ color: theme.palette.text.primary }}
-            showWeekdayLabels={false}
-            renderBlock={(block, activity) => {
-              const clickable = interactive;
-              const isSelected = selectedDate === activity.date;
-              const highlighted =
-                clickable && isSelected
-                  ? React.cloneElement(block as React.ReactElement, {
-                      stroke: theme.palette.text.primary,
-                      strokeWidth: 1.5,
-                    })
-                  : block;
-              const wrapped = clickable ? (
-                <g
-                  onClick={() => onDayClick?.(activity.date)}
-                  style={{ cursor: 'pointer' }}
-                  role="button"
-                  aria-label={`View ${activity.count} contribution${activity.count !== 1 ? 's' : ''} on ${activity.date}`}
-                >
-                  {highlighted}
-                </g>
-              ) : (
-                highlighted
-              );
-              return (
-                <Tooltip
-                  title={`${activity.count} contribution${activity.count !== 1 ? 's' : ''} on ${new Date(activity.date).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}${clickable ? ' — click to view PRs' : ''}`}
-                  arrow
-                  placement="top"
-                  enterDelay={0}
-                  enterNextDelay={0}
-                  leaveDelay={0}
-                  disableInteractive
-                  slotProps={{
-                    popper: {
-                      sx: {
-                        zIndex: theme.zIndex.tooltip,
-                      },
-                    },
-                  }}
-                >
-                  {wrapped}
-                </Tooltip>
-              );
+          >
+            {contributionsLast30Days.toLocaleString()}
+          </Typography>
+          <Typography
+            variant="body2"
+            sx={{
+              color: alpha(theme.palette.common.white, TEXT_OPACITY.faint),
+              fontSize: '0.85rem',
+              mt: 0.5,
             }}
-          />
-        )}
-      </Box>
+          >
+            {subtitle}
+          </Typography>
+        </Box>
+      )}
+
+      {heatmapScroll}
 
       {footerText && (
         <Typography

--- a/src/pages/dashboard/DashboardPage.tsx
+++ b/src/pages/dashboard/DashboardPage.tsx
@@ -22,6 +22,7 @@ const DashboardFeaturePage: React.FC = () => {
     overview,
     trendLabels,
     trendSeries,
+    contributionCalendar,
     featuredWork,
     isFeaturedWorkLoading,
     featuredContributors,
@@ -75,6 +76,7 @@ const DashboardFeaturePage: React.FC = () => {
               range={range}
               trendLabels={trendLabels}
               trendSeries={trendSeries}
+              contributionCalendar={contributionCalendar}
               sections={overview}
               kpis={kpis}
               isLoading={isLoading}

--- a/src/pages/dashboard/dashboardData.ts
+++ b/src/pages/dashboard/dashboardData.ts
@@ -55,6 +55,21 @@ export interface DashboardKpi {
   subtitle: string;
 }
 
+export interface DashboardContributionDay {
+  date: string;
+  count: number;
+  level: 0 | 1 | 2 | 3 | 4;
+}
+
+export interface DashboardContributionCalendar {
+  days: DashboardContributionDay[];
+  totalDaysShown: number;
+  weekCount: number;
+  thisWeekCount: number;
+  weekOverWeekPercent: number | null;
+  weekOverWeekLabel: string;
+}
+
 export interface DashboardFeaturedContributor {
   featuredLabel: string;
   githubId: string;
@@ -123,6 +138,10 @@ const TREND_SERIES_KEYS: TrendSeriesKey[] = [
   'issuesOpened',
 ];
 const CURRENT_LOOKBACK_WINDOW: PresetTimeRange = '35d';
+/** Activity counted over this rolling window (inclusive, ending today). */
+export const CONTRIBUTION_CALENDAR_DAYS = 365;
+/** GitHub-style column count (Sun–Sat weeks). */
+export const CONTRIBUTION_CALENDAR_WEEKS = 53;
 
 type WindowBounds = {
   startMs: number;
@@ -336,6 +355,146 @@ export const buildDashboardTrendData = (
       key,
       values: seriesByKey[key],
     })),
+  };
+};
+
+/** Local calendar date key (yyyy-MM-dd) — matches the user's system day boundaries. */
+const formatCalendarDateKey = (timestamp: number) => {
+  const date = new Date(timestamp);
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+};
+
+const getLocalDayStart = (timestamp: number) => {
+  const date = new Date(timestamp);
+  date.setHours(0, 0, 0, 0);
+  return date.getTime();
+};
+
+const addLocalDays = (dayStartMs: number, days: number) => {
+  const date = new Date(dayStartMs);
+  date.setDate(date.getDate() + days);
+  date.setHours(0, 0, 0, 0);
+  return date.getTime();
+};
+
+/** Sunday 00:00 local for the week containing `timestamp`. */
+const getLocalSundayWeekStart = (timestamp: number) => {
+  const date = new Date(timestamp);
+  date.setHours(0, 0, 0, 0);
+  date.setDate(date.getDate() - date.getDay());
+  return date.getTime();
+};
+
+const parseCalendarDateKey = (dateKey: string) => {
+  const [year, month, day] = dateKey.split('-').map(Number);
+  return getLocalDayStart(new Date(year, month - 1, day).getTime());
+};
+
+const getContributionLevel = (count: number): 0 | 1 | 2 | 3 | 4 => {
+  if (count <= 0) return 0;
+  if (count < 2) return 1;
+  if (count < 3) return 2;
+  if (count < 5) return 3;
+  return 4;
+};
+
+const buildContributionCalendarDateRange = (now = new Date()) => {
+  const rollingEndMs = getLocalDayStart(now.getTime());
+  // Rolling year: if today is May 17, activity range starts May 18 prior year.
+  const rollingStartMs = addLocalDays(
+    rollingEndMs,
+    -(CONTRIBUTION_CALENDAR_DAYS - 1),
+  );
+  // 53 Sun–Sat columns; only render days through today (no future week padding).
+  const gridStartMs =
+    getLocalSundayWeekStart(rollingEndMs) -
+    (CONTRIBUTION_CALENDAR_WEEKS - 1) * WEEK_MS;
+  return { gridStartMs, rollingEndMs, rollingStartMs };
+};
+
+export const buildDashboardContributionCalendar = (
+  prs: CommitLog[],
+  issues: MirrorDashboardIssue[],
+  now = new Date(),
+): DashboardContributionCalendar => {
+  const { gridStartMs, rollingEndMs, rollingStartMs } =
+    buildContributionCalendarDateRange(now);
+  const dataMap = new Map<string, number>();
+
+  for (
+    let dayMs = gridStartMs;
+    dayMs <= rollingEndMs;
+    dayMs = addLocalDays(dayMs, 1)
+  ) {
+    dataMap.set(formatCalendarDateKey(dayMs), 0);
+  }
+
+  const incrementDay = (timestamp: number | null) => {
+    if (timestamp === null) return;
+    const dayMs = getLocalDayStart(timestamp);
+    if (dayMs < rollingStartMs || dayMs > rollingEndMs) return;
+    const dateKey = formatCalendarDateKey(dayMs);
+    if (!dataMap.has(dateKey)) return;
+    dataMap.set(dateKey, (dataMap.get(dateKey) ?? 0) + 1);
+  };
+
+  prs.forEach((pr) => incrementDay(toTimestamp(pr.mergedAt)));
+
+  issues.forEach((issue) => {
+    if (!isResolvedMinerIssue(issue)) return;
+    incrementDay(toTimestamp(issue.solving_pr?.merged_at));
+  });
+
+  const days = Array.from(dataMap.entries())
+    .map(([date, count]) => ({
+      date,
+      count,
+      level: getContributionLevel(count),
+    }))
+    .sort((a, b) => a.date.localeCompare(b.date));
+
+  const thisWeekStart = getLocalSundayWeekStart(now.getTime());
+  const lastWeekStart = thisWeekStart - WEEK_MS;
+
+  let thisWeekCount = 0;
+  let lastWeekCount = 0;
+
+  days.forEach(({ date, count }) => {
+    const dayMs = parseCalendarDateKey(date);
+    if (dayMs >= thisWeekStart) {
+      thisWeekCount += count;
+      return;
+    }
+    if (dayMs >= lastWeekStart) {
+      lastWeekCount += count;
+    }
+  });
+
+  let weekOverWeekPercent: number | null = null;
+  let weekOverWeekLabel = '0% vs last week';
+
+  if (thisWeekCount === 0 && lastWeekCount === 0) {
+    weekOverWeekPercent = 0;
+  } else if (lastWeekCount > 0) {
+    weekOverWeekPercent =
+      ((thisWeekCount - lastWeekCount) / lastWeekCount) * 100;
+    const rounded = Math.round(weekOverWeekPercent);
+    const sign = rounded > 0 ? '+' : '';
+    weekOverWeekLabel = `${sign}${rounded}% vs last week`;
+  } else if (thisWeekCount > 0) {
+    weekOverWeekLabel = 'New activity this week';
+  }
+
+  return {
+    days,
+    totalDaysShown: dataMap.size,
+    weekCount: Math.ceil(days.length / 7),
+    thisWeekCount,
+    weekOverWeekPercent,
+    weekOverWeekLabel,
   };
 };
 

--- a/src/pages/dashboard/useDashboardData.ts
+++ b/src/pages/dashboard/useDashboardData.ts
@@ -25,6 +25,7 @@ import {
   type Repository,
 } from '../../api/models';
 import {
+  buildDashboardContributionCalendar,
   buildDashboardKpis,
   buildDashboardOverview,
   buildDashboardTrendData,
@@ -134,6 +135,15 @@ const useDashboardData = (range: TrendTimeRange) => {
     [datasets.minerIssues.data, datasets.prs.data, range],
   );
 
+  const contributionCalendar = useMemo(
+    () =>
+      buildDashboardContributionCalendar(
+        datasets.prs.data,
+        datasets.minerIssues.data,
+      ),
+    [datasets.minerIssues.data, datasets.prs.data],
+  );
+
   const featuredContributors = useMemo(
     () => buildFeaturedContributors(datasets.prs.data, datasets.miners.data),
     [datasets.miners.data, datasets.prs.data],
@@ -153,7 +163,10 @@ const useDashboardData = (range: TrendTimeRange) => {
     [datasets.prs.data],
   );
 
-  const totalLinesCommitted = Number(linesTotalQuery.data?.linesCommitted) || 0;
+  const totalLinesCommitted = useMemo(
+    () => Number(linesTotalQuery.data?.linesCommitted) || 0,
+    [linesTotalQuery.data],
+  );
 
   const kpis = useMemo(
     () =>
@@ -175,6 +188,7 @@ const useDashboardData = (range: TrendTimeRange) => {
     overview,
     trendLabels: trendData.labels,
     trendSeries: trendData.series,
+    contributionCalendar,
     featuredWork,
     isFeaturedWorkLoading,
     featuredContributors,

--- a/src/pages/dashboard/useDashboardData.ts
+++ b/src/pages/dashboard/useDashboardData.ts
@@ -163,10 +163,7 @@ const useDashboardData = (range: TrendTimeRange) => {
     [datasets.prs.data],
   );
 
-  const totalLinesCommitted = useMemo(
-    () => Number(linesTotalQuery.data?.linesCommitted) || 0,
-    [linesTotalQuery.data],
-  );
+  const totalLinesCommitted = Number(linesTotalQuery.data?.linesCommitted) || 0;
 
   const kpis = useMemo(
     () =>

--- a/src/pages/dashboard/views/ActiveNetwork.tsx
+++ b/src/pages/dashboard/views/ActiveNetwork.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
 import { Box, CircularProgress } from '@mui/material';
 import {
+  type DashboardContributionCalendar,
   type DashboardKpi,
   type DashboardOverviewSection,
   type DashboardTrendSeries,
   type TrendTimeRange,
 } from '../dashboardData';
+import ContributionCalendar from './ContributionCalendar';
 import ContributionTrends from './ContributionTrends';
 import DashboardOverview from './DashboardOverview';
 
@@ -13,6 +15,7 @@ interface ActiveNetworkProps {
   range: TrendTimeRange;
   trendLabels: string[];
   trendSeries: DashboardTrendSeries[];
+  contributionCalendar: DashboardContributionCalendar;
   sections: DashboardOverviewSection[];
   kpis: DashboardKpi[];
   isLoading?: boolean;
@@ -23,6 +26,7 @@ const ActiveNetwork: React.FC<ActiveNetworkProps> = ({
   range,
   trendLabels,
   trendSeries,
+  contributionCalendar,
   sections,
   kpis,
   isLoading = false,
@@ -44,6 +48,11 @@ const ActiveNetwork: React.FC<ActiveNetworkProps> = ({
         series={trendSeries}
         isLoading={isLoading}
         onRangeChange={onRangeChange}
+      />
+
+      <ContributionCalendar
+        calendar={contributionCalendar}
+        isLoading={isLoading}
       />
 
       {isLoading ? (

--- a/src/pages/dashboard/views/ContributionCalendar.tsx
+++ b/src/pages/dashboard/views/ContributionCalendar.tsx
@@ -7,17 +7,12 @@ import {
   CardContent,
   CircularProgress,
   Stack,
-  Tooltip,
   Typography,
   useMediaQuery,
 } from '@mui/material';
 import { alpha, useTheme } from '@mui/material/styles';
-import { ActivityCalendar } from 'react-activity-calendar';
-import {
-  CONTRIBUTION_HEATMAP_SCALE,
-  scrollbarSx,
-  TEXT_OPACITY,
-} from '../../../theme';
+import ContributionHeatmap from '../../../components/ContributionHeatmap';
+import { CONTRIBUTION_HEATMAP_SCALE, TEXT_OPACITY } from '../../../theme';
 import { type DashboardContributionCalendar } from '../dashboardData';
 
 interface ContributionCalendarProps {
@@ -25,24 +20,15 @@ interface ContributionCalendarProps {
   isLoading?: boolean;
 }
 
-/** GitHub-style fixed cells — never shrink to fit (enables horizontal swipe on mobile). */
 const CALENDAR_BLOCK = {
   mobile: { size: 10, margin: 3, fontSize: 10 },
   desktop: { size: 11, margin: 3, fontSize: 11 },
 } as const;
 
-const formatActivityDateLabel = (dateKey: string) => {
-  const [year, month, day] = dateKey.split('-').map(Number);
-  return new Date(year, month - 1, day).toLocaleDateString('en-US', {
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric',
-  });
-};
-
 const ContributionCalendarLegend: React.FC = () => {
   const theme = useTheme();
   const monoFontFamily = theme.typography.fontFamily;
+  const legendColor = alpha(theme.palette.text.primary, TEXT_OPACITY.tertiary);
 
   return (
     <Stack
@@ -58,7 +44,7 @@ const ContributionCalendarLegend: React.FC = () => {
         sx={{
           fontFamily: monoFontFamily,
           fontSize: { xs: '0.62rem', sm: '0.65rem' },
-          color: alpha(theme.palette.text.primary, 0.45),
+          color: legendColor,
         }}
       >
         Less
@@ -80,7 +66,7 @@ const ContributionCalendarLegend: React.FC = () => {
         sx={{
           fontFamily: monoFontFamily,
           fontSize: { xs: '0.62rem', sm: '0.65rem' },
-          color: alpha(theme.palette.text.primary, 0.45),
+          color: legendColor,
         }}
       >
         More
@@ -98,8 +84,6 @@ const ContributionCalendar: React.FC<ContributionCalendarProps> = ({
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
   const scrollRef = useRef<HTMLDivElement>(null);
 
-  const heatmapLevels = [...CONTRIBUTION_HEATMAP_SCALE];
-  const heatmapTheme = { light: heatmapLevels, dark: heatmapLevels };
   const isEmpty = calendar.days.every((day) => day.count === 0);
   const totalContributions = useMemo(
     () => calendar.days.reduce((sum, day) => sum + day.count, 0),
@@ -107,6 +91,27 @@ const ContributionCalendar: React.FC<ContributionCalendarProps> = ({
   );
 
   const blockConfig = isMobile ? CALENDAR_BLOCK.mobile : CALENDAR_BLOCK.desktop;
+
+  const heatmapScrollSx = useMemo(
+    () => ({
+      WebkitOverflowScrolling: 'touch',
+      touchAction: 'pan-x',
+      pb: 0.5,
+      '& .react-activity-calendar': {
+        display: 'inline-block',
+        width: 'max-content',
+        minWidth: 'max-content',
+      },
+      '& .react-activity-calendar svg': {
+        display: 'block',
+      },
+      '& .react-activity-calendar text': {
+        fill: alpha(theme.palette.text.primary, TEXT_OPACITY.tertiary),
+        fontFamily: monoFontFamily,
+      },
+    }),
+    [monoFontFamily, theme.palette.text.primary],
+  );
 
   useEffect(() => {
     const el = scrollRef.current;
@@ -203,148 +208,6 @@ const ContributionCalendar: React.FC<ContributionCalendarProps> = ({
     </Box>
   );
 
-  const heatmapPanel = (
-    <Box
-      sx={{
-        flex: 1,
-        minWidth: 0,
-        display: 'flex',
-        flexDirection: 'column',
-      }}
-    >
-      <Box
-        ref={scrollRef}
-        sx={{
-          width: '100%',
-          maxWidth: '100%',
-          overflowX: 'auto',
-          overflowY: 'hidden',
-          WebkitOverflowScrolling: 'touch',
-          touchAction: 'pan-x',
-          pb: 0.5,
-          ...scrollbarSx,
-          '& .react-activity-calendar': {
-            display: 'inline-block',
-            width: 'max-content',
-            minWidth: 'max-content',
-          },
-          '& .react-activity-calendar svg': {
-            display: 'block',
-          },
-          '& .react-activity-calendar text': {
-            fill: alpha(theme.palette.text.primary, 0.45),
-            fontFamily: monoFontFamily,
-          },
-        }}
-      >
-        {isEmpty ? (
-          <Box
-            sx={{
-              py: 4,
-              display: 'flex',
-              flexDirection: 'column',
-              alignItems: 'center',
-              justifyContent: 'center',
-              minHeight: 120,
-              width: '100%',
-            }}
-          >
-            <Typography
-              sx={{
-                color: alpha(theme.palette.text.primary, TEXT_OPACITY.muted),
-                fontSize: '0.85rem',
-                textAlign: 'center',
-              }}
-            >
-              No contributions yet
-            </Typography>
-            <Typography
-              sx={{
-                color: alpha(theme.palette.text.primary, TEXT_OPACITY.ghost),
-                fontSize: '0.75rem',
-                textAlign: 'center',
-                mt: 0.5,
-              }}
-            >
-              Activity will appear here once PRs merge and issues resolve
-            </Typography>
-          </Box>
-        ) : (
-          <ActivityCalendar
-            data={calendar.days}
-            theme={heatmapTheme}
-            labels={{
-              legend: { less: 'Less', more: 'More' },
-              months: [
-                'Jan',
-                'Feb',
-                'Mar',
-                'Apr',
-                'May',
-                'Jun',
-                'Jul',
-                'Aug',
-                'Sep',
-                'Oct',
-                'Nov',
-                'Dec',
-              ],
-              totalCount: `{{count}} contribution(s) in the last ${calendar.totalDaysShown} day(s)`,
-              weekdays: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
-            }}
-            blockSize={blockConfig.size}
-            blockMargin={blockConfig.margin}
-            fontSize={blockConfig.fontSize}
-            style={{ color: theme.palette.text.primary }}
-            weekStart={0}
-            showWeekdayLabels={['mon', 'wed', 'fri']}
-            showTotalCount={false}
-            showColorLegend={false}
-            renderBlock={(block, activity) => (
-              <Tooltip
-                title={`${activity.count} contribution${activity.count !== 1 ? 's' : ''} on ${formatActivityDateLabel(activity.date)}`}
-                arrow
-                placement="top"
-                enterDelay={0}
-                enterNextDelay={0}
-                leaveDelay={0}
-                disableInteractive
-              >
-                {block}
-              </Tooltip>
-            )}
-          />
-        )}
-      </Box>
-
-      <Box
-        sx={{
-          mt: 1,
-          pt: 1,
-          borderTop: `1px solid ${theme.palette.border.light}`,
-          display: 'flex',
-          flexDirection: { xs: 'column', sm: 'row' },
-          alignItems: { xs: 'flex-start', sm: 'center' },
-          justifyContent: 'space-between',
-          gap: 1,
-        }}
-      >
-        <Typography
-          sx={{
-            fontFamily: monoFontFamily,
-            fontSize: { xs: '0.62rem', sm: '0.65rem' },
-            color: alpha(theme.palette.text.primary, 0.4),
-            lineHeight: 1.35,
-          }}
-        >
-          {totalContributions.toLocaleString()} contribution
-          {totalContributions === 1 ? '' : 's'} in the last year
-        </Typography>
-        {!isEmpty && <ContributionCalendarLegend />}
-      </Box>
-    </Box>
-  );
-
   return (
     <Box
       sx={{
@@ -399,7 +262,60 @@ const ContributionCalendar: React.FC<ContributionCalendarProps> = ({
               alignItems="stretch"
               sx={{ minWidth: 0 }}
             >
-              {heatmapPanel}
+              <Box
+                sx={{
+                  flex: 1,
+                  minWidth: 0,
+                  display: 'flex',
+                  flexDirection: 'column',
+                }}
+              >
+                <ContributionHeatmap
+                  bare
+                  showHeader={false}
+                  data={calendar.days}
+                  contributionsLast30Days={calendar.thisWeekCount}
+                  totalDaysShown={calendar.totalDaysShown}
+                  emptySubtitle="Activity will appear here once PRs merge and issues resolve"
+                  blockSize={blockConfig.size}
+                  blockMargin={blockConfig.margin}
+                  fontSize={blockConfig.fontSize}
+                  weekStart={0}
+                  showWeekdayLabels={['mon', 'wed', 'fri']}
+                  showTotalCount={false}
+                  showColorLegend={false}
+                  scrollContainerRef={scrollRef}
+                  scrollContainerSx={heatmapScrollSx}
+                />
+                <Box
+                  sx={{
+                    mt: 1,
+                    pt: 1,
+                    borderTop: `1px solid ${theme.palette.border.light}`,
+                    display: 'flex',
+                    flexDirection: { xs: 'column', sm: 'row' },
+                    alignItems: { xs: 'flex-start', sm: 'center' },
+                    justifyContent: 'space-between',
+                    gap: 1,
+                  }}
+                >
+                  <Typography
+                    sx={{
+                      fontFamily: monoFontFamily,
+                      fontSize: { xs: '0.62rem', sm: '0.65rem' },
+                      color: alpha(
+                        theme.palette.text.primary,
+                        TEXT_OPACITY.muted,
+                      ),
+                      lineHeight: 1.35,
+                    }}
+                  >
+                    {totalContributions.toLocaleString()} contribution
+                    {totalContributions === 1 ? '' : 's'} in the last year
+                  </Typography>
+                  {!isEmpty && <ContributionCalendarLegend />}
+                </Box>
+              </Box>
               {weekSummaryCard}
             </Stack>
           )}

--- a/src/pages/dashboard/views/ContributionCalendar.tsx
+++ b/src/pages/dashboard/views/ContributionCalendar.tsx
@@ -1,0 +1,412 @@
+import React, { useEffect, useMemo, useRef } from 'react';
+import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
+import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
+import {
+  Box,
+  Card,
+  CardContent,
+  CircularProgress,
+  Stack,
+  Tooltip,
+  Typography,
+  useMediaQuery,
+} from '@mui/material';
+import { alpha, useTheme } from '@mui/material/styles';
+import { ActivityCalendar } from 'react-activity-calendar';
+import {
+  CONTRIBUTION_HEATMAP_SCALE,
+  scrollbarSx,
+  TEXT_OPACITY,
+} from '../../../theme';
+import { type DashboardContributionCalendar } from '../dashboardData';
+
+interface ContributionCalendarProps {
+  calendar: DashboardContributionCalendar;
+  isLoading?: boolean;
+}
+
+/** GitHub-style fixed cells — never shrink to fit (enables horizontal swipe on mobile). */
+const CALENDAR_BLOCK = {
+  mobile: { size: 10, margin: 3, fontSize: 10 },
+  desktop: { size: 11, margin: 3, fontSize: 11 },
+} as const;
+
+const formatActivityDateLabel = (dateKey: string) => {
+  const [year, month, day] = dateKey.split('-').map(Number);
+  return new Date(year, month - 1, day).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+};
+
+const ContributionCalendarLegend: React.FC = () => {
+  const theme = useTheme();
+  const monoFontFamily = theme.typography.fontFamily;
+
+  return (
+    <Stack
+      direction="row"
+      alignItems="center"
+      justifyContent="flex-end"
+      spacing={0.5}
+      useFlexGap
+      flexWrap="wrap"
+    >
+      <Typography
+        component="span"
+        sx={{
+          fontFamily: monoFontFamily,
+          fontSize: { xs: '0.62rem', sm: '0.65rem' },
+          color: alpha(theme.palette.text.primary, 0.45),
+        }}
+      >
+        Less
+      </Typography>
+      {CONTRIBUTION_HEATMAP_SCALE.map((color) => (
+        <Box
+          key={color}
+          sx={{
+            width: { xs: 9, sm: 10 },
+            height: { xs: 9, sm: 10 },
+            borderRadius: '2px',
+            backgroundColor: color,
+            flexShrink: 0,
+          }}
+        />
+      ))}
+      <Typography
+        component="span"
+        sx={{
+          fontFamily: monoFontFamily,
+          fontSize: { xs: '0.62rem', sm: '0.65rem' },
+          color: alpha(theme.palette.text.primary, 0.45),
+        }}
+      >
+        More
+      </Typography>
+    </Stack>
+  );
+};
+
+const ContributionCalendar: React.FC<ContributionCalendarProps> = ({
+  calendar,
+  isLoading = false,
+}) => {
+  const theme = useTheme();
+  const monoFontFamily = theme.typography.fontFamily;
+  const isMobile = useMediaQuery(theme.breakpoints.down('md'));
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  const heatmapLevels = [...CONTRIBUTION_HEATMAP_SCALE];
+  const heatmapTheme = { light: heatmapLevels, dark: heatmapLevels };
+  const isEmpty = calendar.days.every((day) => day.count === 0);
+  const totalContributions = useMemo(
+    () => calendar.days.reduce((sum, day) => sum + day.count, 0),
+    [calendar.days],
+  );
+
+  const blockConfig = isMobile ? CALENDAR_BLOCK.mobile : CALENDAR_BLOCK.desktop;
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el || isEmpty || isLoading) return;
+    el.scrollLeft = el.scrollWidth;
+  }, [calendar.days, isEmpty, isLoading]);
+
+  const weekTrendPositive =
+    calendar.weekOverWeekPercent !== null && calendar.weekOverWeekPercent >= 0;
+  const weekTrendColor =
+    calendar.weekOverWeekPercent === null
+      ? alpha(theme.palette.text.primary, TEXT_OPACITY.muted)
+      : weekTrendPositive
+        ? theme.palette.status.success
+        : theme.palette.status.closed;
+
+  const weekSummaryCard = (
+    <Box
+      sx={{
+        flexShrink: 0,
+        width: { xs: '100%', md: 148 },
+        p: { xs: 1.25, sm: 1.5 },
+        borderRadius: 2,
+        border: `1px solid ${theme.palette.border.light}`,
+        backgroundColor: theme.palette.surface.subtle,
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'center',
+      }}
+    >
+      <Typography
+        sx={{
+          color: alpha(theme.palette.text.primary, TEXT_OPACITY.muted),
+          fontFamily: monoFontFamily,
+          fontSize: '0.62rem',
+          fontWeight: 700,
+          letterSpacing: '0.08em',
+          textTransform: 'uppercase',
+        }}
+      >
+        This week
+      </Typography>
+      <Typography
+        sx={{
+          mt: 0.75,
+          color: theme.palette.diff.additions,
+          fontFamily: monoFontFamily,
+          fontSize: { xs: '2rem', md: '2.35rem' },
+          fontWeight: 700,
+          lineHeight: 1,
+          fontVariantNumeric: 'tabular-nums',
+        }}
+      >
+        {calendar.thisWeekCount.toLocaleString()}
+      </Typography>
+      <Typography
+        sx={{
+          mt: 0.35,
+          color: alpha(theme.palette.text.primary, TEXT_OPACITY.faint),
+          fontFamily: monoFontFamily,
+          fontSize: '0.72rem',
+        }}
+      >
+        Contributions
+      </Typography>
+      <Stack
+        direction="row"
+        spacing={0.25}
+        alignItems="center"
+        sx={{ mt: 1.1 }}
+      >
+        {calendar.weekOverWeekPercent !== null &&
+          (weekTrendPositive ? (
+            <ArrowUpwardIcon
+              sx={{ fontSize: '0.95rem', color: weekTrendColor }}
+            />
+          ) : (
+            <ArrowDownwardIcon
+              sx={{ fontSize: '0.95rem', color: weekTrendColor }}
+            />
+          ))}
+        <Typography
+          sx={{
+            color: weekTrendColor,
+            fontFamily: monoFontFamily,
+            fontSize: '0.68rem',
+            fontWeight: 600,
+            lineHeight: 1.2,
+          }}
+        >
+          {calendar.weekOverWeekLabel}
+        </Typography>
+      </Stack>
+    </Box>
+  );
+
+  const heatmapPanel = (
+    <Box
+      sx={{
+        flex: 1,
+        minWidth: 0,
+        display: 'flex',
+        flexDirection: 'column',
+      }}
+    >
+      <Box
+        ref={scrollRef}
+        sx={{
+          width: '100%',
+          maxWidth: '100%',
+          overflowX: 'auto',
+          overflowY: 'hidden',
+          WebkitOverflowScrolling: 'touch',
+          touchAction: 'pan-x',
+          pb: 0.5,
+          ...scrollbarSx,
+          '& .react-activity-calendar': {
+            display: 'inline-block',
+            width: 'max-content',
+            minWidth: 'max-content',
+          },
+          '& .react-activity-calendar svg': {
+            display: 'block',
+          },
+          '& .react-activity-calendar text': {
+            fill: alpha(theme.palette.text.primary, 0.45),
+            fontFamily: monoFontFamily,
+          },
+        }}
+      >
+        {isEmpty ? (
+          <Box
+            sx={{
+              py: 4,
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              justifyContent: 'center',
+              minHeight: 120,
+              width: '100%',
+            }}
+          >
+            <Typography
+              sx={{
+                color: alpha(theme.palette.text.primary, TEXT_OPACITY.muted),
+                fontSize: '0.85rem',
+                textAlign: 'center',
+              }}
+            >
+              No contributions yet
+            </Typography>
+            <Typography
+              sx={{
+                color: alpha(theme.palette.text.primary, TEXT_OPACITY.ghost),
+                fontSize: '0.75rem',
+                textAlign: 'center',
+                mt: 0.5,
+              }}
+            >
+              Activity will appear here once PRs merge and issues resolve
+            </Typography>
+          </Box>
+        ) : (
+          <ActivityCalendar
+            data={calendar.days}
+            theme={heatmapTheme}
+            labels={{
+              legend: { less: 'Less', more: 'More' },
+              months: [
+                'Jan',
+                'Feb',
+                'Mar',
+                'Apr',
+                'May',
+                'Jun',
+                'Jul',
+                'Aug',
+                'Sep',
+                'Oct',
+                'Nov',
+                'Dec',
+              ],
+              totalCount: `{{count}} contribution(s) in the last ${calendar.totalDaysShown} day(s)`,
+              weekdays: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
+            }}
+            blockSize={blockConfig.size}
+            blockMargin={blockConfig.margin}
+            fontSize={blockConfig.fontSize}
+            style={{ color: theme.palette.text.primary }}
+            weekStart={0}
+            showWeekdayLabels={['mon', 'wed', 'fri']}
+            showTotalCount={false}
+            showColorLegend={false}
+            renderBlock={(block, activity) => (
+              <Tooltip
+                title={`${activity.count} contribution${activity.count !== 1 ? 's' : ''} on ${formatActivityDateLabel(activity.date)}`}
+                arrow
+                placement="top"
+                enterDelay={0}
+                enterNextDelay={0}
+                leaveDelay={0}
+                disableInteractive
+              >
+                {block}
+              </Tooltip>
+            )}
+          />
+        )}
+      </Box>
+
+      <Box
+        sx={{
+          mt: 1,
+          pt: 1,
+          borderTop: `1px solid ${theme.palette.border.light}`,
+          display: 'flex',
+          flexDirection: { xs: 'column', sm: 'row' },
+          alignItems: { xs: 'flex-start', sm: 'center' },
+          justifyContent: 'space-between',
+          gap: 1,
+        }}
+      >
+        <Typography
+          sx={{
+            fontFamily: monoFontFamily,
+            fontSize: { xs: '0.62rem', sm: '0.65rem' },
+            color: alpha(theme.palette.text.primary, 0.4),
+            lineHeight: 1.35,
+          }}
+        >
+          {totalContributions.toLocaleString()} contribution
+          {totalContributions === 1 ? '' : 's'} in the last year
+        </Typography>
+        {!isEmpty && <ContributionCalendarLegend />}
+      </Box>
+    </Box>
+  );
+
+  return (
+    <Box
+      sx={{
+        width: '100%',
+        maxWidth: '100%',
+        mt: 1.35,
+        minWidth: 0,
+      }}
+    >
+      <Typography
+        sx={{
+          mb: 1.1,
+          color: theme.palette.text.primary,
+          fontSize: { xs: '1.02rem', sm: '1.1rem' },
+          fontWeight: 700,
+        }}
+      >
+        Contribution Calendar
+      </Typography>
+
+      <Card
+        elevation={0}
+        sx={{
+          borderRadius: 3,
+          border: `1px solid ${theme.palette.border.light}`,
+          backgroundColor: 'transparent',
+          maxWidth: '100%',
+        }}
+      >
+        <CardContent
+          sx={{
+            p: { xs: 1.35, sm: 1.5 },
+            '&:last-child': { pb: { xs: 1.35, sm: 1.5 } },
+            minWidth: 0,
+          }}
+        >
+          {isLoading ? (
+            <Box
+              sx={{
+                minHeight: 160,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+              }}
+            >
+              <CircularProgress size={28} />
+            </Box>
+          ) : (
+            <Stack
+              direction={{ xs: 'column', md: 'row' }}
+              spacing={{ xs: 1.5, md: 1.75 }}
+              alignItems="stretch"
+              sx={{ minWidth: 0 }}
+            >
+              {heatmapPanel}
+              {weekSummaryCard}
+            </Stack>
+          )}
+        </CardContent>
+      </Card>
+    </Box>
+  );
+};
+
+export default ContributionCalendar;


### PR DESCRIPTION
## Summary

Adds a **Contribution Calendar** section to the dashboard (below Network Activity), styled like GitHub’s contribution graph. The heatmap shows daily network activity over a rolling **365-day** window in a **53-week** Sun–Sat grid, with a weekly summary card and year-to-date contribution count.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

### Before
<img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/63d466fc-65ac-4595-86ae-f7c4cab76884" />

-----------------------------
### After
<img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/41942b5d-892c-4e9e-9674-48eead4b1efa" />

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
