### PR TITLE
Fix: repository Miners tab sort showing duplicate rows and wrong order

### DIFF
--- a/src/components/leaderboard/TopMinersTable.tsx
+++ b/src/components/leaderboard/TopMinersTable.tsx
@@ -337,7 +337,12 @@ const TopMinersTable: React.FC<TopMinersTableProps> = ({
   // "1"). Filters apply downstream and never renumber the rows they keep.
   const rankedMiners = useMemo(() => {
     const canonicalDesc = [...miners]
-      .sort((a, b) => -compareMiners(a, b, sortOption, isWatched))
+      .sort((a, b) => {
+        const cmp = compareMiners(a, b, sortOption, isWatched);
+        if (cmp !== 0) return -cmp;
+        // Tie-break so sort order stays stable across header clicks / re-renders.
+        return a.id.localeCompare(b.id);
+      })
       .map((miner, index) => ({ ...miner, rank: index + 1 }));
     return sortDirection === 'desc'
       ? canonicalDesc

--- a/src/utils/minerMapper.ts
+++ b/src/utils/minerMapper.ts
@@ -5,6 +5,37 @@ import {
 import { type MinerStats } from '../components/leaderboard/types';
 import { parseNumber } from './ExplorerUtils';
 
+/** Stable key for collapsing duplicate evaluation rows that share a GitHub id. */
+const repositoryMinerDedupeKey = (row: RepositoryMiner): string => {
+  const githubId = row.githubId?.trim();
+  return githubId ? githubId : `eval:${row.id}`;
+};
+
+/**
+ * The repo miners endpoint can return multiple `miner_evaluations` rows for the
+ * same GitHub identity (e.g. hotkey changes). Keep the strongest row for the
+ * active scoring track so the table shows one entry per miner.
+ */
+const dedupeRepositoryMinerRows = (
+  rows: RepositoryMiner[],
+  score: (row: RepositoryMiner) => number,
+): RepositoryMiner[] => {
+  const bestByKey = new Map<string, RepositoryMiner>();
+  for (const row of rows) {
+    const key = repositoryMinerDedupeKey(row);
+    const existing = bestByKey.get(key);
+    if (!existing) {
+      bestByKey.set(key, row);
+      continue;
+    }
+    const delta = score(row) - score(existing);
+    if (delta > 0 || (delta === 0 && row.id > existing.id)) {
+      bestByKey.set(key, row);
+    }
+  }
+  return [...bestByKey.values()];
+};
+
 export const mapAllMinersToStats = (
   allMinersStats: MinerEvaluation[],
 ): MinerStats[] => {
@@ -69,7 +100,11 @@ export const mapRepositoryMinersToStats = (
       ? parseNumber(row.issueDiscoveryScore)
       : parseNumber(row.totalScore);
 
-  const ranked = [...rows].sort((a, b) => activeScore(b) - activeScore(a));
+  const ranked = dedupeRepositoryMinerRows(rows, activeScore).sort((a, b) => {
+    const byScore = activeScore(b) - activeScore(a);
+    if (byScore !== 0) return byScore;
+    return b.id - a.id;
+  });
 
   return ranked.map((row, index) => {
     const totalSolvedIssues = parseNumber(row.totalSolvedIssues);
@@ -77,7 +112,8 @@ export const mapRepositoryMinersToStats = (
     const totalClosedIssues = parseNumber(row.totalClosedIssues);
 
     return {
-      id: row.githubId || '',
+      // Evaluation row id — unique even when the API returns duplicate githubIds.
+      id: String(row.id),
       githubId: row.githubId || '',
       author: row.githubUsername || undefined,
       totalScore: activeScore(row),


### PR DESCRIPTION
## Summary

Fixes incorrect sorting and duplicated miner rows on the repository **Miners** tab (e.g. multiple `moktamd` entries with mismatched ranks after sorting by PRs or Score).

## Related Issues

Fixes #1263 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

### Before
[fix Before.webm](https://github.com/user-attachments/assets/4b54058e-6498-46e6-b355-b5325faa8d84)

### After
[fix after.webm](https://github.com/user-attachments/assets/cd9a8055-1035-4992-9e58-2cd6d4efacef)

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes