### PR TITLE
feat(miner-details): add eligibility filter to per-repository standings

### DIFF
--- a/src/components/leaderboard/EligibilityToggle.tsx
+++ b/src/components/leaderboard/EligibilityToggle.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { Box } from '@mui/material';
+import { alpha } from '@mui/material/styles';
+import { FONTS } from './types';
+
+export type EligibilityFilter = 'all' | 'eligible' | 'ineligible';
+
+export const ELIGIBILITY_OPTIONS: Array<{
+  value: EligibilityFilter;
+  label: string;
+}> = [
+  { value: 'all', label: 'All' },
+  { value: 'eligible', label: 'Eligible' },
+  { value: 'ineligible', label: 'Ineligible' },
+];
+
+interface EligibilityToggleProps {
+  value: EligibilityFilter;
+  onChange: (next: EligibilityFilter) => void;
+  /** Tighter pills for the dual watchlist bar. */
+  compact?: boolean;
+}
+
+export const EligibilityToggle: React.FC<EligibilityToggleProps> = ({
+  value,
+  onChange,
+  compact = false,
+}) => (
+  <Box
+    sx={(theme) => ({
+      display: 'inline-flex',
+      gap: compact ? 0.35 : 0.5,
+      p: compact ? 0.35 : 0.5,
+      borderRadius: 1.75,
+      backgroundColor: theme.palette.surface.light,
+      flexShrink: 0,
+    })}
+  >
+    {ELIGIBILITY_OPTIONS.map((option) => {
+      const isActive = value === option.value;
+      return (
+        <Box
+          key={option.value}
+          component="button"
+          type="button"
+          aria-pressed={isActive}
+          onClick={() => onChange(option.value)}
+          sx={(theme) => ({
+            px: compact ? 1 : 1.5,
+            height: compact ? 22 : 24,
+            display: 'flex',
+            alignItems: 'center',
+            border: 0,
+            borderRadius: 1.25,
+            backgroundColor: isActive
+              ? alpha(theme.palette.text.primary, 0.15)
+              : 'transparent',
+            color: isActive
+              ? theme.palette.text.primary
+              : theme.palette.text.tertiary,
+            cursor: 'pointer',
+            fontFamily: FONTS.mono,
+            fontSize: compact ? '0.65rem' : '0.72rem',
+            fontWeight: isActive ? 600 : 500,
+            lineHeight: 1,
+            transition: 'all 0.2s ease',
+            '&:hover': {
+              backgroundColor: alpha(theme.palette.text.primary, 0.1),
+              color: theme.palette.text.primary,
+            },
+            '&:focus-visible': {
+              outline: `1px solid ${theme.palette.border.medium}`,
+              outlineOffset: 1,
+            },
+          })}
+        >
+          {option.label}
+        </Box>
+      );
+    })}
+  </Box>
+);

--- a/src/components/leaderboard/TopMinersTable.tsx
+++ b/src/components/leaderboard/TopMinersTable.tsx
@@ -41,6 +41,7 @@ import {
   type LeaderboardVariant,
   FONTS,
 } from './types';
+import { EligibilityToggle, type EligibilityFilter } from './EligibilityToggle';
 
 type ViewMode = 'cards' | 'list';
 
@@ -110,8 +111,6 @@ const getAllowedSortOptions = (variant: LeaderboardVariant): SortOption[] => {
     ];
   return ['totalScore', 'usdPerDay', 'totalPRs', 'credibility', 'watch'];
 };
