### PR TITLE
fix: resolve usdPerDay mismatch between miner list and detail APIs

### DIFF
--- a/src/components/leaderboard/MinerCard.tsx
+++ b/src/components/leaderboard/MinerCard.tsx
@@ -5,6 +5,7 @@ import ReactECharts from 'echarts-for-react';
 import { useMinerGithubData, useMinerPRs } from '../../api';
 import { CHART_COLORS, RANK_COLORS, STATUS_COLORS } from '../../theme';
 import { getGithubAvatarSrc } from '../../utils/ExplorerUtils';
+import { formatUsdPerDay } from '../../utils/format';
 import { linkResetSx, useLinkBehavior } from '../common/linkBehavior';
 import { WatchlistButton } from '../common';
 import { type MinerStats, type LeaderboardVariant, FONTS } from './types';
@@ -61,11 +62,6 @@ const formatScore = (score: number): string =>
         maximumFractionDigits: 2,
       })
     : '0.00';
-
-/** Miner-wide USD/day, shown as a secondary stat. '—' when unavailable —
- *  per-repo views carry no earnings (earnings is a miner-wide figure). */
-const formatUsdPerDay = (usdPerDay: number | undefined): string =>
-  usdPerDay ? `$${Math.round(usdPerDay).toLocaleString()}/d` : '—';
 
 /* ═══════════════════════════════════════════════════════════════════ */
 
@@ -347,7 +343,7 @@ export const MinerCard: React.FC<MinerCardProps> = ({
                     fontFeatureSettings: TABULAR_NUMS,
                   })}
                 >
-                  ${Math.round(miner.usdPerDay || 0).toLocaleString()}
+                  {formatUsdPerDay(miner.usdPerDay, { includePeriod: false })}
                 </Typography>
                 <Typography
                   sx={(theme) => ({
@@ -372,7 +368,11 @@ export const MinerCard: React.FC<MinerCardProps> = ({
                   fontFeatureSettings: TABULAR_NUMS,
                 })}
               >
-                ~${Math.round((miner.usdPerDay || 0) * 30).toLocaleString()}/mo
+                ~$
+                {((miner.usdPerDay || 0) * 30)
+                  .toFixed(0)
+                  .replace(/\B(?=(\d{3})+(?!\d))/g, ',')}
+                /mo
               </Typography>
             </>
           ) : (
@@ -432,7 +432,9 @@ export const MinerCard: React.FC<MinerCardProps> = ({
           scoreLabel={isWatchlist ? 'OSS' : 'Earnings'}
           scoreValue={Number(miner.totalScore)}
           scoreDisplay={
-            isWatchlist ? undefined : formatUsdPerDay(miner.usdPerDay)
+            isWatchlist
+              ? undefined
+              : formatUsdPerDay(miner.usdPerDay, { includePeriod: true })
           }
           isEligible={isDiscoveries ? discoveriesEligible : ossEligible}
           hideScore={isWatchlist}

--- a/src/components/leaderboard/MinersList.tsx
+++ b/src/components/leaderboard/MinersList.tsx
@@ -3,6 +3,7 @@ import { Avatar, Box, Card, Tooltip, Typography } from '@mui/material';
 import { useMinerGithubData, useMinerPRs } from '../../api';
 import { CHART_COLORS } from '../../theme';
 import { getGithubAvatarSrc, type SortOrder } from '../../utils/ExplorerUtils';
+import { formatUsdPerDay } from '../../utils/format';
 import { DataTable, type DataTableColumn, WatchlistButton } from '../common';
 import { RankIcon } from './RankIcon';
 import {
@@ -146,7 +147,7 @@ export const MinersList: React.FC<MinersListProps> = ({
               color: earningsHighlighted ? 'status.merged' : 'text.secondary',
             }}
           >
-            ${Math.round(miner.usdPerDay || 0).toLocaleString()}
+            {formatUsdPerDay(miner.usdPerDay, { includePeriod: false })}
           </Typography>
         );
       },

--- a/src/components/miners/MinerIdentityRail.tsx
+++ b/src/components/miners/MinerIdentityRail.tsx
@@ -27,6 +27,7 @@ import {
 import { useClipboardCopy } from '../../hooks/useClipboardCopy';
 import { STATUS_COLORS } from '../../theme';
 import { getRepositoryOwnerAvatarSrc } from '../../utils/avatar';
+import { formatUsdPerDay } from '../../utils/format';
 import MinerInsightsCard from './MinerInsightsCard';
 
 type ViewMode = 'prs' | 'issues';
@@ -434,7 +435,10 @@ const MinerIdentityRail: React.FC<MinerIdentityRailProps> = ({
               color: usdPerDay > 0 ? STATUS_COLORS.success : 'text.primary',
             }}
           >
-            ~${Math.round(usdPerDay).toLocaleString()}
+            {formatUsdPerDay(usdPerDay, {
+              includeApprox: true,
+              includePeriod: false,
+            })}
           </Typography>
           <Typography
             sx={{
@@ -453,8 +457,15 @@ const MinerIdentityRail: React.FC<MinerIdentityRailProps> = ({
             mt: 0.6,
           }}
         >
-          ~${Math.round(usdPerDay * 30).toLocaleString()}/mo · ~$
-          {Math.round(lifetimeUsd).toLocaleString()} lifetime
+          ~$
+          {((usdPerDay || 0) * 30)
+            .toFixed(0)
+            .replace(/\B(?=(\d{3})+(?!\d))/g, ',')}
+          /mo · ~$
+          {(lifetimeUsd || 0)
+            .toFixed(0)
+            .replace(/\B(?=(\d{3})+(?!\d))/g, ',')}{' '}
+          lifetime
         </Typography>
       </RailCard>
 

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -89,3 +89,27 @@ export const credibilityColor = (cred: number): string => {
 
 export const getLowerText = (value: string | null | undefined): string =>
   (value ?? '').toLowerCase();
+
+/**
+ * Format USD per day value with consistent rounding.
+ * Uses toFixed(0) for predictable rounding instead of Math.round()
+ * to avoid inconsistencies between API endpoints.
+ *
+ * @param value - The USD per day value
+ * @param options - Formatting options
+ * @returns Formatted string like "$124/d" or "—"
+ */
+export const formatUsdPerDay = (
+  value: number | undefined,
+  options?: { includeApprox?: boolean; includePeriod?: boolean },
+): string => {
+  const { includeApprox = false, includePeriod = true } = options ?? {};
+
+  if (!value || value <= 0) return '—';
+
+  const rounded = Number(value.toFixed(0));
+  const approx = includeApprox ? '~' : '';
+  const period = includePeriod ? '/d' : '';
+
+  return `${approx}$${rounded.toLocaleString()}${period}`;
+};


### PR DESCRIPTION
## Summary

Fixed inconsistent usdPerDay display values between the leaderboard (/repositories) and miner details (/miners/details) pages. The issue was caused by different API responses returning slightly different values (e.g., 123.60 vs 123.08), which when rounded with Math.round() resulted in different displayed values ($124 vs $123).

Solution: Centralized USD/day formatting logic by creating a shared formatUsdPerDay() utility function that uses consistent rounding behavior (.toFixed(0)) across all components.

## Related Issues

Fixes #1241

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)



<!-- Include before/after screenshots for every UI/visual change. Remove this section if not applicable. -->

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
