### PR TITLE
feat(bounties): add inline search to mobile toolbar in IssuesList

### DIFF
--- a/src/components/issues/IssuesList.tsx
+++ b/src/components/issues/IssuesList.tsx
@@ -1015,6 +1015,8 @@ const IssuesList: React.FC<IssuesListProps> = ({
     </Box>
   );
 
+  const usePortal = !!portalTarget && isLargeScreen;
+
   const optionsPortalFilters = (
     <>
       {sortSection}
@@ -1023,10 +1025,12 @@ const IssuesList: React.FC<IssuesListProps> = ({
         {viewToggle}
       </Box>
       {rowsSection}
-      <Box>
-        <Typography sx={sidebarLabelSx}>Search</Typography>
-        <IssuesListSearchTextField fullWidth />
-      </Box>
+      {usePortal && (
+        <Box>
+          <Typography sx={sidebarLabelSx}>Search</Typography>
+          <IssuesListSearchTextField fullWidth />
+        </Box>
+      )}
       <Box>
         <Typography sx={sidebarLabelSx}>Chart</Typography>
         <Stack direction="row" alignItems="center" spacing={1}>
@@ -1044,8 +1048,6 @@ const IssuesList: React.FC<IssuesListProps> = ({
       </Box>
     </>
   );
-
-  const usePortal = !!portalTarget && isLargeScreen;
 
   const hasActiveOptions = searchQuery.trim() !== '' || showChart;
 
@@ -1151,10 +1153,13 @@ const IssuesList: React.FC<IssuesListProps> = ({
             : `1px solid ${theme.palette.border.light}`,
         display: 'flex',
         alignItems: 'center',
-        gap: 2,
+        gap: 1.5,
       }}
     >
-      {!usePortal && <Box sx={{ ml: 'auto' }}>{optionsButton}</Box>}
+      <Box sx={{ flex: 1, minWidth: 0 }}>
+        <IssuesListSearchTextField fullWidth />
+      </Box>
+      <Box sx={{ flexShrink: 0 }}>{optionsButton}</Box>
     </Box>
   );
 
@@ -1199,76 +1204,74 @@ const IssuesList: React.FC<IssuesListProps> = ({
   );
 
   return (
-    <>
-      <DebouncedSearchInput onDebouncedChange={setSearchQuery}>
-        <>
-          {usePortal && portalTarget && (
-            <Portal container={portalTarget}>
-              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-                {optionsPortalFilters}
-              </Box>
-            </Portal>
-          )}
-          {optionsPopover}
-        </>
-      </DebouncedSearchInput>
-      <Card sx={cardSx} elevation={0}>
-        {!usePortal ? inlineToolbar : null}
-        {chartCollapse}
-
-        {viewMode === 'cards' ? (
-          pagedIssues.length > 0 ? (
-            <>
-              <Grid container spacing={2}>
-                {pagedIssues.map((issue) => (
-                  <Grid item xs={12} sm={6} md={4} key={issue.id}>
-                    <BountyCard
-                      issue={issue}
-                      href={getIssueHref ? getIssueHref(issue.id) : undefined}
-                      linkState={linkState}
-                      taoPrice={taoPrice}
-                      alphaPrice={alphaPrice}
-                    />
-                  </Grid>
-                ))}
-              </Grid>
-              {paginationControl}
-            </>
-          ) : (
-            emptyState
-          )
-        ) : (
-          <DataTable<IssueBounty, SortKey>
-            columns={columns}
-            rows={pagedIssues}
-            getRowKey={(issue) => issue.id}
-            getRowHref={
-              getIssueHref ? (issue) => getIssueHref(issue.id) : undefined
-            }
-            linkState={linkState}
-            minWidth={
-              filterType === 'history'
-                ? '1000px'
-                : filterType === 'pending'
-                  ? '900px'
-                  : '750px'
-            }
-            emptyState={emptyState}
-            getRowSx={(issue) =>
-              issue.completedAt && isOutsideScoringWindow(issue.completedAt)
-                ? { opacity: 0.4, filter: 'grayscale(0.5)' }
-                : {}
-            }
-            sort={{
-              field: sortKey,
-              order: sortDirection,
-              onChange: handleSort,
-            }}
-            pagination={paginationControl}
-          />
+    <DebouncedSearchInput onDebouncedChange={setSearchQuery}>
+      <>
+        {usePortal && portalTarget && (
+          <Portal container={portalTarget}>
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+              {optionsPortalFilters}
+            </Box>
+          </Portal>
         )}
-      </Card>
-    </>
+        {optionsPopover}
+        <Card sx={cardSx} elevation={0}>
+          {!usePortal ? inlineToolbar : null}
+          {chartCollapse}
+
+          {viewMode === 'cards' ? (
+            pagedIssues.length > 0 ? (
+              <>
+                <Grid container spacing={2}>
+                  {pagedIssues.map((issue) => (
+                    <Grid item xs={12} sm={6} md={4} key={issue.id}>
+                      <BountyCard
+                        issue={issue}
+                        href={getIssueHref ? getIssueHref(issue.id) : undefined}
+                        linkState={linkState}
+                        taoPrice={taoPrice}
+                        alphaPrice={alphaPrice}
+                      />
+                    </Grid>
+                  ))}
+                </Grid>
+                {paginationControl}
+              </>
+            ) : (
+              emptyState
+            )
+          ) : (
+            <DataTable<IssueBounty, SortKey>
+              columns={columns}
+              rows={pagedIssues}
+              getRowKey={(issue) => issue.id}
+              getRowHref={
+                getIssueHref ? (issue) => getIssueHref(issue.id) : undefined
+              }
+              linkState={linkState}
+              minWidth={
+                filterType === 'history'
+                  ? '1000px'
+                  : filterType === 'pending'
+                    ? '900px'
+                    : '750px'
+              }
+              emptyState={emptyState}
+              getRowSx={(issue) =>
+                issue.completedAt && isOutsideScoringWindow(issue.completedAt)
+                  ? { opacity: 0.4, filter: 'grayscale(0.5)' }
+                  : {}
+              }
+              sort={{
+                field: sortKey,
+                order: sortDirection,
+                onChange: handleSort,
+              }}
+              pagination={paginationControl}
+            />
+          )}
+        </Card>
+      </>
+    </DebouncedSearchInput>
   );
 };
 


### PR DESCRIPTION
## Summary

  On screens below the `xl` breakpoint (< 1536px), the `/bounties` toolbar only showed an Options button — search was hidden inside a popover requiring an extra tap. This PR adds an
  always-visible inline search field to the toolbar so users can filter issues without opening the popover.

  **Changes in `src/components/issues/IssuesList.tsx`:**
  - Moved `usePortal` declaration above `optionsPortalFilters` so the search block can be conditionally rendered
  - `optionsPortalFilters`: search section now renders only when `usePortal` is true (xl+ sidebar), removing the duplicate entry from the mobile popover
  - `inlineToolbar`: added `IssuesListSearchTextField` filling available width, with the Options button pinned right
  - `return`: moved `<Card>` inside `<DebouncedSearchInput>` so the inline search field shares the same search context

  ## Related Issues

  Closes #808

  ## Type of Change

  - [ ] Bug fix
  - [x] New feature
  - [ ] Refactor
  - [ ] Documentation
  - [ ] Other (describe below)

  ## Screenshots

  <!-- Viewport narrowed to ~768px to show mobile toolbar -->

  **Before** — only the Options button visible in the toolbar:

<img width="1052" height="904" alt="Screenshot 2026-05-23 074037" src="https://github.com/user-attachments/assets/9326cf9b-eee7-435a-b152-55f23a72b0c7" />


  **After** — inline search field always visible next to Options button:

 
<img width="1041" height="877" alt="Screenshot 2026-05-23 074052" src="https://github.com/user-attachments/assets/bf26dd1d-daaf-4407-8688-e53c29983176" />


  ## Checklist

  - [x] New components are modularized/separated where sensible
  - [x] Uses predefined theme (e.g. no hardcoded colors)
  - [x] Responsive/mobile checked
  - [x] Tested against the test API
  - [x] `npm run format` and `npm run lint:fix` have been run
  - [x] `npm run build` passes
  - [x] Screenshots included for any UI/visual changes