### PR TITLE
fix(miners): align issue search on mobile

### DIFF
--- a/src/components/miners/MinerOpenDiscoveryIssuesByRepo.tsx
+++ b/src/components/miners/MinerOpenDiscoveryIssuesByRepo.tsx
@@ -493,21 +493,32 @@ const MinerOpenDiscoveryIssuesByRepo: React.FC<
             />
           ),
         }}
-        sx={{
-          mt: 2,
-          mx: { xs: -2, sm: 0 },
-          width: { xs: 'calc(100% + 32px)', sm: 'auto' },
-          maxWidth: { xs: 'calc(100% + 32px)', sm: 400 },
-          minWidth: { xs: 0, sm: 350 },
-          '& .MuiOutlinedInput-root': {
-            fontSize: '0.8rem',
-            color: 'text.primary',
-            backgroundColor: 'surface.subtle',
-            borderRadius: 2,
-            '& fieldset': { borderColor: 'border.light' },
-            '&:hover fieldset': { borderColor: 'border.medium' },
-            '&.Mui-focused fieldset': { borderColor: 'primary.main' },
-          },
+        sx={(theme) => {
+          const mobileSearchOffset = theme.spacing(-2);
+          const mobileSearchWidthOffset = theme.spacing(4);
+
+          return {
+            mt: 2,
+            mx: { xs: mobileSearchOffset, sm: 0 },
+            width: {
+              xs: `calc(100% + ${mobileSearchWidthOffset})`,
+              sm: 'auto',
+            },
+            maxWidth: {
+              xs: `calc(100% + ${mobileSearchWidthOffset})`,
+              sm: 400,
+            },
+            minWidth: { xs: 0, sm: 350 },
+            '& .MuiOutlinedInput-root': {
+              fontSize: '0.8rem',
+              color: 'text.primary',
+              backgroundColor: 'surface.subtle',
+              borderRadius: 2,
+              '& fieldset': { borderColor: 'border.light' },
+              '&:hover fieldset': { borderColor: 'border.medium' },
+              '&.Mui-focused fieldset': { borderColor: 'primary.main' },
+            },
+          };
         }}
       />
     </Box>

--- a/src/components/miners/MinerOpenDiscoveryIssuesByRepo.tsx
+++ b/src/components/miners/MinerOpenDiscoveryIssuesByRepo.tsx
@@ -495,8 +495,9 @@ const MinerOpenDiscoveryIssuesByRepo: React.FC<
         }}
         sx={{
           mt: 2,
-          width: { xs: '100%', sm: 'auto' },
-          maxWidth: { xs: '100%', sm: 400 },
+          mx: { xs: -2, sm: 0 },
+          width: { xs: 'calc(100% + 32px)', sm: 'auto' },
+          maxWidth: { xs: 'calc(100% + 32px)', sm: 400 },
           minWidth: { xs: 0, sm: 350 },
           '& .MuiOutlinedInput-root': {
             fontSize: '0.8rem',


### PR DESCRIPTION
## Summary
- align the miner Issue Discovery search field with the table/card edges on xs viewports
- keep the existing tablet and desktop sizing unchanged

Addresses #867 on the current `test` branch. The original issue refers to the old Repositories tab/search label; that surface has since been refactored into the current Issue Discovery/Open Issues layout.

## Verification
- npm run lint
- npm run build
- git diff --check
- visual check at 375px: /tmp/gittensor-867-after-375.png

Note: build passes with the existing Vite large chunk warning.