### PR TITLE
fix(repositories): keep deep-linked `?page=N` when search hasn't changed

### DIFF
--- a/src/components/leaderboard/TopRepositoriesTable.tsx
+++ b/src/components/leaderboard/TopRepositoriesTable.tsx
@@ -1,4 +1,10 @@
-import React, { useState, useMemo, useCallback } from 'react';
+import React, {
+  useState,
+  useMemo,
+  useCallback,
+  useRef,
+  useEffect,
+} from 'react';
 import {
   Box,
   Card,
@@ -256,8 +262,17 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
   const [showChart, setShowChart] = useState(false);
   const [useLogScale, setUseLogScale] = useState(true);
 
+  const searchQueryRef = useRef(searchQuery);
+  useEffect(() => {
+    searchQueryRef.current = searchQuery;
+  });
+
   const handleSearchChange = useCallback(
-    (value: string) => setFilter('search', value),
+    (value: string) => {
+      if (value === searchQueryRef.current) return;
+      searchQueryRef.current = value;
+      setFilter('search', value);
+    },
     [setFilter],
   );
 


### PR DESCRIPTION
## Summary

The repositories leaderboard's pagination snaps back to page 1 after every click and on direct loads of `/repositories?page=N`. The table routes `DebouncedSearchInput`'s `onDebouncedChange` through `useDataTableParams.setFilter('search', ...)`, whose `useCallback` closes over `react-router-dom`'s `setSearchParams`. That ref is recreated on every URL change, so every `setPage(N)` recreates the callback, which re-fires the wrapper's mount-anchored debounce effect. The fired commit deletes `?page` via the filter's default `resetPageOnChange`, snapping the table back to page 1 right after the click.

Same root cause #1108 fixed for `MinerPRsTable`. This PR applies the same callsite gate: keep the latest committed `searchQuery` in a ref and skip `setFilter('search', ...)` when the wrapper hands back the value we already hold. Typing a new search still commits normally and resets `?page` as intended; the mount fire and any re-render driven by an unrelated URL change no longer touches the page slot.

Closes #1247

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

Verified locally against `npm run dev`:

- Direct load `/repositories?page=1` retains `?page=1` and renders rows 13–15 of 15.
- "Go to next page" / "Go to last page" advance to `?page=1` and stay (no snap-back).
- Typing into the search input still commits the filter after the debounce and resets `?page` so the result list starts at page 1.
- `npm run build` — clean
- `npm run lint` — `--max-warnings 0` clean
- `npx prettier --check` — clean

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked (behavior is URL/query only)
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes

## Screenshots

Before:

https://github.com/user-attachments/assets/954b73cf-c2d0-4d34-9963-4864a8f28216

After:

https://github.com/user-attachments/assets/a05846fa-dd5a-42bb-a8d2-5d09160ec3bd

