### PR TITLE
fix(watchlist): repos chart bars render at zero due to wrong config field

### DIFF
--- a/src/pages/WatchlistPage.tsx
+++ b/src/pages/WatchlistPage.tsx
@@ -1655,7 +1655,7 @@ const ReposList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
     const chartFont = echartsFontFamily(theme);
 
     const chartData = paged.map((repo) => {
-      const weight = parseFloat(String(repo.config?.weight ?? 0));
+      const weight = Number(repo.weight) || 0;
       const ossScore = repo.totalScore || 0;
       const prs = repo.totalPRs || 0;
       const contributors = repo.uniqueMiners?.size || 0;


### PR DESCRIPTION
## Summary

The bar chart on the Watchlist repositories tab renders every bar with value `0`, contradicting the `Weight` column shown in the list view directly beneath it. The chart reads `repo.config?.weight`, but the API config blob has no `weight` field, only `emissionShare`. The access typechecks because `RepositoryConfig` carries a `[key: string]: unknown` index signature, so the value is always `undefined` at runtime and every bar collapses to zero.

Fixed by reading from the already hoisted `repo.weight` field on `WatchedRepoStats`, which was added specifically for downstream sort and render code per the type's own comment at [src/pages/WatchlistPage.tsx:1020-1030](src/pages/WatchlistPage.tsx#L1020-L1030).

### Reproducer

1. Run `npm run dev`
2. Star at least two repositories from the watchlist controls
3. Navigate to `/watchlist?tab=repos`
4. Open the Options panel and enable the chart view via the BarChart icon
5. Every bar renders at zero. With the default log scale they sit below the axis floor and are invisible. With linear scale they render as flat zero-height bars

## Related Issues

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

**Before:** chart toggled on with two pinned repos, every bar at zero (invisible under log scale).

<img width="1657" height="828" alt="b1" src="https://github.com/user-attachments/assets/04b58c6c-567f-4af3-8742-1af78888fe0c" />


**After:** chart toggled on with the same two pinned repos, bars render with values matching the `Weight` column in the list view below.

<img width="1547" height="748" alt="a1" src="https://github.com/user-attachments/assets/2817a63c-5c57-4a54-b25a-f430897daeec" />


## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
