### PR TITLE
fix(repositories): weight precision, paginated next-page, drop repo-name tooltip

### DIFF
--- a/src/components/leaderboard/RepositoryCard.tsx
+++ b/src/components/leaderboard/RepositoryCard.tsx
@@ -4,7 +4,7 @@ import { Avatar, Box, Card, Divider, Tooltip, Typography } from '@mui/material';
 import { alpha } from '@mui/material/styles';
 import { linkResetSx, useLinkBehavior } from '../common/linkBehavior';
 import { WatchlistButton } from '../common';
-import { getRepositoryOwnerAvatarSrc } from '../../utils';
+import { formatWeight, getRepositoryOwnerAvatarSrc } from '../../utils';
 import { RankIcon } from './RankIcon';
 import {
   FONTS,
@@ -220,7 +220,7 @@ export const RepositoryCard: React.FC<RepositoryCardProps> = ({
       <ConfigBar
         label="Weight"
         value={repo.weight}
-        display={repo.weight.toFixed(2)}
+        display={formatWeight(repo.weight)}
         pct={weightPct}
         accent="primary"
       />
@@ -228,7 +228,7 @@ export const RepositoryCard: React.FC<RepositoryCardProps> = ({
       <ConfigBar
         label="Issue Discovery"
         value={repo.issueDiscoveryShare ?? 0}
-        display={(repo.issueDiscoveryShare ?? 0).toFixed(2)}
+        display={formatWeight(repo.issueDiscoveryShare ?? 0)}
         pct={Math.max(0, Math.min(100, (repo.issueDiscoveryShare ?? 0) * 100))}
         accent="discovery"
       />

--- a/src/components/leaderboard/TopRepositoriesTable.tsx
+++ b/src/components/leaderboard/TopRepositoriesTable.tsx
@@ -55,6 +55,7 @@ import {
 import { DebouncedSearchInput } from '../common/DebouncedSearchInput';
 import {
   compareByWatchlist,
+  formatWeight,
   getRepositoryOwnerAvatarSrc,
   truncateText,
 } from '../../utils';
@@ -576,7 +577,7 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
                 ${statRow('Issue score:', item.discoveryScore.toFixed(2))}
                 ${statRow('Issues:', String(item.discoveryIssues))}
                 ${statRow('Issue contributors:', String(item.discoveryContributors))}
-                ${statRow('Weight:', item.weight.toFixed(2))}
+                ${statRow('Weight:', formatWeight(item.weight))}
               </div>
             </div>
           `;
@@ -632,7 +633,7 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
           fontSize: 11,
           formatter: (value: number) => {
             if (value >= 1000) return `${(value / 1000).toFixed(1)}k`;
-            if (sortColumn === 'weight') return value.toFixed(2);
+            if (sortColumn === 'weight') return formatWeight(value);
             if (
               sortColumn === 'totalPRs' ||
               sortColumn === 'contributors' ||
@@ -964,23 +965,21 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
             >
               {(owner[0] || '?').toUpperCase()}
             </Avatar>
-            <Tooltip title={repo.repository || ''} placement="top">
-              <Typography
-                component="span"
-                sx={{
-                  color: 'text.primary',
-                  fontWeight: 500,
-                  transition: 'color 0.2s',
-                  overflow: 'hidden',
-                  textOverflow: 'ellipsis',
-                  whiteSpace: 'nowrap',
-                  maxWidth: '100%',
-                  display: 'inline-block',
-                }}
-              >
-                {truncateText(repo.repository || '', 40)}
-              </Typography>
-            </Tooltip>
+            <Typography
+              component="span"
+              sx={{
+                color: 'text.primary',
+                fontWeight: 500,
+                transition: 'color 0.2s',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+                maxWidth: '100%',
+                display: 'inline-block',
+              }}
+            >
+              {truncateText(repo.repository || '', 40)}
+            </Typography>
           </Box>
         );
       },
@@ -1000,7 +999,7 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
             color: 'text.primary',
           }}
         >
-          {repo.weight.toFixed(2)}
+          {formatWeight(repo.weight)}
         </Typography>
       ),
     },

--- a/src/components/repositories/RepositoryStats.tsx
+++ b/src/components/repositories/RepositoryStats.tsx
@@ -15,7 +15,7 @@ import {
   useRepositoryConfig,
 } from '../../api';
 import { RANK_COLORS, STATUS_COLORS } from '../../theme';
-import { formatTokenAmount } from '../../utils/format';
+import { formatTokenAmount, formatWeight } from '../../utils/format';
 import { isMergedPr } from '../../utils/prStatus';
 
 interface RepositoryStatsProps {
@@ -127,7 +127,7 @@ const RepositoryStats: React.FC<RepositoryStatsProps> = ({
               fontSize: '13px',
             }}
           >
-            {String(repository.config?.emissionShare ?? '')}
+            {formatWeight(repository.config?.emissionShare)}
           </Typography>
         </Box>
 

--- a/src/hooks/useDataTableParams.ts
+++ b/src/hooks/useDataTableParams.ts
@@ -288,9 +288,14 @@ export const useDataTableParams = <
         (prev) => {
           const next = new URLSearchParams(prev);
           const serialized = config.serialize(value);
+          const previous = prev.get(filterParamKey);
+          const valueChanged = previous !== (serialized ?? null);
           if (serialized === null) next.delete(filterParamKey);
           else next.set(filterParamKey, serialized);
-          if (resetPage) next.delete(paramKeys.page);
+          // Only reset the page slot when the filter value actually changed,
+          // so transient re-emissions (e.g. effect deps churning when other
+          // URL params update) don't clobber the user's current page.
+          if (resetPage && valueChanged) next.delete(paramKeys.page);
           return next;
         },
         { replace: true },

--- a/src/pages/WatchlistPage.tsx
+++ b/src/pages/WatchlistPage.tsx
@@ -106,7 +106,7 @@ import {
 } from '../utils/prStatus';
 import { filterPrs, type PrStatusFilter } from '../utils/prTable';
 import { getIssueStatusMeta } from '../utils/issueStatus';
-import { formatDate, formatTokenAmount } from '../utils/format';
+import { formatDate, formatTokenAmount, formatWeight } from '../utils/format';
 import { getRepositoryOwnerAvatarSrc } from '../utils/avatar';
 import theme, {
   CHART_COLORS,
@@ -1191,7 +1191,7 @@ const repoColumns: DataTableColumn<WatchedRepoStats, RepoSortKey>[] = [
     cellSx: repoCellSx,
     renderCell: (repo) => (
       <Typography sx={{ fontSize: '0.75rem', fontWeight: 600 }}>
-        {parseFloat(String(repo.config?.emissionShare ?? 0)).toFixed(2)}
+        {formatWeight(repo.config?.emissionShare)}
       </Typography>
     ),
   },
@@ -1752,7 +1752,7 @@ const ReposList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
                 ${statRow('Issue score:', item.discoveryScore.toFixed(2))}
                 ${statRow('Issues:', String(item.discoveryIssues))}
                 ${statRow('Issue contributors:', String(item.discoveryContributors))}
-                ${statRow('Weight:', item.weight.toFixed(2))}
+                ${statRow('Weight:', formatWeight(item.weight))}
               </div>
             </div>
           `;
@@ -1789,7 +1789,7 @@ const ReposList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
         axisLabel: {
           color: textColor,
           fontSize: 11,
-          formatter: (value: number) => value.toFixed(2),
+          formatter: (value: number) => formatWeight(value),
         },
         splitLine: {
           lineStyle: { color: gridColor, type: 'dashed', opacity: 0.5 },

--- a/src/pages/search/RepositoryTab.tsx
+++ b/src/pages/search/RepositoryTab.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Box, Typography } from '@mui/material';
 import { alpha, type Theme } from '@mui/material/styles';
 import { getRankColors } from '../../components/leaderboard/types';
-import { getGithubAvatarSrc } from '../../utils';
+import { formatWeight, getGithubAvatarSrc } from '../../utils';
 import { type DataTableColumn } from '../../components/common/DataTable';
 import SearchResultsCard from './SearchResultsCard';
 import {
@@ -88,7 +88,7 @@ const repositoryColumns: DataTableColumn<RepoSearchData>[] = [
     header: 'Weight',
     width: '14%',
     align: 'right',
-    renderCell: (repo: RepoSearchData) => repo.weight.toFixed(2),
+    renderCell: (repo: RepoSearchData) => formatWeight(repo.weight),
     cellSx: {
       fontWeight: 600,
     },

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -23,6 +23,21 @@ export const formatTokenAmount = (
 };
 
 /**
+ * Format a weight/share value: round to at most `maxDecimals` decimal places
+ * and trim trailing zeros (e.g. 0.00350 → "0.0035", 1.0 → "1", 1.5 → "1.5").
+ */
+export const formatWeight = (
+  value: string | number | null | undefined,
+  maxDecimals: number = 5,
+): string => {
+  if (value === null || value === undefined) return '0';
+  const num = typeof value === 'string' ? parseFloat(value) : value;
+  if (!Number.isFinite(num)) return '0';
+  const fixed = num.toFixed(maxDecimals);
+  return fixed.includes('.') ? fixed.replace(/\.?0+$/, '') : fixed;
+};
+
+/**
  * Format a USD estimate value for display.
  *
  * @param value - The USD value to format


### PR DESCRIPTION
## Summary
- `formatWeight` helper formats weight/share values up to 5 decimals and trims trailing zeros (so `0.00350` renders as `0.0035`, not `0.04`). Applied across the repositories table, leaderboard card, search results, watchlist row + bar chart, and the repository-details Stats panel. Tooltips and axis labels that surfaced `Weight` use it too.
- Fix `useDataTableParams.setFilter` so it only clears the `page` slot when the filter value actually changes. react-router-dom rebuilds `setSearchParams` on every URL change; that propagated through `useCallback` deps and re-fired `DebouncedSearchInput`'s effect, which called `setFilter('search', '')` and wiped the `page` param immediately after `next-page` was clicked. Most visible in cards view with `rows=12`, but also caused deep links like `?page=N` to reset on load.
- Remove the hover tooltip on the repository-name cell in the repositories table.

## Test plan
- [x] Repositories cards view, rows=12: click "next page" → URL updates to `?page=1` and rows "13–15 of 15" render (verified via Playwright against local dev server).
- [x] Deep-link `/repositories?page=1` keeps you on page 1.
- [x] Typing in the repositories search still clears `page` (filter value actually changed).
- [x] `npx tsc -b` and `eslint` clean.
- [ ] Eyeball weight column in cards/list views and on the watchlist for the expected display.
- [ ] Confirm repo-name cell no longer shows a tooltip on hover.