### PR TITLE
fix(DataTable): make default row hover visible on dark theme

### DIFF
--- a/src/components/common/DataTable.tsx
+++ b/src/components/common/DataTable.tsx
@@ -120,9 +120,10 @@ const tableSx = {
 
 const clickableRowSx: SxProps<Theme> = (theme) => ({
   cursor: 'pointer',
-  transition: 'background-color 0.2s',
+  transition: 'all 0.2s',
+  borderBottom: `1px solid ${theme.palette.surface.light}`,
   '&:hover': {
-    backgroundColor: theme.palette.surface.subtle,
+    backgroundColor: theme.palette.border.subtle,
   },
 });
 


### PR DESCRIPTION
## Summary

Fixes the invisible row hover state on `DataTable`. The default used
`surface.subtle`, which on our dark theme is indistinguishable from
the table background.

Closes #1278 

## Change

Single-file CSS change in `src/components/common/DataTable.tsx`:

- Hover background: `surface.subtle` → `border.subtle`
- Added `borderBottom: 1px solid surface.light` for row separation
- Widened `transition` from `background-color` to `all`

This matches the styling `TopRepositoriesTable` already uses via its
own `getRowSx` override.

## Affected surfaces

- ✅ `RepositoryIssuesTable` — was broken, now visibly hoverable
- ✅ Any other `DataTable` consumer relying on the default — same fix
- ⚪ `TopRepositoriesTable` — no visual change (its consumer-level
  override matches the new default)

## Testing

- [x] Repository → Issues tab: rows highlight on hover, cursor changes
      to pointer, click opens GitHub.
- [x] Repositories list view: hover behavior unchanged.
- [x] Lint passes.
- [x] Type check passes.

##Screenshot
Before Change:

https://github.com/user-attachments/assets/a4f74c90-9bf4-49d2-9038-b9bad6926b62

After Change:

https://github.com/user-attachments/assets/2d3b45e3-e8c3-4c3f-8691-ff1c5a7964cb

