### PR TITLE
refactor(watchlist): extract shared useWatchlistMinerStats hook

### DIFF
--- a/src/pages/WatchlistPage.tsx
+++ b/src/pages/WatchlistPage.tsx
@@ -459,9 +459,33 @@ export const WatchlistContent: React.FC = () => {
   );
 };
 
+/**
+ * Watchlist-scope miner stats: load the leaderboard rollup, filter to the
+ * watched `githubId`s, and flag a row as eligible when either reward track
+ * applies. Shared by `WatchlistPage` (sidebar widgets) and `MinersList`
+ * (table / cards) so both surfaces render from the same source.
+ */
+const useWatchlistMinerStats = (minerIds: string[]) => {
+  const { data: allMinersData, isLoading } = useAllMiners();
+  const watchedSet = useMemo(() => new Set(minerIds), [minerIds]);
+
+  const miners = useMemo(
+    () =>
+      mapAllMinersToStats(allMinersData ?? [])
+        .filter((m) => watchedSet.has(m.githubId))
+        .map((m) => ({
+          ...m,
+          isEligible: Boolean(m.ossIsEligible || m.discoveriesIsEligible),
+        })),
+    [allMinersData, watchedSet],
+  );
+
+  return { miners, isLoading, allMinersData };
+};
+
 const WatchlistPage: React.FC = () => {
   const { ids: minerIds } = useWatchlist('miners');
-  const { data: allMinersData } = useAllMiners();
+  const { miners: minerStats } = useWatchlistMinerStats(minerIds);
 
   const isLargeScreen = useMediaQuery(theme.breakpoints.up('xl'));
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
@@ -470,16 +494,6 @@ const WatchlistPage: React.FC = () => {
     isMobile || isTablet ? '100%' : isLargeScreen ? '340px' : '300px';
 
   const stickySidebarRef = useTwitterStickySidebar();
-
-  const minerStats = useMemo(() => {
-    const watchedSet = new Set(minerIds);
-    return mapAllMinersToStats(allMinersData ?? [])
-      .filter((m) => watchedSet.has(m.githubId))
-      .map((m) => ({
-        ...m,
-        isEligible: Boolean(m.ossIsEligible || m.discoveriesIsEligible),
-      }));
-  }, [allMinersData, minerIds]);
 
   return (
     <Page title="Watchlist">
@@ -938,27 +952,18 @@ const WatchlistOptionsButton: React.FC<WatchlistOptionsButtonProps> = ({
 };
 
 const MinersList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
-  const { data: allMinersStats, isLoading } = useAllMiners();
+  const {
+    miners: minerStats,
+    isLoading,
+    allMinersData,
+  } = useWatchlistMinerStats(itemKeys);
   const { remove } = useWatchlist('miners');
-  const watchedSet = useMemo(() => new Set(itemKeys), [itemKeys]);
-
-  const minerStats = useMemo(() => {
-    const all = mapAllMinersToStats(allMinersStats ?? []);
-    return all
-      .filter((m) => watchedSet.has(m.githubId))
-      .map((m) => ({
-        ...m,
-        // Watchlist cards should be enabled if miner is eligible for either
-        // OSS contributions or Issue Discoveries.
-        isEligible: Boolean(m.ossIsEligible || m.discoveriesIsEligible),
-      }));
-  }, [allMinersStats, watchedSet]);
 
   const unresolvedIds = useMemo(() => {
-    if (isLoading || !allMinersStats) return [];
-    const known = new Set(allMinersStats.map((m) => m.githubId));
+    if (isLoading || !allMinersData) return [];
+    const known = new Set(allMinersData.map((m) => m.githubId));
     return itemKeys.filter((id) => !known.has(id));
-  }, [allMinersStats, isLoading, itemKeys]);
+  }, [allMinersData, isLoading, itemKeys]);
 
   const handleRemoveUnresolved = useCallback(() => {
     unresolvedIds.forEach((id) => remove(id));


### PR DESCRIPTION
## Summary

`WatchlistPage` and `MinersList` each ran the same `useAllMiners()` → `mapAllMinersToStats(...)` → filter watched `githubId`s → `map(isEligible: OSS || Discoveries)` pipeline in a local `useMemo`. Hoist that into a single `useWatchlistMinerStats(minerIds)` hook so the page-level sidebar `Miners Activity` widgets and the table/cards row data share one source.

No behavior change — `MinersList` already passed through `isLoading` and the raw `allMinersData` for its "unresolved miners" warning, both of which the new hook returns alongside the mapped `miners` array.

> Context: I opened this PR originally to fix inflated PR/Issue dot counts on the watchlist Miners tab — the `/miners` rollup was double-counting per-(`uid`, `hotkey`, `repo`) `miner_evaluations` rows for any `githubId` with multiple registrations. That has since been fixed server-side (the test-API rollup now returns the deduped numbers), so the recompute-from-`/prs`-and-mirror-`/issues`-feeds part is no longer needed. What's left is the small refactor that fell out of the original change.

## Related Issues

<!-- No tracking issue. -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

Not applicable — no rendered output changes. The watchlist Miners tab renders the same numbers from the same data source as before, just from a shared hook.

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
