### PR TITLE
feat(watchlist): add source filter chips to Issues tab

### DIFF
--- a/src/pages/WatchlistPage.tsx
+++ b/src/pages/WatchlistPage.tsx
@@ -4213,6 +4213,12 @@ const IssuesList: React.FC<{ minerIds: string[] }> = ({ minerIds }) => {
 
   const isLoading = issueQueries.some((q) => q.isLoading);
 
+  const {
+    active: issueActiveSources,
+    toggle: toggleIssueSource,
+    isAllOn: issueSourcesAllOn,
+  } = usePrSourceFilter();
+
   const [searchQuery, setSearchQuery] = useState('');
   const [statusFilter, setStatusFilter] = useState<IssueStatusFilter>('all');
   const [viewMode, setViewMode] = useWatchlistViewMode();
@@ -4229,7 +4235,14 @@ const IssuesList: React.FC<{ minerIds: string[] }> = ({ minerIds }) => {
 
   useEffect(() => {
     setPage(0);
-  }, [statusFilter, searchQuery, sortField, sortOrder, viewMode]);
+  }, [
+    statusFilter,
+    searchQuery,
+    sortField,
+    sortOrder,
+    viewMode,
+    issueActiveSources,
+  ]);
 
   const handleSort = (field: IssueSortKey) => {
     if (sortField === field) {
@@ -4241,11 +4254,28 @@ const IssuesList: React.FC<{ minerIds: string[] }> = ({ minerIds }) => {
     setPage(0);
   };
 
-  const counts = useMemo(() => getIssueCounts(items), [items]);
+  const issueSourceCounts = useMemo(() => {
+    const tally = { starred: 0, miner: 0, repo: 0 };
+    for (const issue of items) {
+      const sources = sourcesByKey.get(issueKey(issue));
+      if (!sources) continue;
+      for (const s of sources) tally[s] += 1;
+    }
+    return tally;
+  }, [items, sourcesByKey]);
+
+  const scopedItems = useMemo(() => {
+    if (issueSourcesAllOn) return items;
+    return items.filter((issue) =>
+      sourcesByKey.get(issueKey(issue))?.some((s) => issueActiveSources.has(s)),
+    );
+  }, [items, sourcesByKey, issueActiveSources, issueSourcesAllOn]);
+
+  const counts = useMemo(() => getIssueCounts(scopedItems), [scopedItems]);
 
   const filtered = useMemo(
-    () => filterIssues(items, { statusFilter, searchQuery }),
-    [items, statusFilter, searchQuery],
+    () => filterIssues(scopedItems, { statusFilter, searchQuery }),
+    [scopedItems, statusFilter, searchQuery],
   );
 
   const sorted = useMemo(() => {
@@ -4332,6 +4362,35 @@ const IssuesList: React.FC<{ minerIds: string[] }> = ({ minerIds }) => {
                     onClick={() => setStatusFilter(s)}
                   />
                 ))}
+                <Box
+                  sx={{
+                    width: '1px',
+                    height: 20,
+                    backgroundColor: 'border.light',
+                    mx: 0.5,
+                  }}
+                />
+                <FilterButton
+                  label="Starred"
+                  count={issueSourceCounts.starred}
+                  color={SOURCE_META.starred.color}
+                  isActive={issueActiveSources.has('starred')}
+                  onClick={() => toggleIssueSource('starred')}
+                />
+                <FilterButton
+                  label="Miner"
+                  count={issueSourceCounts.miner}
+                  color={SOURCE_META.miner.color}
+                  isActive={issueActiveSources.has('miner')}
+                  onClick={() => toggleIssueSource('miner')}
+                />
+                <FilterButton
+                  label="Repo"
+                  count={issueSourceCounts.repo}
+                  color={SOURCE_META.repo.color}
+                  isActive={issueActiveSources.has('repo')}
+                  onClick={() => toggleIssueSource('repo')}
+                />
               </Box>
             }
             searchValue={draftValue}
@@ -4351,7 +4410,7 @@ const IssuesList: React.FC<{ minerIds: string[] }> = ({ minerIds }) => {
                 }}
               />
             }
-            hasActiveFilter={statusFilter !== 'all'}
+            hasActiveFilter={statusFilter !== 'all' || !issueSourcesAllOn}
           />
         )}
       </DebouncedSearchInput>


### PR DESCRIPTION
## Summary

Adds three multi-select chips (Starred/Miner/Repo) to the Watchlist → Issues tab toolbar, closing the parity gap with the Pull Requests tab where these chips shipped in #1072. Colors and labels mirror the existing source badges (#789, #799). All three are selected by default, preserving the auto-show behavior — toggling chips off hides Issues whose only remaining sources are deselected (union-based, same semantics as the PRs tab).

Reuses `usePrSourceFilter` (persistence under `gittensor.watchlist.prs-source-filter.v1`, cross-tab `storage`-event sync — same key as the PRs tab, so source-filter selection is shared across both tabs and reloads) and the `sourcesByKey` map already computed inside `IssuesList`. No new hooks, no new components. One file touched: `src/pages/WatchlistPage.tsx` (+64/-5).

## Related Issues

None

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

**Before:**
<img width="2559" height="1439" alt="Issue Filter Chips - Before" src="https://github.com/user-attachments/assets/9aae5031-50ca-47fe-9d25-9ebcaade64fb" />

**After:**
<img width="365" height="328" alt="image" src="https://github.com/user-attachments/assets/9264f510-8fca-48fe-8cc4-adbad00b8ab4" />

## Additional Video:

https://github.com/user-attachments/assets/6c24bd9c-c003-42d6-8c33-83dcc7e35663


## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
