### PR TITLE
Align miner activity heatmap summary window

### DIFF
--- a/src/components/ContributionHeatmap.tsx
+++ b/src/components/ContributionHeatmap.tsx
@@ -15,7 +15,7 @@ interface ContributionData {
 
 interface ContributionHeatmapProps {
   data: ContributionData[];
-  contributionsLast30Days: number;
+  contributionsShown: number;
   totalDaysShown: number;
   subtitle?: string;
   footerText?: string;
@@ -28,9 +28,9 @@ interface ContributionHeatmapProps {
 
 const ContributionHeatmap: React.FC<ContributionHeatmapProps> = ({
   data,
-  contributionsLast30Days,
+  contributionsShown,
   totalDaysShown,
-  subtitle = 'network contribution(s) in the last 30 days',
+  subtitle = `network contribution(s) in the last ${totalDaysShown} day(s)`,
   footerText,
   emptyTitle = 'No contributions yet',
   emptySubtitle = 'Activity will appear here once PRs are merged',
@@ -55,7 +55,7 @@ const ContributionHeatmap: React.FC<ContributionHeatmapProps> = ({
             lineHeight: 1,
           }}
         >
-          {contributionsLast30Days.toLocaleString()}
+          {contributionsShown.toLocaleString()}
         </Typography>
         <Typography
           variant="body2"

--- a/src/components/miners/MinerActivity.tsx
+++ b/src/components/miners/MinerActivity.tsx
@@ -362,7 +362,7 @@ const MinerActivity: React.FC<MinerActivityProps> = ({
         return {
           contributionData: [],
           contributionsShown: 0,
-          totalDaysShown: 0,
+          totalDaysShown: 1,
         };
       }
 
@@ -398,7 +398,7 @@ const MinerActivity: React.FC<MinerActivityProps> = ({
 
       const shownCount = Array.from(dataMap.values()).reduce(
         (total, count) => total + count,
-        0
+        0,
       );
 
       const data = Array.from(dataMap.entries())
@@ -415,7 +415,7 @@ const MinerActivity: React.FC<MinerActivityProps> = ({
       return {
         contributionData: data,
         contributionsShown: shownCount,
-        totalDaysShown: daysToShow,
+        totalDaysShown: data.length,
       };
     }, [prs]);
 

--- a/src/components/miners/MinerActivity.tsx
+++ b/src/components/miners/MinerActivity.tsx
@@ -356,12 +356,12 @@ const MinerActivity: React.FC<MinerActivityProps> = ({
   };
 
   // Calculate contribution heatmap data
-  const { contributionData, contributionsLast30Days, totalDaysShown } =
+  const { contributionData, contributionsShown, totalDaysShown } =
     useMemo(() => {
       if (!prs || prs.length === 0) {
         return {
           contributionData: [],
-          contributionsLast30Days: 0,
+          contributionsShown: 0,
           totalDaysShown: 0,
         };
       }
@@ -385,9 +385,6 @@ const MinerActivity: React.FC<MinerActivityProps> = ({
         dataMap.set(format(subDays(today, i), 'yyyy-MM-dd'), 0);
       }
 
-      let last30Count = 0;
-      const thirtyDaysAgo = subDays(today, 30);
-
       prs.forEach((pr) => {
         if (!pr.mergedAt) return;
         const date = new Date(pr.mergedAt);
@@ -397,8 +394,12 @@ const MinerActivity: React.FC<MinerActivityProps> = ({
         if (dataMap.has(dateStr)) {
           dataMap.set(dateStr, (dataMap.get(dateStr) || 0) + 1);
         }
-        if (date >= thirtyDaysAgo) last30Count++;
       });
+
+      const shownCount = Array.from(dataMap.values()).reduce(
+        (total, count) => total + count,
+        0
+      );
 
       const data = Array.from(dataMap.entries())
         .map(([date, count]) => {
@@ -413,7 +414,7 @@ const MinerActivity: React.FC<MinerActivityProps> = ({
 
       return {
         contributionData: data,
-        contributionsLast30Days: last30Count,
+        contributionsShown: shownCount,
         totalDaysShown: daysToShow,
       };
     }, [prs]);
@@ -660,9 +661,9 @@ const MinerActivity: React.FC<MinerActivityProps> = ({
             >
               <ContributionHeatmap
                 data={contributionData}
-                contributionsLast30Days={contributionsLast30Days}
+                contributionsShown={contributionsShown}
                 totalDaysShown={totalDaysShown}
-                subtitle="contribution(s) in the last 30 days"
+                subtitle={`contribution(s) in the last ${totalDaysShown} day(s)`}
                 footerText="* Activity based on merged PRs in Gittensor-tracked repositories"
                 bare
                 selectedDate={selectedDate}


### PR DESCRIPTION
## Summary
- derive the prominent ContributionHeatmap count from the same data rendered in the heatmap
- update the subtitle to use the current totalDaysShown window instead of hardcoded last 30 days
- intentionally avoids reintroducing the rejected range selector from #1151

References #1152.

## Verification
- npm run lint -- --max-warnings 0
- npm run build
- git diff --check