### PR TITLE
fix(code-browser): hide file search when viewing a file

### DIFF
--- a/src/components/repositories/RepositoryCodeBrowser.tsx
+++ b/src/components/repositories/RepositoryCodeBrowser.tsx
@@ -797,11 +797,13 @@ const RepositoryCodeBrowser: React.FC<RepositoryCodeBrowserProps> = ({
             })}
           </Breadcrumbs>
         </Box>
-        <GoToFileSearch
-          pathEntries={goToPathEntries}
-          treeTruncated={treeQuery.data?.truncated === true}
-          onNavigate={handleNavigate}
-        />
+        {!isFile && (
+          <GoToFileSearch
+            pathEntries={goToPathEntries}
+            treeTruncated={treeQuery.data?.truncated === true}
+            onNavigate={handleNavigate}
+          />
+        )}
       </Box>
 
       {/* Latest Commit Header (GitHub style blue/gray bar) */}


### PR DESCRIPTION
The "Search files and folders" input was still rendered when a file
was open, even though there's no file list to filter at that point.
Conditionally render GoToFileSearch only in directory view.

### Screenshots
- **Directory view** — search input is appropriate here:
  _(attach Image 1: repo root showing folders/files)_

<img width="1747" height="874" alt="Image" src="https://github.com/user-attachments/assets/2fc3040c-2dae-4612-a164-659f0a51624d" />

- **File view (`.env.example`)** — search input should not be shown here:
  _(attach Image 2: opened file contents)_

<img width="1701" height="877" alt="Image" src="https://github.com/user-attachments/assets/a6746f67-45b8-4dbb-89d6-36a790bcfaec" />

Fixes #1256 
