### PR TITLE
feat(shortcuts): add g h Home keyboard shortcut

### DIFF
--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -10,6 +10,7 @@ export type KeyboardShortcut = {
 };
 
 const keyboardShortcuts: KeyboardShortcut[] = [
+  { keys: ['g', 'h'], label: 'Home', path: '/' },
   { keys: ['g', 'd'], label: 'Dashboard', path: '/dashboard' },
   { keys: ['g', 'r'], label: 'Repositories', path: '/repositories' },
   { keys: ['g', 'b'], label: 'Bounties', path: '/bounties' },


### PR DESCRIPTION
## Summary

Adds the missing `g h` shortcut for Home (`/`) to `keyboardShortcuts`, completing the g-prefix set alongside Dashboard/Repositories/Bounties/Watchlist/Onboard. The existing `gPrefixRoutes` reducer and `ShortcutsHelpDialog` pick it up automatically — one-line diff in `src/hooks/useKeyboardShortcuts.ts`.

## Related Issues

None

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

**Before:**
<img width="952" height="872" alt="help-dialog-before" src="https://github.com/user-attachments/assets/ba170fc5-ca0c-4560-ade4-575fc53ec8b0" />

**After:**
<img width="952" height="964" alt="help-dialog-after" src="https://github.com/user-attachments/assets/c10af38a-cd23-47a5-a9e3-60f28f4232c4" />

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
