### PR TITLE
fix: clear input function in Repository searchbox

### DIFF
--- a/src/components/common/DebouncedSearchInput.tsx
+++ b/src/components/common/DebouncedSearchInput.tsx
@@ -64,9 +64,17 @@ export function DebouncedSearchInput({
     setDraftValue(initialDraft);
   }, [initialDraft]);
 
+  // Latest-ref so the debounced fire only depends on `debounced` — callers
+  // routed through React Router's `setSearchParams` get a new callback
+  // identity per URL change, which would otherwise re-apply the stale value.
+  const onDebouncedChangeRef = useRef(onDebouncedChange);
   useEffect(() => {
-    onDebouncedChange(debounced);
-  }, [debounced, onDebouncedChange]);
+    onDebouncedChangeRef.current = onDebouncedChange;
+  }, [onDebouncedChange]);
+
+  useEffect(() => {
+    onDebouncedChangeRef.current(debounced);
+  }, [debounced]);
 
   const draftBag = useMemo(
     () => ({ draftValue, setDraftValue }),


### PR DESCRIPTION
## Summary

Fixes the X (clear) button in the search input on `/repositories`. Previously, clicking X would clear the field for a single frame and then the previous search term reappeared, with `?search=…` immediately restored in the URL. The button is now a real no-op-free clear: input empties, URL param is removed, full list shows.

Root cause was a callback-identity cascade in `DebouncedSearchInput`:

- React Router 6's `setSearchParams` is rebuilt on every URL change, so any callback derived from it (`setFilter` → `handleSearchChange` → the `onDebouncedChange` prop) gets a new reference per URL update.
- `DebouncedSearchInput`'s fire-effect had `onDebouncedChange` in its dep array, so it re-ran with the stale `debounced` value the moment the URL changed — re-applying the old search term right after the clear.

Fix uses the latest-ref pattern in `src/components/common/DebouncedSearchInput.tsx`: the fire-effect now depends only on `debounced`, while the callback is read from a ref kept in sync via a separate effect. This fixes the bug at the source and protects every other caller (`IssuesList`, `RepositoryPRsTable`, `RepositoryCodeBrowser`, `LanguageWeightsTable`, `MinerPRsTable`, `MinerOpenDiscoveryIssuesByRepo`, `WatchlistPage`) from the same trap.

## Related Issues

Fixes #1282 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

**Before** — clicking X briefly clears the input, then `git` reappears and `?search=git` is restored:

[before.webm](https://github.com/user-attachments/assets/551dd44b-fd95-431b-b326-68fbc5425134)


**After** — clicking X clears the input and removes `?search=` from the URL:

[after.webm](https://github.com/user-attachments/assets/b1622681-96db-419c-84c4-f5a99d2e263f)


## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
