### PR TITLE
fix(issue-details): improve mobile layout on issue details page

### DIFF
--- a/src/components/issues/IssueHeaderCard.tsx
+++ b/src/components/issues/IssueHeaderCard.tsx
@@ -116,7 +116,10 @@ const IssueHeaderCard: React.FC<IssueHeaderCardProps> = ({ issue }) => {
           }}
         >
           <Box
-            sx={{ gridColumn: { xs: '1 / -1', sm: 'auto' }, minWidth: { sm: 170 } }}
+            sx={{
+              gridColumn: { xs: '1 / -1', sm: 'auto' },
+              minWidth: { sm: 170 },
+            }}
           >
             <Typography
               sx={{
@@ -196,9 +199,7 @@ const IssueHeaderCard: React.FC<IssueHeaderCardProps> = ({ issue }) => {
           </Box>
 
           {issue.authorLogin && (
-            <Box
-              sx={{ minWidth: { sm: 140 } }}
-            >
+            <Box sx={{ minWidth: { sm: 140 } }}>
               <Typography
                 sx={{
                   fontSize: '0.7rem',
@@ -236,9 +237,7 @@ const IssueHeaderCard: React.FC<IssueHeaderCardProps> = ({ issue }) => {
             </Box>
           )}
 
-          <Box
-            sx={{ minWidth: { sm: 160 } }}
-          >
+          <Box sx={{ minWidth: { sm: 160 } }}>
             <Typography
               sx={{
                 fontSize: '0.7rem',

--- a/src/components/issues/IssueHeaderCard.tsx
+++ b/src/components/issues/IssueHeaderCard.tsx
@@ -94,9 +94,11 @@ const IssueHeaderCard: React.FC<IssueHeaderCardProps> = ({ issue }) => {
             sx={{
               fontFamily:
                 '-apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif',
-              fontSize: '1.5rem',
+              fontSize: { xs: '1.2rem', sm: '1.5rem' },
               fontWeight: 600,
               color: 'text.primary',
+              wordBreak: 'break-word',
+              overflowWrap: 'anywhere',
             }}
           >
             {issue.title}
@@ -106,16 +108,15 @@ const IssueHeaderCard: React.FC<IssueHeaderCardProps> = ({ issue }) => {
         {/* Bounty and metadata row */}
         <Box
           sx={{
-            display: 'flex',
-            alignItems: 'flex-start',
-            flexDirection: { xs: 'column', sm: 'row' },
-            columnGap: { sm: 4 },
+            display: 'grid',
+            gridTemplateColumns: { xs: '1fr 1fr', sm: 'auto auto auto' },
+            columnGap: { xs: 2, sm: 4 },
             rowGap: { xs: 1.75, sm: 2 },
-            flexWrap: { xs: 'nowrap', sm: 'wrap' },
+            alignItems: 'flex-start',
           }}
         >
           <Box
-            sx={{ width: { xs: '100%', sm: 'auto' }, minWidth: { sm: 170 } }}
+            sx={{ gridColumn: { xs: '1 / -1', sm: 'auto' }, minWidth: { sm: 170 } }}
           >
             <Typography
               sx={{
@@ -196,7 +197,7 @@ const IssueHeaderCard: React.FC<IssueHeaderCardProps> = ({ issue }) => {
 
           {issue.authorLogin && (
             <Box
-              sx={{ width: { xs: '100%', sm: 'auto' }, minWidth: { sm: 140 } }}
+              sx={{ minWidth: { sm: 140 } }}
             >
               <Typography
                 sx={{
@@ -236,7 +237,7 @@ const IssueHeaderCard: React.FC<IssueHeaderCardProps> = ({ issue }) => {
           )}
 
           <Box
-            sx={{ width: { xs: '100%', sm: 'auto' }, minWidth: { sm: 160 } }}
+            sx={{ minWidth: { sm: 160 } }}
           >
             <Typography
               sx={{

--- a/src/components/issues/IssueHeaderCard.tsx
+++ b/src/components/issues/IssueHeaderCard.tsx
@@ -34,6 +34,13 @@ const IssueHeaderCard: React.FC<IssueHeaderCardProps> = ({ issue }) => {
   const usdEstimate = hasPrices
     ? formatAlphaToUsd(issue.targetBounty, taoPrice, alphaPrice)
     : null;
+  const metaLabelSx = {
+    fontSize: '0.7rem',
+    color: alpha(theme.palette.common.white, TEXT_OPACITY.tertiary),
+    textTransform: 'uppercase' as const,
+    letterSpacing: '0.5px',
+    mb: 0.9,
+  };
 
   return (
     <Card
@@ -121,15 +128,7 @@ const IssueHeaderCard: React.FC<IssueHeaderCardProps> = ({ issue }) => {
               minWidth: { sm: 170 },
             }}
           >
-            <Typography
-              sx={{
-                fontSize: '0.7rem',
-                color: alpha(theme.palette.common.white, TEXT_OPACITY.tertiary),
-                textTransform: 'uppercase',
-                letterSpacing: '0.5px',
-                mb: 0.5,
-              }}
-            >
+            <Typography sx={{ ...metaLabelSx, mb: 0.5 }}>
               {issue.status === 'completed' ? 'Payout' : 'Bounty'}
             </Typography>
             {issue.status === 'registered' ? (
@@ -200,20 +199,7 @@ const IssueHeaderCard: React.FC<IssueHeaderCardProps> = ({ issue }) => {
 
           {issue.authorLogin && (
             <Box sx={{ minWidth: { sm: 140 } }}>
-              <Typography
-                sx={{
-                  fontSize: '0.7rem',
-                  color: alpha(
-                    theme.palette.common.white,
-                    TEXT_OPACITY.tertiary,
-                  ),
-                  textTransform: 'uppercase',
-                  letterSpacing: '0.5px',
-                  mb: 0.9,
-                }}
-              >
-                Author
-              </Typography>
+              <Typography sx={metaLabelSx}>Author</Typography>
               <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
                 <Avatar
                   src={getGithubAvatarSrc(issue.authorLogin)}
@@ -238,17 +224,7 @@ const IssueHeaderCard: React.FC<IssueHeaderCardProps> = ({ issue }) => {
           )}
 
           <Box sx={{ minWidth: { sm: 160 } }}>
-            <Typography
-              sx={{
-                fontSize: '0.7rem',
-                color: alpha(theme.palette.common.white, TEXT_OPACITY.tertiary),
-                textTransform: 'uppercase',
-                letterSpacing: '0.5px',
-                mb: 0.9,
-              }}
-            >
-              Created
-            </Typography>
+            <Typography sx={metaLabelSx}>Created</Typography>
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
               <CalendarTodayOutlinedIcon
                 sx={{

--- a/src/components/issues/IssueSubmissionsTable.tsx
+++ b/src/components/issues/IssueSubmissionsTable.tsx
@@ -21,6 +21,10 @@ import {
   type DataTableColumn,
 } from '../../components/common/DataTable';
 
+// Sum of the fixed column widths below; keeps the table from compressing
+// into an unreadable layout on narrow viewports (scrolls horizontally instead).
+const SUBMISSIONS_TABLE_MIN_WIDTH = 832;
+
 interface IssueSubmissionsTableProps {
   submissions: IssueSubmission[] | undefined;
   isLoading: boolean;
@@ -439,7 +443,7 @@ const IssueSubmissionsTable: React.FC<IssueSubmissionsTableProps> = ({
           <DataTable
             columns={columns}
             rows={otherSubmissions}
-            minWidth={832}
+            minWidth={SUBMISSIONS_TABLE_MIN_WIDTH}
             getRowKey={(submission) =>
               `${submission.repositoryFullName}-${submission.number}`
             }

--- a/src/components/issues/IssueSubmissionsTable.tsx
+++ b/src/components/issues/IssueSubmissionsTable.tsx
@@ -7,7 +7,6 @@ import {
   CircularProgress,
   Typography,
   alpha,
-  useMediaQuery,
   useTheme,
 } from '@mui/material';
 import CalendarTodayOutlinedIcon from '@mui/icons-material/CalendarTodayOutlined';
@@ -34,7 +33,6 @@ const IssueSubmissionsTable: React.FC<IssueSubmissionsTableProps> = ({
   backLabel,
 }) => {
   const theme = useTheme();
-  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
   const linkState = backLabel ? { backLabel } : undefined;
   const winnerSubmission =
     submissions?.find((submission) => submission.isWinner) ?? null;
@@ -441,7 +439,7 @@ const IssueSubmissionsTable: React.FC<IssueSubmissionsTableProps> = ({
           <DataTable
             columns={columns}
             rows={otherSubmissions}
-            minWidth={isMobile ? 832 : undefined}
+            minWidth={832}
             getRowKey={(submission) =>
               `${submission.repositoryFullName}-${submission.number}`
             }

--- a/src/pages/IssueDetailsPage.tsx
+++ b/src/pages/IssueDetailsPage.tsx
@@ -145,6 +145,8 @@ const IssueDetailsPage: React.FC = () => {
                 value={tabValue}
                 onChange={handleTabChange}
                 aria-label="issue details tabs"
+                variant="scrollable"
+                scrollButtons="auto"
                 sx={(theme) => ({
                   '& .MuiTab-root': {
                     color: STATUS_COLORS.open,
@@ -153,7 +155,8 @@ const IssueDetailsPage: React.FC = () => {
                     textTransform: 'none',
                     fontWeight: 500,
                     minHeight: '48px',
-                    fontSize: '14px',
+                    fontSize: { xs: '13px', sm: '14px' },
+                    px: { xs: 1.5, sm: 2 },
                     '&.Mui-selected': {
                       color: theme.palette.text.primary,
                       fontWeight: 600,


### PR DESCRIPTION
- Add scrollable tabs with auto scroll buttons so all tabs are reachable on narrow viewports
- Make issue title font size responsive (1.2rem on xs, 1.5rem on sm+) with word-break to prevent overflow
- Switch meta row (Bounty/Author/Created) from flex-column to a 2-column grid on mobile
- Always apply minWidth={832} on submissions table so columns never compress below readable widths

 ## Summary
 
  Fix several mobile layout issues on the Issue Details page (`/bounties/details`):

  - **Tab bar**: Added `variant="scrollable"` and `scrollButtons="auto"` so all tabs are reachable on narrow viewports without clipping
  - **Issue title**: Font size is now responsive (`1.2rem` on xs, `1.5rem` on sm+) with `wordBreak: 'break-word'` to prevent long titles from
  overflowing
  - **Meta row** (Bounty / Author / Created): Switched from a stacked flex-column to a 2-column CSS grid on mobile — Bounty spans full width on
  row 1, Author and Created sit side-by-side on row 2
  - **Submissions table**: `minWidth={832}` is now always applied (previously only on `isMobile` < 600px), ensuring columns never compress to
  unreadable widths at any viewport

  ## Related Issues
Fixes: https://github.com/entrius/gittensor-ui/issues/939

  ## Type of Change

  - [x] Bug fix
  - [ ] New feature
  - [ ] Refactor
  - [ ] Documentation
  - [ ] Other (describe below)

  ## Screenshot
  
  ## Before: 
<img width="370" height="802" alt="Gittensor-Issue-Details-05-18-2026_11_08_PM" src="https://github.com/user-attachments/assets/393dbac2-394e-4dee-b3b3-a4339e765fef" />

  ## After: 
<img width="370" height="802" alt="Observability-structured-logging-secret-redaction-helpers-Gittensor-05-18-2026_11_08_PM" src="https://github.com/user-attachments/assets/95fb5341-86ba-4ff4-9d5f-53a515f292c8" />


  ## Checklist

  - [x] New components are modularized/separated where sensible
  - [x] Uses predefined theme (e.g. no hardcoded colors)
  - [x] Responsive/mobile checked
  - [x] Tested against the test API
  - [x] `npm run format` and `npm run lint:fix` have been run
  - [x] `npm run build` passes
  - [x] Screenshots included for any UI/visual changes