### PR TITLE
feat(watchlist): add author checklist filter to PRs and Issues

### DIFF
--- a/src/components/common/AuthorChecklistFilter.tsx
+++ b/src/components/common/AuthorChecklistFilter.tsx
@@ -1,0 +1,270 @@
+import React, { useCallback, useMemo, useState } from 'react';
+import {
+  Avatar,
+  Box,
+  Button,
+  Checkbox,
+  FormControlLabel,
+  IconButton,
+  Popover,
+  Stack,
+  Typography,
+  alpha,
+} from '@mui/material';
+import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
+import CloseIcon from '@mui/icons-material/Close';
+import { getRepositoryOwnerAvatarSrc } from '../../utils/avatar';
+import { TEXT_OPACITY, scrollbarSx } from '../../theme';
+
+export type AuthorChecklistOption = {
+  id: string;
+  label: string;
+  count: number;
+};
+
+interface AuthorChecklistFilterProps {
+  options: AuthorChecklistOption[];
+  selected: readonly string[];
+  onChange: (next: readonly string[]) => void;
+}
+
+export const AuthorChecklistFilter: React.FC<AuthorChecklistFilterProps> = ({
+  options,
+  selected,
+  onChange,
+}) => {
+  const selectedSet = useMemo(() => new Set(selected), [selected]);
+  const [anchor, setAnchor] = useState<HTMLElement | null>(null);
+  const isOpen = Boolean(anchor);
+
+  const open = useCallback((event: React.MouseEvent<HTMLElement>) => {
+    setAnchor(event.currentTarget);
+  }, []);
+
+  const close = useCallback(() => setAnchor(null), []);
+
+  if (options.length <= 1) return null;
+
+  const isFiltering = selected.length > 0;
+
+  const toggle = (id: string) => {
+    const next = new Set(selected);
+    if (next.has(id)) next.delete(id);
+    else next.add(id);
+    onChange(Array.from(next));
+  };
+
+  const triggerLabel = (() => {
+    if (!isFiltering) return 'Author';
+    if (selected.length === 1) return selected[0];
+    return `${selected.length} authors`;
+  })();
+
+  return (
+    <>
+      <Box
+        component="button"
+        type="button"
+        onClick={open}
+        aria-haspopup="listbox"
+        aria-expanded={isOpen}
+        sx={(t) => ({
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          width: '100%',
+          gap: 1,
+          px: 1.25,
+          py: 0.75,
+          minHeight: 34,
+          borderRadius: 2,
+          border: `1px solid ${isFiltering ? t.palette.border.medium : t.palette.border.light}`,
+          backgroundColor: isFiltering
+            ? t.palette.surface.light
+            : t.palette.surface.subtle,
+          color: isFiltering ? 'text.primary' : 'text.tertiary',
+          cursor: 'pointer',
+          fontFamily: '"JetBrains Mono", monospace',
+          fontSize: '0.78rem',
+          textAlign: 'left',
+          '&:hover': {
+            borderColor: t.palette.border.medium,
+            backgroundColor: t.palette.surface.light,
+          },
+        })}
+      >
+        <Box
+          component="span"
+          sx={{
+            flex: 1,
+            minWidth: 0,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {triggerLabel}
+        </Box>
+        <Stack direction="row" alignItems="center" spacing={0.25}>
+          {isFiltering ? (
+            <IconButton
+              size="small"
+              aria-label="Clear author filter"
+              onClick={(e) => {
+                e.stopPropagation();
+                onChange([]);
+              }}
+              sx={{
+                p: 0.25,
+                color: 'text.tertiary',
+                '&:hover': { color: 'text.primary' },
+              }}
+            >
+              <CloseIcon sx={{ fontSize: '0.9rem' }} />
+            </IconButton>
+          ) : null}
+          <ArrowDropDownIcon
+            sx={{
+              fontSize: '1.1rem',
+              color: 'text.secondary',
+              transform: isOpen ? 'rotate(180deg)' : 'none',
+              transition: 'transform 0.2s ease',
+            }}
+          />
+        </Stack>
+      </Box>
+
+      <Popover
+        open={isOpen}
+        anchorEl={anchor}
+        onClose={close}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+        transformOrigin={{ vertical: 'top', horizontal: 'left' }}
+        slotProps={{
+          paper: {
+            elevation: 0,
+            sx: (t) => ({
+              mt: 0.5,
+              width: anchor?.offsetWidth ?? 280,
+              minWidth: 240,
+              maxWidth: 320,
+              borderRadius: 2,
+              border: `1px solid ${t.palette.border.medium}`,
+              backgroundColor: t.palette.surface.elevated,
+              backgroundImage: 'none',
+              boxShadow: `0 12px 32px ${alpha(t.palette.common.black, 0.55)}`,
+              overflow: 'hidden',
+            }),
+          },
+        }}
+      >
+        {isFiltering ? (
+          <Box
+            sx={{
+              display: 'flex',
+              justifyContent: 'flex-end',
+              px: 1,
+              pt: 1,
+              pb: 0.25,
+              borderBottom: '1px solid',
+              borderColor: 'border.light',
+            }}
+          >
+            <Button
+              size="small"
+              onClick={() => onChange([])}
+              sx={{
+                minWidth: 0,
+                px: 0.5,
+                py: 0,
+                fontSize: '0.68rem',
+                textTransform: 'none',
+                color: 'text.tertiary',
+                '&:hover': {
+                  color: 'text.primary',
+                  backgroundColor: 'action.hover',
+                },
+              }}
+            >
+              Clear all
+            </Button>
+          </Box>
+        ) : null}
+        <Box
+          role="listbox"
+          aria-multiselectable="true"
+          sx={{
+            maxHeight: 280,
+            overflowY: 'auto',
+            py: 0.5,
+            ...scrollbarSx,
+          }}
+        >
+          {options.map(({ id, label, count }) => (
+            <FormControlLabel
+              key={id}
+              control={
+                <Checkbox
+                  size="small"
+                  checked={selectedSet.has(id)}
+                  onChange={() => toggle(id)}
+                  sx={{ py: 0.25 }}
+                />
+              }
+              label={
+                <Stack
+                  direction="row"
+                  alignItems="center"
+                  spacing={0.75}
+                  sx={{ flex: 1, minWidth: 0 }}
+                >
+                  <Avatar
+                    src={getRepositoryOwnerAvatarSrc(label)}
+                    alt={label}
+                    sx={{ width: 18, height: 18 }}
+                  />
+                  <Typography
+                    sx={{
+                      flex: 1,
+                      fontSize: '0.78rem',
+                      fontFamily: '"JetBrains Mono", monospace',
+                      color: 'text.primary',
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
+                    }}
+                  >
+                    {label}
+                  </Typography>
+                  <Typography
+                    sx={(t) => ({
+                      fontSize: '0.72rem',
+                      fontFamily: '"JetBrains Mono", monospace',
+                      color: alpha(
+                        t.palette.text.primary,
+                        TEXT_OPACITY.tertiary,
+                      ),
+                    })}
+                  >
+                    {count}
+                  </Typography>
+                </Stack>
+              }
+              sx={{
+                mx: 0,
+                px: 1.5,
+                width: '100%',
+                alignItems: 'center',
+                borderRadius: 1,
+                '&:hover': {
+                  backgroundColor: 'surface.light',
+                },
+                '& .MuiFormControlLabel-label': { flex: 1, minWidth: 0 },
+              }}
+            />
+          ))}
+        </Box>
+      </Popover>
+    </>
+  );
+};

--- a/src/pages/WatchlistPage.tsx
+++ b/src/pages/WatchlistPage.tsx
@@ -84,6 +84,10 @@ import type {
 import type { IssueBounty } from '../api/models/Issues';
 import { usePrices } from '../hooks/usePrices';
 import { DebouncedSearchInput } from '../components/common/DebouncedSearchInput';
+import {
+  AuthorChecklistFilter,
+  type AuthorChecklistOption,
+} from '../components/common/AuthorChecklistFilter';
 import { BountyCard } from '../components/issues/BountyCard';
 import { mapAllMinersToStats } from '../utils/minerMapper';
 import {
@@ -695,6 +699,7 @@ const WatchlistOptionsSidebarPanelContent: React.FC<
   Omit<WatchlistOptionsButtonProps, 'hasActiveFilter'>
 > = ({
   filterContent,
+  authorContent,
   sortContent,
   extraContent,
   searchValue,
@@ -708,6 +713,13 @@ const WatchlistOptionsSidebarPanelContent: React.FC<
       <OptionsLabel>Filter</OptionsLabel>
       {filterContent}
     </Box>
+
+    {authorContent != null ? (
+      <Box>
+        <OptionsLabel>Author</OptionsLabel>
+        {authorContent}
+      </Box>
+    ) : null}
 
     {sortContent != null ? (
       <Box>
@@ -767,6 +779,8 @@ const WatchlistOptionsSidebarPanelContent: React.FC<
 /* ─── WatchlistOptionsButton: reusable compact popover for all watchlist list toolbars ─── */
 interface WatchlistOptionsButtonProps {
   filterContent: React.ReactNode;
+  /** Multi-select author checklist (PRs / Issues tabs). */
+  authorContent?: React.ReactNode;
   /** Shown under Filter when set (e.g. repositories card view). */
   sortContent?: React.ReactNode;
   extraContent?: React.ReactNode;
@@ -781,6 +795,7 @@ interface WatchlistOptionsButtonProps {
 
 const WatchlistOptionsButton: React.FC<WatchlistOptionsButtonProps> = ({
   filterContent,
+  authorContent,
   sortContent,
   extraContent,
   searchValue,
@@ -877,6 +892,13 @@ const WatchlistOptionsButton: React.FC<WatchlistOptionsButtonProps> = ({
           <OptionsLabel>Filter</OptionsLabel>
           {filterContent}
         </Box>
+
+        {authorContent != null ? (
+          <Box>
+            <OptionsLabel>Author</OptionsLabel>
+            {authorContent}
+          </Box>
+        ) : null}
 
         {sortContent != null ? (
           <Box>
@@ -1026,6 +1048,34 @@ type WatchedRepoStats = Repository & {
 
 const isPrStatusFilterStored = (v: unknown): v is PrStatusFilter =>
   v === 'all' || v === 'open' || v === 'merged' || v === 'closed';
+
+const isStringArrayStored = (v: unknown): v is string[] =>
+  Array.isArray(v) && v.every((x) => typeof x === 'string');
+
+const buildPrAuthorOptions = (prs: CommitLog[]): AuthorChecklistOption[] => {
+  const counts = new Map<string, number>();
+  for (const pr of prs) {
+    if (!pr.author) continue;
+    counts.set(pr.author, (counts.get(pr.author) ?? 0) + 1);
+  }
+  return Array.from(counts.entries())
+    .map(([author, count]) => ({ id: author, label: author, count }))
+    .sort((a, b) => b.count - a.count || a.label.localeCompare(b.label));
+};
+
+const buildIssueAuthorOptions = (
+  issues: MinerIssue[],
+): AuthorChecklistOption[] => {
+  const counts = new Map<string, number>();
+  for (const issue of issues) {
+    const login = issue.author_login;
+    if (!login) continue;
+    counts.set(login, (counts.get(login) ?? 0) + 1);
+  }
+  return Array.from(counts.entries())
+    .map(([login, count]) => ({ id: login, label: login, count }))
+    .sort((a, b) => b.count - a.count || a.label.localeCompare(b.label));
+};
 
 type RepoSortKey =
   | 'name'
@@ -3235,6 +3285,11 @@ const PRsList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
     'all',
     isPrStatusFilterStored,
   );
+  const [selectedAuthors, setSelectedAuthors] = useSessionStoredState<string[]>(
+    'watchlist:prs:authors',
+    [],
+    isStringArrayStored,
+  );
   const [viewMode, setViewMode] = useWatchlistViewMode();
   const [page, setPage] = useState(0);
   const observerTarget = useRef<HTMLDivElement>(null);
@@ -3252,6 +3307,7 @@ const PRsList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
   }, [
     statusFilter,
     searchQuery,
+    selectedAuthors,
     sortField,
     sortOrder,
     viewMode,
@@ -3296,13 +3352,19 @@ const PRsList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
 
   const counts = useMemo(() => getPrStatusCounts(scopedItems), [scopedItems]);
 
+  const authorOptions = useMemo(
+    () => buildPrAuthorOptions(scopedItems),
+    [scopedItems],
+  );
+
   const filtered = useMemo(() => {
     return filterPrs(scopedItems, {
       statusFilter,
       searchQuery,
       includeNumber: true,
+      authors: selectedAuthors.length > 0 ? selectedAuthors : undefined,
     });
-  }, [scopedItems, statusFilter, searchQuery]);
+  }, [scopedItems, statusFilter, searchQuery, selectedAuthors]);
 
   const sorted = useMemo(() => {
     const dir = sortOrder === 'asc' ? 1 : -1;
@@ -3441,6 +3503,18 @@ const PRsList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
                 />
               </Box>
             }
+            authorContent={
+              authorOptions.length > 1 ? (
+                <AuthorChecklistFilter
+                  options={authorOptions}
+                  selected={selectedAuthors}
+                  onChange={(next) => {
+                    setSelectedAuthors([...next]);
+                    setPage(0);
+                  }}
+                />
+              ) : undefined
+            }
             searchValue={draftValue}
             searchPlaceholder="Search PRs..."
             onSearchChange={setDraftValue}
@@ -3458,7 +3532,11 @@ const PRsList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
                 }}
               />
             }
-            hasActiveFilter={statusFilter !== 'all' || !sourcesAllOn}
+            hasActiveFilter={
+              statusFilter !== 'all' ||
+              !sourcesAllOn ||
+              selectedAuthors.length > 0
+            }
           />
         )}
       </DebouncedSearchInput>
@@ -3678,12 +3756,22 @@ const issueStatusColor = (s: IssueStatusFilter): string => {
 
 const filterIssues = (
   items: MinerIssue[],
-  opts: { statusFilter: IssueStatusFilter; searchQuery: string },
+  opts: {
+    statusFilter: IssueStatusFilter;
+    searchQuery: string;
+    authors?: readonly string[];
+  },
 ): MinerIssue[] => {
   const q = opts.searchQuery.trim().toLowerCase();
+  const authorSet =
+    opts.authors && opts.authors.length > 0 ? new Set(opts.authors) : null;
   return items.filter((i) => {
     if (opts.statusFilter !== 'all' && issueState(i) !== opts.statusFilter)
       return false;
+    if (authorSet) {
+      const login = i.author_login;
+      if (!login || !authorSet.has(login)) return false;
+    }
     if (!q) return true;
     return (
       (i.title || '').toLowerCase().includes(q) ||
@@ -4210,6 +4298,11 @@ const IssuesList: React.FC<{ minerIds: string[] }> = ({ minerIds }) => {
 
   const [searchQuery, setSearchQuery] = useState('');
   const [statusFilter, setStatusFilter] = useState<IssueStatusFilter>('all');
+  const [selectedAuthors, setSelectedAuthors] = useSessionStoredState<string[]>(
+    'watchlist:issues:authors',
+    [],
+    isStringArrayStored,
+  );
   const [viewMode, setViewMode] = useWatchlistViewMode();
   const [page, setPage] = useState(0);
   const observerTarget = useRef<HTMLDivElement>(null);
@@ -4224,7 +4317,14 @@ const IssuesList: React.FC<{ minerIds: string[] }> = ({ minerIds }) => {
 
   useEffect(() => {
     setPage(0);
-  }, [statusFilter, searchQuery, sortField, sortOrder, viewMode]);
+  }, [
+    statusFilter,
+    searchQuery,
+    selectedAuthors,
+    sortField,
+    sortOrder,
+    viewMode,
+  ]);
 
   const handleSort = (field: IssueSortKey) => {
     if (sortField === field) {
@@ -4238,9 +4338,16 @@ const IssuesList: React.FC<{ minerIds: string[] }> = ({ minerIds }) => {
 
   const counts = useMemo(() => getIssueCounts(items), [items]);
 
+  const authorOptions = useMemo(() => buildIssueAuthorOptions(items), [items]);
+
   const filtered = useMemo(
-    () => filterIssues(items, { statusFilter, searchQuery }),
-    [items, statusFilter, searchQuery],
+    () =>
+      filterIssues(items, {
+        statusFilter,
+        searchQuery,
+        authors: selectedAuthors.length > 0 ? selectedAuthors : undefined,
+      }),
+    [items, statusFilter, searchQuery, selectedAuthors],
   );
 
   const sorted = useMemo(() => {
@@ -4329,6 +4436,18 @@ const IssuesList: React.FC<{ minerIds: string[] }> = ({ minerIds }) => {
                 ))}
               </Box>
             }
+            authorContent={
+              authorOptions.length > 1 ? (
+                <AuthorChecklistFilter
+                  options={authorOptions}
+                  selected={selectedAuthors}
+                  onChange={(next) => {
+                    setSelectedAuthors([...next]);
+                    setPage(0);
+                  }}
+                />
+              ) : undefined
+            }
             searchValue={draftValue}
             searchPlaceholder="Search issues..."
             onSearchChange={setDraftValue}
@@ -4346,7 +4465,9 @@ const IssuesList: React.FC<{ minerIds: string[] }> = ({ minerIds }) => {
                 }}
               />
             }
-            hasActiveFilter={statusFilter !== 'all'}
+            hasActiveFilter={
+              statusFilter !== 'all' || selectedAuthors.length > 0
+            }
           />
         )}
       </DebouncedSearchInput>

--- a/src/utils/prTable.ts
+++ b/src/utils/prTable.ts
@@ -5,6 +5,8 @@ export type PrStatusFilter = 'all' | 'open' | 'merged' | 'closed';
 
 interface FilterPrsOptions {
   author?: string | null;
+  /** When non-empty, only PRs whose author is in this list are kept. */
+  authors?: readonly string[];
   includeNumber?: boolean;
   searchQuery?: string;
   statusFilter?: PrStatusFilter;
@@ -14,6 +16,7 @@ export const filterPrs = <T extends CommitLog>(
   prs: T[],
   {
     author,
+    authors,
     includeNumber = false,
     searchQuery = '',
     statusFilter = 'all',
@@ -21,7 +24,10 @@ export const filterPrs = <T extends CommitLog>(
 ) => {
   let filtered = prs;
 
-  if (author) {
+  if (authors && authors.length > 0) {
+    const set = new Set(authors);
+    filtered = filtered.filter((pr) => pr.author != null && set.has(pr.author));
+  } else if (author) {
     filtered = filtered.filter((pr) => pr.author === author);
   }
 


### PR DESCRIPTION
## Summary

Adds a multi-select **Author** filter to the Watchlist **Pull Requests** and **Issues** tabs for faster contributor-focused filtering.

- Added reusable `AuthorChecklistFilter` with dropdown checklist, avatars, usernames, and contribution counts
- Added **Author** section to the Watchlist filters panel (sidebar + mobile options popover)
- **PRs:** filter by `pr.author`
- **Issues:** filter by `author_login`
- Extended `filterPrs()` and `filterIssues()` with multi-author filtering support
- Works alongside existing status, source, and search filters
- Persists selected authors per tab using session storage
- Shows active-filter indicator when author filters are applied

## Related Issues

Closes #1261

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

[watchlist.webm](https://github.com/user-attachments/assets/e3994fe3-05cd-4877-aacd-8fb7774c7785)

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes