### PR TITLE
fix(prs): use day(s) in time decay subline since merge

### DIFF
--- a/src/components/prs/prTimeDecayModel.ts
+++ b/src/components/prs/prTimeDecayModel.ts
@@ -194,5 +194,5 @@ export function buildDecaySubline(projection: DecayProjection): string {
   if (projection.daysSinceMerge > projection.lookbackDays) {
     return `Outside ${projection.lookbackDays}-day scoring window.`;
   }
-  return `${projection.daysSinceMerge.toFixed(1)} days since merge`;
+  return `${projection.daysSinceMerge.toFixed(1)} day(s) since merge`;
 }


### PR DESCRIPTION
## Summary

On merged PR details, the Time Decay card subline from buildDecaySubline showed {t} days since merge, which reads wrong at one day (e.g. “1.0 days since merge”).
Updates the suffix to day(s) so the subline reads “1.0 day(s) since merge” and “2.0 day(s) since merge”.
Change is in prTimeDecayModel.ts; PRTimeDecayChart renders the subline via buildDecaySubline(projection).

## Related Issues

Fixes #1238 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

<img width="1878" height="875" alt="image" src="https://github.com/user-attachments/assets/876ec0f5-b864-4ff0-90a3-404812433b2f" />

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
