### PR TITLE
fix mismatch of GitHub official label in footer links

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -45,7 +45,7 @@ const FOOTER_LINKS: ReadonlyArray<{ label: string; href: string }> = [
     label: 'Community',
     href: 'https://docs.learnbittensor.org/resources/community-links',
   },
-  { label: 'Github', href: 'https://github.com/entrius/gittensor' },
+  { label: 'GitHub', href: 'https://github.com/entrius/gittensor' },
   { label: 'X', href: 'https://x.com/gittensor_io' },
 ];
 


### PR DESCRIPTION
## Summary

Fixed mismatch of GitHub official label in Sidebar Footer links.

## Related Issues

<!-- Link to related issues: Fixes #123, Closes #456 -->
#1226 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

<!-- Include before/after screenshots for every UI/visual change. Remove this section if not applicable. -->

### Before
<img width="1138" height="660" alt="Screenshot 2026-05-18 020634" src="https://github.com/user-attachments/assets/35d4408b-df23-4e85-95d2-1f2e9cf5f74a" />

### After
<img width="370" height="574" alt="Screenshot 2026-05-18 at 5 37 06 PM" src="https://github.com/user-attachments/assets/27482a22-2088-479a-b772-0f115e36be8e" />

## Checklist

- [ ] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