-
-type EligibilityFilter = 'all' | 'eligible' | 'ineligible';
 
 type TopMinersUrlFilters = {
   view: ViewMode;
@@ -976,80 +975,6 @@ const WatchlistEligibilityBar: React.FC<WatchlistEligibilityBarProps> = ({
     </>
   );
 };
-
-interface EligibilityToggleProps {
-  value: EligibilityFilter;
-  onChange: (next: EligibilityFilter) => void;
-  /** Tighter pills for the dual watchlist bar. */
-  compact?: boolean;
-}
-
-const ELIGIBILITY_OPTIONS: Array<{ value: EligibilityFilter; label: string }> =
-  [
-    { value: 'all', label: 'All' },
-    { value: 'eligible', label: 'Eligible' },
-    { value: 'ineligible', label: 'Ineligible' },
-  ];
-
-const EligibilityToggle: React.FC<EligibilityToggleProps> = ({
-  value,
-  onChange,
-  compact = false,
-}) => (
-  <Box
-    sx={(theme) => ({
-      display: 'inline-flex',
-      gap: compact ? 0.35 : 0.5,
-      p: compact ? 0.35 : 0.5,
-      borderRadius: 1.75,
-      backgroundColor: theme.palette.surface.light,
-      flexShrink: 0,
-    })}
-  >
-    {ELIGIBILITY_OPTIONS.map((option) => {
-      const isActive = value === option.value;
-      return (
-        <Box
-          key={option.value}
-          component="button"
-          type="button"
-          aria-pressed={isActive}
-          onClick={() => onChange(option.value)}
-          sx={(theme) => ({
-            px: compact ? 1 : 1.5,
-            height: compact ? 22 : 24,
-            display: 'flex',
-            alignItems: 'center',
-            border: 0,
-            borderRadius: 1.25,
-            backgroundColor: isActive
-              ? alpha(theme.palette.text.primary, 0.15)
-              : 'transparent',
-            color: isActive
-              ? theme.palette.text.primary
-              : theme.palette.text.tertiary,
-            cursor: 'pointer',
-            fontFamily: FONTS.mono,
-            fontSize: compact ? '0.65rem' : '0.72rem',
-            fontWeight: isActive ? 600 : 500,
-            lineHeight: 1,
-            transition: 'all 0.2s ease',
-            '&:hover': {
-              backgroundColor: alpha(theme.palette.text.primary, 0.1),
-              color: theme.palette.text.primary,
-            },
-            '&:focus-visible': {
-              outline: `1px solid ${theme.palette.border.medium}`,
-              outlineOffset: 1,
-            },
-          })}
-        >
-          {option.label}
-        </Box>
-      );
-    })}
-  </Box>
-);
 
 /* ─── ToolbarSidebarPanel: all controls rendered inline for sidebar ── */
 

--- a/src/components/miners/MinerRepoStandings.tsx
+++ b/src/components/miners/MinerRepoStandings.tsx
@@ -28,6 +28,10 @@ import { credibilityColor } from '../../utils/format';
 import { type SortOrder } from '../../utils/ExplorerUtils';
 import { getRepositoryOwnerAvatarSrc } from '../../utils/avatar';
 import { DataTable, type DataTableColumn } from '../common';
+import {
+  EligibilityToggle,
+  type EligibilityFilter,
+} from '../leaderboard/EligibilityToggle';
 import EmptyStateMessage from './EmptyStateMessage';
 import MinerRepoStandingCard, { repoMinersHref } from './MinerRepoStandingCard';
 
@@ -44,16 +48,6 @@ type StandingsSortKey =
   | 'solved'
   | 'valid'
   | 'discoveryScore';
-type EligibilityFilter = 'all' | 'eligible' | 'ineligible';
-
-const ELIGIBILITY_FILTER_OPTIONS: Array<{
-  value: EligibilityFilter;
-  label: string;
-}> = [
-  { value: 'all', label: 'All' },
-  { value: 'eligible', label: 'Eligible' },
-  { value: 'ineligible', label: 'Ineligible' },
-];
 
 const repoTrackEligible = (
   repo: MinerRepositoryEvaluation,
@@ -379,16 +373,9 @@ const MinerRepoStandings: React.FC<MinerRepoStandingsProps> = ({
     if (next) setView(next);
   };
 
-  const handleEligibilityFilterChange = (
-    _event: React.MouseEvent<HTMLElement>,
-    next: EligibilityFilter | null,
-  ) => {
-    if (next) setEligibilityFilter(next);
-  };
-
-  const toggleGroupSx = {
+  const viewToggleGroupSx = {
     '& .MuiToggleButton-root': {
-      color: 'text.secondary',
+      color: 'text.tertiary',
       borderColor: 'border.light',
       height: 32,
       minHeight: 32,
@@ -398,15 +385,19 @@ const MinerRepoStandings: React.FC<MinerRepoStandingsProps> = ({
       display: 'inline-flex',
       alignItems: 'center',
       justifyContent: 'center',
-      textTransform: 'none',
       '&.Mui-selected': {
-        color: 'primary.main',
+        color: 'text.primary',
         backgroundColor: (theme: Theme) =>
-          alpha(theme.palette.primary.main, 0.12),
+          alpha(theme.palette.text.primary, 0.15),
         '&:hover': {
           backgroundColor: (theme: Theme) =>
-            alpha(theme.palette.primary.main, 0.18),
+            alpha(theme.palette.text.primary, 0.1),
         },
+      },
+      '&:hover': {
+        backgroundColor: (theme: Theme) =>
+          alpha(theme.palette.text.primary, 0.1),
+        color: 'text.primary',
       },
     },
   };
@@ -482,20 +473,10 @@ const MinerRepoStandings: React.FC<MinerRepoStandingsProps> = ({
               flexWrap: 'wrap',
             }}
           >
-            <ToggleButtonGroup
+            <EligibilityToggle
               value={eligibilityFilter}
-              exclusive
-              onChange={handleEligibilityFilterChange}
-              size="small"
-              aria-label="Repository eligibility"
-              sx={toggleGroupSx}
-            >
-              {ELIGIBILITY_FILTER_OPTIONS.map((option) => (
-                <ToggleButton key={option.value} value={option.value}>
-                  {option.label}
-                </ToggleButton>
-              ))}
-            </ToggleButtonGroup>
+              onChange={setEligibilityFilter}
+            />
             {view === 'cards' && (
               <>
                 <Typography
@@ -611,7 +592,7 @@ const MinerRepoStandings: React.FC<MinerRepoStandingsProps> = ({
               onChange={handleViewChange}
               size="small"
               aria-label="Standings view"
-              sx={toggleGroupSx}
+              sx={viewToggleGroupSx}
             >
               <ToggleButton value="cards" aria-label="Card grid">
                 <GridViewIcon sx={{ fontSize: '1.05rem' }} />

--- a/src/components/miners/MinerRepoStandings.tsx
+++ b/src/components/miners/MinerRepoStandings.tsx
@@ -14,6 +14,7 @@ import {
   Tooltip,
   Typography,
 } from '@mui/material';
+import type { Theme } from '@mui/material/styles';
 import {
   ArrowDownward as ArrowDownwardIcon,
   ArrowUpward as ArrowUpwardIcon,
@@ -43,6 +44,33 @@ type StandingsSortKey =
   | 'solved'
   | 'valid'
   | 'discoveryScore';
+type EligibilityFilter = 'all' | 'eligible' | 'ineligible';
+
+const ELIGIBILITY_FILTER_OPTIONS: Array<{
+  value: EligibilityFilter;
+  label: string;
+}> = [
+  { value: 'all', label: 'All' },
+  { value: 'eligible', label: 'Eligible' },
+  { value: 'ineligible', label: 'Ineligible' },
+];
+
+const repoTrackEligible = (
+  repo: MinerRepositoryEvaluation,
+  isIssueMode: boolean,
+): boolean => (isIssueMode ? repo.isIssueEligible : repo.isEligible);
+
+const filterReposByEligibility = (
+  repos: MinerRepositoryEvaluation[],
+  filter: EligibilityFilter,
+  isIssueMode: boolean,
+): MinerRepositoryEvaluation[] => {
+  if (filter === 'all') return repos;
+  if (filter === 'eligible') {
+    return repos.filter((r) => repoTrackEligible(r, isIssueMode));
+  }
+  return repos.filter((r) => !repoTrackEligible(r, isIssueMode));
+};
 
 interface MinerRepoStandingsProps {
   githubId: string;
@@ -145,6 +173,8 @@ const MinerRepoStandings: React.FC<MinerRepoStandingsProps> = ({
 }) => {
   const { data: minerStats, isLoading } = useMinerStats(githubId);
   const [view, setView] = useState<StandingsView>('cards');
+  const [eligibilityFilter, setEligibilityFilter] =
+    useState<EligibilityFilter>('all');
   const isIssueMode = viewMode === 'issues';
   const [sortField, setSortField] = useState<StandingsSortKey>(
     isIssueMode ? 'discoveryScore' : 'score',
@@ -157,7 +187,7 @@ const MinerRepoStandings: React.FC<MinerRepoStandingsProps> = ({
     setSortOrder('desc');
   }, [isIssueMode]);
 
-  const baseRows = useMemo(() => {
+  const allRows = useMemo(() => {
     // Pre-migration placeholder rows carry an empty repo name — drop them.
     const repos = (minerStats?.repositories ?? []).filter(
       (r) => r.repositoryFullName.trim().length > 0,
@@ -165,8 +195,13 @@ const MinerRepoStandings: React.FC<MinerRepoStandingsProps> = ({
     return repos.slice();
   }, [minerStats]);
 
+  const filteredRows = useMemo(
+    () => filterReposByEligibility(allRows, eligibilityFilter, isIssueMode),
+    [allRows, eligibilityFilter, isIssueMode],
+  );
+
   const rows = useMemo(() => {
-    const sorted = baseRows.slice().sort((a, b) => {
+    const sorted = filteredRows.slice().sort((a, b) => {
       let comparison = 0;
       switch (sortField) {
         case 'repository':
@@ -203,7 +238,7 @@ const MinerRepoStandings: React.FC<MinerRepoStandingsProps> = ({
       return sortOrder === 'asc' ? comparison : -comparison;
     });
     return sorted;
-  }, [baseRows, sortField, sortOrder]);
+  }, [filteredRows, sortField, sortOrder]);
 
   const handleSortChange = (nextField: StandingsSortKey) => {
     if (nextField === sortField) {
@@ -233,8 +268,8 @@ const MinerRepoStandings: React.FC<MinerRepoStandingsProps> = ({
         { value: 'repository' as const, label: 'Repository' },
       ];
 
-  const eligibleCount = rows.filter((r) =>
-    isIssueMode ? r.isIssueEligible : r.isEligible,
+  const eligibleCount = allRows.filter((r) =>
+    repoTrackEligible(r, isIssueMode),
   ).length;
 
   const prColumns: DataTableColumn<
@@ -344,6 +379,38 @@ const MinerRepoStandings: React.FC<MinerRepoStandingsProps> = ({
     if (next) setView(next);
   };
 
+  const handleEligibilityFilterChange = (
+    _event: React.MouseEvent<HTMLElement>,
+    next: EligibilityFilter | null,
+  ) => {
+    if (next) setEligibilityFilter(next);
+  };
+
+  const toggleGroupSx = {
+    '& .MuiToggleButton-root': {
+      color: 'text.secondary',
+      borderColor: 'border.light',
+      height: 32,
+      minHeight: 32,
+      px: 1.25,
+      py: 0,
+      lineHeight: 1,
+      display: 'inline-flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      textTransform: 'none',
+      '&.Mui-selected': {
+        color: 'primary.main',
+        backgroundColor: (theme: Theme) =>
+          alpha(theme.palette.primary.main, 0.12),
+        '&:hover': {
+          backgroundColor: (theme: Theme) =>
+            alpha(theme.palette.primary.main, 0.18),
+        },
+      },
+    },
+  };
+
   return (
     <Card
       sx={{
@@ -379,10 +446,14 @@ const MinerRepoStandings: React.FC<MinerRepoStandingsProps> = ({
                 fontSize: '0.75rem',
               }}
             >
-              ({rows.length})
+              ({rows.length}
+              {eligibilityFilter !== 'all' && allRows.length !== rows.length
+                ? ` of ${allRows.length}`
+                : ''}
+              )
             </Typography>
           </Box>
-          {rows.length > 0 && (
+          {allRows.length > 0 && (
             <Typography sx={{ fontSize: '0.75rem', color: 'text.secondary' }}>
               {isIssueMode ? 'Issue-discovery eligible' : 'PR eligible'} in{' '}
               <Box
@@ -395,15 +466,36 @@ const MinerRepoStandings: React.FC<MinerRepoStandingsProps> = ({
                   fontWeight: 600,
                 }}
               >
-                {eligibleCount}/{rows.length}
+                {eligibleCount}/{allRows.length}
               </Box>{' '}
-              {rows.length === 1 ? 'repository' : 'repositories'}
+              {allRows.length === 1 ? 'repository' : 'repositories'}
             </Typography>
           )}
         </Box>
 
-        {rows.length > 0 && (
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+        {allRows.length > 0 && (
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 1,
+              flexWrap: 'wrap',
+            }}
+          >
+            <ToggleButtonGroup
+              value={eligibilityFilter}
+              exclusive
+              onChange={handleEligibilityFilterChange}
+              size="small"
+              aria-label="Repository eligibility"
+              sx={toggleGroupSx}
+            >
+              {ELIGIBILITY_FILTER_OPTIONS.map((option) => (
+                <ToggleButton key={option.value} value={option.value}>
+                  {option.label}
+                </ToggleButton>
+              ))}
+            </ToggleButtonGroup>
             {view === 'cards' && (
               <>
                 <Typography
@@ -519,22 +611,7 @@ const MinerRepoStandings: React.FC<MinerRepoStandingsProps> = ({
               onChange={handleViewChange}
               size="small"
               aria-label="Standings view"
-              sx={{
-                '& .MuiToggleButton-root': {
-                  color: 'text.secondary',
-                  borderColor: 'border.light',
-                  px: 1.25,
-                  py: 0.5,
-                  '&.Mui-selected': {
-                    color: 'primary.main',
-                    backgroundColor: (t) => alpha(t.palette.primary.main, 0.12),
-                    '&:hover': {
-                      backgroundColor: (t) =>
-                        alpha(t.palette.primary.main, 0.18),
-                    },
-                  },
-                },
-              }}
+              sx={toggleGroupSx}
             >
               <ToggleButton value="cards" aria-label="Card grid">
                 <GridViewIcon sx={{ fontSize: '1.05rem' }} />
@@ -551,8 +628,12 @@ const MinerRepoStandings: React.FC<MinerRepoStandingsProps> = ({
         <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
           <CircularProgress size={36} sx={{ color: 'primary.main' }} />
         </Box>
-      ) : rows.length === 0 ? (
+      ) : allRows.length === 0 ? (
         <EmptyStateMessage message="No per-repository evaluations for this miner yet." />
+      ) : rows.length === 0 ? (
+        <EmptyStateMessage
+          message={`No ${eligibilityFilter === 'eligible' ? 'eligible' : 'ineligible'} repositories for this miner.`}
+        />
       ) : view === 'cards' ? (
         <Box
           sx={{


### PR DESCRIPTION
## Summary

Adds an All / Eligible / Ineligible filter to the per-repository standings section on the miner details page, making it easier to focus on repositories that are currently earning (or not earning) rewards on the active track.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

### Before
<img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/8c9b4206-1536-441f-8019-210239e80285" />

### After
[gorec-2026-05-22-06-52-42.webm](https://github.com/user-attachments/assets/f98cc017-027d-4523-b5bb-810b3daf0752)

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
