### PR TITLE
fix(RepoCheck): conditional contributing instructions + typo

### DIFF
--- a/src/components/repositories/RepositoryCheckTab.tsx
+++ b/src/components/repositories/RepositoryCheckTab.tsx
@@ -327,6 +327,12 @@ const RepositoryCheckTab: React.FC<RepositoryCheckTabProps> = ({
     return Math.round((passed / checks.length) * 100);
   }, [checks]);
 
+  const hasContributing = useMemo(
+    () =>
+      checks.find((c) => c.name === 'Contributing Guidelines')?.passed ?? false,
+    [checks],
+  );
+
   // Loading is gated on the two critical calls (repo + tree); community profile
   // and issue counts are best-effort and render fallbacks when missing.
   const loading =
@@ -592,9 +598,39 @@ const RepositoryCheckTab: React.FC<RepositoryCheckTabProps> = ({
                   lineHeight: 1.6,
                 }}
               >
-                To start contributing, fork the repository, clone it locally,
-                and check the <b>CONTRIBUTING.md</b> file for setup
-                instructions.
+                {hasContributing ? (
+                  <>
+                    To start contributing, fork the repository, clone it
+                    locally, and check the{' '}
+                    <Box
+                      component="a"
+                      href={`https://github.com/${repositoryFullName}/blob/${branch}/CONTRIBUTING.md`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      sx={{ color: 'text.primary', fontWeight: 600 }}
+                    >
+                      CONTRIBUTING.md
+                    </Box>{' '}
+                    file for setup instructions.
+                  </>
+                ) : (
+                  <>
+                    To start contributing, fork the repository and clone it
+                    locally. This repository does not have a{' '}
+                    <b>CONTRIBUTING.md</b> yet — refer to the{' '}
+                    <Box
+                      component="a"
+                      href={`https://github.com/${repositoryFullName}#readme`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      sx={{ color: 'text.primary', fontWeight: 600 }}
+                    >
+                      README
+                    </Box>{' '}
+                    for setup instructions, or consider opening a PR to add
+                    contributing guidelines.
+                  </>
+                )}
               </Typography>
             </Card>
           </Box>


### PR DESCRIPTION
## Summary

Fixes the contradiction on the Repo Check page where the *Activity & Feasibility* panel always instructed users to check `CONTRIBUTING.md`, even when the *Community Standards* panel on the same page flagged that the file did not exist.

Closes #1280

## Changes

- Added a `hasContributing` memo that reuses the existing `Contributing Guidelines` check result, so the two panels can never disagree.
- Replaced the hardcoded instruction string with a conditional:
  - If `CONTRIBUTING.md` exists → original sentence, with `CONTRIBUTING.md` rendered as a link to the file on the repo's default branch.
  - If it doesn't → fallback sentence pointing to the README and suggesting a PR to add contributing guidelines.
- Fixed `instructions.l` typo.

## Testing

Verified on two repos:

- `infiniflow/ragflow` (no `CONTRIBUTING.md`) → fallback text renders, README link works, Community Standards card stays red ❌.
- A repo with `CONTRIBUTING.md` present → original text renders, link points to the correct branch, Community Standards card stays green ✓.

## Screenshots
Before change:


<img width="1889" height="818" alt="1 (2)" src="https://github.com/user-attachments/assets/3e650ed2-a253-4cc8-8932-0ed999943f3c" />

After change:

<img width="1418" height="857" alt="Screenshot 2026-05-27 041735" src="https://github.com/user-attachments/assets/c98598fd-8101-40c0-b7a3-db2cd732c0a6" />