### PR TITLE
fix(repository): scope PR status counts to active author filter

### DIFF
--- a/src/components/repositories/RepositoryPRsTable.tsx
+++ b/src/components/repositories/RepositoryPRsTable.tsx
@@ -106,16 +106,20 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
     );
   }, [allMinerPRs, repositoryFullName]);
 
-  const counts = useMemo(() => {
-    if (!allPRs) return { all: 0, open: 0, merged: 0, closed: 0 };
-    return getPrStatusCounts(allPRs);
-  }, [allPRs]);
+  const authorScopedPRs = useMemo(() => {
+    if (authorFilter === AUTHOR_FILTER_ALL) return allPRs;
+    return allPRs.filter((pr) => pr.author === authorFilter);
+  }, [allPRs, authorFilter]);
 
-  const filteredPRs = useMemo(() => {
-    const byStatus = filterPrs(allPRs ?? [], { statusFilter: filter });
-    if (authorFilter === AUTHOR_FILTER_ALL) return byStatus;
-    return byStatus.filter((pr) => pr.author === authorFilter);
-  }, [allPRs, filter, authorFilter]);
+  const counts = useMemo(
+    () => getPrStatusCounts(authorScopedPRs),
+    [authorScopedPRs],
+  );
+
+  const filteredPRs = useMemo(
+    () => filterPrs(authorScopedPRs, { statusFilter: filter }),
+    [authorScopedPRs, filter],
+  );
 
   const sortedPRs = useMemo(() => {
     const dir = sortOrder === 'asc' ? 1 : -1;


### PR DESCRIPTION
Closes #1287
 
## Problem
 
On the repository Pull Requests page, applying an author filter updated the table rows and the `Pull Requests (N)` header count, but the **All / Open / Merged / Closed** tab counts continued to show repo-wide totals. Two different "truths" were rendered side by side, which is confusing and makes the tab counts useless for navigating within the filtered view.
 
## Root cause
 
In `RepositoryPRsTable.tsx`, `counts` was derived from `allPRs` (the full repo PR list) and never saw `authorFilter`:
 
```ts
const counts = useMemo(() => {
  if (!allPRs) return { all: 0, open: 0, merged: 0, closed: 0 };
  return getPrStatusCounts(allPRs);
}, [allPRs]);
```
 
Meanwhile `filteredPRs` correctly applied both the status and author filters, so the table and `sortedPRs.length` reflected the author filter but the tab counts did not.
 
## Fix
 
Introduce an `authorScopedPRs` memo that applies only the author filter, and derive both `counts` and `filteredPRs` from it. Author is treated as the outer scope; status filters within it. This matches GitHub's own behavior and what users expect from a filter-and-tab pattern.
 
```ts
const authorScopedPRs = useMemo(() => {
  if (authorFilter === AUTHOR_FILTER_ALL) return allPRs;
  return allPRs.filter((pr) => pr.author === authorFilter);
}, [allPRs, authorFilter]);
 
const counts = useMemo(
  () => getPrStatusCounts(authorScopedPRs),
  [authorScopedPRs],
);
 
const filteredPRs = useMemo(
  () => filterPrs(authorScopedPRs, { statusFilter: filter }),
  [authorScopedPRs, filter],
);
```
 
Side benefit: the author filter is no longer applied twice (once in the count path, once in the filter path).
 
`AuthorFilter` continues to receive `items={allPRs}`, so the author dropdown still lists every author regardless of active status — switching status tabs doesn't shrink the author list, which is the correct behavior.
 
## Behavior change
 
With author = `bittoby` on `entrius/allways`:
 
| | Before | After |
|---|---|---|
| Header count | `Pull Requests (3)` | `Pull Requests (3)` |
| Table rows | 3 | 3 |
| Tab counts | All 131 · Open 3 · Merged 26 · Closed 102 | All 3 · Open 0 · Merged 2 · Closed 1 |
 
With no author filter active, behavior is unchanged.
 
## Testing
 
- [x] No author filter: tab counts match previous repo-wide totals
- [x] Apply author filter: tab counts shrink to that author's PRs across statuses
- [x] Switch status tabs while author filter is active: counts stay stable, only the highlighted tab changes
- [x] Clear the author filter: counts return to repo-wide totals
- [x] Deep-link `?prAuthor=<author-with-no-prs>`: all tab counts read 0 and empty state renders (previously the tab counts lied about there being PRs available)
- [x] Deep-link `?prAuthor=<unknown-author>`: same — counts read 0, empty state renders
## Screenshots
 
_Before:_ 

https://github.com/user-attachments/assets/b43c8ab4-33d4-4eb0-8db8-db9dff70c794
 
_After:_ 

https://github.com/user-attachments/assets/a876a199-be91-40ed-b7ce-7bfa6fecd39b

