### PR TITLE
feat(leaderboard): rebuild and restore the network leaderboard

### DIFF
--- a/src/api/DashboardApi.ts
+++ b/src/api/DashboardApi.ts
@@ -43,6 +43,12 @@ export const useLanguagesAndWeights = () =>
 export const useRepoCommits = () =>
   useDashboardQuery<RepoChanges[]>('useRepoCommits', '/repos/commits');
 
+export const useRecentCommits = (limit = 500) =>
+  useDashboardQuery<CommitLog[]>('useRecentCommits', '/commits', undefined, {
+    page: 1,
+    limit,
+  });
+
 // das-gittensor's /dash/lines/total responds with `{ linesCommitted }` — and
 // because the value is a SQL SUM it arrives as a string. Consumers unwrap and
 // coerce it (see useDashboardData).

--- a/src/components/common/WatchlistButton.tsx
+++ b/src/components/common/WatchlistButton.tsx
@@ -37,10 +37,16 @@ export const WatchlistButton: React.FC<WatchlistButtonProps> = ({
         aria-pressed={watched}
         sx={{
           color: watched ? 'warning.main' : 'text.tertiary',
-          transition: 'color 0.15s, transform 0.15s',
+          transition: 'color 0.15s, transform 0.15s, outline-color 0.15s',
           '&:hover': {
             color: 'warning.light',
             transform: 'scale(1.08)',
+            backgroundColor: 'rgba(255,255,255,0.06)',
+          },
+          '&:focus-visible': {
+            outline: '2px solid',
+            outlineColor: 'primary.main',
+            outlineOffset: 2,
             backgroundColor: 'rgba(255,255,255,0.06)',
           },
           ...sx,

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -11,6 +11,7 @@ import {
 } from '@mui/material';
 import { useLocation } from 'react-router-dom';
 import DashboardIcon from '@mui/icons-material/Dashboard';
+import LeaderboardIcon from '@mui/icons-material/Leaderboard';
 import VisibilityIcon from '@mui/icons-material/Visibility';
 import BugReportIcon from '@mui/icons-material/BugReport';
 import FolderCopyIcon from '@mui/icons-material/FolderCopy';
@@ -84,6 +85,7 @@ const Sidebar: React.FC<SidebarProps> = ({ onNavigate, collapsed = false }) => {
 
   const navItems = [
     { label: 'dashboard', path: '/dashboard', icon: <DashboardIcon /> },
+    { label: 'leaderboard', path: '/leaderboard', icon: <LeaderboardIcon /> },
     { label: 'repositories', path: '/repositories', icon: <FolderCopyIcon /> },
     {
       label: 'watchlist',

--- a/src/components/leaderboard/GhIcons.tsx
+++ b/src/components/leaderboard/GhIcons.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+
+interface IconProps {
+  size?: number;
+  color?: string;
+  title?: string;
+}
+
+const sharedStyle = { flexShrink: 0, display: 'block' } as const;
+
+export const GhPrIcon: React.FC<IconProps> = ({
+  size = 14,
+  color = 'currentColor',
+  title,
+}) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 16 16"
+    fill={color}
+    aria-hidden={!title}
+    role={title ? 'img' : undefined}
+    style={sharedStyle}
+  >
+    {title && <title>{title}</title>}
+    <path d="M1.5 3.25a2.25 2.25 0 1 1 3 2.122v5.256a2.251 2.251 0 1 1-1.5 0V5.372A2.25 2.25 0 0 1 1.5 3.25Zm5.677-.177L9.573.677A.25.25 0 0 1 10 .854V2.5h1A2.5 2.5 0 0 1 13.5 5v5.628a2.251 2.251 0 1 1-1.5 0V5a1 1 0 0 0-1-1h-1v1.646a.25.25 0 0 1-.427.177L7.177 3.427a.25.25 0 0 1 0-.354ZM3.75 2.5a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm0 9.5a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm8.25.75a.75.75 0 1 0 1.5 0 .75.75 0 0 0-1.5 0Z" />
+  </svg>
+);
+
+export const GhIssueIcon: React.FC<IconProps> = ({
+  size = 14,
+  color = 'currentColor',
+  title,
+}) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 16 16"
+    fill={color}
+    aria-hidden={!title}
+    role={title ? 'img' : undefined}
+    style={sharedStyle}
+  >
+    {title && <title>{title}</title>}
+    <path d="M8 9.5a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Z" />
+    <path
+      fillRule="evenodd"
+      d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0ZM1.5 8a6.5 6.5 0 1 0 13 0 6.5 6.5 0 0 0-13 0Z"
+    />
+  </svg>
+);

--- a/src/components/leaderboard/LeaderboardInsights.tsx
+++ b/src/components/leaderboard/LeaderboardInsights.tsx
@@ -1227,30 +1227,15 @@ const LeaderboardInsights: React.FC<LeaderboardInsightsProps> = ({
 
   return (
     <Card
-      sx={(t) => ({
+      sx={{
         p: 0,
         overflow: 'hidden',
         position: 'relative',
-        backgroundColor: t.palette.background.paper,
-        backgroundImage: `
-          radial-gradient(ellipse 120% 70% at 50% -10%, ${alpha(
-            t.palette.text.primary,
-            0.07,
-          )} 0%, ${alpha(t.palette.text.primary, 0)} 55%),
-          linear-gradient(180deg, ${alpha(t.palette.common.black, 0)} 60%, ${alpha(
-            t.palette.common.black,
-            0.3,
-          )} 100%)
-        `,
-        borderColor: t.palette.border.medium,
-        boxShadow: [
-          `inset 0 1px 0 ${alpha(t.palette.text.primary, 0.09)}`,
-          `inset 0 -1px 0 ${alpha(t.palette.common.black, 0.4)}`,
-          `0 1px 0 ${alpha(t.palette.text.primary, 0.02)}`,
-          `0 12px 36px -8px ${alpha(t.palette.common.black, 0.6)}`,
-          `0 4px 12px -4px ${alpha(t.palette.common.black, 0.4)}`,
-        ].join(', '),
-      })}
+        borderRadius: 3,
+        border: '1px solid',
+        borderColor: 'border.light',
+        backgroundColor: 'background.default',
+      }}
     >
       <Box
         sx={{

--- a/src/components/leaderboard/LeaderboardInsights.tsx
+++ b/src/components/leaderboard/LeaderboardInsights.tsx
@@ -1,0 +1,1338 @@
+import React, { useMemo } from 'react';
+import {
+  Avatar,
+  Box,
+  Card,
+  Skeleton,
+  Tooltip,
+  Typography,
+  alpha,
+} from '@mui/material';
+import {
+  EmojiEvents as TrophyIcon,
+  ShowChart as ChartIcon,
+  Workspaces as CompositionIcon,
+  Whatshot as HotRepoIcon,
+} from '@mui/icons-material';
+import {
+  RANK_COLORS,
+  STATUS_COLORS,
+  TOOLTIP_TONE_COLORS,
+  tooltipSlotProps,
+} from '../../theme';
+import { getRepositoryOwnerAvatarSrc } from '../../utils/avatar';
+import { parseNumber } from '../../utils/ExplorerUtils';
+import { LinkBox } from '../common/linkBehavior';
+import { usePrices } from '../../hooks/usePrices';
+import type { MinerEvaluation } from '../../api';
+import {
+  useMinerActivityIndex,
+  type NetworkRepoActivity,
+} from './useMinerActivityIndex';
+import {
+  COHORT_COLORS,
+  COHORT_DESCRIPTIONS,
+  COHORT_KEYS,
+  COHORT_LABELS,
+  cohortOf,
+  isAnyEligibleNow,
+  type CohortKey,
+} from './eligibilityCohort';
+
+interface LeaderboardInsightsProps {
+  miners: MinerEvaluation[] | undefined;
+  isLoading: boolean;
+  selectedRepo?: string | null;
+  onSelectRepo?: (repo: string) => void;
+  selectedCohort?: CohortKey | null;
+  onSelectCohort?: (cohort: CohortKey) => void;
+}
+
+// Mirrors validator constants.py (OSS_EMISSION_SHARE=0.90, ISSUES_TREASURY_SHARE=0.10).
+const CONTRIB_EMISSION_SHARE = 0.9;
+const TREASURY_EMISSION_SHARE = 0.1;
+
+const fmtUsd = (n: number): string => {
+  if (n < 1) return '<$1';
+  if (n >= 10_000) return `$${(n / 1000).toFixed(1)}k`;
+  return `$${Math.round(n).toLocaleString()}`;
+};
+
+const combinedScore = (m: MinerEvaluation): number =>
+  parseNumber(m.totalScore) + parseNumber(m.issueDiscoveryScore);
+
+type Composition = Record<CohortKey, number>;
+
+const EARNING_COHORTS: ReadonlySet<CohortKey> = new Set([
+  'dual',
+  'ossOnly',
+  'discoveryOnly',
+]);
+
+interface NetworkSummary {
+  total: number;
+  dailyPool: number;
+  earnerCount: number;
+  composition: Composition;
+}
+
+interface EarnerLite {
+  githubId: string;
+  username: string;
+  usdPerDay: number;
+}
+
+interface PodiumRow {
+  githubId: string;
+  username: string;
+  combinedScore: number;
+  usdPerDay: number;
+}
+
+const deriveSummary = (miners: MinerEvaluation[]): NetworkSummary => {
+  const composition: Composition = COHORT_KEYS.reduce(
+    (acc, key) => ({ ...acc, [key]: 0 }),
+    {} as Composition,
+  );
+  let dailyPool = 0;
+  let earnerCount = 0;
+  for (const m of miners) {
+    const cohort = cohortOf(m);
+    composition[cohort] += 1;
+    if (EARNING_COHORTS.has(cohort)) {
+      const usd = parseNumber(m.usdPerDay);
+      if (usd > 0) {
+        dailyPool += usd;
+        earnerCount += 1;
+      }
+    }
+  }
+  return { total: miners.length, dailyPool, earnerCount, composition };
+};
+
+const deriveTopEarners = (miners: MinerEvaluation[], n: number): EarnerLite[] =>
+  [...miners]
+    .filter((m) => parseNumber(m.usdPerDay) > 0 && isAnyEligibleNow(m))
+    .sort((a, b) => parseNumber(b.usdPerDay) - parseNumber(a.usdPerDay))
+    .slice(0, n)
+    .map((m) => ({
+      githubId: m.githubId,
+      username: m.githubUsername ?? `uid-${m.uid}`,
+      usdPerDay: parseNumber(m.usdPerDay),
+    }));
+
+const derivePodium = (miners: MinerEvaluation[]): PodiumRow[] =>
+  [...miners]
+    .filter((m) => combinedScore(m) > 0)
+    .sort((a, b) => combinedScore(b) - combinedScore(a))
+    .slice(0, 3)
+    .map((m) => ({
+      githubId: m.githubId,
+      username: m.githubUsername ?? `uid-${m.uid}`,
+      combinedScore: combinedScore(m),
+      usdPerDay: parseNumber(m.usdPerDay),
+    }));
+
+const ZoneTitle: React.FC<{ icon: React.ReactNode; label: string }> = ({
+  icon,
+  label,
+}) => (
+  <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, mb: 1.25 }}>
+    <Box sx={{ color: alpha('#fff', 0.4), display: 'flex' }}>{icon}</Box>
+    <Typography variant="statLabel">{label}</Typography>
+  </Box>
+);
+
+type ZonePosition = 1 | 2 | 3 | 4;
+
+const Zone: React.FC<{
+  children: React.ReactNode;
+  position: ZonePosition;
+  sx?: object;
+}> = ({ children, position, sx }) => {
+  const isRightEdge = {
+    xs: true,
+    sm: position === 2 || position === 4,
+    lg: position === 4,
+  };
+  const isBottomEdge = {
+    xs: position === 4,
+    sm: position === 3 || position === 4,
+    lg: true,
+  };
+  return (
+    <Box
+      sx={(t) => ({
+        px: { xs: 2.25, sm: 3 },
+        py: { xs: 2, sm: 2.25 },
+        borderRight: {
+          xs: 'none',
+          sm: isRightEdge.sm ? 'none' : `1px solid ${t.palette.border.light}`,
+          lg: isRightEdge.lg ? 'none' : `1px solid ${t.palette.border.light}`,
+        },
+        borderBottom: {
+          xs: isBottomEdge.xs ? 'none' : `1px solid ${t.palette.border.light}`,
+          sm: isBottomEdge.sm ? 'none' : `1px solid ${t.palette.border.light}`,
+          lg: 'none',
+        },
+        display: 'flex',
+        flexDirection: 'column',
+        minWidth: 0,
+        ...sx,
+      })}
+    >
+      {children}
+    </Box>
+  );
+};
+
+const fmtPrice = (n: number): string => {
+  if (n <= 0) return '—';
+  if (n >= 100) return `$${n.toFixed(2)}`;
+  if (n >= 1) return `$${n.toFixed(2)}`;
+  return `$${n.toFixed(3)}`;
+};
+
+const TokenTickerRow: React.FC<{
+  symbol: string;
+  symbolColor: string;
+  tip: string;
+  price: number;
+  loading: boolean;
+}> = ({ symbol, symbolColor, tip, price, loading }) => (
+  <Tooltip title={tip} arrow placement="top" slotProps={tooltipSlotProps}>
+    <Box
+      sx={{
+        display: 'inline-grid',
+        gridTemplateColumns: '32px auto',
+        alignItems: 'baseline',
+        columnGap: '6px',
+        cursor: 'help',
+        fontFamily: '"JetBrains Mono", monospace',
+      }}
+    >
+      <Typography
+        component="span"
+        sx={{
+          fontFamily: 'inherit',
+          fontSize: '0.62rem',
+          fontWeight: 700,
+          color: symbolColor,
+          letterSpacing: '0.3px',
+          textAlign: 'left',
+        }}
+      >
+        {symbol}
+      </Typography>
+      <Typography
+        component="span"
+        sx={{
+          fontFamily: 'inherit',
+          fontSize: '0.8rem',
+          fontWeight: 700,
+          color: loading ? alpha('#fff', 0.35) : 'text.primary',
+          letterSpacing: '-0.01em',
+          lineHeight: 1.05,
+        }}
+      >
+        {loading ? '—' : fmtPrice(price)}
+      </Typography>
+    </Box>
+  </Tooltip>
+);
+
+const TokenTicker: React.FC<{
+  taoPrice: number;
+  alphaPrice: number;
+  hasPrices: boolean;
+}> = ({ taoPrice, alphaPrice, hasPrices }) => (
+  <Box
+    sx={{
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'flex-start',
+      gap: '4px',
+      pt: '4px',
+    }}
+  >
+    <TokenTickerRow
+      symbol="TAO"
+      symbolColor="#5eead4"
+      tip="TAO spot price — drives the USD value of every miner emission."
+      price={taoPrice}
+      loading={!hasPrices}
+    />
+    <TokenTickerRow
+      symbol="α74"
+      symbolColor={STATUS_COLORS.warning}
+      tip="Subnet 74 alpha token spot price — the gittensor reward token."
+      price={alphaPrice}
+      loading={!hasPrices}
+    />
+  </Box>
+);
+
+const EmissionSplitBar: React.FC<{ pool: number }> = ({ pool }) => {
+  const contribShare = CONTRIB_EMISSION_SHARE;
+  const treasuryShare = TREASURY_EMISSION_SHARE;
+  const contribUsd = pool * contribShare;
+  const treasuryUsd = pool * treasuryShare;
+  const contribColor = STATUS_COLORS.merged;
+  const treasuryColor = STATUS_COLORS.info;
+  const tooltipBody = (
+    <Box sx={{ lineHeight: 1.45, maxWidth: 260 }}>
+      <Box sx={{ fontWeight: 700, fontSize: '0.78rem' }}>
+        Emission allocation
+      </Box>
+      <Box sx={{ fontSize: '0.7rem', opacity: 0.82, mt: '4px' }}>
+        Of the {fmtUsd(pool)} daily pool, {Math.round(contribShare * 100)}% is
+        distributed to miners via OSS + Discovery scoring, and{' '}
+        {Math.round(treasuryShare * 100)}% flows to the issues treasury (UID
+        111). Allocation is fixed by the validator and applies network-wide.
+      </Box>
+    </Box>
+  );
+  return (
+    <Tooltip
+      title={tooltipBody}
+      arrow
+      placement="top"
+      slotProps={tooltipSlotProps}
+    >
+      <Box sx={{ mt: 0.85, cursor: 'help' }}>
+        <Box
+          sx={{
+            display: 'flex',
+            height: 10,
+            borderRadius: 999,
+            overflow: 'hidden',
+          }}
+        >
+          <Box
+            sx={{
+              width: `${contribShare * 100}%`,
+              backgroundColor: contribColor,
+            }}
+          />
+          <Box
+            sx={{
+              width: `${treasuryShare * 100}%`,
+              backgroundColor: treasuryColor,
+            }}
+          />
+        </Box>
+        <Box
+          sx={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'baseline',
+            mt: '6px',
+            fontSize: '0.66rem',
+            fontFamily: '"JetBrains Mono", monospace',
+            lineHeight: 1.1,
+          }}
+        >
+          <Box
+            sx={{ display: 'inline-flex', alignItems: 'center', gap: '6px' }}
+          >
+            <Box
+              component="span"
+              sx={{
+                width: 7,
+                height: 7,
+                borderRadius: '50%',
+                backgroundColor: contribColor,
+              }}
+            />
+            <Box
+              component="span"
+              sx={{ color: alpha('#fff', 0.55), fontWeight: 500 }}
+            >
+              Miners
+            </Box>
+            <Box
+              component="span"
+              sx={{ color: 'text.primary', fontWeight: 700 }}
+            >
+              {fmtUsd(contribUsd)}
+            </Box>
+            <Box
+              component="span"
+              sx={{ color: alpha('#fff', 0.4), fontSize: '0.6rem' }}
+            >
+              {Math.round(contribShare * 100)}%
+            </Box>
+          </Box>
+          <Box
+            sx={{ display: 'inline-flex', alignItems: 'center', gap: '6px' }}
+          >
+            <Box
+              component="span"
+              sx={{
+                width: 7,
+                height: 7,
+                borderRadius: '50%',
+                backgroundColor: treasuryColor,
+              }}
+            />
+            <Box
+              component="span"
+              sx={{ color: alpha('#fff', 0.55), fontWeight: 500 }}
+            >
+              Treasury
+            </Box>
+            <Box
+              component="span"
+              sx={{ color: 'text.primary', fontWeight: 700 }}
+            >
+              {fmtUsd(treasuryUsd)}
+            </Box>
+            <Box
+              component="span"
+              sx={{ color: alpha('#fff', 0.4), fontSize: '0.6rem' }}
+            >
+              {Math.round(treasuryShare * 100)}%
+            </Box>
+          </Box>
+        </Box>
+      </Box>
+    </Tooltip>
+  );
+};
+
+const DailyPoolZone: React.FC<{
+  pool: number;
+  earners: EarnerLite[];
+}> = ({ pool, earners }) => {
+  const { taoPrice, alphaPrice, hasPrices } = usePrices();
+  return (
+    <Zone position={1}>
+      <ZoneTitle
+        icon={<ChartIcon sx={{ fontSize: '0.9rem' }} />}
+        label="Daily emissions"
+      />
+      <Box
+        sx={(t) => ({
+          display: 'flex',
+          alignItems: 'flex-start',
+          justifyContent: 'space-between',
+          flexWrap: 'wrap',
+          rowGap: 1,
+          columnGap: 1.5,
+          pb: 0.75,
+          borderBottom: `1px dashed ${t.palette.border.light}`,
+        })}
+      >
+        <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 0.5 }}>
+          <Typography
+            sx={{
+              fontSize: { xs: '1.85rem', md: '2.2rem' },
+              fontWeight: 700,
+              lineHeight: 1,
+              fontFamily: '"JetBrains Mono", monospace',
+              color: pool > 0 ? STATUS_COLORS.success : 'text.primary',
+              letterSpacing: '-0.02em',
+            }}
+          >
+            {fmtUsd(pool)}
+          </Typography>
+          <Typography
+            sx={{ fontSize: '0.88rem', color: alpha('#fff', 0.45), ml: 0.25 }}
+          >
+            /day
+          </Typography>
+        </Box>
+        <TokenTicker
+          taoPrice={taoPrice}
+          alphaPrice={alphaPrice}
+          hasPrices={hasPrices}
+        />
+      </Box>
+      {pool > 0 && <EmissionSplitBar pool={pool} />}
+      {earners.length > 0 && (
+        <Box sx={{ mt: 'auto', pt: 2 }}>
+          <Typography
+            sx={{
+              fontSize: '0.62rem',
+              color: alpha('#fff', 0.4),
+              textTransform: 'uppercase',
+              letterSpacing: '0.6px',
+              mb: 0.75,
+            }}
+          >
+            Top earners
+          </Typography>
+          <Box
+            sx={{
+              display: 'flex',
+              flexWrap: 'nowrap',
+              alignItems: 'center',
+              pl: '6px',
+            }}
+          >
+            {earners.map((e, idx) => {
+              const rank = idx + 1;
+              const ringColor =
+                rank === 1
+                  ? RANK_COLORS.first
+                  : rank === 2
+                    ? RANK_COLORS.second
+                    : rank === 3
+                      ? RANK_COLORS.third
+                      : null;
+              return (
+                <Tooltip
+                  key={e.githubId}
+                  title={`#${rank} · ${e.username} · ${fmtUsd(e.usdPerDay)}/day`}
+                  placement="top"
+                  arrow
+                  slotProps={tooltipSlotProps}
+                >
+                  <LinkBox
+                    href={`/miners/details?githubId=${e.githubId}`}
+                    aria-label={`${e.username}, ranked ${rank}, ${fmtUsd(e.usdPerDay)} per day`}
+                    sx={{
+                      display: 'inline-flex',
+                      ml: '-6px',
+                      borderRadius: '50%',
+                      transition: 'transform 0.15s, z-index 0s',
+                      position: 'relative',
+                      zIndex: earners.length - idx,
+                      '&:hover': {
+                        transform: 'translateY(-2px) scale(1.08)',
+                        zIndex: earners.length + 1,
+                      },
+                    }}
+                  >
+                    <Avatar
+                      src={getRepositoryOwnerAvatarSrc(e.username)}
+                      alt={e.username}
+                      sx={(t) => ({
+                        width: 28,
+                        height: 28,
+                        fontSize: '0.68rem',
+                        border: `2px solid ${
+                          ringColor ?? t.palette.background.paper
+                        }`,
+                        boxShadow: ringColor
+                          ? `0 0 0 1px ${alpha(ringColor, 0.4)}`
+                          : `0 0 0 1px ${t.palette.border.medium}`,
+                      })}
+                    />
+                  </LinkBox>
+                </Tooltip>
+              );
+            })}
+          </Box>
+        </Box>
+      )}
+    </Zone>
+  );
+};
+
+interface Segment {
+  key: CohortKey;
+  label: string;
+  color: string;
+  count: number;
+}
+
+const CompositionZone: React.FC<{
+  summary: NetworkSummary;
+  position: ZonePosition;
+  selectedCohort: CohortKey | null;
+  onSelectCohort?: (cohort: CohortKey) => void;
+}> = ({ summary, position, selectedCohort, onSelectCohort }) => {
+  const segments: Segment[] = [
+    {
+      key: 'dual',
+      label: COHORT_LABELS.dual,
+      color: COHORT_COLORS.dual,
+      count: summary.composition.dual,
+    },
+    {
+      key: 'ossOnly',
+      label: COHORT_LABELS.ossOnly,
+      color: COHORT_COLORS.ossOnly,
+      count: summary.composition.ossOnly,
+    },
+    {
+      key: 'discoveryOnly',
+      label: COHORT_LABELS.discoveryOnly,
+      color: COHORT_COLORS.discoveryOnly,
+      count: summary.composition.discoveryOnly,
+    },
+    {
+      key: 'activeOnly',
+      label: COHORT_LABELS.activeOnly,
+      color: COHORT_COLORS.activeOnly,
+      count: summary.composition.activeOnly,
+    },
+    {
+      key: 'inactive',
+      label: COHORT_LABELS.inactive,
+      color: COHORT_COLORS.inactive,
+      count: summary.composition.inactive,
+    },
+  ];
+  const total = summary.total || 1;
+  const isInteractive = !!onSelectCohort;
+
+  const segmentTooltip = (s: Segment) => {
+    const isActive = selectedCohort === s.key;
+    const isClickable = isInteractive && s.count > 0;
+    return (
+      <Box sx={{ lineHeight: 1.45, maxWidth: 260 }}>
+        <Box sx={{ fontWeight: 700, fontSize: '0.78rem' }}>
+          {s.label} · {s.count.toLocaleString()} miner
+          {s.count === 1 ? '' : 's'}
+        </Box>
+        <Box sx={{ fontSize: '0.7rem', opacity: 0.82, mt: '2px' }}>
+          {COHORT_DESCRIPTIONS[s.key]}
+        </Box>
+        {isClickable && (
+          <Box
+            sx={{
+              fontSize: '0.68rem',
+              fontWeight: 700,
+              mt: '4px',
+              color: isActive
+                ? TOOLTIP_TONE_COLORS.negative
+                : TOOLTIP_TONE_COLORS.positive,
+            }}
+          >
+            →{' '}
+            {isActive
+              ? 'Click to clear the cohort filter'
+              : 'Click to filter the table to this cohort'}
+          </Box>
+        )}
+      </Box>
+    );
+  };
+
+  return (
+    <Zone position={position}>
+      <ZoneTitle
+        icon={<CompositionIcon sx={{ fontSize: '0.9rem' }} />}
+        label="Eligibility mix"
+      />
+      <Box
+        sx={{
+          display: 'flex',
+          height: 9,
+          borderRadius: 999,
+          overflow: 'hidden',
+          mb: 1.25,
+        }}
+      >
+        {segments.map((s) => {
+          if (s.count === 0) return null;
+          const widthPct = (s.count / total) * 100;
+          const isActive = selectedCohort === s.key;
+          const dimmed = selectedCohort !== null && !isActive;
+          const handle =
+            isInteractive && s.count > 0
+              ? () => onSelectCohort!(s.key)
+              : undefined;
+          return (
+            <Tooltip
+              key={s.key}
+              title={segmentTooltip(s)}
+              arrow
+              placement="top"
+              slotProps={tooltipSlotProps}
+            >
+              <Box
+                component={handle ? 'button' : 'div'}
+                type={handle ? 'button' : undefined}
+                onClick={handle}
+                aria-pressed={handle ? isActive : undefined}
+                aria-label={
+                  handle
+                    ? isActive
+                      ? `Clear ${s.label} cohort filter`
+                      : `Filter to ${s.label} cohort`
+                    : undefined
+                }
+                sx={{
+                  width: `${widthPct}%`,
+                  backgroundColor: s.color,
+                  border: 'none',
+                  padding: 0,
+                  cursor: handle ? 'pointer' : 'help',
+                  opacity: dimmed ? 0.35 : 1,
+                  boxShadow: isActive
+                    ? `inset 0 0 0 2px ${alpha('#fff', 0.85)}`
+                    : 'none',
+                  transition: 'opacity 0.15s, box-shadow 0.15s',
+                  '&:hover': handle
+                    ? {
+                        opacity: 1,
+                        boxShadow: isActive
+                          ? `inset 0 0 0 2px ${alpha('#fff', 0.95)}`
+                          : `inset 0 0 0 1px ${alpha('#fff', 0.55)}`,
+                      }
+                    : { opacity: dimmed ? 0.45 : 0.85 },
+                }}
+              />
+            </Tooltip>
+          );
+        })}
+      </Box>
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 0.5,
+          mt: 'auto',
+          flexGrow: 1,
+          justifyContent: 'flex-end',
+        }}
+      >
+        {segments.map((s) => {
+          const isActive = selectedCohort === s.key;
+          const dimmed = selectedCohort !== null && !isActive;
+          const handle =
+            isInteractive && s.count > 0
+              ? () => onSelectCohort!(s.key)
+              : undefined;
+          return (
+            <Tooltip
+              key={s.key}
+              title={segmentTooltip(s)}
+              arrow
+              placement="left"
+              slotProps={tooltipSlotProps}
+            >
+              <Box
+                component={handle ? 'button' : 'div'}
+                type={handle ? 'button' : undefined}
+                onClick={handle}
+                aria-pressed={handle ? isActive : undefined}
+                sx={(t) => ({
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 1,
+                  minWidth: 0,
+                  width: '100%',
+                  textAlign: 'left',
+                  background: isActive ? alpha(s.color, 0.16) : 'transparent',
+                  border: `1px solid ${
+                    isActive ? alpha(s.color, 0.55) : 'transparent'
+                  }`,
+                  borderRadius: 1,
+                  px: '6px',
+                  py: '3px',
+                  ml: '-6px',
+                  cursor: handle ? 'pointer' : 'default',
+                  font: 'inherit',
+                  color: 'inherit',
+                  opacity: dimmed ? 0.55 : 1,
+                  transition:
+                    'background-color 0.15s, border-color 0.15s, opacity 0.15s',
+                  '&:hover': handle
+                    ? {
+                        backgroundColor: isActive
+                          ? alpha(s.color, 0.22)
+                          : alpha(t.palette.text.primary, 0.04),
+                      }
+                    : undefined,
+                })}
+              >
+                <Box
+                  sx={{
+                    width: 8,
+                    height: 8,
+                    borderRadius: '50%',
+                    backgroundColor: s.color,
+                    flexShrink: 0,
+                  }}
+                />
+                <Typography
+                  sx={{
+                    fontSize: '0.72rem',
+                    color: isActive ? 'text.primary' : alpha('#fff', 0.6),
+                    fontWeight: isActive ? 600 : 400,
+                    flex: 1,
+                    minWidth: 0,
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                  }}
+                >
+                  {s.label}
+                </Typography>
+                <Typography
+                  sx={{
+                    fontSize: '0.72rem',
+                    fontWeight: 700,
+                    color: s.count === 0 ? alpha('#fff', 0.3) : 'text.primary',
+                    fontFamily: '"JetBrains Mono", monospace',
+                  }}
+                >
+                  {s.count}
+                </Typography>
+              </Box>
+            </Tooltip>
+          );
+        })}
+      </Box>
+    </Zone>
+  );
+};
+
+const PODIUM_COLOR = [
+  RANK_COLORS.first,
+  RANK_COLORS.second,
+  RANK_COLORS.third,
+] as const;
+const PODIUM_MEDAL = ['🥇', '🥈', '🥉'] as const;
+
+const PodiumZone: React.FC<{
+  rows: PodiumRow[];
+  position: ZonePosition;
+}> = ({ rows, position }) => (
+  <Zone position={position}>
+    <ZoneTitle
+      icon={<TrophyIcon sx={{ fontSize: '0.9rem' }} />}
+      label="Top scorers"
+    />
+    {rows.length === 0 ? (
+      <Typography sx={{ fontSize: '0.78rem', color: alpha('#fff', 0.45) }}>
+        No scored miners yet
+      </Typography>
+    ) : (
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 0.5,
+          flexGrow: 1,
+          justifyContent: 'space-between',
+        }}
+      >
+        {rows.map((row, idx) => {
+          const color = PODIUM_COLOR[idx];
+          const medal = PODIUM_MEDAL[idx];
+          return (
+            <LinkBox
+              key={row.githubId}
+              href={`/miners/details?githubId=${row.githubId}`}
+              sx={(t) => ({
+                display: 'grid',
+                gridTemplateColumns: '3px auto 28px minmax(0, 1fr) auto',
+                alignItems: 'center',
+                gap: 1.1,
+                px: 0,
+                py: 0.55,
+                color: 'inherit',
+                transition: 'transform 0.15s',
+                '&:hover': { transform: 'translateX(2px)' },
+                '&:hover .podium-name': { color: t.palette.text.primary },
+                '&:hover .podium-rail': {
+                  boxShadow: `0 0 0 1px ${alpha(color, 0.4)}`,
+                },
+              })}
+            >
+              <Box
+                className="podium-rail"
+                aria-hidden
+                sx={{
+                  width: 3,
+                  height: 28,
+                  borderRadius: 999,
+                  backgroundColor: color,
+                  transition: 'box-shadow 0.15s',
+                }}
+              />
+              <Typography
+                aria-hidden
+                sx={{
+                  fontSize: '1.1rem',
+                  lineHeight: 1,
+                  textAlign: 'center',
+                  minWidth: 22,
+                }}
+              >
+                {medal}
+              </Typography>
+              <Avatar
+                src={getRepositoryOwnerAvatarSrc(row.username)}
+                alt={row.username}
+                sx={(t) => ({
+                  width: 28,
+                  height: 28,
+                  border: `1px solid ${t.palette.border.medium}`,
+                })}
+              />
+              <Box sx={{ minWidth: 0 }}>
+                <Typography
+                  className="podium-name"
+                  sx={{
+                    fontSize: '0.85rem',
+                    fontWeight: 600,
+                    color: alpha('#fff', 0.9),
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                    transition: 'color 0.15s',
+                    letterSpacing: '-0.005em',
+                  }}
+                >
+                  {row.username}
+                </Typography>
+                <Typography
+                  sx={{
+                    fontSize: '0.65rem',
+                    color:
+                      row.usdPerDay > 0
+                        ? alpha('#fff', 0.55)
+                        : alpha('#fff', 0.35),
+                    fontFamily: '"JetBrains Mono", monospace',
+                  }}
+                >
+                  {row.usdPerDay > 0
+                    ? `${fmtUsd(row.usdPerDay)}/day`
+                    : 'no $ yet'}
+                </Typography>
+              </Box>
+              <Box sx={{ textAlign: 'right' }}>
+                <Typography
+                  sx={{
+                    fontFamily: '"JetBrains Mono", monospace',
+                    fontSize: '1.15rem',
+                    fontWeight: 700,
+                    color,
+                    letterSpacing: '-0.03em',
+                    lineHeight: 1,
+                  }}
+                >
+                  {row.combinedScore.toFixed(0)}
+                </Typography>
+                <Typography
+                  sx={{
+                    fontFamily: '"JetBrains Mono", monospace',
+                    fontSize: '0.55rem',
+                    color: alpha('#fff', 0.4),
+                    letterSpacing: '0.4px',
+                    textTransform: 'uppercase',
+                    mt: '2px',
+                  }}
+                >
+                  score
+                </Typography>
+              </Box>
+            </LinkBox>
+          );
+        })}
+      </Box>
+    )}
+  </Zone>
+);
+
+const RepoTooltipContent: React.FC<{
+  name: string;
+  count: number;
+  minerCount: number;
+  lookbackLabel: string;
+  action: 'filter' | 'clear' | null;
+}> = ({ name, count, minerCount, lookbackLabel, action }) => {
+  const prsPerMiner = minerCount > 0 ? count / minerCount : 0;
+  const densityLabel =
+    minerCount > 0
+      ? ` · ≈${prsPerMiner.toFixed(prsPerMiner >= 10 ? 0 : 1)}/miner`
+      : '';
+  return (
+    <Box sx={{ lineHeight: 1.45 }}>
+      <Box sx={{ fontWeight: 700, fontSize: '0.78rem' }}>{name}</Box>
+      <Box sx={{ fontSize: '0.72rem', opacity: 0.85 }}>
+        {count.toLocaleString()} merged PR{count === 1 ? '' : 's'} by{' '}
+        {minerCount.toLocaleString()} miner{minerCount === 1 ? '' : 's'}
+        {densityLabel}
+      </Box>
+      <Box sx={{ fontSize: '0.7rem', opacity: 0.6, mt: '2px' }}>
+        Over the {lookbackLabel}
+      </Box>
+      {action && (
+        <Box
+          sx={{
+            fontSize: '0.7rem',
+            fontWeight: 700,
+            mt: '4px',
+            color:
+              action === 'clear'
+                ? TOOLTIP_TONE_COLORS.negative
+                : TOOLTIP_TONE_COLORS.positive,
+          }}
+        >
+          {action === 'clear'
+            ? '→ Click to clear the table filter'
+            : '→ Click to filter the table to this repo'}
+        </Box>
+      )}
+    </Box>
+  );
+};
+
+const HotRepoZone: React.FC<{
+  repos: NetworkRepoActivity[];
+  selectedRepo: string | null;
+  onSelectRepo?: (repo: string) => void;
+  position: ZonePosition;
+}> = ({ repos, selectedRepo, onSelectRepo, position }) => {
+  const lookbackLabel = 'last 30d';
+  if (repos.length === 0) {
+    return (
+      <Zone position={position}>
+        <ZoneTitle
+          icon={<HotRepoIcon sx={{ fontSize: '0.9rem' }} />}
+          label={`Hottest repos · ${lookbackLabel}`}
+        />
+        <Typography sx={{ fontSize: '0.78rem', color: alpha('#fff', 0.45) }}>
+          No merged PRs yet in this window
+        </Typography>
+      </Zone>
+    );
+  }
+  const [hero, ...runnersUp] = repos;
+  const heroSlash = hero.name.lastIndexOf('/');
+  const heroOwner = heroSlash >= 0 ? hero.name.slice(0, heroSlash) : '';
+  const heroShort = heroSlash >= 0 ? hero.name.slice(heroSlash + 1) : hero.name;
+  const heroCount = hero.count;
+  const isHeroSelected = selectedRepo === hero.name;
+  const heroTooltip = (
+    <RepoTooltipContent
+      name={hero.name}
+      count={hero.count}
+      minerCount={hero.minerCount}
+      lookbackLabel={lookbackLabel}
+      action={onSelectRepo ? (isHeroSelected ? 'clear' : 'filter') : null}
+    />
+  );
+  const handleHeroClick = onSelectRepo
+    ? (e: React.MouseEvent) => {
+        e.preventDefault();
+        e.stopPropagation();
+        onSelectRepo(hero.name);
+      }
+    : undefined;
+  return (
+    <Zone position={position}>
+      <ZoneTitle
+        icon={<HotRepoIcon sx={{ fontSize: '0.9rem' }} />}
+        label={`Hottest repos · ${lookbackLabel}`}
+      />
+      <Tooltip
+        title={heroTooltip}
+        arrow
+        placement="right"
+        slotProps={tooltipSlotProps}
+      >
+        <Box
+          component={handleHeroClick ? 'button' : 'div'}
+          type={handleHeroClick ? 'button' : undefined}
+          onClick={handleHeroClick}
+          sx={(t) => ({
+            display: 'grid',
+            gridTemplateColumns: 'auto minmax(0, 1fr) auto',
+            alignItems: 'center',
+            columnGap: 1,
+            width: '100%',
+            border: 'none',
+            borderRadius: 1,
+            backgroundColor: isHeroSelected
+              ? alpha(t.palette.primary.main, 0.12)
+              : 'transparent',
+            color: 'inherit',
+            textAlign: 'left',
+            cursor: handleHeroClick ? 'pointer' : 'default',
+            font: 'inherit',
+            px: 0.75,
+            py: 0.4,
+            mb: 0.5,
+            transition: 'background-color 0.15s, transform 0.15s',
+            '&:hover': handleHeroClick
+              ? {
+                  backgroundColor: alpha(
+                    isHeroSelected ? t.palette.primary.main : '#fff',
+                    isHeroSelected ? 0.18 : 0.04,
+                  ),
+                  transform: 'translateX(2px)',
+                }
+              : undefined,
+            '&:hover .hot-repo-short': {
+              color: isHeroSelected
+                ? t.palette.primary.main
+                : t.palette.text.primary,
+            },
+          })}
+        >
+          <Avatar
+            src={getRepositoryOwnerAvatarSrc(heroOwner || hero.name)}
+            alt={heroOwner || hero.name}
+            sx={(t) => ({
+              width: 28,
+              height: 28,
+              border: `1px solid ${t.palette.border.medium}`,
+              backgroundColor: t.palette.background.paper,
+            })}
+          />
+          <Typography
+            className="hot-repo-short"
+            sx={{
+              fontSize: '0.95rem',
+              fontWeight: 700,
+              fontFamily: '"JetBrains Mono", monospace',
+              color: isHeroSelected ? 'primary.main' : 'text.primary',
+              letterSpacing: '-0.01em',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+              minWidth: 0,
+              transition: 'color 0.15s',
+            }}
+          >
+            {heroShort}
+          </Typography>
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'baseline',
+              gap: '4px',
+              flexShrink: 0,
+            }}
+          >
+            <Typography
+              sx={(t) => ({
+                fontFamily: '"JetBrains Mono", monospace',
+                fontSize: '1.15rem',
+                fontWeight: 700,
+                color: isHeroSelected
+                  ? t.palette.primary.main
+                  : STATUS_COLORS.merged,
+                letterSpacing: '-0.03em',
+                lineHeight: 1,
+              })}
+            >
+              {heroCount.toLocaleString()}
+            </Typography>
+            <Typography
+              sx={{
+                fontFamily: '"JetBrains Mono", monospace',
+                fontSize: '0.6rem',
+                color: alpha('#fff', 0.45),
+                letterSpacing: '0.4px',
+                textTransform: 'uppercase',
+                lineHeight: 1,
+              }}
+            >
+              PR{heroCount === 1 ? '' : 's'}
+            </Typography>
+          </Box>
+        </Box>
+      </Tooltip>
+      {runnersUp.length > 0 && (
+        <Box sx={{ mt: 'auto', pt: 1.75 }}>
+          <Typography
+            sx={{
+              fontSize: '0.62rem',
+              color: alpha('#fff', 0.4),
+              textTransform: 'uppercase',
+              letterSpacing: '0.6px',
+              mb: 0.75,
+            }}
+          >
+            Runners-up
+          </Typography>
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+            {runnersUp.slice(0, 3).map((r) => {
+              const slash = r.name.lastIndexOf('/');
+              const short = slash >= 0 ? r.name.slice(slash + 1) : r.name;
+              const owner = slash >= 0 ? r.name.slice(0, slash) : r.name;
+              const isSelected = selectedRepo === r.name;
+              const handle = onSelectRepo
+                ? (e: React.MouseEvent) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    onSelectRepo(r.name);
+                  }
+                : undefined;
+              return (
+                <Tooltip
+                  key={r.name}
+                  title={
+                    <RepoTooltipContent
+                      name={r.name}
+                      count={r.count}
+                      minerCount={r.minerCount}
+                      lookbackLabel={lookbackLabel}
+                      action={
+                        onSelectRepo ? (isSelected ? 'clear' : 'filter') : null
+                      }
+                    />
+                  }
+                  arrow
+                  placement="right"
+                  slotProps={tooltipSlotProps}
+                >
+                  <Box
+                    component={onSelectRepo ? 'button' : 'div'}
+                    type={onSelectRepo ? 'button' : undefined}
+                    onClick={handle}
+                    sx={(t) => ({
+                      display: 'grid',
+                      gridTemplateColumns: 'auto minmax(0, 1fr) auto',
+                      alignItems: 'center',
+                      gap: 1,
+                      px: 0.75,
+                      py: 0.4,
+                      border: 'none',
+                      borderRadius: 1,
+                      backgroundColor: isSelected
+                        ? alpha(t.palette.primary.main, 0.12)
+                        : 'transparent',
+                      color: 'inherit',
+                      cursor: onSelectRepo ? 'pointer' : 'default',
+                      textAlign: 'left',
+                      width: '100%',
+                      transition: 'background-color 0.15s',
+                      '&:hover': onSelectRepo
+                        ? { backgroundColor: alpha('#fff', 0.04) }
+                        : undefined,
+                    })}
+                  >
+                    <Avatar
+                      src={getRepositoryOwnerAvatarSrc(owner)}
+                      alt={owner}
+                      sx={(t) => ({
+                        width: 18,
+                        height: 18,
+                        border: `1px solid ${t.palette.border.light}`,
+                        backgroundColor: t.palette.background.paper,
+                      })}
+                    />
+                    <Typography
+                      sx={{
+                        fontSize: '0.74rem',
+                        fontFamily: '"JetBrains Mono", monospace',
+                        color: isSelected
+                          ? 'primary.main'
+                          : alpha('#fff', 0.78),
+                        fontWeight: isSelected ? 700 : 600,
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        whiteSpace: 'nowrap',
+                      }}
+                    >
+                      {short}
+                    </Typography>
+                    <Typography
+                      sx={{
+                        fontSize: '0.7rem',
+                        fontFamily: '"JetBrains Mono", monospace',
+                        fontWeight: 700,
+                        color: isSelected
+                          ? 'primary.main'
+                          : alpha('#fff', 0.55),
+                      }}
+                    >
+                      {r.count}
+                    </Typography>
+                  </Box>
+                </Tooltip>
+              );
+            })}
+          </Box>
+        </Box>
+      )}
+    </Zone>
+  );
+};
+
+const LeaderboardInsights: React.FC<LeaderboardInsightsProps> = ({
+  miners,
+  isLoading,
+  selectedRepo = null,
+  onSelectRepo,
+  selectedCohort = null,
+  onSelectCohort,
+}) => {
+  const list = useMemo(() => miners ?? [], [miners]);
+  // React Query dedupes the underlying /dash/commits fetch with the table.
+  const { network } = useMinerActivityIndex({ lookbackDays: 30 });
+
+  const summary = useMemo(() => deriveSummary(list), [list]);
+  const earners = useMemo(() => deriveTopEarners(list, 8), [list]);
+  const podium = useMemo(() => derivePodium(list), [list]);
+
+  if (isLoading && list.length === 0) {
+    return (
+      <Card sx={{ p: 2.5 }}>
+        <Skeleton variant="text" width="30%" />
+        <Skeleton
+          variant="rectangular"
+          height={160}
+          sx={{ mt: 1, borderRadius: 1 }}
+        />
+      </Card>
+    );
+  }
+
+  return (
+    <Card
+      sx={(t) => ({
+        p: 0,
+        overflow: 'hidden',
+        position: 'relative',
+        backgroundColor: t.palette.background.paper,
+        backgroundImage: `
+          radial-gradient(ellipse 120% 70% at 50% -10%, ${alpha(
+            t.palette.text.primary,
+            0.07,
+          )} 0%, ${alpha(t.palette.text.primary, 0)} 55%),
+          linear-gradient(180deg, ${alpha('#000', 0)} 60%, ${alpha(
+            '#000',
+            0.3,
+          )} 100%)
+        `,
+        borderColor: t.palette.border.medium,
+        boxShadow: [
+          `inset 0 1px 0 ${alpha(t.palette.text.primary, 0.09)}`,
+          `inset 0 -1px 0 ${alpha('#000', 0.4)}`,
+          `0 1px 0 ${alpha(t.palette.text.primary, 0.02)}`,
+          `0 12px 36px -8px ${alpha('#000', 0.6)}`,
+          `0 4px 12px -4px ${alpha('#000', 0.4)}`,
+        ].join(', '),
+      })}
+    >
+      <Box
+        sx={{
+          display: 'grid',
+          gridTemplateColumns: {
+            xs: '1fr',
+            sm: 'repeat(2, minmax(0, 1fr))',
+            lg: '1.05fr 1.05fr 1fr 1fr',
+          },
+        }}
+      >
+        <DailyPoolZone pool={summary.dailyPool} earners={earners} />
+        <CompositionZone
+          summary={summary}
+          position={2}
+          selectedCohort={selectedCohort}
+          onSelectCohort={onSelectCohort}
+        />
+        <PodiumZone rows={podium} position={3} />
+        <HotRepoZone
+          repos={network.topRepos}
+          selectedRepo={selectedRepo}
+          onSelectRepo={onSelectRepo}
+          position={4}
+        />
+      </Box>
+    </Card>
+  );
+};
+
+export default LeaderboardInsights;

--- a/src/components/leaderboard/LeaderboardInsights.tsx
+++ b/src/components/leaderboard/LeaderboardInsights.tsx
@@ -23,7 +23,6 @@ import {
 import { getRepositoryOwnerAvatarSrc } from '../../utils/avatar';
 import { parseNumber } from '../../utils/ExplorerUtils';
 import { LinkBox } from '../common/linkBehavior';
-import { usePrices } from '../../hooks/usePrices';
 import type { MinerEvaluation } from '../../api';
 import {
   useMinerActivityIndex,
@@ -138,7 +137,14 @@ const ZoneTitle: React.FC<{ icon: React.ReactNode; label: string }> = ({
   label,
 }) => (
   <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, mb: 1.25 }}>
-    <Box sx={{ color: alpha('#fff', 0.4), display: 'flex' }}>{icon}</Box>
+    <Box
+      sx={(t) => ({
+        color: alpha(t.palette.text.primary, 0.4),
+        display: 'flex',
+      })}
+    >
+      {icon}
+    </Box>
     <Typography variant="statLabel">{label}</Typography>
   </Box>
 );
@@ -185,92 +191,6 @@ const Zone: React.FC<{
     </Box>
   );
 };
-
-const fmtPrice = (n: number): string => {
-  if (n <= 0) return '—';
-  if (n >= 100) return `$${n.toFixed(2)}`;
-  if (n >= 1) return `$${n.toFixed(2)}`;
-  return `$${n.toFixed(3)}`;
-};
-
-const TokenTickerRow: React.FC<{
-  symbol: string;
-  symbolColor: string;
-  tip: string;
-  price: number;
-  loading: boolean;
-}> = ({ symbol, symbolColor, tip, price, loading }) => (
-  <Tooltip title={tip} arrow placement="top" slotProps={tooltipSlotProps}>
-    <Box
-      sx={{
-        display: 'inline-grid',
-        gridTemplateColumns: '32px auto',
-        alignItems: 'baseline',
-        columnGap: '6px',
-        cursor: 'help',
-        fontFamily: '"JetBrains Mono", monospace',
-      }}
-    >
-      <Typography
-        component="span"
-        sx={{
-          fontFamily: 'inherit',
-          fontSize: '0.62rem',
-          fontWeight: 700,
-          color: symbolColor,
-          letterSpacing: '0.3px',
-          textAlign: 'left',
-        }}
-      >
-        {symbol}
-      </Typography>
-      <Typography
-        component="span"
-        sx={{
-          fontFamily: 'inherit',
-          fontSize: '0.8rem',
-          fontWeight: 700,
-          color: loading ? alpha('#fff', 0.35) : 'text.primary',
-          letterSpacing: '-0.01em',
-          lineHeight: 1.05,
-        }}
-      >
-        {loading ? '—' : fmtPrice(price)}
-      </Typography>
-    </Box>
-  </Tooltip>
-);
-
-const TokenTicker: React.FC<{
-  taoPrice: number;
-  alphaPrice: number;
-  hasPrices: boolean;
-}> = ({ taoPrice, alphaPrice, hasPrices }) => (
-  <Box
-    sx={{
-      display: 'flex',
-      flexDirection: 'column',
-      alignItems: 'flex-start',
-      gap: '4px',
-      pt: '4px',
-    }}
-  >
-    <TokenTickerRow
-      symbol="TAO"
-      symbolColor="#5eead4"
-      tip="TAO spot price — drives the USD value of every miner emission."
-      price={taoPrice}
-      loading={!hasPrices}
-    />
-    <TokenTickerRow
-      symbol="α74"
-      symbolColor={STATUS_COLORS.warning}
-      tip="Subnet 74 alpha token spot price — the gittensor reward token."
-      price={alphaPrice}
-      loading={!hasPrices}
-    />
-  </Box>
-);
 
 const EmissionSplitBar: React.FC<{ pool: number }> = ({ pool }) => {
   const contribShare = CONTRIB_EMISSION_SHARE;
@@ -346,7 +266,10 @@ const EmissionSplitBar: React.FC<{ pool: number }> = ({ pool }) => {
             />
             <Box
               component="span"
-              sx={{ color: alpha('#fff', 0.55), fontWeight: 500 }}
+              sx={(t) => ({
+                color: alpha(t.palette.text.primary, 0.55),
+                fontWeight: 500,
+              })}
             >
               Miners
             </Box>
@@ -358,7 +281,10 @@ const EmissionSplitBar: React.FC<{ pool: number }> = ({ pool }) => {
             </Box>
             <Box
               component="span"
-              sx={{ color: alpha('#fff', 0.4), fontSize: '0.6rem' }}
+              sx={(t) => ({
+                color: alpha(t.palette.text.primary, 0.4),
+                fontSize: '0.6rem',
+              })}
             >
               {Math.round(contribShare * 100)}%
             </Box>
@@ -377,7 +303,10 @@ const EmissionSplitBar: React.FC<{ pool: number }> = ({ pool }) => {
             />
             <Box
               component="span"
-              sx={{ color: alpha('#fff', 0.55), fontWeight: 500 }}
+              sx={(t) => ({
+                color: alpha(t.palette.text.primary, 0.55),
+                fontWeight: 500,
+              })}
             >
               Treasury
             </Box>
@@ -389,7 +318,10 @@ const EmissionSplitBar: React.FC<{ pool: number }> = ({ pool }) => {
             </Box>
             <Box
               component="span"
-              sx={{ color: alpha('#fff', 0.4), fontSize: '0.6rem' }}
+              sx={(t) => ({
+                color: alpha(t.palette.text.primary, 0.4),
+                fontSize: '0.6rem',
+              })}
             >
               {Math.round(treasuryShare * 100)}%
             </Box>
@@ -404,7 +336,6 @@ const DailyPoolZone: React.FC<{
   pool: number;
   earners: EarnerLite[];
 }> = ({ pool, earners }) => {
-  const { taoPrice, alphaPrice, hasPrices } = usePrices();
   return (
     <Zone position={1}>
       <ZoneTitle
@@ -414,51 +345,45 @@ const DailyPoolZone: React.FC<{
       <Box
         sx={(t) => ({
           display: 'flex',
-          alignItems: 'flex-start',
-          justifyContent: 'space-between',
-          flexWrap: 'wrap',
-          rowGap: 1,
-          columnGap: 1.5,
+          alignItems: 'baseline',
+          gap: 0.5,
           pb: 0.75,
           borderBottom: `1px dashed ${t.palette.border.light}`,
         })}
       >
-        <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 0.5 }}>
-          <Typography
-            sx={{
-              fontSize: { xs: '1.85rem', md: '2.2rem' },
-              fontWeight: 700,
-              lineHeight: 1,
-              fontFamily: '"JetBrains Mono", monospace',
-              color: pool > 0 ? STATUS_COLORS.success : 'text.primary',
-              letterSpacing: '-0.02em',
-            }}
-          >
-            {fmtUsd(pool)}
-          </Typography>
-          <Typography
-            sx={{ fontSize: '0.88rem', color: alpha('#fff', 0.45), ml: 0.25 }}
-          >
-            /day
-          </Typography>
-        </Box>
-        <TokenTicker
-          taoPrice={taoPrice}
-          alphaPrice={alphaPrice}
-          hasPrices={hasPrices}
-        />
+        <Typography
+          sx={{
+            fontSize: { xs: '1.85rem', md: '2.2rem' },
+            fontWeight: 700,
+            lineHeight: 1,
+            fontFamily: '"JetBrains Mono", monospace',
+            color: pool > 0 ? STATUS_COLORS.success : 'text.primary',
+            letterSpacing: '-0.02em',
+          }}
+        >
+          {fmtUsd(pool)}
+        </Typography>
+        <Typography
+          sx={(t) => ({
+            fontSize: '0.88rem',
+            color: alpha(t.palette.text.primary, 0.45),
+            ml: 0.25,
+          })}
+        >
+          /day
+        </Typography>
       </Box>
       {pool > 0 && <EmissionSplitBar pool={pool} />}
       {earners.length > 0 && (
         <Box sx={{ mt: 'auto', pt: 2 }}>
           <Typography
-            sx={{
+            sx={(t) => ({
               fontSize: '0.62rem',
-              color: alpha('#fff', 0.4),
+              color: alpha(t.palette.text.primary, 0.4),
               textTransform: 'uppercase',
               letterSpacing: '0.6px',
               mb: 0.75,
-            }}
+            })}
           >
             Top earners
           </Typography>
@@ -655,7 +580,7 @@ const CompositionZone: React.FC<{
                       : `Filter to ${s.label} cohort`
                     : undefined
                 }
-                sx={{
+                sx={(t) => ({
                   width: `${widthPct}%`,
                   backgroundColor: s.color,
                   border: 'none',
@@ -663,18 +588,18 @@ const CompositionZone: React.FC<{
                   cursor: handle ? 'pointer' : 'help',
                   opacity: dimmed ? 0.35 : 1,
                   boxShadow: isActive
-                    ? `inset 0 0 0 2px ${alpha('#fff', 0.85)}`
+                    ? `inset 0 0 0 2px ${alpha(t.palette.text.primary, 0.85)}`
                     : 'none',
                   transition: 'opacity 0.15s, box-shadow 0.15s',
                   '&:hover': handle
                     ? {
                         opacity: 1,
                         boxShadow: isActive
-                          ? `inset 0 0 0 2px ${alpha('#fff', 0.95)}`
-                          : `inset 0 0 0 1px ${alpha('#fff', 0.55)}`,
+                          ? `inset 0 0 0 2px ${alpha(t.palette.text.primary, 0.95)}`
+                          : `inset 0 0 0 1px ${alpha(t.palette.text.primary, 0.55)}`,
                       }
                     : { opacity: dimmed ? 0.45 : 0.85 },
-                }}
+                })}
               />
             </Tooltip>
           );
@@ -750,26 +675,31 @@ const CompositionZone: React.FC<{
                   }}
                 />
                 <Typography
-                  sx={{
+                  sx={(t) => ({
                     fontSize: '0.72rem',
-                    color: isActive ? 'text.primary' : alpha('#fff', 0.6),
+                    color: isActive
+                      ? t.palette.text.primary
+                      : alpha(t.palette.text.primary, 0.6),
                     fontWeight: isActive ? 600 : 400,
                     flex: 1,
                     minWidth: 0,
                     overflow: 'hidden',
                     textOverflow: 'ellipsis',
                     whiteSpace: 'nowrap',
-                  }}
+                  })}
                 >
                   {s.label}
                 </Typography>
                 <Typography
-                  sx={{
+                  sx={(t) => ({
                     fontSize: '0.72rem',
                     fontWeight: 700,
-                    color: s.count === 0 ? alpha('#fff', 0.3) : 'text.primary',
+                    color:
+                      s.count === 0
+                        ? alpha(t.palette.text.primary, 0.3)
+                        : t.palette.text.primary,
                     fontFamily: '"JetBrains Mono", monospace',
-                  }}
+                  })}
                 >
                   {s.count}
                 </Typography>
@@ -787,7 +717,6 @@ const PODIUM_COLOR = [
   RANK_COLORS.second,
   RANK_COLORS.third,
 ] as const;
-const PODIUM_MEDAL = ['🥇', '🥈', '🥉'] as const;
 
 const PodiumZone: React.FC<{
   rows: PodiumRow[];
@@ -799,7 +728,12 @@ const PodiumZone: React.FC<{
       label="Top scorers"
     />
     {rows.length === 0 ? (
-      <Typography sx={{ fontSize: '0.78rem', color: alpha('#fff', 0.45) }}>
+      <Typography
+        sx={(t) => ({
+          fontSize: '0.78rem',
+          color: alpha(t.palette.text.primary, 0.45),
+        })}
+      >
         No scored miners yet
       </Typography>
     ) : (
@@ -814,7 +748,6 @@ const PodiumZone: React.FC<{
       >
         {rows.map((row, idx) => {
           const color = PODIUM_COLOR[idx];
-          const medal = PODIUM_MEDAL[idx];
           return (
             <LinkBox
               key={row.githubId}
@@ -849,13 +782,16 @@ const PodiumZone: React.FC<{
               <Typography
                 aria-hidden
                 sx={{
-                  fontSize: '1.1rem',
+                  fontFamily: '"JetBrains Mono", monospace',
+                  fontSize: '0.95rem',
+                  fontWeight: 700,
+                  color,
                   lineHeight: 1,
                   textAlign: 'center',
                   minWidth: 22,
                 }}
               >
-                {medal}
+                {idx + 1}
               </Typography>
               <Avatar
                 src={getRepositoryOwnerAvatarSrc(row.username)}
@@ -869,28 +805,28 @@ const PodiumZone: React.FC<{
               <Box sx={{ minWidth: 0 }}>
                 <Typography
                   className="podium-name"
-                  sx={{
+                  sx={(t) => ({
                     fontSize: '0.85rem',
                     fontWeight: 600,
-                    color: alpha('#fff', 0.9),
+                    color: alpha(t.palette.text.primary, 0.9),
                     overflow: 'hidden',
                     textOverflow: 'ellipsis',
                     whiteSpace: 'nowrap',
                     transition: 'color 0.15s',
                     letterSpacing: '-0.005em',
-                  }}
+                  })}
                 >
                   {row.username}
                 </Typography>
                 <Typography
-                  sx={{
+                  sx={(t) => ({
                     fontSize: '0.65rem',
                     color:
                       row.usdPerDay > 0
-                        ? alpha('#fff', 0.55)
-                        : alpha('#fff', 0.35),
+                        ? alpha(t.palette.text.primary, 0.55)
+                        : alpha(t.palette.text.primary, 0.35),
                     fontFamily: '"JetBrains Mono", monospace',
-                  }}
+                  })}
                 >
                   {row.usdPerDay > 0
                     ? `${fmtUsd(row.usdPerDay)}/day`
@@ -911,14 +847,14 @@ const PodiumZone: React.FC<{
                   {row.combinedScore.toFixed(0)}
                 </Typography>
                 <Typography
-                  sx={{
+                  sx={(t) => ({
                     fontFamily: '"JetBrains Mono", monospace',
                     fontSize: '0.55rem',
-                    color: alpha('#fff', 0.4),
+                    color: alpha(t.palette.text.primary, 0.4),
                     letterSpacing: '0.4px',
                     textTransform: 'uppercase',
                     mt: '2px',
-                  }}
+                  })}
                 >
                   score
                 </Typography>
@@ -989,7 +925,12 @@ const HotRepoZone: React.FC<{
           icon={<HotRepoIcon sx={{ fontSize: '0.9rem' }} />}
           label={`Hottest repos · ${lookbackLabel}`}
         />
-        <Typography sx={{ fontSize: '0.78rem', color: alpha('#fff', 0.45) }}>
+        <Typography
+          sx={(t) => ({
+            fontSize: '0.78rem',
+            color: alpha(t.palette.text.primary, 0.45),
+          })}
+        >
           No merged PRs yet in this window
         </Typography>
       </Zone>
@@ -1118,14 +1059,14 @@ const HotRepoZone: React.FC<{
               {heroCount.toLocaleString()}
             </Typography>
             <Typography
-              sx={{
+              sx={(t) => ({
                 fontFamily: '"JetBrains Mono", monospace',
                 fontSize: '0.6rem',
-                color: alpha('#fff', 0.45),
+                color: alpha(t.palette.text.primary, 0.45),
                 letterSpacing: '0.4px',
                 textTransform: 'uppercase',
                 lineHeight: 1,
-              }}
+              })}
             >
               PR{heroCount === 1 ? '' : 's'}
             </Typography>
@@ -1135,13 +1076,13 @@ const HotRepoZone: React.FC<{
       {runnersUp.length > 0 && (
         <Box sx={{ mt: 'auto', pt: 1.75 }}>
           <Typography
-            sx={{
+            sx={(t) => ({
               fontSize: '0.62rem',
-              color: alpha('#fff', 0.4),
+              color: alpha(t.palette.text.primary, 0.4),
               textTransform: 'uppercase',
               letterSpacing: '0.6px',
               mb: 0.75,
-            }}
+            })}
           >
             Runners-up
           </Typography>
@@ -1198,7 +1139,12 @@ const HotRepoZone: React.FC<{
                       width: '100%',
                       transition: 'background-color 0.15s',
                       '&:hover': onSelectRepo
-                        ? { backgroundColor: alpha('#fff', 0.04) }
+                        ? {
+                            backgroundColor: alpha(
+                              t.palette.text.primary,
+                              0.04,
+                            ),
+                          }
                         : undefined,
                     })}
                   >
@@ -1213,29 +1159,29 @@ const HotRepoZone: React.FC<{
                       })}
                     />
                     <Typography
-                      sx={{
+                      sx={(t) => ({
                         fontSize: '0.74rem',
                         fontFamily: '"JetBrains Mono", monospace',
                         color: isSelected
-                          ? 'primary.main'
-                          : alpha('#fff', 0.78),
+                          ? t.palette.primary.main
+                          : alpha(t.palette.text.primary, 0.78),
                         fontWeight: isSelected ? 700 : 600,
                         overflow: 'hidden',
                         textOverflow: 'ellipsis',
                         whiteSpace: 'nowrap',
-                      }}
+                      })}
                     >
                       {short}
                     </Typography>
                     <Typography
-                      sx={{
+                      sx={(t) => ({
                         fontSize: '0.7rem',
                         fontFamily: '"JetBrains Mono", monospace',
                         fontWeight: 700,
                         color: isSelected
-                          ? 'primary.main'
-                          : alpha('#fff', 0.55),
-                      }}
+                          ? t.palette.primary.main
+                          : alpha(t.palette.text.primary, 0.55),
+                      })}
                     >
                       {r.count}
                     </Typography>
@@ -1291,18 +1237,18 @@ const LeaderboardInsights: React.FC<LeaderboardInsightsProps> = ({
             t.palette.text.primary,
             0.07,
           )} 0%, ${alpha(t.palette.text.primary, 0)} 55%),
-          linear-gradient(180deg, ${alpha('#000', 0)} 60%, ${alpha(
-            '#000',
+          linear-gradient(180deg, ${alpha(t.palette.common.black, 0)} 60%, ${alpha(
+            t.palette.common.black,
             0.3,
           )} 100%)
         `,
         borderColor: t.palette.border.medium,
         boxShadow: [
           `inset 0 1px 0 ${alpha(t.palette.text.primary, 0.09)}`,
-          `inset 0 -1px 0 ${alpha('#000', 0.4)}`,
+          `inset 0 -1px 0 ${alpha(t.palette.common.black, 0.4)}`,
           `0 1px 0 ${alpha(t.palette.text.primary, 0.02)}`,
-          `0 12px 36px -8px ${alpha('#000', 0.6)}`,
-          `0 4px 12px -4px ${alpha('#000', 0.4)}`,
+          `0 12px 36px -8px ${alpha(t.palette.common.black, 0.6)}`,
+          `0 4px 12px -4px ${alpha(t.palette.common.black, 0.4)}`,
         ].join(', '),
       })}
     >

--- a/src/components/leaderboard/LeaderboardInsights.tsx
+++ b/src/components/leaderboard/LeaderboardInsights.tsx
@@ -754,7 +754,7 @@ const PodiumZone: React.FC<{
               href={`/miners/details?githubId=${row.githubId}`}
               sx={(t) => ({
                 display: 'grid',
-                gridTemplateColumns: '3px auto 28px minmax(0, 1fr) auto',
+                gridTemplateColumns: '28px minmax(0, 1fr) auto',
                 alignItems: 'center',
                 gap: 1.1,
                 px: 0,
@@ -763,36 +763,8 @@ const PodiumZone: React.FC<{
                 transition: 'transform 0.15s',
                 '&:hover': { transform: 'translateX(2px)' },
                 '&:hover .podium-name': { color: t.palette.text.primary },
-                '&:hover .podium-rail': {
-                  boxShadow: `0 0 0 1px ${alpha(color, 0.4)}`,
-                },
               })}
             >
-              <Box
-                className="podium-rail"
-                aria-hidden
-                sx={{
-                  width: 3,
-                  height: 28,
-                  borderRadius: 999,
-                  backgroundColor: color,
-                  transition: 'box-shadow 0.15s',
-                }}
-              />
-              <Typography
-                aria-hidden
-                sx={{
-                  fontFamily: '"JetBrains Mono", monospace',
-                  fontSize: '0.95rem',
-                  fontWeight: 700,
-                  color,
-                  lineHeight: 1,
-                  textAlign: 'center',
-                  minWidth: 22,
-                }}
-              >
-                {idx + 1}
-              </Typography>
               <Avatar
                 src={getRepositoryOwnerAvatarSrc(row.username)}
                 alt={row.username}
@@ -1173,18 +1145,39 @@ const HotRepoZone: React.FC<{
                     >
                       {short}
                     </Typography>
-                    <Typography
-                      sx={(t) => ({
-                        fontSize: '0.7rem',
-                        fontFamily: '"JetBrains Mono", monospace',
-                        fontWeight: 700,
-                        color: isSelected
-                          ? t.palette.primary.main
-                          : alpha(t.palette.text.primary, 0.55),
-                      })}
+                    <Box
+                      sx={{
+                        display: 'inline-flex',
+                        alignItems: 'baseline',
+                        gap: '4px',
+                        justifySelf: 'end',
+                      }}
                     >
-                      {r.count}
-                    </Typography>
+                      <Typography
+                        sx={(t) => ({
+                          fontSize: '0.7rem',
+                          fontFamily: '"JetBrains Mono", monospace',
+                          fontWeight: 700,
+                          color: isSelected
+                            ? t.palette.primary.main
+                            : alpha(t.palette.text.primary, 0.55),
+                        })}
+                      >
+                        {r.count}
+                      </Typography>
+                      <Typography
+                        sx={(t) => ({
+                          fontFamily: '"JetBrains Mono", monospace',
+                          fontSize: '0.55rem',
+                          color: alpha(t.palette.text.primary, 0.4),
+                          letterSpacing: '0.4px',
+                          textTransform: 'uppercase',
+                          lineHeight: 1,
+                        })}
+                      >
+                        PR{r.count === 1 ? '' : 's'}
+                      </Typography>
+                    </Box>
                   </Box>
                 </Tooltip>
               );

--- a/src/components/leaderboard/MinerStatus.tsx
+++ b/src/components/leaderboard/MinerStatus.tsx
@@ -1,0 +1,183 @@
+import React from 'react';
+import { Box, Tooltip, Typography, alpha } from '@mui/material';
+import type { MinerEvaluation } from '../../api';
+import { MINER_STATUS_COLORS, tooltipSlotProps } from '../../theme';
+import { parseNumber } from '../../utils/ExplorerUtils';
+import type { MinerActivity } from './useMinerActivityIndex';
+
+export type MinerStatusKind =
+  | 'penalized'
+  | 'hot'
+  | 'climbing'
+  | 'rising'
+  | 'dormant'
+  | 'cooling'
+  | 'specialist'
+  | 'dual'
+  | 'none';
+
+export interface MinerStatus {
+  kind: MinerStatusKind;
+  icon: string;
+  label: string;
+  hint: string;
+}
+
+const REGISTRY: Record<
+  Exclude<MinerStatusKind, 'none'>,
+  Omit<MinerStatus, 'kind'>
+> = {
+  penalized: {
+    icon: '⚠️',
+    label: 'Penalized',
+    hint: 'Validator flagged this miner — see the details page for the failed_reason',
+  },
+  hot: {
+    icon: '🔥',
+    label: 'Hot',
+    hint: '≥3 merged PRs in the last 3 days',
+  },
+  climbing: {
+    icon: '🚀',
+    label: 'Climbing',
+    hint: 'Up ≥3 ranks since yesterday',
+  },
+  rising: {
+    icon: '📈',
+    label: 'Rising',
+    hint: 'Merged PRs up ≥50% this week vs the prior week',
+  },
+  dormant: {
+    icon: '💤',
+    label: 'Dormant',
+    hint: 'No merged PRs in the last 14 days',
+  },
+  cooling: {
+    icon: '🌙',
+    label: 'Cooling',
+    hint: 'No merged PRs this week (was active last week)',
+  },
+  specialist: {
+    icon: '🎯',
+    label: 'Specialist',
+    hint: '≤2 unique repos with ≥5 merged PRs (deep focus)',
+  },
+  dual: {
+    icon: '⚖️',
+    label: 'Dual',
+    hint: 'Eligible in both OSS and Discovery in at least one repo',
+  },
+};
+
+const TONE: Record<
+  Exclude<MinerStatusKind, 'none'>,
+  string
+> = MINER_STATUS_COLORS;
+
+export const STATUS_NONE: MinerStatus = {
+  kind: 'none',
+  icon: '',
+  label: '',
+  hint: '',
+};
+
+const make = (kind: Exclude<MinerStatusKind, 'none'>): MinerStatus => ({
+  kind,
+  ...REGISTRY[kind],
+});
+
+interface DeriveExtras {
+  previousRank?: number;
+  currentRank?: number;
+}
+
+export const deriveMinerStatus = (
+  miner: MinerEvaluation,
+  activity: MinerActivity,
+  extras: DeriveExtras = {},
+): MinerStatus => {
+  const failed = (miner.failedReason ?? '').trim();
+  if (failed) return { ...make('penalized'), hint: failed };
+
+  const recent3 = activity.dailyMerged.slice(-3).reduce((a, b) => a + b, 0);
+  const recent14 = activity.dailyMerged.slice(-14).reduce((a, b) => a + b, 0);
+  if (recent3 >= 3) return make('hot');
+
+  const { previousRank, currentRank } = extras;
+  if (
+    previousRank !== undefined &&
+    currentRank !== undefined &&
+    previousRank - currentRank >= 3
+  ) {
+    return make('climbing');
+  }
+
+  const last7 = activity.dailyMerged.slice(-7).reduce((a, b) => a + b, 0);
+  const prior7 =
+    activity.dailyMerged.length >= 14
+      ? activity.dailyMerged.slice(-14, -7).reduce((a, b) => a + b, 0)
+      : 0;
+  if (last7 >= 3 && prior7 > 0 && last7 >= prior7 * 1.5) return make('rising');
+
+  if (recent14 === 0) return make('dormant');
+
+  const uniqueRepos = parseNumber(miner.uniqueReposCount);
+  const merged = parseNumber(miner.totalMergedPrs);
+  if (uniqueRepos > 0 && uniqueRepos <= 2 && merged >= 5) {
+    return make('specialist');
+  }
+  if (miner.isEligible && miner.isIssueEligible) return make('dual');
+
+  if (last7 === 0 && prior7 > 0) return make('cooling');
+
+  return STATUS_NONE;
+};
+
+export const StatusBadge: React.FC<{ status: MinerStatus }> = ({ status }) => {
+  if (status.kind === 'none') return null;
+  const color = TONE[status.kind];
+  return (
+    <Tooltip
+      title={`${status.label} · ${status.hint}`}
+      arrow
+      placement="top"
+      slotProps={tooltipSlotProps}
+    >
+      <Box
+        sx={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: '3px',
+          px: '6px',
+          py: '2px',
+          borderRadius: '999px',
+          backgroundColor: alpha(color, 0.12),
+          border: `1px solid ${alpha(color, 0.3)}`,
+          color,
+          fontSize: '0.62rem',
+          fontWeight: 700,
+          letterSpacing: '0.3px',
+          lineHeight: 1,
+          flexShrink: 0,
+          whiteSpace: 'nowrap',
+        }}
+      >
+        <Box component="span" aria-hidden sx={{ fontSize: '0.7rem' }}>
+          {status.icon}
+        </Box>
+        <Typography
+          component="span"
+          sx={{
+            fontSize: 'inherit',
+            fontWeight: 'inherit',
+            letterSpacing: 'inherit',
+            color: 'inherit',
+            lineHeight: 1,
+          }}
+        >
+          {status.label}
+        </Typography>
+      </Box>
+    </Tooltip>
+  );
+};

--- a/src/components/leaderboard/MinerStatus.tsx
+++ b/src/components/leaderboard/MinerStatus.tsx
@@ -1,5 +1,16 @@
 import React from 'react';
 import { Box, Tooltip, Typography, alpha } from '@mui/material';
+import {
+  ReportProblemOutlined,
+  LocalFireDepartmentOutlined,
+  KeyboardDoubleArrowUp,
+  TrendingUp,
+  BedtimeOutlined,
+  TrendingDown,
+  GpsFixed,
+  Balance,
+  type SvgIconComponent,
+} from '@mui/icons-material';
 import type { MinerEvaluation } from '../../api';
 import { MINER_STATUS_COLORS, tooltipSlotProps } from '../../theme';
 import { parseNumber } from '../../utils/ExplorerUtils';
@@ -18,7 +29,7 @@ export type MinerStatusKind =
 
 export interface MinerStatus {
   kind: MinerStatusKind;
-  icon: string;
+  Icon: SvgIconComponent | null;
   label: string;
   hint: string;
 }
@@ -28,42 +39,42 @@ const REGISTRY: Record<
   Omit<MinerStatus, 'kind'>
 > = {
   penalized: {
-    icon: '⚠️',
+    Icon: ReportProblemOutlined,
     label: 'Penalized',
     hint: 'Validator flagged this miner — see the details page for the failed_reason',
   },
   hot: {
-    icon: '🔥',
+    Icon: LocalFireDepartmentOutlined,
     label: 'Hot',
     hint: '≥3 merged PRs in the last 3 days',
   },
   climbing: {
-    icon: '🚀',
+    Icon: KeyboardDoubleArrowUp,
     label: 'Climbing',
     hint: 'Up ≥3 ranks since yesterday',
   },
   rising: {
-    icon: '📈',
+    Icon: TrendingUp,
     label: 'Rising',
     hint: 'Merged PRs up ≥50% this week vs the prior week',
   },
   dormant: {
-    icon: '💤',
+    Icon: BedtimeOutlined,
     label: 'Dormant',
     hint: 'No merged PRs in the last 14 days',
   },
   cooling: {
-    icon: '🌙',
+    Icon: TrendingDown,
     label: 'Cooling',
     hint: 'No merged PRs this week (was active last week)',
   },
   specialist: {
-    icon: '🎯',
+    Icon: GpsFixed,
     label: 'Specialist',
     hint: '≤2 unique repos with ≥5 merged PRs (deep focus)',
   },
   dual: {
-    icon: '⚖️',
+    Icon: Balance,
     label: 'Dual',
     hint: 'Eligible in both OSS and Discovery in at least one repo',
   },
@@ -76,7 +87,7 @@ const TONE: Record<
 
 export const STATUS_NONE: MinerStatus = {
   kind: 'none',
-  icon: '',
+  Icon: null,
   label: '',
   hint: '',
 };
@@ -136,6 +147,7 @@ export const deriveMinerStatus = (
 export const StatusBadge: React.FC<{ status: MinerStatus }> = ({ status }) => {
   if (status.kind === 'none') return null;
   const color = TONE[status.kind];
+  const Icon = status.Icon;
   return (
     <Tooltip
       title={`${status.label} · ${status.hint}`}
@@ -162,9 +174,9 @@ export const StatusBadge: React.FC<{ status: MinerStatus }> = ({ status }) => {
           whiteSpace: 'nowrap',
         }}
       >
-        <Box component="span" aria-hidden sx={{ fontSize: '0.7rem' }}>
-          {status.icon}
-        </Box>
+        {Icon && (
+          <Icon aria-hidden sx={{ fontSize: '0.8rem', color: 'inherit' }} />
+        )}
         <Typography
           component="span"
           sx={{

--- a/src/components/leaderboard/MinersLeaderTable.tsx
+++ b/src/components/leaderboard/MinersLeaderTable.tsx
@@ -1,0 +1,3543 @@
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import {
+  Avatar,
+  Box,
+  Card,
+  Chip,
+  FormControl,
+  IconButton,
+  InputAdornment,
+  MenuItem,
+  Select,
+  TextField,
+  Tooltip,
+  Typography,
+  alpha,
+} from '@mui/material';
+import {
+  ArrowDownward as ArrowDownwardIcon,
+  ArrowUpward as ArrowUpwardIcon,
+  Close as ClearIcon,
+  Search as SearchIcon,
+  Sort as SortIcon,
+  StarBorder as StarBorderIcon,
+  ViewList as ViewListIcon,
+  ViewModule as ViewModuleIcon,
+} from '@mui/icons-material';
+import { GhIssueIcon, GhPrIcon } from './GhIcons';
+import { DataTable, type DataTableColumn } from '../common/DataTable';
+import { ClearSearchAdornment } from '../common/ClearSearchAdornment';
+import TablePagination from '../common/TablePagination';
+import { WatchlistButton } from '../common/WatchlistButton';
+import {
+  LEADERBOARD_TRACK_COLORS,
+  STATUS_COLORS,
+  TOOLTIP_TONE_COLORS,
+  tooltipSlotProps,
+} from '../../theme';
+import { getRepositoryOwnerAvatarSrc } from '../../utils/avatar';
+import { parseNumber } from '../../utils/ExplorerUtils';
+import { paginateItems } from '../../utils';
+import { useDataTableParams } from '../../hooks/useDataTableParams';
+import { useWatchlist } from '../../hooks/useWatchlist';
+import type { MinerEvaluation } from '../../api';
+import {
+  openPrSlotsAllowed,
+  resolveRepoThresholds,
+  splitEarnings,
+} from './scoring';
+import {
+  LEADERBOARD_VALID_ROWS,
+  LEADERBOARD_VIEW_QUERY_PARAM,
+  clampRowsForLeaderboardView,
+  defaultRowsForLeaderboardView,
+  getLeaderboardViewModeFromQuery,
+  readStoredLeaderboardViewMode,
+  rowsOptionsForLeaderboardView,
+  writeStoredLeaderboardViewMode,
+  type LeaderboardViewMode,
+} from './leaderboardViewMode';
+import Sparkline from './Sparkline';
+import SparklineDetailModal from './SparklineDetailModal';
+import {
+  useMinerActivityIndex,
+  type MinerActivity,
+} from './useMinerActivityIndex';
+import {
+  deriveMinerStatus,
+  StatusBadge,
+  type MinerStatus,
+} from './MinerStatus';
+import { NetworkPulsePill } from './NetworkPulsePill';
+import { useRankSnapshot } from './useRankSnapshot';
+import {
+  cohortOf,
+  COHORT_COLORS,
+  COHORT_DESCRIPTIONS,
+  COHORT_LABELS,
+  isAnyEligibleNow,
+  isDiscoveryEligibleNow,
+  isOssEligibleNow,
+  isPenalized,
+  type CohortKey,
+} from './eligibilityCohort';
+
+interface MinersLeaderTableProps {
+  miners: MinerEvaluation[];
+  isLoading: boolean;
+  selectedRepo: string | null;
+  onSelectRepo: (repo: string | null) => void;
+  selectedCohort: CohortKey | null;
+  onClearCohort: () => void;
+}
+
+const SORT_FIELDS = [
+  'score',
+  'usd',
+  'credibility',
+  'volume',
+  'active',
+  'movement',
+  'reviewHits',
+  'openPrRisk',
+  'watch',
+] as const;
+type SortField = (typeof SORT_FIELDS)[number];
+
+type EligibilityFilter = 'all' | 'eligible' | 'ineligible';
+
+const EMPTY_ACTIVITY: MinerActivity = {
+  dailyMerged: [],
+  dailyOss: [],
+  dailyDiscovery: [],
+  topRepos: [],
+  lastActiveAt: null,
+  reviewHits: 0,
+};
+
+// Network defaults from ELIGIBILITY_FIELD_DEFS; leaderboard lacks per-repo data.
+const NETWORK_OPEN_PR_THRESHOLDS = resolveRepoThresholds(undefined);
+
+const combinedScore = (m: MinerEvaluation): number =>
+  parseNumber(m.totalScore) + parseNumber(m.issueDiscoveryScore);
+
+const round1 = (n: number): number => Math.round(n * 10) / 10;
+
+// Sum of the per-track values as shown in the UI — so the displayed Score
+// always equals the visible OSS + Discovery, avoiding "rounded parts don't add up".
+const displayedCombinedScore = (m: MinerEvaluation): number =>
+  round1(parseNumber(m.totalScore)) +
+  round1(parseNumber(m.issueDiscoveryScore));
+
+const totalVolume = (m: MinerEvaluation): number =>
+  parseNumber(m.totalMergedPrs) + parseNumber(m.totalSolvedIssues);
+
+interface OpenPrRisk {
+  open: number;
+  allowed: number;
+  ratio: number;
+}
+
+const computeOpenPrRisk = (m: MinerEvaluation): OpenPrRisk => {
+  const open = Math.max(0, Math.round(parseNumber(m.totalOpenPrs)));
+  const tokenScore = Math.max(0, parseNumber(m.totalTokenScore));
+  const allowed = openPrSlotsAllowed(NETWORK_OPEN_PR_THRESHOLDS, tokenScore);
+  const ratio = allowed > 0 ? open / allowed : open > 0 ? Infinity : 0;
+  return { open, allowed, ratio };
+};
+
+const fmtUsd = (n: number): string => {
+  if (n <= 0) return '—';
+  if (n < 1) return '<$1';
+  if (n >= 10_000) return `$${(n / 1000).toFixed(1)}k`;
+  return `$${Math.round(n).toLocaleString()}`;
+};
+
+const formatLastActive = (iso: string | null | undefined): string => {
+  if (!iso) return '—';
+  const t = Date.parse(iso);
+  if (!Number.isFinite(t)) return '—';
+  const mins = Math.floor((Date.now() - t) / 60_000);
+  if (mins < 1) return 'just now';
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days}d ago`;
+  const months = Math.floor(days / 30);
+  return `${months}mo ago`;
+};
+
+const SparklineButton: React.FC<{
+  username: string;
+  githubId?: string;
+  primaryValues: readonly number[];
+  secondaryValues: readonly number[];
+  width: number;
+  height: number;
+  primaryLabel?: string;
+  secondaryLabel?: string;
+  emphasis?: boolean;
+}> = ({
+  username,
+  githubId,
+  primaryValues,
+  secondaryValues,
+  width,
+  height,
+  primaryLabel = 'OSS',
+  secondaryLabel = 'Discovery',
+  emphasis = false,
+}) => {
+  const [open, setOpen] = useState(false);
+  const totalPrimary = primaryValues.reduce((a, b) => a + b, 0);
+  const totalSecondary = secondaryValues.reduce((a, b) => a + b, 0);
+  const hasAny = totalPrimary > 0 || totalSecondary > 0;
+  return (
+    <>
+      <Box
+        component="button"
+        type="button"
+        aria-label={`Open ${username}'s activity chart`}
+        disabled={!hasAny}
+        onClick={(e) => {
+          e.stopPropagation();
+          if (hasAny) setOpen(true);
+        }}
+        sx={(t) => ({
+          background: 'transparent',
+          border: 'none',
+          padding: 0,
+          borderRadius: 0.5,
+          cursor: hasAny ? 'pointer' : 'default',
+          display: 'inline-flex',
+          alignItems: 'center',
+          transition: 'opacity 0.12s',
+          '&:hover': hasAny ? { opacity: 0.75 } : undefined,
+          '&:focus-visible': hasAny
+            ? {
+                outline: `2px solid ${t.palette.primary.main}`,
+                outlineOffset: 2,
+              }
+            : undefined,
+          '&:disabled': { cursor: 'default' },
+        })}
+      >
+        <Sparkline
+          values={primaryValues}
+          secondaryValues={secondaryValues}
+          width={width}
+          height={height}
+          primaryLabel={primaryLabel}
+          secondaryLabel={secondaryLabel}
+          emphasis={emphasis}
+        />
+      </Box>
+      <SparklineDetailModal
+        open={open}
+        onClose={() => setOpen(false)}
+        username={username}
+        githubId={githubId}
+        primaryValues={primaryValues}
+        secondaryValues={secondaryValues}
+        primaryLabel={primaryLabel}
+        secondaryLabel={secondaryLabel}
+      />
+    </>
+  );
+};
+
+// Only re-renders when integer width changes by >1px so resize observers don't churn.
+const ResponsiveSparklineButton: React.FC<{
+  username: string;
+  githubId?: string;
+  primaryValues: readonly number[];
+  secondaryValues: readonly number[];
+  height: number;
+  primaryLabel?: string;
+  secondaryLabel?: string;
+  emphasis?: boolean;
+}> = ({
+  username,
+  githubId,
+  primaryValues,
+  secondaryValues,
+  height,
+  primaryLabel,
+  secondaryLabel,
+  emphasis,
+}) => {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [width, setWidth] = useState(0);
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el || typeof ResizeObserver === 'undefined') return;
+    const ro = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (!entry) return;
+      const next = Math.floor(entry.contentRect.width);
+      setWidth((prev) => (Math.abs(prev - next) > 1 ? next : prev));
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+  return (
+    <Box
+      ref={containerRef}
+      sx={{
+        width: '100%',
+        minWidth: 0,
+        height,
+        display: 'flex',
+        alignItems: 'center',
+        '& > button': { width: '100%' },
+      }}
+    >
+      {width > 0 && (
+        <SparklineButton
+          username={username}
+          githubId={githubId}
+          primaryValues={primaryValues}
+          secondaryValues={secondaryValues}
+          width={width}
+          height={height}
+          primaryLabel={primaryLabel}
+          secondaryLabel={secondaryLabel}
+          emphasis={emphasis}
+        />
+      )}
+    </Box>
+  );
+};
+
+/* ─── Cell components ──────────────────────────────────────────────────── */
+
+const TooltipSplitBar: React.FC<{
+  segments: Array<{ label: string; value: number; color: string }>;
+}> = ({ segments }) => {
+  const total = segments.reduce((a, s) => a + s.value, 0);
+  if (total <= 0) return null;
+  return (
+    <Box sx={{ mt: '6px' }}>
+      <Box
+        sx={{
+          display: 'flex',
+          height: 5,
+          borderRadius: 999,
+          overflow: 'hidden',
+          backgroundColor: alpha('#fff', 0.08),
+        }}
+      >
+        {segments.map((s) => {
+          const pct = (s.value / total) * 100;
+          if (pct <= 0) return null;
+          return (
+            <Box
+              key={s.label}
+              sx={{ width: `${pct}%`, backgroundColor: s.color }}
+            />
+          );
+        })}
+      </Box>
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          mt: '3px',
+          fontSize: '0.62rem',
+          color: alpha('#fff', 0.5),
+        }}
+      >
+        {segments.map((s) => {
+          const pct = Math.round((s.value / total) * 100);
+          return (
+            <Box
+              key={s.label}
+              component="span"
+              sx={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: '4px',
+              }}
+            >
+              <Box
+                component="span"
+                sx={{
+                  width: 6,
+                  height: 6,
+                  borderRadius: '50%',
+                  backgroundColor: s.color,
+                }}
+              />
+              {s.label} {pct}%
+            </Box>
+          );
+        })}
+      </Box>
+    </Box>
+  );
+};
+
+const RowTooltipContent: React.FC<{
+  title: React.ReactNode;
+  body?: React.ReactNode;
+  action?: string;
+  tone?: 'default' | 'positive' | 'caution' | 'negative';
+}> = ({ title, body, action, tone = 'default' }) => {
+  const titleColor =
+    tone === 'positive'
+      ? TOOLTIP_TONE_COLORS.positive
+      : tone === 'caution'
+        ? TOOLTIP_TONE_COLORS.caution
+        : tone === 'negative'
+          ? TOOLTIP_TONE_COLORS.negative
+          : 'inherit';
+  return (
+    <Box sx={{ lineHeight: 1.45, maxWidth: 280 }}>
+      <Box sx={{ fontWeight: 700, fontSize: '0.78rem', color: titleColor }}>
+        {title}
+      </Box>
+      {body && (
+        <Box sx={{ fontSize: '0.7rem', opacity: 0.82, mt: '2px' }}>{body}</Box>
+      )}
+      {action && (
+        <Box
+          sx={{
+            fontSize: '0.68rem',
+            fontWeight: 700,
+            mt: '4px',
+            color: TOOLTIP_TONE_COLORS.positive,
+          }}
+        >
+          → {action}
+        </Box>
+      )}
+    </Box>
+  );
+};
+
+const MovementGlyph: React.FC<{
+  globalRank: number;
+  previousRank: number | undefined;
+  isHydrated: boolean;
+}> = ({ globalRank, previousRank, isHydrated }) => {
+  if (!isHydrated) {
+    return (
+      <Typography
+        aria-hidden
+        sx={{
+          fontFamily: '"JetBrains Mono", monospace',
+          fontSize: '0.6rem',
+          color: alpha('#fff', 0.18),
+          lineHeight: 1,
+        }}
+      >
+        ·
+      </Typography>
+    );
+  }
+  if (previousRank === undefined) {
+    return (
+      <Tooltip
+        title={
+          <RowTooltipContent
+            title="New to the leaderboard"
+            body="Movement arrows appear once you've been ranked for at least one full UTC day. Check back tomorrow."
+          />
+        }
+        arrow
+        placement="right"
+        slotProps={tooltipSlotProps}
+      >
+        <Typography
+          sx={{
+            fontFamily: '"JetBrains Mono", monospace',
+            fontSize: '0.6rem',
+            color: alpha('#fff', 0.3),
+            lineHeight: 1,
+            cursor: 'help',
+          }}
+        >
+          new
+        </Typography>
+      </Tooltip>
+    );
+  }
+  const delta = previousRank - globalRank;
+  if (delta === 0) {
+    return (
+      <Tooltip
+        title={
+          <RowTooltipContent
+            title={`Holding at #${globalRank}`}
+            body="No rank change since yesterday's UTC snapshot."
+          />
+        }
+        arrow
+        placement="right"
+        slotProps={tooltipSlotProps}
+      >
+        <Typography
+          sx={{
+            fontFamily: '"JetBrains Mono", monospace',
+            fontSize: '0.65rem',
+            color: alpha('#fff', 0.3),
+            lineHeight: 1,
+            cursor: 'help',
+          }}
+        >
+          ·
+        </Typography>
+      </Tooltip>
+    );
+  }
+  const up = delta > 0;
+  const abs = Math.abs(delta);
+  return (
+    <Tooltip
+      title={
+        <RowTooltipContent
+          title={`${up ? '↑' : '↓'} ${abs} rank${abs === 1 ? '' : 's'} since yesterday`}
+          body={
+            <>
+              <Box
+                component="span"
+                sx={{ fontFamily: '"JetBrains Mono", monospace' }}
+              >
+                #{previousRank} → #{globalRank}
+              </Box>{' '}
+              ({up ? 'climbed' : 'slipped'} by {abs}) since the last UTC
+              snapshot.
+            </>
+          }
+          tone={up ? 'positive' : 'negative'}
+        />
+      }
+      arrow
+      placement="right"
+      slotProps={tooltipSlotProps}
+    >
+      <Typography
+        sx={{
+          fontFamily: '"JetBrains Mono", monospace',
+          fontSize: '0.66rem',
+          fontWeight: 700,
+          color: up ? STATUS_COLORS.success : STATUS_COLORS.closed,
+          lineHeight: 1,
+          letterSpacing: '-0.02em',
+          cursor: 'help',
+        }}
+      >
+        {up ? '↑' : '↓'}
+        {abs}
+      </Typography>
+    </Tooltip>
+  );
+};
+
+const RankCell: React.FC<{
+  globalRank: number;
+  previousRank: number | undefined;
+  isHydrated: boolean;
+}> = ({ globalRank, previousRank, isHydrated }) => {
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        gap: '3px',
+      }}
+    >
+      <Typography
+        sx={{
+          fontFamily: '"JetBrains Mono", monospace',
+          fontSize: '0.85rem',
+          fontWeight: 600,
+          color: alpha('#fff', 0.7),
+          lineHeight: 1,
+          letterSpacing: '-0.02em',
+          textAlign: 'center',
+        }}
+      >
+        {globalRank}
+      </Typography>
+      <MovementGlyph
+        globalRank={globalRank}
+        previousRank={previousRank}
+        isHydrated={isHydrated}
+      />
+    </Box>
+  );
+};
+
+const IdentityCell: React.FC<{
+  miner: MinerEvaluation;
+  status: MinerStatus;
+}> = ({ miner, status }) => {
+  const username = miner.githubUsername ?? `uid-${miner.uid}`;
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 0 }}>
+      <Avatar
+        src={getRepositoryOwnerAvatarSrc(username)}
+        alt={username}
+        sx={(t) => ({
+          width: 26,
+          height: 26,
+          border: `1px solid ${t.palette.border.medium}`,
+          flexShrink: 0,
+        })}
+      />
+      <Box
+        sx={{
+          minWidth: 0,
+          flex: 1,
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 0.4,
+        }}
+      >
+        <Typography
+          sx={{
+            fontSize: '0.85rem',
+            fontWeight: 600,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+            lineHeight: 1.2,
+          }}
+        >
+          {username}
+        </Typography>
+        {status.kind !== 'none' && (
+          <Box sx={{ display: 'flex' }}>
+            <StatusBadge status={status} />
+          </Box>
+        )}
+      </Box>
+    </Box>
+  );
+};
+
+const trackTooltip = (args: {
+  trackLabel: string;
+  trackBadge: string;
+  count: number;
+  countSuffix: string;
+  score: number;
+  eligible: boolean;
+  eligibleRepos: number;
+}) => {
+  const eligibilityLine = args.eligible
+    ? `Eligible in ${args.eligibleRepos} repo${args.eligibleRepos === 1 ? '' : 's'} — earning on this track.`
+    : args.score > 0
+      ? 'Scoring on this track but below the eligibility threshold in every repo — no payout yet.'
+      : 'No activity on this track yet.';
+  return (
+    <RowTooltipContent
+      title={`${args.trackLabel} track`}
+      body={
+        <>
+          <Box
+            component="span"
+            sx={{ fontFamily: '"JetBrains Mono", monospace' }}
+          >
+            {args.count.toLocaleString()}
+          </Box>{' '}
+          {args.countSuffix} · score{' '}
+          <Box
+            component="span"
+            sx={{ fontFamily: '"JetBrains Mono", monospace' }}
+          >
+            {args.score.toFixed(2)}
+          </Box>
+          <Box sx={{ mt: '4px' }}>{eligibilityLine}</Box>
+        </>
+      }
+      tone={args.eligible ? 'positive' : args.score > 0 ? 'caution' : 'default'}
+    />
+  );
+};
+
+const EligibilityPill: React.FC<{
+  trackColor: string;
+  eligible: boolean;
+  trackBadge: string;
+  eligibleRepos: number;
+}> = ({ trackColor, eligible, trackBadge, eligibleRepos }) => {
+  if (!eligible) return null;
+  return (
+    <Box
+      sx={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: '5px',
+        px: '8px',
+        py: '4px',
+        borderRadius: 0.75,
+        backgroundColor: alpha(trackColor, 0.16),
+        border: `1px solid ${alpha(trackColor, 0.55)}`,
+        lineHeight: 1,
+        width: 'fit-content',
+      }}
+    >
+      <Box
+        component="span"
+        sx={{
+          fontSize: '0.62rem',
+          fontWeight: 700,
+          letterSpacing: '0.5px',
+          fontFamily: '"JetBrains Mono", monospace',
+          color: trackColor,
+          lineHeight: 1,
+        }}
+      >
+        {trackBadge}
+      </Box>
+      <Box
+        component="span"
+        aria-hidden
+        sx={{
+          width: '1px',
+          height: '9px',
+          backgroundColor: alpha(trackColor, 0.45),
+          flexShrink: 0,
+        }}
+      />
+      <Box
+        component="span"
+        aria-label={`Eligible in ${eligibleRepos} repo${eligibleRepos === 1 ? '' : 's'}`}
+        sx={{
+          fontSize: '0.62rem',
+          fontWeight: 700,
+          fontFamily: '"JetBrains Mono", monospace',
+          color: trackColor,
+          lineHeight: 1,
+          opacity: 0.85,
+          fontVariantNumeric: 'tabular-nums',
+        }}
+      >
+        {eligibleRepos}
+      </Box>
+    </Box>
+  );
+};
+
+// Always returns a color so every row/card carries a rail matching its cohort.
+const resolveMinerAccentColor = (m: MinerEvaluation): string => {
+  if ((m.failedReason ?? '').trim()) return STATUS_COLORS.closed;
+  return COHORT_COLORS[cohortOf(m)];
+};
+
+const ContributionStatsRow: React.FC<{
+  track: TrackInfo;
+}> = ({ track }) => {
+  const { Icon, count, score } = track;
+  const iconColor =
+    count > 0
+      ? LEADERBOARD_TRACK_COLORS.dual
+      : alpha(LEADERBOARD_TRACK_COLORS.dual, 0.35);
+  return (
+    <>
+      <Tooltip
+        title={trackTooltip(track)}
+        arrow
+        placement="top"
+        slotProps={tooltipSlotProps}
+      >
+        <Box
+          sx={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            cursor: 'help',
+          }}
+        >
+          <Icon size={13} color={iconColor} />
+        </Box>
+      </Tooltip>
+      <Typography
+        sx={{
+          fontSize: '0.82rem',
+          fontWeight: 600,
+          fontFamily: '"JetBrains Mono", monospace',
+          color: alpha('#fff', count > 0 ? 0.38 : 0.18),
+          lineHeight: 1.2,
+          textAlign: 'right',
+          fontVariantNumeric: 'tabular-nums',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {count > 0 ? count.toLocaleString() : '—'}
+      </Typography>
+      <Box
+        component="span"
+        aria-hidden
+        sx={{
+          fontFamily: '"JetBrains Mono", monospace',
+          fontSize: '0.7rem',
+          color: alpha('#fff', 0.38),
+          fontWeight: 500,
+          lineHeight: 1,
+          letterSpacing: '-0.01em',
+          justifySelf: 'center',
+          // visibility:hidden preserves grid column width across OSS/DISC rows.
+          visibility: score > 0 ? 'visible' : 'hidden',
+        }}
+      >
+        →
+      </Box>
+      <Typography
+        sx={{
+          fontSize: '0.82rem',
+          fontWeight: 700,
+          fontFamily: '"JetBrains Mono", monospace',
+          color: alpha('#fff', score > 0 ? 0.38 : 0.18),
+          lineHeight: 1.2,
+          letterSpacing: '-0.02em',
+          textAlign: 'right',
+          fontVariantNumeric: 'tabular-nums',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {score > 0 ? score.toFixed(1) : '—'}
+      </Typography>
+    </>
+  );
+};
+
+const trackStatsGridSx = {
+  display: 'grid',
+  gridTemplateColumns: 'auto auto 1fr auto',
+  alignItems: 'center',
+  columnGap: '6px',
+  rowGap: '6px',
+  minWidth: 0,
+} as const;
+
+interface TrackInfo {
+  Icon: React.ComponentType<{ size?: number; color?: string }>;
+  trackColor: string;
+  count: number;
+  score: number;
+  eligible: boolean;
+  eligibleRepos: number;
+  countSuffix: string;
+  trackLabel: string;
+  trackBadge: string;
+}
+
+const tracksFor = (miner: MinerEvaluation): [TrackInfo, TrackInfo] => [
+  {
+    Icon: GhPrIcon,
+    trackColor: STATUS_COLORS.merged,
+    count: parseNumber(miner.totalMergedPrs),
+    score: parseNumber(miner.totalScore),
+    eligible: isOssEligibleNow(miner),
+    eligibleRepos: miner.eligibleRepoCount ?? 0,
+    countSuffix: 'merged',
+    trackLabel: 'OSS',
+    trackBadge: 'OSS',
+  },
+  {
+    Icon: GhIssueIcon,
+    trackColor: STATUS_COLORS.info,
+    count: parseNumber(miner.totalSolvedIssues),
+    score: parseNumber(miner.issueDiscoveryScore),
+    eligible: isDiscoveryEligibleNow(miner),
+    eligibleRepos: miner.issueEligibleRepoCount ?? 0,
+    countSuffix: 'solved',
+    trackLabel: 'Discovery',
+    trackBadge: 'DISC',
+  },
+];
+
+const EligibilityCell: React.FC<{ miner: MinerEvaluation }> = ({ miner }) => {
+  const eligibleTracks = tracksFor(miner).filter((t) => t.eligible);
+  if (eligibleTracks.length === 0) {
+    return (
+      <Tooltip
+        title={
+          <RowTooltipContent
+            title="No eligible tracks"
+            body="This miner hasn't crossed the eligibility threshold on either OSS or Discovery, so no payout is flowing."
+            tone="caution"
+          />
+        }
+        arrow
+        placement="top"
+        slotProps={tooltipSlotProps}
+      >
+        <Box
+          component="span"
+          sx={{
+            fontFamily: '"JetBrains Mono", monospace',
+            fontSize: '0.75rem',
+            color: alpha('#fff', 0.28),
+            cursor: 'help',
+          }}
+        >
+          —
+        </Box>
+      </Tooltip>
+    );
+  }
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'row',
+        flexWrap: 'wrap',
+        gap: '6px',
+        minWidth: 0,
+        alignItems: 'center',
+      }}
+    >
+      {eligibleTracks.map((t) => (
+        <Tooltip
+          key={t.trackLabel}
+          title={trackTooltip(t)}
+          arrow
+          placement="top"
+          slotProps={tooltipSlotProps}
+        >
+          <Box sx={{ display: 'inline-flex' }}>
+            <EligibilityPill
+              trackColor={t.trackColor}
+              eligible={t.eligible}
+              trackBadge={t.trackBadge}
+              eligibleRepos={t.eligibleRepos}
+            />
+          </Box>
+        </Tooltip>
+      ))}
+    </Box>
+  );
+};
+
+const ContributionStatsCell: React.FC<{ miner: MinerEvaluation }> = ({
+  miner,
+}) => {
+  const tracks = tracksFor(miner);
+  return (
+    <Box sx={trackStatsGridSx}>
+      {tracks.map((t) => (
+        <ContributionStatsRow key={t.trackLabel} track={t} />
+      ))}
+    </Box>
+  );
+};
+
+const RepoChip: React.FC<{
+  name: string;
+  count: number;
+  active: boolean;
+  onClick: (repo: string) => void;
+}> = ({ name, count, active, onClick }) => {
+  const slash = name.lastIndexOf('/');
+  const short = slash >= 0 ? name.slice(slash + 1) : name;
+  return (
+    <Tooltip
+      title={
+        <RowTooltipContent
+          title={name}
+          body={
+            <>
+              <Box
+                component="span"
+                sx={{ fontFamily: '"JetBrains Mono", monospace' }}
+              >
+                {count.toLocaleString()}
+              </Box>{' '}
+              merged PR{count === 1 ? '' : 's'} from this miner in the last 30d.
+            </>
+          }
+          action={
+            active
+              ? 'Click to clear the repo filter'
+              : 'Click to filter the table to this repo'
+          }
+        />
+      }
+      arrow
+      placement="top"
+      slotProps={tooltipSlotProps}
+    >
+      <Box
+        component="button"
+        type="button"
+        onClick={(e) => {
+          e.stopPropagation();
+          onClick(name);
+        }}
+        sx={(t) => ({
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          gap: '8px',
+          width: '100%',
+          px: 0,
+          py: 0,
+          border: 'none',
+          borderRadius: '2px',
+          backgroundColor: 'transparent',
+          color: active
+            ? t.palette.primary.main
+            : alpha(t.palette.text.primary, 0.7),
+          fontFamily: '"JetBrains Mono", monospace',
+          fontSize: '0.72rem',
+          fontWeight: active ? 700 : 500,
+          lineHeight: 1.3,
+          cursor: 'pointer',
+          minWidth: 0,
+          textAlign: 'left',
+          transition: 'color 0.12s',
+          '&:hover': {
+            color: active ? t.palette.primary.main : t.palette.text.primary,
+            '& .repo-chip-name': {
+              textDecoration: 'underline',
+              textUnderlineOffset: 2,
+            },
+          },
+          '&:focus-visible': {
+            outline: `2px solid ${t.palette.primary.main}`,
+            outlineOffset: 2,
+          },
+        })}
+      >
+        <Box
+          component="span"
+          className="repo-chip-name"
+          sx={{
+            flex: 1,
+            minWidth: 0,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+            textAlign: 'left',
+          }}
+        >
+          {short}
+        </Box>
+        <Box
+          component="span"
+          sx={{
+            fontSize: '0.65rem',
+            color: alpha('#fff', 0.4),
+            fontWeight: 500,
+            flexShrink: 0,
+            textAlign: 'right',
+          }}
+        >
+          {count}
+        </Box>
+      </Box>
+    </Tooltip>
+  );
+};
+
+const TopReposCell: React.FC<{
+  repos: { name: string; count: number }[];
+  selectedRepo: string | null;
+  onSelectRepo: (repo: string) => void;
+}> = ({ repos, selectedRepo, onSelectRepo }) => {
+  if (repos.length === 0) {
+    return (
+      <Typography
+        sx={{
+          fontSize: '0.7rem',
+          color: alpha('#fff', 0.3),
+          fontFamily: '"JetBrains Mono", monospace',
+        }}
+      >
+        —
+      </Typography>
+    );
+  }
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '2px',
+        minWidth: 0,
+      }}
+    >
+      {repos.map((r) => (
+        <RepoChip
+          key={r.name}
+          name={r.name}
+          count={r.count}
+          active={selectedRepo === r.name}
+          onClick={onSelectRepo}
+        />
+      ))}
+    </Box>
+  );
+};
+
+/* ─── Mobile card view ────────────────────────────────────────────────── */
+
+const StatTile: React.FC<{
+  label: string;
+  value: React.ReactNode;
+  valueColor?: string;
+  valueSize?: string;
+  valueWeight?: number;
+  suffix?: React.ReactNode;
+  secondaryValue?: React.ReactNode;
+  icon?: React.ReactNode;
+  tooltip?: React.ReactNode;
+}> = ({
+  label,
+  value,
+  valueColor,
+  valueSize,
+  valueWeight,
+  suffix,
+  secondaryValue,
+  icon,
+  tooltip,
+}) => {
+  const inner = (
+    <Box
+      sx={(t) => ({
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '6px',
+        px: 1.25,
+        py: 1,
+        backgroundColor: alpha(t.palette.text.primary, 0.025),
+        border: `1px solid ${t.palette.border.subtle}`,
+        borderRadius: 1.25,
+        minWidth: 0,
+        cursor: tooltip ? 'help' : 'default',
+        transition: 'background-color 0.12s, border-color 0.12s',
+        '&:hover': tooltip
+          ? {
+              backgroundColor: alpha(t.palette.text.primary, 0.045),
+              borderColor: t.palette.border.light,
+            }
+          : undefined,
+      })}
+    >
+      <Typography
+        sx={{
+          fontSize: '0.55rem',
+          color: alpha('#fff', 0.5),
+          textTransform: 'uppercase',
+          letterSpacing: '0.8px',
+          fontWeight: 700,
+          lineHeight: 1,
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {label}
+      </Typography>
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'baseline',
+          gap: '5px',
+          minWidth: 0,
+        }}
+      >
+        {icon && (
+          <Box
+            sx={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              flexShrink: 0,
+              alignSelf: 'center',
+            }}
+          >
+            {icon}
+          </Box>
+        )}
+        <Typography
+          sx={{
+            fontFamily: '"JetBrains Mono", monospace',
+            fontSize: valueSize ?? '1.05rem',
+            fontWeight: valueWeight ?? 700,
+            color: valueColor ?? 'text.primary',
+            lineHeight: 1.1,
+            letterSpacing: '-0.02em',
+            fontVariantNumeric: 'tabular-nums',
+            whiteSpace: 'nowrap',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            minWidth: 0,
+          }}
+        >
+          {value}
+        </Typography>
+        {suffix && (
+          <Box
+            component="span"
+            sx={{
+              fontFamily: '"JetBrains Mono", monospace',
+              fontSize: '0.68rem',
+              color: alpha('#fff', 0.4),
+              fontWeight: 500,
+              flexShrink: 0,
+            }}
+          >
+            {suffix}
+          </Box>
+        )}
+        {secondaryValue !== undefined && secondaryValue !== null && (
+          <Box
+            component="span"
+            sx={{
+              display: 'inline-flex',
+              alignItems: 'baseline',
+              gap: '4px',
+              fontFamily: '"JetBrains Mono", monospace',
+              fontSize: '0.78rem',
+              color: alpha('#fff', 0.55),
+              fontWeight: 600,
+              fontVariantNumeric: 'tabular-nums',
+              flexShrink: 0,
+              ml: '2px',
+            }}
+          >
+            <Box
+              component="span"
+              aria-hidden
+              sx={{
+                fontSize: '0.7rem',
+                color: alpha('#fff', 0.3),
+                fontWeight: 500,
+              }}
+            >
+              →
+            </Box>
+            {secondaryValue}
+          </Box>
+        )}
+      </Box>
+    </Box>
+  );
+  if (!tooltip) return inner;
+  return (
+    <Tooltip title={tooltip} arrow placement="top" slotProps={tooltipSlotProps}>
+      {inner}
+    </Tooltip>
+  );
+};
+
+const MobileMinerCard: React.FC<{
+  row: RankedMiner;
+  isHydrated: boolean;
+  selectedRepo: string | null;
+  onSelectRepo: (repo: string) => void;
+}> = ({ row, isHydrated, selectedRepo, onSelectRepo }) => {
+  const navigate = useNavigate();
+  const username = row.miner.githubUsername ?? `uid-${row.miner.uid}`;
+  const usd = parseNumber(row.miner.usdPerDay);
+  const { open, allowed, ratio } = row.openPrRisk;
+  const failed = (row.miner.failedReason ?? '').toLowerCase();
+  const flaggedByValidator = failed.includes('open pr');
+  const openPrColor =
+    flaggedByValidator || ratio >= 1 || open > allowed
+      ? STATUS_COLORS.closed
+      : ratio >= 0.5
+        ? STATUS_COLORS.warningOrange
+        : open === 0
+          ? alpha('#fff', 0.55)
+          : STATUS_COLORS.success;
+  const hits = row.activity.reviewHits;
+  const mergedTotal = parseNumber(row.miner.totalMergedPrs);
+  const ossScore = parseNumber(row.miner.totalScore);
+  const solvedTotal = parseNumber(row.miner.totalSolvedIssues);
+  const discoveryScore = parseNumber(row.miner.issueDiscoveryScore);
+  const reviewsValue =
+    hits === 0 ? (mergedTotal > 0 ? '·' : '—') : String(hits);
+  const reviewsColor =
+    hits === 0
+      ? alpha('#fff', mergedTotal > 0 ? 0.32 : 0.25)
+      : hits >= 5
+        ? STATUS_COLORS.closed
+        : STATUS_COLORS.warningOrange;
+  const lastActiveLabel = formatLastActive(row.activity.lastActiveAt);
+  const lastActiveColor = row.activity.lastActiveAt
+    ? alpha('#fff', 0.75)
+    : alpha('#fff', 0.3);
+  const topRepos = row.activity.topRepos.slice(0, 2);
+  const isEligibleAny = isAnyEligibleNow(row.miner);
+  const accentColor = resolveMinerAccentColor(row.miner);
+
+  return (
+    <Box
+      role="button"
+      tabIndex={0}
+      onClick={() => navigate(`/miners/details?githubId=${row.miner.githubId}`)}
+      onKeyDown={(event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          navigate(`/miners/details?githubId=${row.miner.githubId}`);
+        }
+      }}
+      sx={(t) => ({
+        cursor: 'pointer',
+        position: 'relative',
+        width: '100%',
+        minWidth: 0,
+        maxWidth: '100%',
+        boxSizing: 'border-box',
+        overflow: 'hidden',
+        pl: { xs: 1.75, sm: 2 },
+        pr: { xs: 1.5, sm: 1.75 },
+        py: 1.5,
+        backgroundColor: t.palette.surface.subtle,
+        border: `1px solid ${alpha(accentColor, isEligibleAny ? 0.45 : 0.25)}`,
+        borderRadius: 2,
+        filter: isEligibleAny ? 'none' : 'brightness(0.88) saturate(0.92)',
+        '&::before': {
+          content: '""',
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          bottom: 0,
+          width: 3,
+          backgroundColor: accentColor,
+          boxShadow: `0 0 8px 0 ${alpha(accentColor, isEligibleAny ? 0.45 : 0.2)}`,
+        },
+        transition:
+          'background-color 0.15s, border-color 0.15s, transform 0.15s, filter 0.15s',
+        '&:hover': {
+          backgroundColor: t.palette.surface.light,
+          borderColor: t.palette.border.medium,
+          filter: isEligibleAny ? 'none' : 'brightness(0.98) saturate(0.98)',
+        },
+        '&:focus-visible': {
+          outline: `2px solid ${t.palette.primary.main}`,
+          outlineOffset: -2,
+        },
+      })}
+    >
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+        <RankCell
+          globalRank={row.rank}
+          previousRank={row.previousRank}
+          isHydrated={isHydrated}
+        />
+        <Avatar
+          src={getRepositoryOwnerAvatarSrc(username)}
+          alt={username}
+          sx={(t) => ({
+            width: 32,
+            height: 32,
+            border: `1px solid ${t.palette.border.medium}`,
+            flexShrink: 0,
+          })}
+        />
+        <Box
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 0.5,
+            flex: 1,
+            minWidth: 0,
+          }}
+        >
+          <Typography
+            sx={{
+              fontSize: '0.95rem',
+              fontWeight: 700,
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+              lineHeight: 1.2,
+              letterSpacing: '-0.005em',
+              minWidth: 0,
+            }}
+          >
+            {username}
+          </Typography>
+          {(row.status.kind !== 'none' || isAnyEligibleNow(row.miner)) && (
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 0.75,
+                flexWrap: 'wrap',
+                rowGap: 0.5,
+                minWidth: 0,
+              }}
+            >
+              {row.status.kind !== 'none' && (
+                <Box sx={{ display: 'inline-flex', flexShrink: 0 }}>
+                  <StatusBadge status={row.status} />
+                </Box>
+              )}
+              {isAnyEligibleNow(row.miner) && (
+                <Box sx={{ display: 'inline-flex', flexShrink: 0 }}>
+                  <EligibilityCell miner={row.miner} />
+                </Box>
+              )}
+            </Box>
+          )}
+        </Box>
+        <Box
+          sx={{ flexShrink: 0 }}
+          onClick={(e) => e.stopPropagation()}
+          onKeyDown={(e) => e.stopPropagation()}
+        >
+          <WatchlistButton
+            category="miners"
+            itemKey={row.miner.githubId}
+            size="small"
+          />
+        </Box>
+      </Box>
+
+      <Box
+        onClick={(e) => e.stopPropagation()}
+        sx={{
+          mt: 1.5,
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 0.6,
+          minWidth: 0,
+        }}
+      >
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'baseline',
+            justifyContent: 'space-between',
+            gap: 1,
+          }}
+        >
+          <Typography
+            sx={{
+              fontSize: '0.55rem',
+              color: alpha('#fff', 0.5),
+              textTransform: 'uppercase',
+              letterSpacing: '0.8px',
+              fontWeight: 700,
+              lineHeight: 1,
+            }}
+          >
+            30-day activity
+          </Typography>
+          <Typography
+            sx={{
+              fontSize: '0.65rem',
+              fontFamily: '"JetBrains Mono", monospace',
+              fontWeight: 600,
+              color: lastActiveColor,
+              lineHeight: 1,
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {lastActiveLabel}
+          </Typography>
+        </Box>
+        <Box
+          sx={(t) => ({
+            display: 'flex',
+            alignItems: 'stretch',
+            justifyContent: 'stretch',
+            py: 0.75,
+            px: 1,
+            borderRadius: 1.25,
+            backgroundColor: alpha(t.palette.text.primary, 0.025),
+            border: `1px solid ${t.palette.border.subtle}`,
+            minWidth: 0,
+            overflow: 'hidden',
+            height: 56,
+          })}
+        >
+          <ResponsiveSparklineButton
+            username={username}
+            githubId={row.miner.githubId}
+            primaryValues={row.activity.dailyOss}
+            secondaryValues={row.activity.dailyDiscovery}
+            height={42}
+            primaryLabel="OSS"
+            secondaryLabel="Discovery"
+            emphasis
+          />
+        </Box>
+      </Box>
+
+      <Box
+        sx={{
+          mt: 1.5,
+          display: 'grid',
+          gridTemplateColumns: { xs: '1fr 1fr', sm: '1fr 1fr 1fr' },
+          gap: 1,
+          minWidth: 0,
+        }}
+      >
+        <StatTile
+          label="Score"
+          value={
+            row.combined > 0
+              ? displayedCombinedScore(row.miner).toFixed(1)
+              : '—'
+          }
+          valueColor={row.combined > 0 ? 'text.primary' : alpha('#fff', 0.3)}
+          tooltip={
+            <RowTooltipContent
+              title={`Combined score · ${row.combined.toFixed(2)}`}
+              body={
+                <>
+                  OSS{' '}
+                  <Box
+                    component="span"
+                    sx={{ fontFamily: '"JetBrains Mono", monospace' }}
+                  >
+                    {parseNumber(row.miner.totalScore).toFixed(2)}
+                  </Box>{' '}
+                  · Discovery{' '}
+                  <Box
+                    component="span"
+                    sx={{ fontFamily: '"JetBrains Mono", monospace' }}
+                  >
+                    {parseNumber(row.miner.issueDiscoveryScore).toFixed(2)}
+                  </Box>
+                  <Box sx={{ mt: '4px' }}>
+                    Ranked across the whole network by this combined value.
+                  </Box>
+                </>
+              }
+            />
+          }
+        />
+        <StatTile
+          label="$/Day"
+          value={
+            usd > 0 ? (
+              fmtUsd(usd)
+            ) : (
+              <Box
+                component="span"
+                sx={{
+                  fontSize: '0.72rem',
+                  fontStyle: 'italic',
+                  fontWeight: 500,
+                  letterSpacing: 0,
+                }}
+              >
+                no payout
+              </Box>
+            )
+          }
+          valueColor={usd > 0 ? STATUS_COLORS.success : alpha('#fff', 0.32)}
+          tooltip={
+            usd > 0 ? undefined : (
+              <RowTooltipContent
+                title="Not earning yet"
+                body="Below the eligibility threshold on both tracks — emissions only flow once a miner qualifies in at least one repo."
+              />
+            )
+          }
+        />
+        <StatTile
+          label="Open PRs"
+          value={open}
+          suffix={`/${allowed}`}
+          valueColor={openPrColor}
+          tooltip={
+            <RowTooltipContent
+              title={
+                flaggedByValidator
+                  ? 'Validator-flagged: over the open-PR cap'
+                  : `${open} open PR${open === 1 ? '' : 's'} across the network`
+              }
+              body={
+                <>
+                  Network default allowance for this token score is{' '}
+                  <Box
+                    component="span"
+                    sx={{ fontFamily: '"JetBrains Mono", monospace' }}
+                  >
+                    {allowed}
+                  </Box>{' '}
+                  open PR{allowed === 1 ? '' : 's'}. Per-repo limits may differ
+                  — the details page has the exact cap per repo.
+                </>
+              }
+              tone={
+                flaggedByValidator || ratio >= 1
+                  ? 'negative'
+                  : ratio >= 0.5
+                    ? 'caution'
+                    : 'default'
+              }
+            />
+          }
+        />
+        <StatTile
+          label="Merged PRs"
+          value={mergedTotal > 0 ? mergedTotal.toLocaleString() : '—'}
+          valueSize="0.82rem"
+          valueWeight={600}
+          valueColor={alpha('#fff', mergedTotal > 0 ? 0.38 : 0.18)}
+          icon={
+            <GhPrIcon
+              size={13}
+              color={
+                mergedTotal > 0
+                  ? LEADERBOARD_TRACK_COLORS.dual
+                  : alpha(LEADERBOARD_TRACK_COLORS.dual, 0.35)
+              }
+            />
+          }
+          secondaryValue={ossScore > 0 ? ossScore.toFixed(1) : undefined}
+        />
+        <StatTile
+          label="Issues Solved"
+          value={solvedTotal > 0 ? solvedTotal.toLocaleString() : '—'}
+          valueSize="0.82rem"
+          valueWeight={600}
+          valueColor={alpha('#fff', solvedTotal > 0 ? 0.38 : 0.18)}
+          icon={
+            <GhIssueIcon
+              size={13}
+              color={
+                solvedTotal > 0
+                  ? LEADERBOARD_TRACK_COLORS.dual
+                  : alpha(LEADERBOARD_TRACK_COLORS.dual, 0.35)
+              }
+            />
+          }
+          secondaryValue={
+            discoveryScore > 0 ? discoveryScore.toFixed(1) : undefined
+          }
+        />
+        <StatTile
+          label="Reviews"
+          value={reviewsValue}
+          valueColor={reviewsColor}
+          tooltip={
+            <RowTooltipContent
+              title={
+                hits === 0
+                  ? mergedTotal > 0
+                    ? 'No maintainer review hits'
+                    : 'No review activity yet'
+                  : `${hits} maintainer review hit${hits === 1 ? '' : 's'}`
+              }
+              body={
+                hits === 0
+                  ? mergedTotal > 0
+                    ? 'Clean record — no maintainer pushback on merged PRs in the last 30 days.'
+                    : 'Reviews are counted on merged PRs; this miner has none in the lookback window yet.'
+                  : "Times a maintainer requested changes on this miner's PRs in the last 30 days. High counts can signal quality issues."
+              }
+              tone={hits >= 5 ? 'negative' : hits > 0 ? 'caution' : 'default'}
+            />
+          }
+        />
+      </Box>
+
+      <Box
+        onClick={(e) => e.stopPropagation()}
+        sx={(t) => ({
+          mt: 1,
+          px: 1.25,
+          py: 0.85,
+          borderRadius: 1.25,
+          backgroundColor: alpha(t.palette.text.primary, 0.02),
+          border: `1px solid ${t.palette.border.subtle}`,
+          display: 'grid',
+          gridTemplateColumns: '1fr 1fr',
+          columnGap: 1.5,
+          alignItems: 'center',
+          '& > * + *': {
+            borderLeft: `1px solid ${t.palette.border.light}`,
+            pl: 1.5,
+          },
+        })}
+      >
+        {[0, 1].map((slot) => {
+          const repo = topRepos[slot];
+          return (
+            <Box
+              key={repo?.name ?? `empty-${slot}`}
+              sx={{
+                minWidth: 0,
+                display: 'flex',
+                alignItems: 'center',
+              }}
+            >
+              {repo ? (
+                <RepoChip
+                  name={repo.name}
+                  count={repo.count}
+                  active={selectedRepo === repo.name}
+                  onClick={onSelectRepo}
+                />
+              ) : (
+                <Typography
+                  aria-hidden
+                  sx={{
+                    fontFamily: '"JetBrains Mono", monospace',
+                    fontSize: '0.72rem',
+                    color: alpha('#fff', 0.22),
+                    lineHeight: 1.3,
+                  }}
+                >
+                  —
+                </Typography>
+              )}
+            </Box>
+          );
+        })}
+      </Box>
+    </Box>
+  );
+};
+
+/* ─── Toolbar ─────────────────────────────────────────────────────────── */
+
+interface ToolbarProps {
+  total: number;
+  filteredCount: number;
+  search: string;
+  onSearch: (s: string) => void;
+  filter: EligibilityFilter;
+  onFilter: (f: EligibilityFilter) => void;
+  counts: Record<EligibilityFilter, number>;
+  trackedOnly: boolean;
+  onTrackedOnly: (next: boolean) => void;
+  watchedCount: number;
+  selectedRepo: string | null;
+  onClearRepo: () => void;
+  selectedCohort: CohortKey | null;
+  onClearCohort: () => void;
+  sortField: SortField;
+  sortDir: 'asc' | 'desc';
+  onSortFieldChange: (field: SortField) => void;
+  onSortDirToggle: () => void;
+  viewMode: LeaderboardViewMode;
+  onViewModeChange: (mode: LeaderboardViewMode) => void;
+  rowsPerPage: number;
+  rowsPerPageOptions: readonly number[];
+  onRowsPerPageChange: (rows: number) => void;
+}
+
+const SORT_FIELD_LABELS: Record<SortField, string> = {
+  score: 'Score',
+  usd: '$/Day',
+  credibility: 'Success rate',
+  volume: 'Volume (PRs + issues)',
+  active: 'Last active',
+  movement: 'Rank movement',
+  reviewHits: 'Maintainer reviews',
+  openPrRisk: 'Open-PR risk',
+  watch: 'Tracked first',
+};
+
+const ELIGIBILITY_SEGMENTS: ReadonlyArray<{
+  key: EligibilityFilter;
+  label: string;
+}> = [
+  { key: 'all', label: 'All' },
+  { key: 'eligible', label: 'Eligible' },
+  { key: 'ineligible', label: 'Ineligible' },
+] as const;
+
+const EligibilitySegmentedControl: React.FC<{
+  filter: EligibilityFilter;
+  onFilter: (next: EligibilityFilter) => void;
+}> = ({ filter, onFilter }) => (
+  <Box
+    role="group"
+    aria-label="Filter miners by eligibility"
+    sx={(t) => ({
+      display: 'inline-flex',
+      width: { xs: '100%', md: 'auto' },
+      padding: '3px',
+      borderRadius: 2,
+      backgroundColor: t.palette.surface.subtle,
+      border: `1px solid ${t.palette.border.light}`,
+      gap: '2px',
+    })}
+  >
+    {ELIGIBILITY_SEGMENTS.map(({ key, label }) => {
+      const active = filter === key;
+      return (
+        <Box
+          key={key}
+          component="button"
+          type="button"
+          aria-pressed={active}
+          onClick={() => onFilter(key)}
+          sx={(t) => ({
+            flex: { xs: 1, md: 'none' },
+            minWidth: { md: 92 },
+            position: 'relative',
+            px: { xs: 1.25, md: 2 },
+            py: '7px',
+            border: 'none',
+            borderRadius: 1.5,
+            backgroundColor: active
+              ? alpha(t.palette.text.primary, 0.08)
+              : 'transparent',
+            color: active
+              ? t.palette.text.primary
+              : alpha(t.palette.text.primary, 0.6),
+            cursor: 'pointer',
+            font: 'inherit',
+            fontSize: '0.78rem',
+            fontWeight: active ? 700 : 600,
+            letterSpacing: '0.2px',
+            lineHeight: 1.2,
+            transition: 'background-color 0.15s, color 0.15s, box-shadow 0.15s',
+            boxShadow: active
+              ? `inset 0 0 0 1px ${alpha(t.palette.text.primary, 0.1)}`
+              : 'none',
+            '&::after': active
+              ? {
+                  content: '""',
+                  position: 'absolute',
+                  left: '20%',
+                  right: '20%',
+                  bottom: 3,
+                  height: 2,
+                  borderRadius: 999,
+                  backgroundColor: t.palette.primary.main,
+                }
+              : undefined,
+            '&:hover': {
+              backgroundColor: active
+                ? alpha(t.palette.text.primary, 0.1)
+                : alpha(t.palette.text.primary, 0.04),
+              color: t.palette.text.primary,
+            },
+            '&:focus-visible': {
+              outline: `2px solid ${t.palette.primary.main}`,
+              outlineOffset: 2,
+            },
+          })}
+        >
+          {label}
+        </Box>
+      );
+    })}
+  </Box>
+);
+
+const ViewModeToggle: React.FC<{
+  viewMode: LeaderboardViewMode;
+  onChange: (mode: LeaderboardViewMode) => void;
+}> = ({ viewMode, onChange }) => {
+  const options: {
+    value: LeaderboardViewMode;
+    label: string;
+    Icon: typeof ViewListIcon;
+  }[] = [
+    { value: 'list', label: 'Table view', Icon: ViewListIcon },
+    { value: 'cards', label: 'Card view', Icon: ViewModuleIcon },
+  ];
+  return (
+    <Box
+      sx={(t) => ({
+        display: 'inline-flex',
+        alignItems: 'center',
+        borderRadius: 2,
+        border: '1px solid',
+        borderColor: t.palette.border.light,
+        overflow: 'hidden',
+        flexShrink: 0,
+      })}
+      role="group"
+      aria-label="Toggle leaderboard view mode"
+    >
+      {options.map(({ value, label, Icon }) => {
+        const isActive = viewMode === value;
+        return (
+          <Tooltip key={value} title={label} placement="top" arrow>
+            <IconButton
+              onClick={() => onChange(value)}
+              size="small"
+              aria-label={label}
+              aria-pressed={isActive}
+              sx={(t) => ({
+                borderRadius: 0,
+                padding: '6px 10px',
+                color: isActive
+                  ? t.palette.text.primary
+                  : t.palette.text.tertiary,
+                backgroundColor: isActive
+                  ? t.palette.surface.light
+                  : 'transparent',
+                '&:hover': {
+                  backgroundColor: t.palette.surface.light,
+                  color: t.palette.text.primary,
+                },
+                '&:focus-visible': {
+                  outline: `2px solid ${t.palette.primary.main}`,
+                  outlineOffset: -2,
+                },
+              })}
+            >
+              <Icon fontSize="small" />
+            </IconButton>
+          </Tooltip>
+        );
+      })}
+    </Box>
+  );
+};
+
+const Toolbar: React.FC<ToolbarProps> = ({
+  total,
+  filteredCount,
+  search,
+  onSearch,
+  filter,
+  onFilter,
+  counts,
+  trackedOnly,
+  onTrackedOnly,
+  watchedCount,
+  selectedRepo,
+  onClearRepo,
+  selectedCohort,
+  onClearCohort,
+  sortField,
+  sortDir,
+  onSortFieldChange,
+  onSortDirToggle,
+  viewMode,
+  onViewModeChange,
+  rowsPerPage,
+  rowsPerPageOptions,
+  onRowsPerPageChange,
+}) => {
+  const primarySummary =
+    filteredCount === total
+      ? `${total.toLocaleString()} miners`
+      : `${filteredCount.toLocaleString()} of ${total.toLocaleString()}`;
+  const breakdownSummary =
+    total > 0
+      ? `${counts.eligible.toLocaleString()} eligible · ${counts.ineligible.toLocaleString()} ineligible`
+      : null;
+  return (
+    <Box
+      sx={{
+        p: { xs: 1.75, sm: 2.5 },
+        borderBottom: '1px solid',
+        borderColor: 'border.light',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 1.5,
+      }}
+    >
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'baseline',
+          justifyContent: 'space-between',
+          gap: 1.5,
+          flexWrap: 'wrap',
+          rowGap: 1,
+        }}
+      >
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 1.25,
+            minWidth: 0,
+            flexWrap: 'wrap',
+            rowGap: 0.75,
+          }}
+        >
+          <Tooltip
+            title={
+              <RowTooltipContent
+                title="Network leaderboard"
+                body="Ranked by combined OSS + Discovery score across the whole network."
+              />
+            }
+            arrow
+            placement="top"
+            slotProps={tooltipSlotProps}
+          >
+            <Typography
+              variant="sectionTitle"
+              sx={{ cursor: 'help', whiteSpace: 'nowrap' }}
+            >
+              Network leaderboard
+            </Typography>
+          </Tooltip>
+          <NetworkPulsePill />
+        </Box>
+        <Box
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'flex-end',
+            gap: '2px',
+            flexShrink: 0,
+            minWidth: 0,
+          }}
+        >
+          <Typography
+            sx={{
+              fontSize: '0.72rem',
+              fontWeight: 600,
+              color: alpha('#fff', 0.7),
+              fontFamily: '"JetBrains Mono", monospace',
+              whiteSpace: 'nowrap',
+              lineHeight: 1.1,
+            }}
+          >
+            {primarySummary}
+          </Typography>
+          {breakdownSummary && (
+            <Typography
+              sx={{
+                fontSize: '0.62rem',
+                color: alpha('#fff', 0.4),
+                fontFamily: '"JetBrains Mono", monospace',
+                whiteSpace: 'nowrap',
+                lineHeight: 1.1,
+                textAlign: 'right',
+              }}
+            >
+              {breakdownSummary}
+            </Typography>
+          )}
+        </Box>
+      </Box>
+
+      <Box sx={{ display: { xs: 'block', md: 'none' } }}>
+        <EligibilitySegmentedControl filter={filter} onFilter={onFilter} />
+      </Box>
+
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: { xs: 'column', md: 'row' },
+          alignItems: { xs: 'stretch', md: 'center' },
+          gap: 1,
+        }}
+      >
+        <Box sx={{ display: { xs: 'none', md: 'inline-flex' } }}>
+          <EligibilitySegmentedControl filter={filter} onFilter={onFilter} />
+        </Box>
+        <Box
+          sx={{
+            display: 'flex',
+            flexDirection: { xs: 'column', sm: 'row' },
+            alignItems: { xs: 'stretch', sm: 'center' },
+            gap: 1,
+            width: { xs: '100%', md: 'auto' },
+          }}
+        >
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 0.5,
+              flex: { xs: 'none', sm: 1, md: 'none' },
+              width: { xs: '100%', sm: 'auto', md: 'auto' },
+              minWidth: 0,
+            }}
+          >
+            <FormControl
+              size="small"
+              sx={{
+                width: { xs: '100%', md: 200 },
+                flex: { xs: 1, md: 'none' },
+              }}
+            >
+              <Select
+                value={sortField}
+                onChange={(event) =>
+                  onSortFieldChange(event.target.value as SortField)
+                }
+                displayEmpty
+                startAdornment={
+                  <SortIcon
+                    sx={{
+                      fontSize: '0.95rem',
+                      mr: 0.75,
+                      color: alpha('#fff', 0.4),
+                    }}
+                  />
+                }
+                renderValue={(value) => (
+                  <Box
+                    component="span"
+                    sx={{
+                      fontSize: '0.78rem',
+                      fontWeight: 600,
+                      color: 'text.primary',
+                      whiteSpace: 'nowrap',
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      minWidth: 0,
+                      flex: 1,
+                    }}
+                  >
+                    {SORT_FIELD_LABELS[value as SortField]}
+                  </Box>
+                )}
+                sx={{
+                  fontSize: '0.8rem',
+                  backgroundColor: 'surface.subtle',
+                  borderRadius: 2,
+                  '& .MuiOutlinedInput-notchedOutline': {
+                    borderColor: 'border.light',
+                  },
+                  '& .MuiSelect-select': {
+                    py: '6.5px',
+                    pl: '10px',
+                    display: 'flex',
+                    alignItems: 'center',
+                  },
+                }}
+                // Opaque surface.elevated so the table doesn't bleed through.
+                MenuProps={{
+                  slotProps: {
+                    paper: {
+                      sx: (t) => ({
+                        backgroundColor: t.palette.surface.elevated,
+                        backgroundImage: 'none',
+                        border: `1px solid ${t.palette.border.light}`,
+                        boxShadow: '0 12px 32px rgba(0, 0, 0, 0.55)',
+                      }),
+                    },
+                  },
+                }}
+              >
+                {SORT_FIELDS.map((field) => (
+                  <MenuItem
+                    key={field}
+                    value={field}
+                    sx={(t) => ({
+                      fontSize: '0.8rem',
+                      '&.Mui-selected': {
+                        backgroundColor: alpha(t.palette.primary.main, 0.18),
+                      },
+                      '&.Mui-selected:hover': {
+                        backgroundColor: alpha(t.palette.primary.main, 0.26),
+                      },
+                    })}
+                  >
+                    {SORT_FIELD_LABELS[field]}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+            <Tooltip
+              title={
+                sortDir === 'desc'
+                  ? 'Descending — click for ascending'
+                  : 'Ascending — click for descending'
+              }
+              arrow
+              placement="top"
+              slotProps={tooltipSlotProps}
+            >
+              <IconButton
+                size="small"
+                onClick={onSortDirToggle}
+                aria-label={`Toggle sort direction (currently ${sortDir})`}
+                sx={(t) => ({
+                  border: `1px solid ${t.palette.border.light}`,
+                  borderRadius: 1.5,
+                  width: 32,
+                  height: 32,
+                  backgroundColor: 'surface.subtle',
+                  color: alpha(t.palette.text.primary, 0.7),
+                  '&:hover': { backgroundColor: t.palette.surface.light },
+                  '&:focus-visible': {
+                    outline: `2px solid ${t.palette.primary.main}`,
+                    outlineOffset: 2,
+                    backgroundColor: t.palette.surface.light,
+                  },
+                })}
+              >
+                {sortDir === 'desc' ? (
+                  <ArrowDownwardIcon sx={{ fontSize: '0.95rem' }} />
+                ) : (
+                  <ArrowUpwardIcon sx={{ fontSize: '0.95rem' }} />
+                )}
+              </IconButton>
+            </Tooltip>
+          </Box>
+
+          <Box sx={{ display: 'inline-flex' }}>
+            <ViewModeToggle viewMode={viewMode} onChange={onViewModeChange} />
+          </Box>
+
+          <FormControl
+            size="small"
+            sx={{
+              display: { xs: 'flex', md: 'inline-flex' },
+              width: { xs: '100%', sm: 110, md: 96 },
+              flexShrink: 0,
+            }}
+          >
+            <Select
+              value={rowsPerPage}
+              onChange={(e) => onRowsPerPageChange(Number(e.target.value))}
+              displayEmpty
+              renderValue={(value) => (
+                <Box
+                  component="span"
+                  sx={{
+                    display: 'inline-flex',
+                    alignItems: 'baseline',
+                    gap: '5px',
+                    fontSize: '0.78rem',
+                    fontWeight: 600,
+                    color: 'text.primary',
+                  }}
+                >
+                  <Box
+                    component="span"
+                    sx={{
+                      fontSize: '0.6rem',
+                      color: alpha('#fff', 0.5),
+                      textTransform: 'uppercase',
+                      letterSpacing: '0.4px',
+                      fontWeight: 700,
+                    }}
+                  >
+                    Rows
+                  </Box>
+                  {String(value)}
+                </Box>
+              )}
+              sx={{
+                fontSize: '0.8rem',
+                backgroundColor: 'surface.subtle',
+                borderRadius: 2,
+                '& .MuiOutlinedInput-notchedOutline': {
+                  borderColor: 'border.light',
+                },
+                '& .MuiSelect-select': {
+                  py: '6.5px',
+                  pl: '12px',
+                  display: 'flex',
+                  alignItems: 'center',
+                },
+              }}
+              MenuProps={{
+                slotProps: {
+                  paper: {
+                    sx: (t) => ({
+                      backgroundColor: t.palette.surface.elevated,
+                      backgroundImage: 'none',
+                      border: `1px solid ${t.palette.border.light}`,
+                      boxShadow: '0 12px 32px rgba(0, 0, 0, 0.55)',
+                    }),
+                  },
+                },
+              }}
+            >
+              {rowsPerPageOptions.map((value) => (
+                <MenuItem
+                  key={value}
+                  value={value}
+                  sx={(t) => ({
+                    fontSize: '0.8rem',
+                    '&.Mui-selected': {
+                      backgroundColor: alpha(t.palette.primary.main, 0.18),
+                    },
+                    '&.Mui-selected:hover': {
+                      backgroundColor: alpha(t.palette.primary.main, 0.26),
+                    },
+                  })}
+                >
+                  {value}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        </Box>
+
+        {(watchedCount > 0 ||
+          trackedOnly ||
+          selectedRepo ||
+          selectedCohort) && (
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              flexWrap: 'wrap',
+              gap: 1,
+              minWidth: 0,
+            }}
+          >
+            {(watchedCount > 0 || trackedOnly) && (
+              <Tooltip
+                title={
+                  <RowTooltipContent
+                    title={
+                      trackedOnly ? 'Showing tracked only' : 'Filter to tracked'
+                    }
+                    body={
+                      watchedCount === 0
+                        ? "You don't track any miners yet. Star a miner's row to add them to your watchlist."
+                        : `Limit the leaderboard to the ${watchedCount.toLocaleString()} miner${watchedCount === 1 ? '' : 's'} you've starred. Stacks with the eligibility filter and any active repo filter.`
+                    }
+                    action={
+                      trackedOnly
+                        ? 'Click to clear and see every miner again'
+                        : watchedCount > 0
+                          ? 'Click to limit the table to your tracked miners'
+                          : undefined
+                    }
+                  />
+                }
+                arrow
+                placement="top"
+                slotProps={tooltipSlotProps}
+              >
+                <Chip
+                  icon={
+                    <StarBorderIcon
+                      sx={{
+                        fontSize: '0.95rem !important',
+                        ml: '4px !important',
+                      }}
+                    />
+                  }
+                  label={`Tracked · ${watchedCount.toLocaleString()}`}
+                  onClick={() => onTrackedOnly(!trackedOnly)}
+                  size="small"
+                  disabled={!trackedOnly && watchedCount === 0}
+                  sx={(t) => ({
+                    height: 28,
+                    cursor:
+                      watchedCount === 0 && !trackedOnly
+                        ? 'default'
+                        : 'pointer',
+                    fontSize: '0.72rem',
+                    fontWeight: 600,
+                    borderRadius: 1.5,
+                    color: trackedOnly
+                      ? t.palette.warning.main
+                      : alpha(t.palette.text.primary, 0.55),
+                    backgroundColor: trackedOnly
+                      ? alpha(t.palette.warning.main, 0.16)
+                      : t.palette.surface.subtle,
+                    border: `1px solid ${
+                      trackedOnly
+                        ? t.palette.warning.main
+                        : t.palette.border.light
+                    }`,
+                    '& .MuiChip-icon': {
+                      color: trackedOnly
+                        ? t.palette.warning.main
+                        : alpha(t.palette.text.primary, 0.45),
+                    },
+                    '&:hover': {
+                      backgroundColor: trackedOnly
+                        ? alpha(t.palette.warning.main, 0.22)
+                        : t.palette.surface.light,
+                    },
+                    '&.Mui-disabled': {
+                      opacity: 0.45,
+                    },
+                  })}
+                />
+              </Tooltip>
+            )}
+            {selectedRepo && (
+              <Chip
+                icon={<ClearIcon sx={{ fontSize: '0.85rem !important' }} />}
+                label={`repo: ${selectedRepo}`}
+                onClick={onClearRepo}
+                size="small"
+                sx={(t) => ({
+                  height: 28,
+                  cursor: 'pointer',
+                  fontSize: '0.7rem',
+                  fontWeight: 600,
+                  borderRadius: 1.5,
+                  color: t.palette.primary.main,
+                  backgroundColor: alpha(t.palette.primary.main, 0.16),
+                  border: `1px solid ${t.palette.primary.main}`,
+                  '& .MuiChip-icon': { color: t.palette.primary.main },
+                })}
+              />
+            )}
+            {selectedCohort && (
+              <Tooltip
+                title={
+                  <RowTooltipContent
+                    title={`Cohort filter · ${COHORT_LABELS[selectedCohort]}`}
+                    body={COHORT_DESCRIPTIONS[selectedCohort]}
+                    action="Click to clear the cohort filter"
+                  />
+                }
+                arrow
+                placement="top"
+                slotProps={tooltipSlotProps}
+              >
+                <Chip
+                  icon={<ClearIcon sx={{ fontSize: '0.85rem !important' }} />}
+                  label={`cohort: ${COHORT_LABELS[selectedCohort]}`}
+                  onClick={onClearCohort}
+                  size="small"
+                  sx={(t) => ({
+                    height: 28,
+                    cursor: 'pointer',
+                    fontSize: '0.7rem',
+                    fontWeight: 600,
+                    borderRadius: 1.5,
+                    color: t.palette.info.main,
+                    backgroundColor: alpha(t.palette.info.main, 0.16),
+                    border: `1px solid ${t.palette.info.main}`,
+                    '& .MuiChip-icon': { color: t.palette.info.main },
+                  })}
+                />
+              </Tooltip>
+            )}
+          </Box>
+        )}
+
+        <TextField
+          size="small"
+          placeholder="Search miner, UID, hotkey…"
+          value={search}
+          onChange={(e) => onSearch(e.target.value)}
+          InputProps={{
+            startAdornment: (
+              <InputAdornment position="start">
+                <SearchIcon
+                  sx={{ fontSize: '1rem', color: alpha('#fff', 0.4) }}
+                />
+              </InputAdornment>
+            ),
+            endAdornment: (
+              <ClearSearchAdornment
+                visible={Boolean(search)}
+                onClear={() => onSearch('')}
+              />
+            ),
+          }}
+          sx={{
+            width: { xs: '100%', md: 260 },
+            ml: { xs: 0, md: 'auto' },
+            '& .MuiOutlinedInput-root': {
+              fontSize: '0.8rem',
+              backgroundColor: 'surface.subtle',
+              borderRadius: 2,
+              '& fieldset': { borderColor: 'border.light' },
+            },
+          }}
+        />
+      </Box>
+    </Box>
+  );
+};
+
+/* ─── Main table component ─────────────────────────────────────────────── */
+
+interface RankedMiner {
+  miner: MinerEvaluation;
+  rank: number;
+  position: number;
+  combined: number;
+  activity: MinerActivity;
+  status: MinerStatus;
+  openPrRisk: OpenPrRisk;
+  previousRank: number | undefined;
+}
+
+type LeaderboardUrlFilters = {
+  search: string;
+  eligible: EligibilityFilter;
+  trackedOnly: boolean;
+};
+
+const eligibleFilterConfig = {
+  paramKey: 'eligible',
+  parse: (raw: string | null): EligibilityFilter =>
+    raw === 'true'
+      ? 'eligible'
+      : raw === 'false'
+        ? 'ineligible'
+        : raw === 'all'
+          ? 'all'
+          : 'all',
+  serialize: (value: EligibilityFilter): string | null => {
+    if (value === 'all') return null;
+    return value === 'eligible' ? 'true' : 'false';
+  },
+};
+
+const searchFilterConfig = {
+  paramKey: 'search',
+  parse: (raw: string | null): string => raw ?? '',
+  serialize: (value: string): string | null => value.trim() || null,
+};
+
+const trackedOnlyFilterConfig = {
+  paramKey: 'tracked',
+  parse: (raw: string | null): boolean => raw === '1',
+  serialize: (value: boolean): string | null => (value ? '1' : null),
+};
+
+const MinersLeaderTable: React.FC<MinersLeaderTableProps> = ({
+  miners,
+  isLoading,
+  selectedRepo,
+  onSelectRepo,
+  selectedCohort,
+  onClearCohort,
+}) => {
+  const navigate = useNavigate();
+  const { isWatched, count: watchedCount } = useWatchlist('miners');
+  const { index: activityIndex, isLoading: isLoadingActivity } =
+    useMinerActivityIndex({ lookbackDays: 30, topReposLimit: 2 });
+
+  const [searchParams, setSearchParams] = useSearchParams();
+  const initialViewMode = useMemo<LeaderboardViewMode>(() => {
+    return getLeaderboardViewModeFromQuery(
+      searchParams.get(LEADERBOARD_VIEW_QUERY_PARAM),
+      readStoredLeaderboardViewMode(),
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+  const [viewMode, setViewMode] =
+    useState<LeaderboardViewMode>(initialViewMode);
+  const effectiveViewMode: LeaderboardViewMode = viewMode;
+
+  const filtersConfig = useMemo(
+    () => ({
+      search: searchFilterConfig,
+      eligible: eligibleFilterConfig,
+      trackedOnly: trackedOnlyFilterConfig,
+    }),
+    [],
+  );
+  const {
+    sortField,
+    sortOrder: sortDir,
+    setSort,
+    page,
+    setPage,
+    rowsPerPage,
+    setRowsPerPage,
+    filters,
+    setFilter,
+  } = useDataTableParams<SortField, LeaderboardUrlFilters>({
+    sortKeys: SORT_FIELDS,
+    defaultSortKey: 'score',
+    defaultSortOrder: 'desc',
+    defaultRowsPerPage: defaultRowsForLeaderboardView(initialViewMode),
+    rowsPerPageOptions: LEADERBOARD_VALID_ROWS,
+    filters: filtersConfig,
+  });
+  const search = filters.search;
+  const filter = filters.eligible;
+  const trackedOnly = filters.trackedOnly;
+  const setSearch = (value: string) => setFilter('search', value);
+  const setEligibility = (value: EligibilityFilter) =>
+    setFilter('eligible', value);
+  const setTrackedOnly = (value: boolean) => setFilter('trackedOnly', value);
+
+  const handleViewModeChange = useCallback(
+    (next: LeaderboardViewMode) => {
+      setViewMode(next);
+      writeStoredLeaderboardViewMode(next);
+      setSearchParams(
+        (prev) => {
+          const params = new URLSearchParams(prev);
+          if (next === 'list') params.delete(LEADERBOARD_VIEW_QUERY_PARAM);
+          else params.set(LEADERBOARD_VIEW_QUERY_PARAM, next);
+          return params;
+        },
+        { replace: true },
+      );
+      // List [10,25,50] and cards [12,24,48] don't overlap — clamp on switch.
+      setRowsPerPage(clampRowsForLeaderboardView(rowsPerPage, next));
+    },
+    [setSearchParams, setRowsPerPage, rowsPerPage],
+  );
+
+  // Parent owns ?repo; reset page ourselves but preserve initial deep-links.
+  const lastSelectedRepoRef = useRef<string | null>(selectedRepo);
+  useEffect(() => {
+    if (lastSelectedRepoRef.current === selectedRepo) return;
+    lastSelectedRepoRef.current = selectedRepo;
+    setPage(0);
+  }, [selectedRepo, setPage]);
+
+  const lastSelectedCohortRef = useRef<CohortKey | null>(selectedCohort);
+  useEffect(() => {
+    if (lastSelectedCohortRef.current === selectedCohort) return;
+    lastSelectedCohortRef.current = selectedCohort;
+    setPage(0);
+  }, [selectedCohort, setPage]);
+
+  const rankedBase = useMemo(() => {
+    return [...miners]
+      .map((m) => ({
+        miner: m,
+        combined: combinedScore(m),
+        activity: activityIndex.get(m.githubId) ?? EMPTY_ACTIVITY,
+        openPrRisk: computeOpenPrRisk(m),
+      }))
+      .sort((a, b) => {
+        const aPen = isPenalized(a.miner);
+        const bPen = isPenalized(b.miner);
+        if (aPen !== bPen) return aPen ? 1 : -1;
+        return b.combined - a.combined;
+      })
+      .map((row, index) => ({ ...row, rank: index + 1 }));
+  }, [miners, activityIndex]);
+
+  const currentRanks = useMemo(() => {
+    const map = new Map<string, number>();
+    for (const row of rankedBase) map.set(row.miner.githubId, row.rank);
+    return map;
+  }, [rankedBase]);
+  const { previousRanks, isHydrated: isRankSnapshotHydrated } =
+    useRankSnapshot(currentRanks);
+
+  const ranked = useMemo<RankedMiner[]>(() => {
+    return rankedBase.map((row) => {
+      const previousRank = previousRanks.get(row.miner.githubId);
+      return {
+        ...row,
+        position: 0,
+        previousRank,
+        status: deriveMinerStatus(row.miner, row.activity, {
+          previousRank,
+          currentRank: row.rank,
+        }),
+      };
+    });
+  }, [rankedBase, previousRanks]);
+
+  // Scope excludes the eligibility tab so the toolbar counts stay stable.
+  const scope = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    const repoLc = selectedRepo?.toLowerCase() ?? null;
+    return ranked.filter(({ miner, activity }) => {
+      if (selectedCohort && cohortOf(miner) !== selectedCohort) return false;
+      if (trackedOnly && !isWatched(miner.githubId)) return false;
+      if (repoLc) {
+        const hit = activity.topRepos.some(
+          (r) => r.name.toLowerCase() === repoLc,
+        );
+        if (!hit) return false;
+      }
+      if (!q) return true;
+      const username = (miner.githubUsername ?? '').toLowerCase();
+      const uid = String(miner.uid);
+      const hotkey = (miner.hotkey ?? '').toLowerCase();
+      return username.includes(q) || uid.includes(q) || hotkey.includes(q);
+    });
+  }, [ranked, trackedOnly, isWatched, search, selectedRepo, selectedCohort]);
+
+  const counts = useMemo(
+    () => ({
+      all: scope.length,
+      eligible: scope.filter((r) => isAnyEligibleNow(r.miner)).length,
+      ineligible: scope.filter((r) => !isAnyEligibleNow(r.miner)).length,
+    }),
+    [scope],
+  );
+
+  const filtered = useMemo(() => {
+    if (filter === 'all') return scope;
+    return scope.filter(({ miner }) => {
+      const eligible = isAnyEligibleNow(miner);
+      return filter === 'eligible' ? eligible : !eligible;
+    });
+  }, [scope, filter]);
+
+  const sorted = useMemo(() => {
+    const next = [...filtered];
+    next.sort((a, b) => {
+      // Penalized miners sink to the bottom regardless of sort field/direction.
+      const aPen = isPenalized(a.miner);
+      const bPen = isPenalized(b.miner);
+      if (aPen !== bPen) return aPen ? 1 : -1;
+
+      let cmp = 0;
+      switch (sortField) {
+        case 'score':
+          cmp = a.combined - b.combined;
+          break;
+        case 'usd':
+          cmp = parseNumber(a.miner.usdPerDay) - parseNumber(b.miner.usdPerDay);
+          break;
+        case 'credibility':
+          cmp =
+            parseNumber(a.miner.credibility) - parseNumber(b.miner.credibility);
+          break;
+        case 'volume':
+          cmp = totalVolume(a.miner) - totalVolume(b.miner);
+          break;
+        case 'active': {
+          const at = a.activity.lastActiveAt
+            ? Date.parse(a.activity.lastActiveAt)
+            : 0;
+          const bt = b.activity.lastActiveAt
+            ? Date.parse(b.activity.lastActiveAt)
+            : 0;
+          cmp = at - bt;
+          break;
+        }
+        case 'reviewHits':
+          cmp = a.activity.reviewHits - b.activity.reviewHits;
+          break;
+        case 'openPrRisk': {
+          const ar = a.openPrRisk.ratio;
+          const br = b.openPrRisk.ratio;
+          if (ar === br) cmp = a.openPrRisk.open - b.openPrRisk.open;
+          else cmp = ar - br;
+          break;
+        }
+        case 'movement': {
+          // Miners without a baseline sink to the bottom via -Infinity.
+          const aDelta =
+            a.previousRank !== undefined ? a.previousRank - a.rank : -Infinity;
+          const bDelta =
+            b.previousRank !== undefined ? b.previousRank - b.rank : -Infinity;
+          cmp = aDelta - bDelta;
+          break;
+        }
+        case 'watch': {
+          const aw = isWatched(a.miner.githubId) ? 1 : 0;
+          const bw = isWatched(b.miner.githubId) ? 1 : 0;
+          cmp = aw - bw;
+          break;
+        }
+      }
+      return sortDir === 'asc' ? cmp : -cmp;
+    });
+    return next;
+  }, [filtered, sortField, sortDir, isWatched]);
+
+  const totalPages = Math.max(1, Math.ceil(sorted.length / rowsPerPage));
+  const paged = useMemo(() => {
+    const slice = paginateItems(sorted, page, rowsPerPage);
+    return slice.map((row, index) => ({
+      ...row,
+      position: page * rowsPerPage + index + 1,
+    }));
+  }, [sorted, page, rowsPerPage]);
+
+  const handleRepoChipClick = (repo: string) => {
+    onSelectRepo(selectedRepo === repo ? null : repo);
+  };
+
+  const tierSm = { xs: 'table-cell' } as const;
+  const tierMd = { xs: 'table-cell' } as const;
+  const tierLg = { xs: 'table-cell' } as const;
+
+  // Force flex-end + collapsed icon so right-aligned header text stays flush.
+  const rightSortLabelSx = {
+    '& .MuiTableSortLabel-root': {
+      width: '100%',
+      justifyContent: 'flex-end',
+    },
+    '& .MuiTableSortLabel-icon': {
+      width: 0,
+      marginLeft: '2px',
+      marginRight: 0,
+      overflow: 'visible',
+    },
+  } as const;
+
+  const columns: DataTableColumn<RankedMiner, SortField>[] = [
+    {
+      key: 'rank',
+      header: '#',
+      width: 48,
+      sortKey: 'movement',
+      renderCell: (row) => (
+        <RankCell
+          globalRank={row.rank}
+          previousRank={row.previousRank}
+          isHydrated={isRankSnapshotHydrated}
+        />
+      ),
+    },
+    {
+      key: 'miner',
+      header: 'Miner',
+      width: 184,
+      renderCell: (row) => (
+        <IdentityCell miner={row.miner} status={row.status} />
+      ),
+    },
+    {
+      key: 'trend',
+      header: 'Trend',
+      width: 172,
+      headerSx: { display: tierMd },
+      cellSx: { display: tierMd },
+      renderCell: (row) => (
+        <Box
+          sx={(t) => ({
+            display: 'inline-flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            px: '6px',
+            py: '4px',
+            borderRadius: 1,
+            backgroundColor: alpha(t.palette.text.primary, 0.025),
+            border: `1px solid ${t.palette.border.subtle}`,
+          })}
+        >
+          <SparklineButton
+            username={row.miner.githubUsername ?? `uid-${row.miner.uid}`}
+            githubId={row.miner.githubId}
+            primaryValues={row.activity.dailyOss}
+            secondaryValues={row.activity.dailyDiscovery}
+            width={156}
+            height={32}
+            primaryLabel="OSS"
+            secondaryLabel="Discovery"
+          />
+        </Box>
+      ),
+    },
+    {
+      key: 'eligibility',
+      header: 'Eligibility',
+      width: 120,
+      headerSx: { display: tierSm },
+      cellSx: { display: tierSm },
+      renderCell: (row) => <EligibilityCell miner={row.miner} />,
+    },
+    {
+      key: 'contributions',
+      header: 'Contributions',
+      width: 130,
+      headerSx: { display: tierSm },
+      cellSx: { display: tierSm },
+      renderCell: (row) => <ContributionStatsCell miner={row.miner} />,
+    },
+    {
+      key: 'score',
+      header: 'Score',
+      width: 72,
+      align: 'right',
+      sortKey: 'score',
+      headerSx: {
+        ...rightSortLabelSx,
+        textAlign: 'right',
+        pr: '12px',
+      },
+      cellSx: { pr: '12px' },
+      renderCell: (row) => {
+        const oss = parseNumber(row.miner.totalScore);
+        const disc = parseNumber(row.miner.issueDiscoveryScore);
+        const structural = parseNumber(row.miner.totalStructuralScore);
+        const leaf = parseNumber(row.miner.totalLeafScore);
+        const structuralCount = parseNumber(row.miner.totalStructuralCount);
+        const leafCount = parseNumber(row.miner.totalLeafCount);
+        const tokenScore = parseNumber(row.miner.totalTokenScore);
+        return (
+          <Tooltip
+            title={
+              row.combined > 0 ? (
+                <RowTooltipContent
+                  title={`Combined score ${row.combined.toFixed(2)}`}
+                  body={
+                    <>
+                      OSS{' '}
+                      <Box
+                        component="span"
+                        sx={{
+                          fontFamily: '"JetBrains Mono", monospace',
+                          fontWeight: 700,
+                        }}
+                      >
+                        {oss.toFixed(2)}
+                      </Box>{' '}
+                      + Discovery{' '}
+                      <Box
+                        component="span"
+                        sx={{
+                          fontFamily: '"JetBrains Mono", monospace',
+                          fontWeight: 700,
+                        }}
+                      >
+                        {disc.toFixed(2)}
+                      </Box>
+                      <TooltipSplitBar
+                        segments={[
+                          {
+                            label: 'OSS',
+                            value: oss,
+                            color: STATUS_COLORS.merged,
+                          },
+                          {
+                            label: 'Discovery',
+                            value: disc,
+                            color: STATUS_COLORS.info,
+                          },
+                        ]}
+                      />
+                      {tokenScore > 0 && (structural > 0 || leaf > 0) && (
+                        <Box sx={{ mt: '8px' }}>
+                          <Box sx={{ fontSize: '0.66rem', opacity: 0.75 }}>
+                            Token score {tokenScore.toFixed(0)} — code AST
+                            breakdown:
+                          </Box>
+                          <TooltipSplitBar
+                            segments={[
+                              {
+                                label: `Structural · ${structuralCount.toLocaleString()}`,
+                                value: structural,
+                                color: STATUS_COLORS.success,
+                              },
+                              {
+                                label: `Leaf · ${leafCount.toLocaleString()}`,
+                                value: leaf,
+                                color: STATUS_COLORS.warning,
+                              },
+                            ]}
+                          />
+                        </Box>
+                      )}
+                      <Box sx={{ mt: '6px' }}>
+                        Drives the global ranking — sum of the miner&apos;s OSS
+                        contribution score and Issue-Discovery score.
+                      </Box>
+                    </>
+                  }
+                />
+              ) : (
+                <RowTooltipContent
+                  title="No score yet"
+                  body="This miner has no scored PRs or solved issues on record."
+                />
+              )
+            }
+            arrow
+            placement="top"
+            slotProps={tooltipSlotProps}
+          >
+            <Box
+              sx={{
+                display: 'flex',
+                justifyContent: 'flex-end',
+                width: '100%',
+                cursor: 'help',
+              }}
+            >
+              <Typography
+                component="span"
+                sx={{
+                  fontFamily: '"JetBrains Mono", monospace',
+                  fontSize: '0.9rem',
+                  fontWeight: 700,
+                  color: row.combined > 0 ? 'text.primary' : alpha('#fff', 0.3),
+                  fontVariantNumeric: 'tabular-nums',
+                  lineHeight: 1,
+                }}
+              >
+                {row.combined > 0
+                  ? displayedCombinedScore(row.miner).toFixed(1)
+                  : '—'}
+              </Typography>
+            </Box>
+          </Tooltip>
+        );
+      },
+    },
+    {
+      key: 'usd',
+      header: '$/Day',
+      width: 76,
+      align: 'right',
+      sortKey: 'usd',
+      headerSx: rightSortLabelSx,
+      renderCell: (row) => {
+        const usd = parseNumber(row.miner.usdPerDay);
+        const alphaPerDay = parseNumber(row.miner.alphaPerDay);
+        const ossScore = parseNumber(row.miner.totalScore);
+        const discScore = parseNumber(row.miner.issueDiscoveryScore);
+        const split = splitEarnings(
+          usd,
+          ossScore,
+          discScore,
+          !!row.miner.isEligible,
+          !!row.miner.isIssueEligible,
+        );
+        return (
+          <Tooltip
+            title={
+              usd > 0 ? (
+                <RowTooltipContent
+                  title={`${fmtUsd(usd)} per day`}
+                  body={
+                    <>
+                      Predicted USD payout — this miner&apos;s share of the
+                      subnet alpha emission
+                      {alphaPerDay > 0
+                        ? ` (≈${alphaPerDay.toFixed(2)} α/day)`
+                        : ''}{' '}
+                      × TAO × α74 spot prices.
+                      {(split.oss > 0 || split.discovery > 0) && (
+                        <TooltipSplitBar
+                          segments={[
+                            {
+                              label: `OSS · ${fmtUsd(split.oss)}`,
+                              value: split.oss,
+                              color: STATUS_COLORS.merged,
+                            },
+                            {
+                              label: `Discovery · ${fmtUsd(split.discovery)}`,
+                              value: split.discovery,
+                              color: STATUS_COLORS.info,
+                            },
+                          ]}
+                        />
+                      )}
+                    </>
+                  }
+                  tone="positive"
+                />
+              ) : (
+                <RowTooltipContent
+                  title="No earnings yet"
+                  body="Not eligible in any repo on either track — emissions only flow once a miner crosses an eligibility threshold somewhere."
+                />
+              )
+            }
+            arrow
+            placement="top"
+            slotProps={tooltipSlotProps}
+          >
+            <Typography
+              sx={{
+                fontFamily: '"JetBrains Mono", monospace',
+                fontSize: '0.85rem',
+                fontWeight: usd > 0 ? 700 : 500,
+                color: usd > 0 ? STATUS_COLORS.success : alpha('#fff', 0.3),
+                cursor: 'help',
+              }}
+            >
+              {fmtUsd(usd)}
+            </Typography>
+          </Tooltip>
+        );
+      },
+    },
+    {
+      key: 'reviewHits',
+      header: (
+        <Tooltip
+          title={
+            <RowTooltipContent
+              title="Maintainer pushback"
+              body={
+                <>
+                  Total &quot;changes requested&quot; reviews across this
+                  miner&apos;s recent PRs. Each hit docks 15% of that PR&apos;s
+                  earned score (validator&apos;s REVIEW_PENALTY_RATE). Lower is
+                  better.
+                </>
+              }
+            />
+          }
+          arrow
+          placement="top"
+          slotProps={tooltipSlotProps}
+        >
+          <Box
+            component="span"
+            sx={{ display: 'inline-block', cursor: 'help' }}
+          >
+            Reviews
+          </Box>
+        </Tooltip>
+      ),
+      headerSx: { display: tierLg, whiteSpace: 'nowrap', ...rightSortLabelSx },
+      cellSx: { display: tierLg },
+      width: 68,
+      align: 'right',
+      sortKey: 'reviewHits',
+      renderCell: (row) => {
+        const hits = row.activity.reviewHits;
+        const merged = parseNumber(row.miner.totalMergedPrs);
+        const penaltyPct = Math.min(100, hits * 15);
+        let tooltipNode: React.ReactNode;
+        if (hits === 0 && merged === 0) {
+          tooltipNode = (
+            <RowTooltipContent
+              title="No reviews yet"
+              body="No merged PRs in the recent window — nothing to be reviewed."
+            />
+          );
+        } else if (hits === 0) {
+          tooltipNode = (
+            <RowTooltipContent
+              title="Clean ship rate"
+              body="Zero maintainer 'changes requested' reviews on recent PRs — work is landing cleanly."
+              tone="positive"
+            />
+          );
+        } else {
+          tooltipNode = (
+            <RowTooltipContent
+              title={`${hits} 'changes requested' review${hits === 1 ? '' : 's'}`}
+              body={
+                <>
+                  Maintainers asked for changes on this miner&apos;s recent PRs.
+                  Each hit docks 15% off that PR&apos;s earned score, so the
+                  cumulative drag is up to ≈
+                  <Box
+                    component="span"
+                    sx={{
+                      fontFamily: '"JetBrains Mono", monospace',
+                      fontWeight: 700,
+                    }}
+                  >
+                    {penaltyPct}%
+                  </Box>{' '}
+                  of an affected PR&apos;s payout.
+                </>
+              }
+              tone={hits >= 5 ? 'negative' : 'caution'}
+            />
+          );
+        }
+        return (
+          <Tooltip
+            title={tooltipNode}
+            arrow
+            placement="top"
+            slotProps={tooltipSlotProps}
+          >
+            <Typography
+              sx={{
+                fontFamily: '"JetBrains Mono", monospace',
+                fontSize: hits > 0 ? '0.82rem' : '0.7rem',
+                fontWeight: hits > 0 ? 700 : 500,
+                color:
+                  hits === 0
+                    ? alpha('#fff', merged > 0 ? 0.28 : 0.2)
+                    : hits >= 5
+                      ? STATUS_COLORS.closed
+                      : STATUS_COLORS.warningOrange,
+                cursor: 'help',
+                lineHeight: 1,
+              }}
+            >
+              {hits === 0 ? (merged > 0 ? '·' : '—') : hits}
+            </Typography>
+          </Tooltip>
+        );
+      },
+    },
+    {
+      key: 'openPrRisk',
+      header: (
+        <Tooltip
+          title={
+            <RowTooltipContent
+              title="Open-PR slot usage"
+              body={
+                <>
+                  Open PRs the miner has across all repos / total slots allowed
+                  at their current token-score. Slot math mirrors the
+                  validator&apos;s <em>calculate_open_pr_threshold</em>: base{' '}
+                  {NETWORK_OPEN_PR_THRESHOLDS.openPrSlotBase} + ⌊token_score
+                  &#47; {NETWORK_OPEN_PR_THRESHOLDS.openPrSlotTokenScore}⌋,
+                  capped at {NETWORK_OPEN_PR_THRESHOLDS.maxOpenPrSlots}.
+                  Exceeding the per-repo limit zeroes that repo&apos;s PR score,
+                  so values close to or over the line are a risk signal.
+                </>
+              }
+            />
+          }
+          arrow
+          placement="top"
+          slotProps={tooltipSlotProps}
+        >
+          <Box
+            component="span"
+            sx={{ display: 'inline-block', cursor: 'help' }}
+          >
+            Open PRs
+          </Box>
+        </Tooltip>
+      ),
+      width: 88,
+      align: 'right',
+      sortKey: 'openPrRisk',
+      headerSx: { display: tierLg, whiteSpace: 'nowrap', ...rightSortLabelSx },
+      cellSx: { display: tierLg },
+      renderCell: (row) => {
+        const { open, allowed, ratio } = row.openPrRisk;
+        const failed = row.miner.failedReason ?? '';
+        const flaggedByValidator =
+          typeof failed === 'string' &&
+          failed.toLowerCase().includes('open pr');
+        // Validator flag forces red since aggregate math can hide per-repo penalty.
+        let tone: 'positive' | 'caution' | 'negative' | 'default';
+        if (flaggedByValidator || ratio >= 1 || open > allowed)
+          tone = 'negative';
+        else if (ratio >= 0.5) tone = 'caution';
+        else if (open === 0) tone = 'default';
+        else tone = 'positive';
+        const color =
+          tone === 'negative'
+            ? STATUS_COLORS.closed
+            : tone === 'caution'
+              ? STATUS_COLORS.warningOrange
+              : tone === 'positive'
+                ? STATUS_COLORS.success
+                : alpha('#fff', 0.3);
+        const tooltipNode = (() => {
+          if (open === 0) {
+            return (
+              <RowTooltipContent
+                title="No open PRs"
+                body={
+                  <>
+                    Nothing in flight — collateral isn&apos;t locked up and the
+                    open-PR penalty can&apos;t trigger.
+                  </>
+                }
+              />
+            );
+          }
+          if (flaggedByValidator) {
+            return (
+              <RowTooltipContent
+                title="In penalty: too many open PRs"
+                body={
+                  <>
+                    The validator flagged this miner with{' '}
+                    <Box
+                      component="span"
+                      sx={{ fontFamily: '"JetBrains Mono", monospace' }}
+                    >
+                      {failed}
+                    </Box>
+                    . PR score zeroed in at least one repo until the count drops
+                    back under the dynamic threshold.
+                  </>
+                }
+                tone="negative"
+              />
+            );
+          }
+          return (
+            <RowTooltipContent
+              title={
+                <>
+                  <Box
+                    component="span"
+                    sx={{ fontFamily: '"JetBrains Mono", monospace' }}
+                  >
+                    {open}
+                  </Box>{' '}
+                  open / ≈
+                  <Box
+                    component="span"
+                    sx={{ fontFamily: '"JetBrains Mono", monospace' }}
+                  >
+                    {allowed}
+                  </Box>{' '}
+                  allowed
+                </>
+              }
+              body={
+                <>
+                  Approximate — the validator&apos;s open-PR limit is per-repo,
+                  but the leaderboard aggregates across all repos so this reads
+                  as a network-wide triage signal.{' '}
+                  {tone === 'negative'
+                    ? 'At or over the aggregate cap — verify per-repo on the miner details page.'
+                    : tone === 'caution'
+                      ? 'Closing in on the cap — every extra open PR raises the slash risk.'
+                      : 'Plenty of headroom under the cap.'}
+                </>
+              }
+              tone={tone === 'default' ? undefined : tone}
+            />
+          );
+        })();
+        return (
+          <Tooltip
+            title={tooltipNode}
+            arrow
+            placement="top"
+            slotProps={tooltipSlotProps}
+          >
+            <Typography
+              component="span"
+              sx={{
+                fontFamily: '"JetBrains Mono", monospace',
+                fontSize: '0.82rem',
+                fontWeight: open > 0 ? 700 : 500,
+                color: open > 0 ? color : alpha('#fff', 0.3),
+                lineHeight: 1,
+                cursor: 'help',
+                whiteSpace: 'nowrap',
+              }}
+            >
+              {open}
+              <Box
+                component="span"
+                sx={{
+                  fontSize: '0.66rem',
+                  color: alpha('#fff', 0.45),
+                  fontWeight: 500,
+                  ml: '2px',
+                }}
+              >
+                /{allowed}
+              </Box>
+            </Typography>
+          </Tooltip>
+        );
+      },
+    },
+    {
+      key: 'topRepos',
+      header: 'Top Repos',
+      width: 140,
+      headerSx: { display: tierLg },
+      cellSx: { display: tierLg },
+      renderCell: (row) => (
+        <TopReposCell
+          repos={row.activity.topRepos}
+          selectedRepo={selectedRepo}
+          onSelectRepo={handleRepoChipClick}
+        />
+      ),
+    },
+    {
+      key: 'active',
+      header: 'Active',
+      headerSx: { display: tierMd, whiteSpace: 'nowrap', ...rightSortLabelSx },
+      cellSx: { display: tierMd },
+      width: 68,
+      align: 'right',
+      sortKey: 'active',
+      renderCell: (row) => {
+        const iso = row.activity.lastActiveAt;
+        const absolute = iso
+          ? new Date(iso).toLocaleString(undefined, {
+              dateStyle: 'medium',
+              timeStyle: 'short',
+            })
+          : null;
+        return (
+          <Tooltip
+            title={
+              absolute ? (
+                <RowTooltipContent
+                  title={`Last active ${formatLastActive(iso)}`}
+                  body={
+                    <>
+                      <Box
+                        component="span"
+                        sx={{ fontFamily: '"JetBrains Mono", monospace' }}
+                      >
+                        {absolute}
+                      </Box>
+                      <Box sx={{ mt: '4px' }}>
+                        Timestamp of the miner&apos;s most recent merged PR or
+                        solved issue.
+                      </Box>
+                    </>
+                  }
+                />
+              ) : (
+                <RowTooltipContent
+                  title="Never active"
+                  body="No merged PRs or solved issues on record for this miner."
+                />
+              )
+            }
+            arrow
+            placement="top"
+            slotProps={tooltipSlotProps}
+          >
+            <Typography
+              sx={{
+                fontFamily: '"JetBrains Mono", monospace',
+                fontSize: '0.74rem',
+                whiteSpace: 'nowrap',
+                color: iso ? alpha('#fff', 0.65) : alpha('#fff', 0.3),
+                cursor: 'help',
+              }}
+            >
+              {formatLastActive(iso)}
+            </Typography>
+          </Tooltip>
+        );
+      },
+    },
+    {
+      key: 'watch',
+      header: <StarBorderIcon sx={{ fontSize: '1rem' }} />,
+      width: 40,
+      headerSx: { display: tierSm },
+      cellSx: { display: tierSm },
+      sortKey: 'watch',
+      renderCell: (row) => (
+        <Box sx={{ display: 'flex', justifyContent: 'center' }}>
+          <WatchlistButton
+            category="miners"
+            itemKey={row.miner.githubId}
+            size="small"
+          />
+        </Box>
+      ),
+    },
+  ];
+
+  const showInitialLoading =
+    (isLoading && miners.length === 0) ||
+    (isLoadingActivity && activityIndex.size === 0 && miners.length === 0);
+
+  const toolbar = (
+    <Toolbar
+      total={miners.length}
+      filteredCount={scope.length}
+      search={search}
+      onSearch={setSearch}
+      filter={filter}
+      onFilter={setEligibility}
+      counts={counts}
+      trackedOnly={trackedOnly}
+      onTrackedOnly={setTrackedOnly}
+      watchedCount={watchedCount}
+      selectedRepo={selectedRepo}
+      onClearRepo={() => onSelectRepo(null)}
+      selectedCohort={selectedCohort}
+      onClearCohort={onClearCohort}
+      sortField={sortField}
+      sortDir={sortDir}
+      onSortFieldChange={setSort}
+      onSortDirToggle={() => setSort(sortField)}
+      viewMode={viewMode}
+      onViewModeChange={handleViewModeChange}
+      rowsPerPage={rowsPerPage}
+      rowsPerPageOptions={rowsOptionsForLeaderboardView(effectiveViewMode)}
+      onRowsPerPageChange={setRowsPerPage}
+    />
+  );
+
+  const emptyState = (
+    <Box sx={{ textAlign: 'center', py: 6 }}>
+      <Typography sx={{ fontSize: '0.85rem', color: alpha('#fff', 0.5) }}>
+        {miners.length === 0
+          ? 'No miners registered yet.'
+          : 'No miners match these filters.'}
+      </Typography>
+    </Box>
+  );
+
+  const paginationControls =
+    totalPages > 1 ? (
+      <TablePagination
+        page={page}
+        totalPages={totalPages}
+        onPageChange={setPage}
+      />
+    ) : undefined;
+
+  if (effectiveViewMode === 'cards') {
+    return (
+      <Card sx={{ p: 0, overflow: 'hidden' }}>
+        {toolbar}
+        {showInitialLoading ? (
+          <Box sx={{ py: 6, textAlign: 'center', color: 'text.secondary' }}>
+            Loading miners…
+          </Box>
+        ) : paged.length === 0 ? (
+          emptyState
+        ) : (
+          <Box
+            sx={{
+              display: 'grid',
+              gridTemplateColumns: {
+                // minmax(0,1fr) prevents nowrap content from expanding columns past viewport.
+                xs: 'minmax(0, 1fr)',
+                sm: 'repeat(2, minmax(0, 1fr))',
+                lg: 'repeat(3, minmax(0, 1fr))',
+              },
+              gap: { xs: 1.25, sm: 1.5 },
+              p: { xs: 1.25, sm: 1.5 },
+            }}
+          >
+            {paged.map((row) => (
+              <MobileMinerCard
+                key={row.miner.githubId}
+                row={row}
+                isHydrated={isRankSnapshotHydrated}
+                selectedRepo={selectedRepo}
+                onSelectRepo={handleRepoChipClick}
+              />
+            ))}
+          </Box>
+        )}
+        {paginationControls}
+      </Card>
+    );
+  }
+
+  return (
+    <Card sx={{ p: 0, overflow: 'hidden' }}>
+      <DataTable<RankedMiner, SortField>
+        columns={columns}
+        rows={paged}
+        getRowKey={(row) => row.miner.githubId}
+        onRowClick={(row) =>
+          navigate(`/miners/details?githubId=${row.miner.githubId}`)
+        }
+        getRowSx={(row) => {
+          const ineligible = !isAnyEligibleNow(row.miner);
+          const accent = resolveMinerAccentColor(row.miner);
+          return {
+            cursor: 'pointer',
+            ...(ineligible && {
+              filter: 'brightness(0.88) saturate(0.92)',
+              '& td': { color: 'rgba(255, 255, 255, 0.82)' },
+            }),
+            '& > td:first-of-type': {
+              boxShadow: `inset 3px 0 0 0 ${accent}`,
+            },
+            '&:hover': {
+              filter: ineligible
+                ? 'brightness(0.98) saturate(0.98)'
+                : undefined,
+            },
+            '&:focus-visible': {
+              outline: '2px solid',
+              outlineColor: 'primary.main',
+              outlineOffset: -2,
+              backgroundColor: 'rgba(29, 55, 252, 0.08)',
+            },
+          };
+        }}
+        isLoading={showInitialLoading}
+        header={toolbar}
+        emptyState={emptyState}
+        // Omitting `sort` flips DataTable to non-sortable headers.
+        pagination={paginationControls}
+      />
+    </Card>
+  );
+};
+
+export default MinersLeaderTable;

--- a/src/components/leaderboard/MinersLeaderTable.tsx
+++ b/src/components/leaderboard/MinersLeaderTable.tsx
@@ -36,7 +36,7 @@ import { DataTable, type DataTableColumn } from '../common/DataTable';
 import { ClearSearchAdornment } from '../common/ClearSearchAdornment';
 import TablePagination from '../common/TablePagination';
 import { WatchlistButton } from '../common/WatchlistButton';
-import {
+import theme, {
   LEADERBOARD_TRACK_COLORS,
   STATUS_COLORS,
   TOOLTIP_TONE_COLORS,
@@ -332,7 +332,7 @@ const TooltipSplitBar: React.FC<{
           height: 5,
           borderRadius: 999,
           overflow: 'hidden',
-          backgroundColor: alpha('#fff', 0.08),
+          backgroundColor: alpha(theme.palette.common.white, 0.08),
         }}
       >
         {segments.map((s) => {
@@ -352,7 +352,7 @@ const TooltipSplitBar: React.FC<{
           justifyContent: 'space-between',
           mt: '3px',
           fontSize: '0.62rem',
-          color: alpha('#fff', 0.5),
+          color: alpha(theme.palette.common.white, 0.5),
         }}
       >
         {segments.map((s) => {
@@ -435,7 +435,7 @@ const MovementGlyph: React.FC<{
         sx={{
           fontFamily: '"JetBrains Mono", monospace',
           fontSize: '0.6rem',
-          color: alpha('#fff', 0.18),
+          color: alpha(theme.palette.common.white, 0.18),
           lineHeight: 1,
         }}
       >
@@ -460,7 +460,7 @@ const MovementGlyph: React.FC<{
           sx={{
             fontFamily: '"JetBrains Mono", monospace',
             fontSize: '0.6rem',
-            color: alpha('#fff', 0.3),
+            color: alpha(theme.palette.common.white, 0.3),
             lineHeight: 1,
             cursor: 'help',
           }}
@@ -488,7 +488,7 @@ const MovementGlyph: React.FC<{
           sx={{
             fontFamily: '"JetBrains Mono", monospace',
             fontSize: '0.65rem',
-            color: alpha('#fff', 0.3),
+            color: alpha(theme.palette.common.white, 0.3),
             lineHeight: 1,
             cursor: 'help',
           }}
@@ -561,7 +561,7 @@ const RankCell: React.FC<{
           fontFamily: '"JetBrains Mono", monospace',
           fontSize: '0.85rem',
           fontWeight: 600,
-          color: alpha('#fff', 0.7),
+          color: alpha(theme.palette.common.white, 0.7),
           lineHeight: 1,
           letterSpacing: '-0.02em',
           textAlign: 'center',
@@ -769,7 +769,7 @@ const ContributionStatsRow: React.FC<{
           fontSize: '0.82rem',
           fontWeight: 600,
           fontFamily: '"JetBrains Mono", monospace',
-          color: alpha('#fff', count > 0 ? 0.38 : 0.18),
+          color: alpha(theme.palette.common.white, count > 0 ? 0.38 : 0.18),
           lineHeight: 1.2,
           textAlign: 'right',
           fontVariantNumeric: 'tabular-nums',
@@ -784,7 +784,7 @@ const ContributionStatsRow: React.FC<{
         sx={{
           fontFamily: '"JetBrains Mono", monospace',
           fontSize: '0.7rem',
-          color: alpha('#fff', 0.38),
+          color: alpha(theme.palette.common.white, 0.38),
           fontWeight: 500,
           lineHeight: 1,
           letterSpacing: '-0.01em',
@@ -800,7 +800,7 @@ const ContributionStatsRow: React.FC<{
           fontSize: '0.82rem',
           fontWeight: 700,
           fontFamily: '"JetBrains Mono", monospace',
-          color: alpha('#fff', score > 0 ? 0.38 : 0.18),
+          color: alpha(theme.palette.common.white, score > 0 ? 0.38 : 0.18),
           lineHeight: 1.2,
           letterSpacing: '-0.02em',
           textAlign: 'right',
@@ -881,7 +881,7 @@ const EligibilityCell: React.FC<{ miner: MinerEvaluation }> = ({ miner }) => {
           sx={{
             fontFamily: '"JetBrains Mono", monospace',
             fontSize: '0.75rem',
-            color: alpha('#fff', 0.28),
+            color: alpha(theme.palette.common.white, 0.28),
             cursor: 'help',
           }}
         >
@@ -1031,7 +1031,7 @@ const RepoChip: React.FC<{
           component="span"
           sx={{
             fontSize: '0.65rem',
-            color: alpha('#fff', 0.4),
+            color: alpha(theme.palette.common.white, 0.4),
             fontWeight: 500,
             flexShrink: 0,
             textAlign: 'right',
@@ -1054,7 +1054,7 @@ const TopReposCell: React.FC<{
       <Typography
         sx={{
           fontSize: '0.7rem',
-          color: alpha('#fff', 0.3),
+          color: alpha(theme.palette.common.white, 0.3),
           fontFamily: '"JetBrains Mono", monospace',
         }}
       >
@@ -1132,7 +1132,7 @@ const StatTile: React.FC<{
       <Typography
         sx={{
           fontSize: '0.55rem',
-          color: alpha('#fff', 0.5),
+          color: alpha(theme.palette.common.white, 0.5),
           textTransform: 'uppercase',
           letterSpacing: '0.8px',
           fontWeight: 700,
@@ -1185,7 +1185,7 @@ const StatTile: React.FC<{
             sx={{
               fontFamily: '"JetBrains Mono", monospace',
               fontSize: '0.68rem',
-              color: alpha('#fff', 0.4),
+              color: alpha(theme.palette.common.white, 0.4),
               fontWeight: 500,
               flexShrink: 0,
             }}
@@ -1202,7 +1202,7 @@ const StatTile: React.FC<{
               gap: '4px',
               fontFamily: '"JetBrains Mono", monospace',
               fontSize: '0.78rem',
-              color: alpha('#fff', 0.55),
+              color: alpha(theme.palette.common.white, 0.55),
               fontWeight: 600,
               fontVariantNumeric: 'tabular-nums',
               flexShrink: 0,
@@ -1214,7 +1214,7 @@ const StatTile: React.FC<{
               aria-hidden
               sx={{
                 fontSize: '0.7rem',
-                color: alpha('#fff', 0.3),
+                color: alpha(theme.palette.common.white, 0.3),
                 fontWeight: 500,
               }}
             >
@@ -1252,7 +1252,7 @@ const MobileMinerCard: React.FC<{
       : ratio >= 0.5
         ? STATUS_COLORS.warningOrange
         : open === 0
-          ? alpha('#fff', 0.55)
+          ? alpha(theme.palette.common.white, 0.55)
           : STATUS_COLORS.success;
   const hits = row.activity.reviewHits;
   const mergedTotal = parseNumber(row.miner.totalMergedPrs);
@@ -1263,14 +1263,14 @@ const MobileMinerCard: React.FC<{
     hits === 0 ? (mergedTotal > 0 ? '·' : '—') : String(hits);
   const reviewsColor =
     hits === 0
-      ? alpha('#fff', mergedTotal > 0 ? 0.32 : 0.25)
+      ? alpha(theme.palette.common.white, mergedTotal > 0 ? 0.32 : 0.25)
       : hits >= 5
         ? STATUS_COLORS.closed
         : STATUS_COLORS.warningOrange;
   const lastActiveLabel = formatLastActive(row.activity.lastActiveAt);
   const lastActiveColor = row.activity.lastActiveAt
-    ? alpha('#fff', 0.75)
-    : alpha('#fff', 0.3);
+    ? alpha(theme.palette.common.white, 0.75)
+    : alpha(theme.palette.common.white, 0.3);
   const topRepos = row.activity.topRepos.slice(0, 2);
   const isEligibleAny = isAnyEligibleNow(row.miner);
   const accentColor = resolveMinerAccentColor(row.miner);
@@ -1421,7 +1421,7 @@ const MobileMinerCard: React.FC<{
           <Typography
             sx={{
               fontSize: '0.55rem',
-              color: alpha('#fff', 0.5),
+              color: alpha(theme.palette.common.white, 0.5),
               textTransform: 'uppercase',
               letterSpacing: '0.8px',
               fontWeight: 700,
@@ -1487,7 +1487,11 @@ const MobileMinerCard: React.FC<{
               ? displayedCombinedScore(row.miner).toFixed(1)
               : '—'
           }
-          valueColor={row.combined > 0 ? 'text.primary' : alpha('#fff', 0.3)}
+          valueColor={
+            row.combined > 0
+              ? 'text.primary'
+              : alpha(theme.palette.common.white, 0.3)
+          }
           tooltip={
             <RowTooltipContent
               title={`Combined score · ${row.combined.toFixed(2)}`}
@@ -1534,7 +1538,11 @@ const MobileMinerCard: React.FC<{
               </Box>
             )
           }
-          valueColor={usd > 0 ? STATUS_COLORS.success : alpha('#fff', 0.32)}
+          valueColor={
+            usd > 0
+              ? STATUS_COLORS.success
+              : alpha(theme.palette.common.white, 0.32)
+          }
           tooltip={
             usd > 0 ? undefined : (
               <RowTooltipContent
@@ -1584,7 +1592,10 @@ const MobileMinerCard: React.FC<{
           value={mergedTotal > 0 ? mergedTotal.toLocaleString() : '—'}
           valueSize="0.82rem"
           valueWeight={600}
-          valueColor={alpha('#fff', mergedTotal > 0 ? 0.38 : 0.18)}
+          valueColor={alpha(
+            theme.palette.common.white,
+            mergedTotal > 0 ? 0.38 : 0.18,
+          )}
           icon={
             <GhPrIcon
               size={13}
@@ -1602,7 +1613,10 @@ const MobileMinerCard: React.FC<{
           value={solvedTotal > 0 ? solvedTotal.toLocaleString() : '—'}
           valueSize="0.82rem"
           valueWeight={600}
-          valueColor={alpha('#fff', solvedTotal > 0 ? 0.38 : 0.18)}
+          valueColor={alpha(
+            theme.palette.common.white,
+            solvedTotal > 0 ? 0.38 : 0.18,
+          )}
           icon={
             <GhIssueIcon
               size={13}
@@ -1686,7 +1700,7 @@ const MobileMinerCard: React.FC<{
                   sx={{
                     fontFamily: '"JetBrains Mono", monospace',
                     fontSize: '0.72rem',
-                    color: alpha('#fff', 0.22),
+                    color: alpha(theme.palette.common.white, 0.22),
                     lineHeight: 1.3,
                   }}
                 >
@@ -1992,7 +2006,7 @@ const Toolbar: React.FC<ToolbarProps> = ({
             sx={{
               fontSize: '0.72rem',
               fontWeight: 600,
-              color: alpha('#fff', 0.7),
+              color: alpha(theme.palette.common.white, 0.7),
               fontFamily: '"JetBrains Mono", monospace',
               whiteSpace: 'nowrap',
               lineHeight: 1.1,
@@ -2004,7 +2018,7 @@ const Toolbar: React.FC<ToolbarProps> = ({
             <Typography
               sx={{
                 fontSize: '0.62rem',
-                color: alpha('#fff', 0.4),
+                color: alpha(theme.palette.common.white, 0.4),
                 fontFamily: '"JetBrains Mono", monospace',
                 whiteSpace: 'nowrap',
                 lineHeight: 1.1,
@@ -2069,7 +2083,7 @@ const Toolbar: React.FC<ToolbarProps> = ({
                     sx={{
                       fontSize: '0.95rem',
                       mr: 0.75,
-                      color: alpha('#fff', 0.4),
+                      color: alpha(theme.palette.common.white, 0.4),
                     }}
                   />
                 }
@@ -2112,7 +2126,7 @@ const Toolbar: React.FC<ToolbarProps> = ({
                         backgroundColor: t.palette.surface.elevated,
                         backgroundImage: 'none',
                         border: `1px solid ${t.palette.border.light}`,
-                        boxShadow: '0 12px 32px rgba(0, 0, 0, 0.55)',
+                        boxShadow: `0 12px 32px ${alpha(theme.palette.common.black, 0.55)}`,
                       }),
                     },
                   },
@@ -2207,7 +2221,7 @@ const Toolbar: React.FC<ToolbarProps> = ({
                     component="span"
                     sx={{
                       fontSize: '0.6rem',
-                      color: alpha('#fff', 0.5),
+                      color: alpha(theme.palette.common.white, 0.5),
                       textTransform: 'uppercase',
                       letterSpacing: '0.4px',
                       fontWeight: 700,
@@ -2239,7 +2253,7 @@ const Toolbar: React.FC<ToolbarProps> = ({
                       backgroundColor: t.palette.surface.elevated,
                       backgroundImage: 'none',
                       border: `1px solid ${t.palette.border.light}`,
-                      boxShadow: '0 12px 32px rgba(0, 0, 0, 0.55)',
+                      boxShadow: `0 12px 32px ${alpha(theme.palette.common.black, 0.55)}`,
                     }),
                   },
                 },
@@ -2417,7 +2431,10 @@ const Toolbar: React.FC<ToolbarProps> = ({
             startAdornment: (
               <InputAdornment position="start">
                 <SearchIcon
-                  sx={{ fontSize: '1rem', color: alpha('#fff', 0.4) }}
+                  sx={{
+                    fontSize: '1rem',
+                    color: alpha(theme.palette.common.white, 0.4),
+                  }}
                 />
               </InputAdornment>
             ),
@@ -2943,7 +2960,10 @@ const MinersLeaderTable: React.FC<MinersLeaderTableProps> = ({
                   fontFamily: '"JetBrains Mono", monospace',
                   fontSize: '0.9rem',
                   fontWeight: 700,
-                  color: row.combined > 0 ? 'text.primary' : alpha('#fff', 0.3),
+                  color:
+                    row.combined > 0
+                      ? 'text.primary'
+                      : alpha(theme.palette.common.white, 0.3),
                   fontVariantNumeric: 'tabular-nums',
                   lineHeight: 1,
                 }}
@@ -3026,7 +3046,10 @@ const MinersLeaderTable: React.FC<MinersLeaderTableProps> = ({
                 fontFamily: '"JetBrains Mono", monospace',
                 fontSize: '0.85rem',
                 fontWeight: usd > 0 ? 700 : 500,
-                color: usd > 0 ? STATUS_COLORS.success : alpha('#fff', 0.3),
+                color:
+                  usd > 0
+                    ? STATUS_COLORS.success
+                    : alpha(theme.palette.common.white, 0.3),
                 cursor: 'help',
               }}
             >
@@ -3129,7 +3152,7 @@ const MinersLeaderTable: React.FC<MinersLeaderTableProps> = ({
                 fontWeight: hits > 0 ? 700 : 500,
                 color:
                   hits === 0
-                    ? alpha('#fff', merged > 0 ? 0.28 : 0.2)
+                    ? alpha(theme.palette.common.white, merged > 0 ? 0.28 : 0.2)
                     : hits >= 5
                       ? STATUS_COLORS.closed
                       : STATUS_COLORS.warningOrange,
@@ -3201,7 +3224,7 @@ const MinersLeaderTable: React.FC<MinersLeaderTableProps> = ({
               ? STATUS_COLORS.warningOrange
               : tone === 'positive'
                 ? STATUS_COLORS.success
-                : alpha('#fff', 0.3);
+                : alpha(theme.palette.common.white, 0.3);
         const tooltipNode = (() => {
           if (open === 0) {
             return (
@@ -3286,7 +3309,8 @@ const MinersLeaderTable: React.FC<MinersLeaderTableProps> = ({
                 fontFamily: '"JetBrains Mono", monospace',
                 fontSize: '0.82rem',
                 fontWeight: open > 0 ? 700 : 500,
-                color: open > 0 ? color : alpha('#fff', 0.3),
+                color:
+                  open > 0 ? color : alpha(theme.palette.common.white, 0.3),
                 lineHeight: 1,
                 cursor: 'help',
                 whiteSpace: 'nowrap',
@@ -3297,7 +3321,7 @@ const MinersLeaderTable: React.FC<MinersLeaderTableProps> = ({
                 component="span"
                 sx={{
                   fontSize: '0.66rem',
-                  color: alpha('#fff', 0.45),
+                  color: alpha(theme.palette.common.white, 0.45),
                   fontWeight: 500,
                   ml: '2px',
                 }}
@@ -3376,7 +3400,9 @@ const MinersLeaderTable: React.FC<MinersLeaderTableProps> = ({
                 fontFamily: '"JetBrains Mono", monospace',
                 fontSize: '0.74rem',
                 whiteSpace: 'nowrap',
-                color: iso ? alpha('#fff', 0.65) : alpha('#fff', 0.3),
+                color: iso
+                  ? alpha(theme.palette.common.white, 0.65)
+                  : alpha(theme.palette.common.white, 0.3),
                 cursor: 'help',
               }}
             >
@@ -3439,7 +3465,12 @@ const MinersLeaderTable: React.FC<MinersLeaderTableProps> = ({
 
   const emptyState = (
     <Box sx={{ textAlign: 'center', py: 6 }}>
-      <Typography sx={{ fontSize: '0.85rem', color: alpha('#fff', 0.5) }}>
+      <Typography
+        sx={{
+          fontSize: '0.85rem',
+          color: alpha(theme.palette.common.white, 0.5),
+        }}
+      >
         {miners.length === 0
           ? 'No miners registered yet.'
           : 'No miners match these filters.'}
@@ -3512,7 +3543,7 @@ const MinersLeaderTable: React.FC<MinersLeaderTableProps> = ({
             cursor: 'pointer',
             ...(ineligible && {
               filter: 'brightness(0.88) saturate(0.92)',
-              '& td': { color: 'rgba(255, 255, 255, 0.82)' },
+              '& td': { color: alpha(theme.palette.common.white, 0.82) },
             }),
             '& > td:first-of-type': {
               boxShadow: `inset 3px 0 0 0 ${accent}`,
@@ -3526,7 +3557,7 @@ const MinersLeaderTable: React.FC<MinersLeaderTableProps> = ({
               outline: '2px solid',
               outlineColor: 'primary.main',
               outlineOffset: -2,
-              backgroundColor: 'rgba(29, 55, 252, 0.08)',
+              backgroundColor: alpha(theme.palette.primary.main, 0.08),
             },
           };
         }}

--- a/src/components/leaderboard/MinersLeaderTable.tsx
+++ b/src/components/leaderboard/MinersLeaderTable.tsx
@@ -32,6 +32,7 @@ import {
   ViewModule as ViewModuleIcon,
 } from '@mui/icons-material';
 import { GhIssueIcon, GhPrIcon } from './GhIcons';
+import { RankIcon } from './RankIcon';
 import { DataTable, type DataTableColumn } from '../common/DataTable';
 import { ClearSearchAdornment } from '../common/ClearSearchAdornment';
 import TablePagination from '../common/TablePagination';
@@ -79,7 +80,6 @@ import { NetworkPulsePill } from './NetworkPulsePill';
 import { useRankSnapshot } from './useRankSnapshot';
 import {
   cohortOf,
-  COHORT_COLORS,
   COHORT_DESCRIPTIONS,
   COHORT_LABELS,
   isAnyEligibleNow,
@@ -556,19 +556,7 @@ const RankCell: React.FC<{
         gap: '3px',
       }}
     >
-      <Typography
-        sx={{
-          fontFamily: '"JetBrains Mono", monospace',
-          fontSize: '0.85rem',
-          fontWeight: 600,
-          color: alpha(theme.palette.common.white, 0.7),
-          lineHeight: 1,
-          letterSpacing: '-0.02em',
-          textAlign: 'center',
-        }}
-      >
-        {globalRank}
-      </Typography>
+      <RankIcon rank={globalRank} />
       <MovementGlyph
         globalRank={globalRank}
         previousRank={previousRank}
@@ -729,12 +717,6 @@ const EligibilityPill: React.FC<{
       </Box>
     </Box>
   );
-};
-
-// Always returns a color so every row/card carries a rail matching its cohort.
-const resolveMinerAccentColor = (m: MinerEvaluation): string => {
-  if ((m.failedReason ?? '').trim()) return STATUS_COLORS.closed;
-  return COHORT_COLORS[cohortOf(m)];
 };
 
 const ContributionStatsRow: React.FC<{
@@ -1273,7 +1255,6 @@ const MobileMinerCard: React.FC<{
     : alpha(theme.palette.common.white, 0.3);
   const topRepos = row.activity.topRepos.slice(0, 2);
   const isEligibleAny = isAnyEligibleNow(row.miner);
-  const accentColor = resolveMinerAccentColor(row.miner);
 
   return (
     <Box
@@ -1297,20 +1278,10 @@ const MobileMinerCard: React.FC<{
         pl: { xs: 1.75, sm: 2 },
         pr: { xs: 1.5, sm: 1.75 },
         py: 1.5,
-        backgroundColor: t.palette.surface.subtle,
-        border: `1px solid ${alpha(accentColor, isEligibleAny ? 0.45 : 0.25)}`,
+        backgroundColor: t.palette.surface.transparent,
+        border: `1px solid ${t.palette.border.light}`,
         borderRadius: 2,
         filter: isEligibleAny ? 'none' : 'brightness(0.88) saturate(0.92)',
-        '&::before': {
-          content: '""',
-          position: 'absolute',
-          top: 0,
-          left: 0,
-          bottom: 0,
-          width: 3,
-          backgroundColor: accentColor,
-          boxShadow: `0 0 8px 0 ${alpha(accentColor, isEligibleAny ? 0.45 : 0.2)}`,
-        },
         transition:
           'background-color 0.15s, border-color 0.15s, transform 0.15s, filter 0.15s',
         '&:hover': {
@@ -1814,18 +1785,6 @@ const EligibilitySegmentedControl: React.FC<{
             boxShadow: active
               ? `inset 0 0 0 1px ${alpha(t.palette.text.primary, 0.1)}`
               : 'none',
-            '&::after': active
-              ? {
-                  content: '""',
-                  position: 'absolute',
-                  left: '20%',
-                  right: '20%',
-                  bottom: 3,
-                  height: 2,
-                  borderRadius: 999,
-                  backgroundColor: t.palette.primary.main,
-                }
-              : undefined,
             '&:hover': {
               backgroundColor: active
                 ? alpha(t.palette.text.primary, 0.1)
@@ -2800,7 +2759,7 @@ const MinersLeaderTable: React.FC<MinersLeaderTableProps> = ({
       key: 'trend',
       header: 'Trend',
       width: 172,
-      headerSx: { display: tierMd },
+      headerSx: { display: tierMd, textAlign: 'center' },
       cellSx: { display: tierMd },
       renderCell: (row) => (
         <Box
@@ -2824,6 +2783,7 @@ const MinersLeaderTable: React.FC<MinersLeaderTableProps> = ({
             height={32}
             primaryLabel="OSS"
             secondaryLabel="Discovery"
+            emphasis
           />
         </Box>
       ),
@@ -3489,7 +3449,16 @@ const MinersLeaderTable: React.FC<MinersLeaderTableProps> = ({
 
   if (effectiveViewMode === 'cards') {
     return (
-      <Card sx={{ p: 0, overflow: 'hidden' }}>
+      <Card
+        sx={{
+          p: 0,
+          overflow: 'hidden',
+          borderRadius: 3,
+          border: '1px solid',
+          borderColor: 'border.light',
+          backgroundColor: 'background.default',
+        }}
+      >
         {toolbar}
         {showInitialLoading ? (
           <Box sx={{ py: 6, textAlign: 'center', color: 'text.secondary' }}>
@@ -3528,7 +3497,16 @@ const MinersLeaderTable: React.FC<MinersLeaderTableProps> = ({
   }
 
   return (
-    <Card sx={{ p: 0, overflow: 'hidden' }}>
+    <Card
+      sx={{
+        p: 0,
+        overflow: 'hidden',
+        borderRadius: 3,
+        border: '1px solid',
+        borderColor: 'border.light',
+        backgroundColor: 'transparent',
+      }}
+    >
       <DataTable<RankedMiner, SortField>
         columns={columns}
         rows={paged}
@@ -3538,17 +3516,17 @@ const MinersLeaderTable: React.FC<MinersLeaderTableProps> = ({
         }
         getRowSx={(row) => {
           const ineligible = !isAnyEligibleNow(row.miner);
-          const accent = resolveMinerAccentColor(row.miner);
           return {
             cursor: 'pointer',
+            transition: 'all 0.2s',
+            borderBottom: '1px solid',
+            borderColor: 'surface.light',
             ...(ineligible && {
               filter: 'brightness(0.88) saturate(0.92)',
               '& td': { color: alpha(theme.palette.common.white, 0.82) },
             }),
-            '& > td:first-of-type': {
-              boxShadow: `inset 3px 0 0 0 ${accent}`,
-            },
             '&:hover': {
+              backgroundColor: 'border.subtle',
               filter: ineligible
                 ? 'brightness(0.98) saturate(0.98)'
                 : undefined,

--- a/src/components/leaderboard/NetworkPulsePill.tsx
+++ b/src/components/leaderboard/NetworkPulsePill.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Box, Tooltip, alpha } from '@mui/material';
-import { STATUS_COLORS, tooltipSlotProps } from '../../theme';
+import theme, { STATUS_COLORS, tooltipSlotProps } from '../../theme';
 import { useMinerActivityIndex } from './useMinerActivityIndex';
 
 export const NetworkPulsePill: React.FC = () => {
@@ -16,7 +16,7 @@ export const NetworkPulsePill: React.FC = () => {
     color = STATUS_COLORS.success;
   } else if (lowSample) {
     label = `${last7}/${prior7} PRs · last vs prior 7d`;
-    color = alpha('#fff', 0.5);
+    color = alpha(theme.palette.common.white, 0.5);
   } else {
     const delta = last7 - prior7;
     const pct = Math.round((Math.abs(delta) / prior7) * 100);
@@ -27,7 +27,7 @@ export const NetworkPulsePill: React.FC = () => {
         ? STATUS_COLORS.success
         : delta < 0
           ? STATUS_COLORS.warningOrange
-          : alpha('#fff', 0.5);
+          : alpha(theme.palette.common.white, 0.5);
   }
   return (
     <Tooltip

--- a/src/components/leaderboard/NetworkPulsePill.tsx
+++ b/src/components/leaderboard/NetworkPulsePill.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { Box, Tooltip, alpha } from '@mui/material';
+import { STATUS_COLORS, tooltipSlotProps } from '../../theme';
+import { useMinerActivityIndex } from './useMinerActivityIndex';
+
+export const NetworkPulsePill: React.FC = () => {
+  const { network } = useMinerActivityIndex({ lookbackDays: 30 });
+  const { last7, prior7 } = network;
+  if (last7 === 0 && prior7 === 0) return null;
+  let label: string;
+  let color: string;
+  // Low sample (<5 PRs) makes the % delta meaningless — show raw counts instead.
+  const lowSample = prior7 < 5;
+  if (prior7 === 0) {
+    label = `${last7.toLocaleString()} new PR${last7 === 1 ? '' : 's'} this week`;
+    color = STATUS_COLORS.success;
+  } else if (lowSample) {
+    label = `${last7}/${prior7} PRs · last vs prior 7d`;
+    color = alpha('#fff', 0.5);
+  } else {
+    const delta = last7 - prior7;
+    const pct = Math.round((Math.abs(delta) / prior7) * 100);
+    const arrow = delta > 0 ? '↑' : delta < 0 ? '↓' : '·';
+    label = `${arrow}${pct}% · ${last7.toLocaleString()}/${prior7.toLocaleString()} PRs (7d)`;
+    color =
+      delta > 0
+        ? STATUS_COLORS.success
+        : delta < 0
+          ? STATUS_COLORS.warningOrange
+          : alpha('#fff', 0.5);
+  }
+  return (
+    <Tooltip
+      title={
+        <Box sx={{ lineHeight: 1.45, maxWidth: 260 }}>
+          <Box sx={{ fontWeight: 700, fontSize: '0.78rem' }}>
+            Network PR velocity
+          </Box>
+          <Box sx={{ fontSize: '0.7rem', opacity: 0.82, mt: '2px' }}>
+            <Box
+              component="span"
+              sx={{ fontFamily: '"JetBrains Mono", monospace' }}
+            >
+              {last7.toLocaleString()}
+            </Box>{' '}
+            merged PRs in the last 7 days vs{' '}
+            <Box
+              component="span"
+              sx={{ fontFamily: '"JetBrains Mono", monospace' }}
+            >
+              {prior7.toLocaleString()}
+            </Box>{' '}
+            the week before. Tracks rolling network activity — the daily
+            emissions pool only shows the snapshot incentive rate.
+          </Box>
+        </Box>
+      }
+      arrow
+      placement="top"
+      slotProps={tooltipSlotProps}
+    >
+      <Box
+        sx={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: '4px',
+          px: '8px',
+          py: '3px',
+          borderRadius: 999,
+          fontSize: '0.66rem',
+          fontWeight: 700,
+          letterSpacing: '0.2px',
+          color,
+          backgroundColor: alpha(color, 0.12),
+          border: `1px solid ${alpha(color, 0.3)}`,
+          fontFamily: '"JetBrains Mono", monospace',
+          cursor: 'help',
+          alignSelf: 'center',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {label}
+      </Box>
+    </Tooltip>
+  );
+};

--- a/src/components/leaderboard/Sparkline.tsx
+++ b/src/components/leaderboard/Sparkline.tsx
@@ -1,0 +1,225 @@
+import React from 'react';
+import { Box, Tooltip } from '@mui/material';
+import { STATUS_COLORS, tooltipSlotProps } from '../../theme';
+
+interface SparklineProps {
+  values: readonly number[];
+  secondaryValues?: readonly number[];
+  width?: number;
+  height?: number;
+  color?: string;
+  secondaryColor?: string;
+  label?: React.ReactNode;
+  primaryLabel?: string;
+  secondaryLabel?: string;
+  emphasis?: boolean;
+}
+
+interface BarSpec {
+  x: number;
+  barWidth: number;
+  primaryY: number;
+  primaryH: number;
+  secondaryY: number;
+  secondaryH: number;
+}
+
+const computeBars = (
+  primary: readonly number[],
+  secondary: readonly number[] | null,
+  width: number,
+  height: number,
+  scaleMax: number,
+  padV = 2,
+): BarSpec[] => {
+  const cols = primary.length;
+  if (cols === 0) return [];
+  const slot = width / cols;
+  const barWidth = Math.max(1, slot * 0.72);
+  const offset = (slot - barWidth) / 2;
+  const usable = height - padV * 2;
+  const baseline = height - padV;
+  return primary.map((p, i) => {
+    const s = secondary?.[i] ?? 0;
+    const primaryH = scaleMax > 0 ? (p / scaleMax) * usable : 0;
+    const secondaryH = scaleMax > 0 ? (s / scaleMax) * usable : 0;
+    const x = i * slot + offset;
+    return {
+      x,
+      barWidth,
+      primaryY: baseline - primaryH,
+      primaryH,
+      secondaryY: baseline - primaryH - secondaryH,
+      secondaryH,
+    };
+  });
+};
+
+const sumLast = (values: readonly number[], n: number): number =>
+  values.slice(-n).reduce((a, b) => a + b, 0);
+
+const Sparkline: React.FC<SparklineProps> = ({
+  values,
+  secondaryValues,
+  width = 96,
+  height = 22,
+  color = STATUS_COLORS.merged,
+  secondaryColor = STATUS_COLORS.info,
+  label,
+  primaryLabel = 'merged',
+  secondaryLabel = 'discovery',
+  emphasis = false,
+}) => {
+  const primaryOpacity = emphasis ? 0.95 : 0.78;
+  const secondaryOpacity = emphasis ? 0.95 : 0.78;
+  const hasSecondary =
+    !!secondaryValues &&
+    secondaryValues.length === values.length &&
+    secondaryValues.some((v) => v > 0);
+
+  const total = values.reduce((a, b) => a + b, 0);
+  const totalSecondary = hasSecondary
+    ? secondaryValues!.reduce((a, b) => a + b, 0)
+    : 0;
+  const last7 = sumLast(values, 7);
+  const last7Secondary = hasSecondary ? sumLast(secondaryValues!, 7) : 0;
+  const prior7 =
+    values.length >= 14
+      ? values.slice(-14, -7).reduce((a, b) => a + b, 0)
+      : null;
+
+  let trendText = '';
+  if (prior7 !== null) {
+    if (prior7 === 0 && last7 > 0) trendText = ' · new this week';
+    else if (prior7 > 0) {
+      const arrow = last7 > prior7 ? '↑' : last7 < prior7 ? '↓' : '·';
+      const pct = Math.round((Math.abs(last7 - prior7) / prior7) * 100);
+      trendText = ` · ${arrow}${pct}% vs prior 7d`;
+    }
+  }
+
+  const defaultTooltip: React.ReactNode = (() => {
+    if (total === 0 && totalSecondary === 0) {
+      return `No PR activity in the last ${values.length} days`;
+    }
+    if (!hasSecondary) {
+      return `${total} ${primaryLabel} in ${values.length}d · ${last7} in the last 7d${trendText}`;
+    }
+    return (
+      <Box sx={{ lineHeight: 1.45 }}>
+        <Box sx={{ fontWeight: 700, fontSize: '0.78rem' }}>
+          {values.length}d activity{trendText}
+        </Box>
+        <Box sx={{ fontSize: '0.72rem', opacity: 0.85, mt: '2px' }}>
+          <Box component="span" sx={{ color }}>
+            ● {primaryLabel}
+          </Box>{' '}
+          {total} ({last7} this week)
+        </Box>
+        <Box sx={{ fontSize: '0.72rem', opacity: 0.85 }}>
+          <Box component="span" sx={{ color: secondaryColor }}>
+            ● {secondaryLabel}
+          </Box>{' '}
+          {totalSecondary} ({last7Secondary} this week)
+        </Box>
+      </Box>
+    );
+  })();
+
+  const tooltip = label ?? defaultTooltip;
+
+  if (values.length === 0 || (total === 0 && totalSecondary === 0)) {
+    const lookback = values.length || 30;
+    return (
+      <Tooltip
+        title={tooltip}
+        arrow
+        placement="top"
+        slotProps={tooltipSlotProps}
+      >
+        <Box
+          sx={{
+            width,
+            height,
+            display: 'inline-flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            fontFamily: '"JetBrains Mono", monospace',
+            color: 'text.tertiary',
+            ...(emphasis
+              ? {
+                  fontSize: '0.7rem',
+                  letterSpacing: '0.3px',
+                  opacity: 0.55,
+                  textTransform: 'uppercase',
+                  fontWeight: 600,
+                }
+              : { fontSize: '0.65rem', opacity: 0.3 }),
+          }}
+        >
+          {emphasis ? `No activity · last ${lookback}d` : '—'}
+        </Box>
+      </Tooltip>
+    );
+  }
+
+  const stackedTotals = values.map(
+    (v, i) => v + (hasSecondary ? (secondaryValues?.[i] ?? 0) : 0),
+  );
+  const scaleMax = Math.max(...stackedTotals, 0);
+
+  const bars = computeBars(
+    values,
+    hasSecondary ? secondaryValues! : null,
+    width,
+    height,
+    scaleMax,
+  );
+
+  const cornerRadius = Math.min(1.5, bars[0]?.barWidth / 3 || 0);
+
+  return (
+    <Tooltip title={tooltip} arrow placement="top" slotProps={tooltipSlotProps}>
+      <Box sx={{ display: 'inline-block', width, height, flexShrink: 0 }}>
+        <svg
+          width={width}
+          height={height}
+          viewBox={`0 0 ${width} ${height}`}
+          style={{ display: 'block', overflow: 'hidden' }}
+          aria-hidden
+        >
+          {bars.map((b, i) => (
+            <React.Fragment key={i}>
+              {b.primaryH > 0 && (
+                <rect
+                  x={b.x}
+                  y={b.primaryY}
+                  width={b.barWidth}
+                  height={b.primaryH}
+                  fill={color}
+                  opacity={primaryOpacity}
+                  rx={cornerRadius}
+                  ry={cornerRadius}
+                />
+              )}
+              {b.secondaryH > 0 && (
+                <rect
+                  x={b.x}
+                  y={b.secondaryY}
+                  width={b.barWidth}
+                  height={b.secondaryH}
+                  fill={secondaryColor}
+                  opacity={secondaryOpacity}
+                  rx={cornerRadius}
+                  ry={cornerRadius}
+                />
+              )}
+            </React.Fragment>
+          ))}
+        </svg>
+      </Box>
+    </Tooltip>
+  );
+};
+
+export default Sparkline;

--- a/src/components/leaderboard/SparklineDetailModal.tsx
+++ b/src/components/leaderboard/SparklineDetailModal.tsx
@@ -1,0 +1,687 @@
+import React, { useMemo, useState } from 'react';
+import {
+  Avatar,
+  Box,
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  Stack,
+  ToggleButton,
+  ToggleButtonGroup,
+  Tooltip,
+  Typography,
+  alpha,
+  useTheme,
+} from '@mui/material';
+import { type Theme } from '@mui/material/styles';
+import CloseIcon from '@mui/icons-material/Close';
+import ShowChartIcon from '@mui/icons-material/ShowChart';
+import BarChartIcon from '@mui/icons-material/BarChart';
+import StackedBarChartIcon from '@mui/icons-material/StackedBarChart';
+import ReactECharts from 'echarts-for-react';
+import { format, startOfDay, startOfHour, subDays, subHours } from 'date-fns';
+import { LEADERBOARD_TRACK_COLORS, tooltipSlotProps } from '../../theme';
+import { getRepositoryOwnerAvatarSrc } from '../../utils/avatar';
+import {
+  echartsAxisTooltipChrome,
+  echartsFontFamily,
+  echartsMutedCartesianAxisColors,
+  echartsTransparentBackground,
+} from '../../utils/echarts/gittensorChartTheme';
+import { useRecentCommits } from '../../api';
+import { isDiscoveryCommit } from './useMinerActivityIndex';
+
+interface SparklineDetailModalProps {
+  open: boolean;
+  onClose: () => void;
+  username: string;
+  /** GitHub numeric ID — required for the 1D view's hourly bucketing. */
+  githubId?: string;
+  primaryValues: readonly number[];
+  secondaryValues: readonly number[];
+  primaryLabel?: string;
+  secondaryLabel?: string;
+}
+
+type ChartMode = 'stack' | 'bar' | 'line';
+type RangeKey = '1d' | '7d' | '30d';
+
+interface RangeOption {
+  key: RangeKey;
+  label: string;
+  /** Number of buckets in this range. */
+  points: number;
+  /** Width of one bucket in milliseconds. */
+  bucketMs: number;
+  /** Date-fns label format used for the x-axis tick. */
+  tickFormat: string;
+}
+
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
+
+const RANGE_OPTIONS: readonly RangeOption[] = [
+  {
+    key: '1d',
+    label: '1D',
+    points: 8,
+    bucketMs: 3 * HOUR_MS,
+    tickFormat: 'HH:mm',
+  },
+  { key: '7d', label: '7D', points: 7, bucketMs: DAY_MS, tickFormat: 'MMM d' },
+  {
+    key: '30d',
+    label: '30D',
+    points: 30,
+    bucketMs: DAY_MS,
+    tickFormat: 'MMM d',
+  },
+] as const;
+
+interface GradientStop {
+  offset: number;
+  opacity: number;
+}
+
+const AREA_GRADIENT: readonly GradientStop[] = [
+  { offset: 0, opacity: 0.36 },
+  { offset: 1, opacity: 0 },
+];
+
+const BAR_GRADIENT: readonly GradientStop[] = [
+  { offset: 0, opacity: 0.95 },
+  { offset: 1, opacity: 0.55 },
+];
+
+const buildBuckets = (range: RangeOption, now = Date.now()) => {
+  const totalMs = range.points * range.bucketMs;
+  const anchor =
+    range.key === '1d'
+      ? startOfHour(subHours(now, totalMs / HOUR_MS)).getTime()
+      : startOfDay(subDays(now, range.points - 1)).getTime();
+  return Array.from({ length: range.points }, (_, i) => {
+    const startMs = anchor + i * range.bucketMs;
+    return {
+      startMs,
+      endMs: startMs + range.bucketMs,
+      label: format(new Date(startMs), range.tickFormat),
+    };
+  });
+};
+
+const totalOf = (xs: readonly number[]) => xs.reduce((a, b) => a + b, 0);
+
+const findPeak = (
+  primary: readonly number[],
+  secondary: readonly number[],
+  labels: readonly string[],
+): { total: number; label: string } => {
+  let bestTotal = 0;
+  let bestLabel = '';
+  for (let i = 0; i < primary.length; i += 1) {
+    const t = (primary[i] ?? 0) + (secondary[i] ?? 0);
+    if (t > bestTotal) {
+      bestTotal = t;
+      bestLabel = labels[i] ?? '';
+    }
+  }
+  return { total: bestTotal, label: bestLabel };
+};
+
+const linearFill = (color: string, stops: readonly GradientStop[]) => ({
+  type: 'linear' as const,
+  x: 0,
+  y: 0,
+  x2: 0,
+  y2: 1,
+  colorStops: stops.map((s) => ({
+    offset: s.offset,
+    color: alpha(color, s.opacity),
+  })),
+});
+
+const headerStatTileSx = (theme: Theme) => ({
+  flex: '1 1 0',
+  minWidth: 0,
+  px: 1.25,
+  py: 1,
+  borderRadius: 1.5,
+  border: `1px solid ${theme.palette.border.subtle}`,
+  backgroundColor: alpha(theme.palette.text.primary, 0.025),
+});
+
+const capsuleToggleSx = (theme: Theme, count: number, index: number) => ({
+  position: 'relative',
+  gap: 0,
+  p: 0.25,
+  borderRadius: 999,
+  border: `1px solid ${alpha(theme.palette.text.primary, 0.1)}`,
+  backgroundColor: alpha(theme.palette.text.primary, 0.035),
+  overflow: 'hidden',
+  // Pill width matches a single button so translateX(i × 100%) snaps to button i.
+  '&::before': {
+    content: '""',
+    position: 'absolute',
+    top: 3,
+    bottom: 3,
+    left: 3,
+    width: `calc((100% - 6px) / ${count})`,
+    borderRadius: 999,
+    backgroundColor: alpha(theme.palette.primary.main, 0.92),
+    boxShadow: `0 6px 16px ${alpha(theme.palette.primary.main, 0.22)}`,
+    transform: `translateX(${index * 100}%)`,
+    transition: 'transform 0.22s ease, box-shadow 0.22s ease',
+  },
+  '& .MuiToggleButtonGroup-grouped': {
+    zIndex: 1,
+    flex: 1,
+    border: 0,
+    borderRadius: '999px !important',
+    minWidth: 40,
+    height: 28,
+    px: 1,
+    color: alpha(theme.palette.text.primary, 0.6),
+    fontSize: '0.7rem',
+    fontWeight: 700,
+    letterSpacing: '0.04em',
+    textTransform: 'uppercase',
+    '&.Mui-selected, &.Mui-selected:hover': {
+      color: theme.palette.background.paper,
+      backgroundColor: 'transparent',
+    },
+    '&:hover': {
+      backgroundColor: 'transparent',
+      color: theme.palette.text.primary,
+    },
+  },
+});
+
+const StatTile: React.FC<{
+  label: string;
+  value: React.ReactNode;
+  caption?: React.ReactNode;
+  accentColor?: string;
+}> = ({ label, value, caption, accentColor }) => {
+  const theme = useTheme();
+  return (
+    <Box sx={headerStatTileSx(theme)}>
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: '6px',
+          mb: '4px',
+        }}
+      >
+        {accentColor && (
+          <Box
+            component="span"
+            sx={{
+              width: 8,
+              height: 8,
+              borderRadius: '50%',
+              backgroundColor: accentColor,
+              flexShrink: 0,
+            }}
+          />
+        )}
+        <Typography
+          sx={{
+            fontSize: '0.58rem',
+            color: alpha(theme.palette.text.primary, 0.5),
+            textTransform: 'uppercase',
+            letterSpacing: '0.6px',
+            fontWeight: 700,
+            lineHeight: 1,
+          }}
+        >
+          {label}
+        </Typography>
+      </Box>
+      <Typography
+        sx={{
+          fontFamily: '"JetBrains Mono", monospace',
+          fontSize: '1.1rem',
+          fontWeight: 700,
+          color: 'text.primary',
+          lineHeight: 1.1,
+          letterSpacing: '-0.02em',
+          fontVariantNumeric: 'tabular-nums',
+        }}
+      >
+        {value}
+      </Typography>
+      {caption && (
+        <Typography
+          sx={{
+            fontSize: '0.65rem',
+            color: alpha(theme.palette.text.primary, 0.45),
+            fontFamily: '"JetBrains Mono", monospace',
+            mt: '2px',
+            lineHeight: 1.2,
+          }}
+        >
+          {caption}
+        </Typography>
+      )}
+    </Box>
+  );
+};
+
+const SparklineDetailModal: React.FC<SparklineDetailModalProps> = ({
+  open,
+  onClose,
+  username,
+  githubId,
+  primaryValues,
+  secondaryValues,
+  primaryLabel = 'OSS',
+  secondaryLabel = 'Discovery',
+}) => {
+  const theme = useTheme();
+  const [mode, setMode] = useState<ChartMode>('stack');
+  const [range, setRange] = useState<RangeKey>('30d');
+
+  // 1D view re-buckets raw commits into 3-hour slots; daily props can't do it.
+  const { data: recentCommits } = useRecentCommits(500);
+
+  const activeRange = useMemo(
+    () => RANGE_OPTIONS.find((r) => r.key === range) ?? RANGE_OPTIONS[2],
+    [range],
+  );
+
+  const { labels, primary, secondary } = useMemo(() => {
+    if (range === '1d') {
+      const buckets = buildBuckets(activeRange);
+      const oss = new Array(buckets.length).fill(0);
+      const disc = new Array(buckets.length).fill(0);
+      const commits = recentCommits ?? [];
+      for (const c of commits) {
+        if (githubId && c.githubId?.trim() !== githubId) continue;
+        if (!c.mergedAt) continue;
+        const t = Date.parse(c.mergedAt);
+        if (!Number.isFinite(t)) continue;
+        const slot = buckets.findIndex((b) => t >= b.startMs && t < b.endMs);
+        if (slot < 0) continue;
+        if (isDiscoveryCommit(c)) disc[slot] += 1;
+        else oss[slot] += 1;
+      }
+      return {
+        labels: buckets.map((b) => b.label),
+        primary: oss,
+        secondary: disc,
+      };
+    }
+    const len = Math.min(
+      activeRange.points,
+      Math.max(primaryValues.length, secondaryValues.length),
+    );
+    const buckets = buildBuckets(activeRange);
+    return {
+      labels: buckets.map((b) => b.label),
+      primary: [...primaryValues.slice(-len)],
+      secondary: [...secondaryValues.slice(-len)],
+    };
+  }, [
+    range,
+    activeRange,
+    recentCommits,
+    githubId,
+    primaryValues,
+    secondaryValues,
+  ]);
+
+  const totalPrimary = totalOf(primary);
+  const totalSecondary = totalOf(secondary);
+  const grandTotal = totalPrimary + totalSecondary;
+  const peak = useMemo(
+    () => findPeak(primary, secondary, labels),
+    [primary, secondary, labels],
+  );
+
+  const chartOption = useMemo(() => {
+    const primaryColor = LEADERBOARD_TRACK_COLORS.oss;
+    const secondaryColor = LEADERBOARD_TRACK_COLORS.discovery;
+    const chartFont = echartsFontFamily(theme);
+    const { labelColor, axisLineColor, splitLineColor } =
+      echartsMutedCartesianAxisColors(theme);
+
+    const buildSeries = (
+      name: string,
+      data: number[],
+      color: string,
+      isPrimary: boolean,
+    ) => {
+      if (mode === 'line') {
+        return {
+          name,
+          type: 'line' as const,
+          smooth: 0.25,
+          showSymbol: false,
+          symbol: 'circle',
+          symbolSize: 6,
+          data,
+          lineStyle: { width: 2.25, color },
+          areaStyle: { color: linearFill(color, AREA_GRADIENT) },
+          emphasis: { focus: 'series' as const, scale: true },
+        };
+      }
+      const stacked = mode === 'stack';
+      return {
+        name,
+        type: 'bar' as const,
+        data,
+        stack: stacked ? 'total' : undefined,
+        barCategoryGap: stacked ? '32%' : '28%',
+        barGap: stacked ? 0 : '14%',
+        barMaxWidth: stacked ? 28 : 18,
+        itemStyle: {
+          color: linearFill(color, BAR_GRADIENT),
+          borderRadius: stacked && isPrimary ? 0 : [4, 4, 0, 0],
+        },
+        emphasis: { focus: 'series' as const },
+      };
+    };
+
+    return {
+      ...echartsTransparentBackground(),
+      animationDuration: 420,
+      color: [primaryColor, secondaryColor],
+      legend: { show: false },
+      grid: { left: '2%', right: '2%', top: 12, bottom: 6, containLabel: true },
+      tooltip: {
+        trigger: 'axis',
+        confine: true,
+        appendTo: () => document.body,
+        axisPointer: {
+          type: mode === 'line' ? 'line' : 'shadow',
+          lineStyle: {
+            color: alpha(theme.palette.text.primary, 0.22),
+            width: 1,
+          },
+          shadowStyle: { color: alpha(theme.palette.text.primary, 0.05) },
+        },
+        ...echartsAxisTooltipChrome(theme),
+        padding: [10, 12],
+        textStyle: {
+          color: theme.palette.text.primary,
+          fontFamily: chartFont,
+          fontSize: 11,
+        },
+        formatter: (
+          params: Array<{
+            axisValueLabel: string;
+            seriesName: string;
+            value: number;
+            color: string;
+          }>,
+        ) => {
+          const rows = params
+            .map((p) => {
+              const dot = `<span style="display:inline-block;width:8px;height:8px;border-radius:50%;background:${p.color};margin-right:8px;"></span>`;
+              return `<div style="display:flex;align-items:center;justify-content:space-between;gap:18px;">
+                <span style="color:${alpha(theme.palette.text.primary, 0.7)};">${dot}${p.seriesName}</span>
+                <span style="color:${theme.palette.text.primary};font-weight:700;">${p.value ?? 0}</span>
+              </div>`;
+            })
+            .join('');
+          const sum = params.reduce((s, p) => s + (p.value ?? 0), 0);
+          const totalRow =
+            params.length > 1
+              ? `<div style="margin-top:4px;padding-top:6px;border-top:1px solid ${alpha(theme.palette.text.primary, 0.1)};display:flex;justify-content:space-between;gap:18px;">
+                  <span style="color:${theme.palette.text.primary};font-weight:700;font-size:10px;letter-spacing:0.04em;text-transform:uppercase;">Total</span>
+                  <span style="color:${theme.palette.text.primary};font-weight:700;">${sum}</span>
+                </div>`
+              : '';
+          return `<div style="font-family:${chartFont};min-width:160px;display:grid;gap:6px;">
+            <div style="color:${theme.palette.text.primary};font-weight:700;">${params[0]?.axisValueLabel ?? ''}</div>
+            ${rows}${totalRow}
+          </div>`;
+        },
+      },
+      xAxis: {
+        type: 'category',
+        boundaryGap: mode !== 'line',
+        data: labels,
+        axisLabel: {
+          color: labelColor,
+          fontFamily: chartFont,
+          fontSize: 10,
+          hideOverlap: true,
+        },
+        axisLine: { lineStyle: { color: axisLineColor } },
+        axisTick: { show: false },
+      },
+      yAxis: {
+        type: 'value',
+        min: 0,
+        minInterval: 1,
+        splitNumber: 4,
+        axisLabel: { color: labelColor, fontFamily: chartFont, fontSize: 10 },
+        splitLine: {
+          lineStyle: { color: splitLineColor, type: 'dashed' as const },
+        },
+        axisLine: { show: false },
+        axisTick: { show: false },
+      },
+      series: [
+        buildSeries(primaryLabel, primary, primaryColor, true),
+        buildSeries(secondaryLabel, secondary, secondaryColor, false),
+      ],
+    };
+  }, [theme, labels, primary, secondary, primaryLabel, secondaryLabel, mode]);
+
+  const rangeIndex = RANGE_OPTIONS.findIndex((r) => r.key === range);
+  const modeIndex = (['stack', 'bar', 'line'] as ChartMode[]).indexOf(mode);
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      fullWidth
+      maxWidth="md"
+      aria-labelledby="sparkline-detail-title"
+      // Portal'd dialog clicks still bubble through React tree to ancestor SparklineButton.
+      onClick={(e) => e.stopPropagation()}
+      PaperProps={{
+        sx: (t) => ({
+          backgroundColor: t.palette.background.paper,
+          backgroundImage: `radial-gradient(ellipse 120% 60% at 50% -10%, ${alpha(t.palette.text.primary, 0.05)} 0%, transparent 55%)`,
+          border: `1px solid ${t.palette.border.light}`,
+          borderRadius: 2.5,
+        }),
+      }}
+    >
+      <DialogTitle
+        id="sparkline-detail-title"
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 1.5,
+          pr: 1,
+          py: 1.75,
+        }}
+      >
+        <Avatar
+          src={getRepositoryOwnerAvatarSrc(username)}
+          alt={username}
+          sx={(t) => ({
+            width: 36,
+            height: 36,
+            border: `1px solid ${t.palette.border.medium}`,
+          })}
+        />
+        <Box sx={{ minWidth: 0, flex: 1 }}>
+          <Typography
+            variant="h6"
+            component="span"
+            sx={{
+              fontSize: '1rem',
+              fontWeight: 700,
+              lineHeight: 1.2,
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+              display: 'block',
+            }}
+          >
+            {username}
+          </Typography>
+          <Typography
+            sx={{
+              fontSize: '0.7rem',
+              color: alpha(theme.palette.text.primary, 0.55),
+              fontFamily: '"JetBrains Mono", monospace',
+              lineHeight: 1.2,
+            }}
+          >
+            Activity · {activeRange.label} window ·{' '}
+            {grandTotal.toLocaleString()} merged PR{grandTotal === 1 ? '' : 's'}
+          </Typography>
+        </Box>
+        <IconButton
+          aria-label="close activity chart"
+          onClick={onClose}
+          size="small"
+        >
+          <CloseIcon fontSize="small" />
+        </IconButton>
+      </DialogTitle>
+
+      <DialogContent sx={{ pt: 0.5, pb: 2.5 }}>
+        <Stack direction="row" spacing={1} sx={{ mb: 1.5 }}>
+          <StatTile
+            label={primaryLabel}
+            value={totalPrimary.toLocaleString()}
+            caption="merged PRs"
+            accentColor={LEADERBOARD_TRACK_COLORS.oss}
+          />
+          <StatTile
+            label={secondaryLabel}
+            value={totalSecondary.toLocaleString()}
+            caption="merged PRs"
+            accentColor={LEADERBOARD_TRACK_COLORS.discovery}
+          />
+          <StatTile
+            label="Max"
+            value={peak.total > 0 ? peak.total.toLocaleString() : '—'}
+            caption={peak.total > 0 ? peak.label : 'no activity'}
+          />
+        </Stack>
+
+        <Stack
+          direction={{ xs: 'column', sm: 'row' }}
+          spacing={1}
+          alignItems={{ xs: 'stretch', sm: 'center' }}
+          justifyContent="space-between"
+          sx={{ mb: 1.25 }}
+        >
+          <ToggleButtonGroup
+            value={range}
+            exclusive
+            size="small"
+            onChange={(_, v: RangeKey | null) => v && setRange(v)}
+            aria-label="Range"
+            sx={capsuleToggleSx(theme, RANGE_OPTIONS.length, rangeIndex)}
+          >
+            {RANGE_OPTIONS.map(({ key, label }) => (
+              <ToggleButton key={key} value={key}>
+                {label}
+              </ToggleButton>
+            ))}
+          </ToggleButtonGroup>
+
+          <ToggleButtonGroup
+            value={mode}
+            exclusive
+            size="small"
+            onChange={(_, v: ChartMode | null) => v && setMode(v)}
+            aria-label="Chart format"
+            sx={capsuleToggleSx(theme, 3, modeIndex)}
+          >
+            <Tooltip
+              title="Stacked bars"
+              arrow
+              placement="top"
+              slotProps={tooltipSlotProps}
+            >
+              <ToggleButton value="stack" aria-label="Stacked bars">
+                <StackedBarChartIcon sx={{ fontSize: 16 }} />
+              </ToggleButton>
+            </Tooltip>
+            <Tooltip
+              title="Grouped bars"
+              arrow
+              placement="top"
+              slotProps={tooltipSlotProps}
+            >
+              <ToggleButton value="bar" aria-label="Grouped bars">
+                <BarChartIcon sx={{ fontSize: 16 }} />
+              </ToggleButton>
+            </Tooltip>
+            <Tooltip
+              title="Line chart"
+              arrow
+              placement="top"
+              slotProps={tooltipSlotProps}
+            >
+              <ToggleButton value="line" aria-label="Line chart">
+                <ShowChartIcon sx={{ fontSize: 16 }} />
+              </ToggleButton>
+            </Tooltip>
+          </ToggleButtonGroup>
+        </Stack>
+
+        <Box
+          sx={(t) => ({
+            width: '100%',
+            height: 170,
+            borderRadius: 2,
+            border: `1px solid ${t.palette.border.subtle}`,
+            backgroundColor: alpha(t.palette.text.primary, 0.02),
+            p: 1,
+            position: 'relative',
+          })}
+        >
+          {grandTotal === 0 ? (
+            <Stack
+              alignItems="center"
+              justifyContent="center"
+              spacing={0.5}
+              sx={{ height: '100%', textAlign: 'center' }}
+            >
+              <Typography
+                sx={{
+                  fontSize: '0.9rem',
+                  fontWeight: 700,
+                  color: alpha(theme.palette.text.primary, 0.7),
+                }}
+              >
+                No PR activity in this window
+              </Typography>
+              <Typography
+                sx={{
+                  fontSize: '0.75rem',
+                  color: alpha(theme.palette.text.primary, 0.45),
+                }}
+              >
+                Try a wider range or check back later.
+              </Typography>
+            </Stack>
+          ) : (
+            <ReactECharts
+              option={chartOption}
+              style={{ width: '100%', height: '100%' }}
+              opts={{ renderer: 'svg' }}
+              // notMerge prevents stale path data on line ↔ bar swaps.
+              notMerge
+            />
+          )}
+        </Box>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default SparklineDetailModal;

--- a/src/components/leaderboard/SparklineDetailModal.tsx
+++ b/src/components/leaderboard/SparklineDetailModal.tsx
@@ -168,10 +168,10 @@ const capsuleToggleSx = (theme: Theme, count: number, index: number) => ({
     left: 3,
     width: `calc((100% - 6px) / ${count})`,
     borderRadius: 999,
-    backgroundColor: alpha(theme.palette.primary.main, 0.92),
-    boxShadow: `0 6px 16px ${alpha(theme.palette.primary.main, 0.22)}`,
+    backgroundColor: alpha(theme.palette.text.primary, 0.14),
+    boxShadow: 'none',
     transform: `translateX(${index * 100}%)`,
-    transition: 'transform 0.22s ease, box-shadow 0.22s ease',
+    transition: 'transform 0.22s ease',
   },
   '& .MuiToggleButtonGroup-grouped': {
     zIndex: 1,
@@ -187,7 +187,7 @@ const capsuleToggleSx = (theme: Theme, count: number, index: number) => ({
     letterSpacing: '0.04em',
     textTransform: 'uppercase',
     '&.Mui-selected, &.Mui-selected:hover': {
-      color: theme.palette.background.paper,
+      color: theme.palette.text.primary,
       backgroundColor: 'transparent',
     },
     '&:hover': {
@@ -486,8 +486,8 @@ const SparklineDetailModal: React.FC<SparklineDetailModalProps> = ({
       onClick={(e) => e.stopPropagation()}
       PaperProps={{
         sx: (t) => ({
-          backgroundColor: t.palette.background.paper,
-          backgroundImage: `radial-gradient(ellipse 120% 60% at 50% -10%, ${alpha(t.palette.text.primary, 0.05)} 0%, transparent 55%)`,
+          backgroundColor: t.palette.background.default,
+          backgroundImage: 'none',
           border: `1px solid ${t.palette.border.light}`,
           borderRadius: 2.5,
         }),

--- a/src/components/leaderboard/eligibilityCohort.ts
+++ b/src/components/leaderboard/eligibilityCohort.ts
@@ -1,0 +1,80 @@
+import { alpha } from '@mui/material/styles';
+import { LEADERBOARD_TRACK_COLORS, STATUS_COLORS } from '../../theme';
+import { parseNumber } from '../../utils/ExplorerUtils';
+import type { MinerEvaluation } from '../../api';
+
+export type CohortKey =
+  | 'dual'
+  | 'ossOnly'
+  | 'discoveryOnly'
+  | 'activeOnly'
+  | 'inactive';
+
+export const COHORT_KEYS: readonly CohortKey[] = [
+  'dual',
+  'ossOnly',
+  'discoveryOnly',
+  'activeOnly',
+  'inactive',
+] as const;
+
+const KEY_SET = new Set<CohortKey>(COHORT_KEYS);
+
+export const COHORT_LABELS: Record<CohortKey, string> = {
+  dual: 'Dual-track',
+  ossOnly: 'OSS only',
+  discoveryOnly: 'Discovery only',
+  activeOnly: 'Below threshold',
+  inactive: 'Inactive',
+};
+
+// Shared between the Eligibility Mix segments and the row/card accent rails.
+export const COHORT_COLORS: Record<CohortKey, string> = {
+  dual: LEADERBOARD_TRACK_COLORS.dual,
+  ossOnly: LEADERBOARD_TRACK_COLORS.oss,
+  discoveryOnly: LEADERBOARD_TRACK_COLORS.discovery,
+  activeOnly: STATUS_COLORS.warning,
+  inactive: alpha('#fff', 0.22),
+};
+
+export const COHORT_DESCRIPTIONS: Record<CohortKey, string> = {
+  dual: 'Eligible for both OSS contributions and Issue discovery in at least one repo.',
+  ossOnly:
+    'Eligible for OSS contributions in at least one repo, but not yet for Issue discovery anywhere.',
+  discoveryOnly:
+    'Eligible for Issue discovery in at least one repo, but not yet for OSS contributions anywhere.',
+  activeOnly:
+    'Has merged PRs or solved issues on record but has not crossed an eligibility threshold yet.',
+  inactive: 'Registered miners with no merged PRs or solved issues on record.',
+};
+
+const isActive = (m: MinerEvaluation): boolean =>
+  parseNumber(m.totalPrs) > 0 || parseNumber(m.totalSolvedIssues) > 0;
+
+export const isPenalized = (m: MinerEvaluation): boolean =>
+  (m.failedReason ?? '').trim().length > 0;
+
+// Single source of truth for "currently earning" — keeps cohort, pill, and dim in sync.
+export const isOssEligibleNow = (m: MinerEvaluation): boolean =>
+  !isPenalized(m) && !!m.isEligible && (m.eligibleRepoCount ?? 0) > 0;
+
+export const isDiscoveryEligibleNow = (m: MinerEvaluation): boolean =>
+  !isPenalized(m) && !!m.isIssueEligible && (m.issueEligibleRepoCount ?? 0) > 0;
+
+export const isAnyEligibleNow = (m: MinerEvaluation): boolean =>
+  isOssEligibleNow(m) || isDiscoveryEligibleNow(m);
+
+export const cohortOf = (m: MinerEvaluation): CohortKey => {
+  const oss = isOssEligibleNow(m);
+  const disc = isDiscoveryEligibleNow(m);
+  if (oss && disc) return 'dual';
+  if (oss) return 'ossOnly';
+  if (disc) return 'discoveryOnly';
+  if (isActive(m)) return 'activeOnly';
+  return 'inactive';
+};
+
+export const parseCohortParam = (raw: string | null): CohortKey | null => {
+  if (raw === null) return null;
+  return KEY_SET.has(raw as CohortKey) ? (raw as CohortKey) : null;
+};

--- a/src/components/leaderboard/eligibilityCohort.ts
+++ b/src/components/leaderboard/eligibilityCohort.ts
@@ -1,5 +1,5 @@
 import { alpha } from '@mui/material/styles';
-import { LEADERBOARD_TRACK_COLORS, STATUS_COLORS } from '../../theme';
+import theme, { LEADERBOARD_TRACK_COLORS, STATUS_COLORS } from '../../theme';
 import { parseNumber } from '../../utils/ExplorerUtils';
 import type { MinerEvaluation } from '../../api';
 
@@ -34,7 +34,7 @@ export const COHORT_COLORS: Record<CohortKey, string> = {
   ossOnly: LEADERBOARD_TRACK_COLORS.oss,
   discoveryOnly: LEADERBOARD_TRACK_COLORS.discovery,
   activeOnly: STATUS_COLORS.warning,
-  inactive: alpha('#fff', 0.22),
+  inactive: alpha(theme.palette.common.white, 0.22),
 };
 
 export const COHORT_DESCRIPTIONS: Record<CohortKey, string> = {

--- a/src/components/leaderboard/index.ts
+++ b/src/components/leaderboard/index.ts
@@ -1,7 +1,7 @@
-// Components
+export { default as LeaderboardInsights } from './LeaderboardInsights';
+export { default as MinersLeaderTable } from './MinersLeaderTable';
 export { default as TopMinersTable } from './TopMinersTable';
 export { default as TopRepositoriesTable } from './TopRepositoriesTable';
 export { ActivitySidebarCards } from './ActivitySidebarCards';
 
-// Types and utilities
 export type { MinerStats } from './types';

--- a/src/components/leaderboard/leaderboardViewMode.ts
+++ b/src/components/leaderboard/leaderboardViewMode.ts
@@ -1,0 +1,65 @@
+export type LeaderboardViewMode = 'cards' | 'list';
+
+export const LEADERBOARD_VIEW_QUERY_PARAM = 'view';
+const LEADERBOARD_VIEW_STORAGE_KEY = 'leaderboard:viewMode';
+
+export const readStoredLeaderboardViewMode = (): LeaderboardViewMode => {
+  try {
+    return window.localStorage.getItem(LEADERBOARD_VIEW_STORAGE_KEY) === 'cards'
+      ? 'cards'
+      : 'list';
+  } catch {
+    return 'list';
+  }
+};
+
+export const writeStoredLeaderboardViewMode = (
+  mode: LeaderboardViewMode,
+): void => {
+  try {
+    window.localStorage.setItem(LEADERBOARD_VIEW_STORAGE_KEY, mode);
+  } catch {
+    // localStorage unavailable (private mode, quota).
+  }
+};
+
+export const getLeaderboardViewModeFromQuery = (
+  value: string | null,
+  fallback: LeaderboardViewMode,
+): LeaderboardViewMode => {
+  if (value === 'cards') return 'cards';
+  if (value === 'list') return 'list';
+  return fallback;
+};
+
+// Card sizes divide by 1/2/3 so the last grid row is never partial across breakpoints.
+export const LEADERBOARD_LIST_ROWS = [10, 25, 50] as const;
+export const LEADERBOARD_CARD_ROWS = [12, 24, 48] as const;
+export const LEADERBOARD_DEFAULT_LIST_ROWS = 25;
+export const LEADERBOARD_DEFAULT_CARD_ROWS = 12;
+
+export const LEADERBOARD_VALID_ROWS: readonly number[] = [
+  ...LEADERBOARD_LIST_ROWS,
+  ...LEADERBOARD_CARD_ROWS,
+];
+
+export const rowsOptionsForLeaderboardView = (
+  mode: LeaderboardViewMode,
+): readonly number[] =>
+  mode === 'cards' ? LEADERBOARD_CARD_ROWS : LEADERBOARD_LIST_ROWS;
+
+export const defaultRowsForLeaderboardView = (
+  mode: LeaderboardViewMode,
+): number =>
+  mode === 'cards'
+    ? LEADERBOARD_DEFAULT_CARD_ROWS
+    : LEADERBOARD_DEFAULT_LIST_ROWS;
+
+export const clampRowsForLeaderboardView = (
+  rows: number,
+  mode: LeaderboardViewMode,
+): number => {
+  const options = rowsOptionsForLeaderboardView(mode);
+  if ((options as readonly number[]).includes(rows)) return rows;
+  return defaultRowsForLeaderboardView(mode);
+};

--- a/src/components/leaderboard/scoring.ts
+++ b/src/components/leaderboard/scoring.ts
@@ -1,0 +1,87 @@
+// Mirrors gittensor/constants.py and gittensor/validator/oss_contributions/scoring.py.
+import { ELIGIBILITY_FIELD_DEFS } from '../../utils/repoConfig';
+import type { RepositoryConfig } from '../../api';
+
+const DEFAULT_THRESHOLDS: Record<string, number> = Object.fromEntries(
+  ELIGIBILITY_FIELD_DEFS.map((d) => [d.key, d.default]),
+);
+
+export interface RepoThresholds {
+  minValidMergedPrs: number;
+  minCredibility: number;
+  minTokenScoreForBaseScore: number;
+  minValidSolvedIssues: number;
+  minIssueCredibility: number;
+  openPrSlotBase: number;
+  openPrSlotTokenScore: number;
+  maxOpenPrSlots: number;
+}
+
+const pickNumber = (
+  raw: RepositoryConfig['eligibility'] | undefined,
+  key: keyof NonNullable<RepositoryConfig['eligibility']>,
+): number | undefined => {
+  const v = raw?.[key];
+  return typeof v === 'number' && Number.isFinite(v) ? v : undefined;
+};
+
+export const resolveRepoThresholds = (
+  config?: RepositoryConfig,
+): RepoThresholds => {
+  const e = config?.eligibility;
+  return {
+    minValidMergedPrs:
+      pickNumber(e, 'min_valid_merged_prs') ??
+      DEFAULT_THRESHOLDS.min_valid_merged_prs,
+    minCredibility:
+      pickNumber(e, 'min_credibility') ?? DEFAULT_THRESHOLDS.min_credibility,
+    minTokenScoreForBaseScore:
+      pickNumber(e, 'min_token_score_for_base_score') ??
+      DEFAULT_THRESHOLDS.min_token_score_for_base_score,
+    minValidSolvedIssues:
+      pickNumber(e, 'min_valid_solved_issues') ??
+      DEFAULT_THRESHOLDS.min_valid_solved_issues,
+    minIssueCredibility:
+      pickNumber(e, 'min_issue_credibility') ??
+      DEFAULT_THRESHOLDS.min_issue_credibility,
+    openPrSlotBase:
+      pickNumber(e, 'excessive_pr_penalty_base_threshold') ??
+      DEFAULT_THRESHOLDS.excessive_pr_penalty_base_threshold,
+    openPrSlotTokenScore:
+      pickNumber(e, 'open_pr_threshold_token_score') ??
+      DEFAULT_THRESHOLDS.open_pr_threshold_token_score,
+    maxOpenPrSlots:
+      pickNumber(e, 'max_open_pr_threshold') ??
+      DEFAULT_THRESHOLDS.max_open_pr_threshold,
+  };
+};
+
+// Mirrors `calculate_open_pr_threshold` in the validator.
+export const openPrSlotsAllowed = (
+  thresholds: RepoThresholds,
+  totalTokenScore: number,
+): number => {
+  const bonus = Math.floor(totalTokenScore / thresholds.openPrSlotTokenScore);
+  return Math.min(thresholds.openPrSlotBase + bonus, thresholds.maxOpenPrSlots);
+};
+
+export const splitEarnings = (
+  usdPerDay: number,
+  ossScore: number,
+  issueScore: number,
+  ossEligible: boolean,
+  issueEligible: boolean,
+): { oss: number; discovery: number } => {
+  const combined = ossScore + issueScore;
+  let ossShare = 0;
+  let discoveryShare = 0;
+  if (ossEligible && issueEligible) {
+    ossShare = combined > 0 ? ossScore / combined : 0.5;
+    discoveryShare = 1 - ossShare;
+  } else if (ossEligible) {
+    ossShare = 1;
+  } else if (issueEligible) {
+    discoveryShare = 1;
+  }
+  return { oss: usdPerDay * ossShare, discovery: usdPerDay * discoveryShare };
+};

--- a/src/components/leaderboard/useMinerActivityIndex.ts
+++ b/src/components/leaderboard/useMinerActivityIndex.ts
@@ -1,0 +1,220 @@
+import { useMemo } from 'react';
+import { useRecentCommits, type CommitLog } from '../../api';
+import { parseNumber } from '../../utils/ExplorerUtils';
+
+export interface MinerActivity {
+  dailyMerged: number[];
+  dailyOss: number[];
+  dailyDiscovery: number[];
+  topRepos: { name: string; count: number }[];
+  lastActiveAt: string | null;
+  reviewHits: number;
+}
+
+export type MinerActivityIndex = Map<string, MinerActivity>;
+
+export interface NetworkRepoActivity {
+  name: string;
+  count: number;
+  minerCount: number;
+}
+
+export interface NetworkActivity {
+  dailyMerged: number[];
+  dailyOss: number[];
+  dailyDiscovery: number[];
+  last7: number;
+  prior7: number;
+  topRepos: NetworkRepoActivity[];
+}
+
+interface Options {
+  lookbackDays?: number;
+  topReposLimit?: number;
+  commitLimit?: number;
+}
+
+const MS_PER_DAY = 86_400_000;
+const REVIEW_PENALTY_RATE = 0.15;
+
+const startOfUtcDay = (ms: number): number => {
+  const d = new Date(ms);
+  d.setUTCHours(0, 0, 0, 0);
+  return d.getTime();
+};
+
+const emptyMiner = (lookbackDays: number): MinerActivity => ({
+  dailyMerged: new Array(lookbackDays).fill(0),
+  dailyOss: new Array(lookbackDays).fill(0),
+  dailyDiscovery: new Array(lookbackDays).fill(0),
+  topRepos: [],
+  lastActiveAt: null,
+  reviewHits: 0,
+});
+
+// Mirrors `isIssueDiscoveryContributionPr` in `utils/ExplorerUtils.ts`.
+export const isDiscoveryCommit = (commit: CommitLog): boolean => {
+  const im = commit.issueMultiplier;
+  if (im !== undefined && im !== null && String(im).trim() !== '') {
+    if (parseNumber(im) > 0) return true;
+  }
+  if (commit.labelMultiplier !== undefined && commit.labelMultiplier !== null) {
+    if (parseNumber(commit.labelMultiplier) > 0) return true;
+  }
+  if (commit.label !== undefined && commit.label !== null) {
+    if (String(commit.label).trim() !== '') return true;
+  }
+  return false;
+};
+
+// multiplier = max(0, 1 - 0.15 × N), so N = round((1 - m) / 0.15).
+const inferReviewHits = (multiplier: string | undefined): number => {
+  if (multiplier === undefined) return 0;
+  const m = parseNumber(multiplier);
+  if (!Number.isFinite(m) || m >= 1) return 0;
+  return Math.max(0, Math.round((1 - m) / REVIEW_PENALTY_RATE));
+};
+
+interface BuildResult {
+  index: MinerActivityIndex;
+  network: NetworkActivity;
+}
+
+const buildIndex = (
+  commits: CommitLog[],
+  lookbackDays: number,
+  topReposLimit: number,
+): BuildResult => {
+  const today = startOfUtcDay(Date.now());
+  const windowStart = today - (lookbackDays - 1) * MS_PER_DAY;
+  const index = new Map<string, MinerActivity>();
+  const networkDaily = new Array(lookbackDays).fill(0);
+  const networkOss = new Array(lookbackDays).fill(0);
+  const networkDiscovery = new Array(lookbackDays).fill(0);
+  const repoTotals = new Map<
+    string,
+    { count: number; minerIds: Set<string> }
+  >();
+
+  for (const commit of commits) {
+    const githubId = commit.githubId?.trim();
+    if (!githubId) continue;
+
+    let entry = index.get(githubId);
+    if (!entry) {
+      entry = emptyMiner(lookbackDays);
+      index.set(githubId, entry);
+    }
+
+    if (commit.mergedAt) {
+      const mergedAt = Date.parse(commit.mergedAt);
+      if (Number.isFinite(mergedAt) && mergedAt >= windowStart) {
+        const day = startOfUtcDay(mergedAt);
+        const slot = Math.round((day - windowStart) / MS_PER_DAY);
+        if (slot >= 0 && slot < lookbackDays) {
+          entry.dailyMerged[slot] += 1;
+          networkDaily[slot] += 1;
+          if (isDiscoveryCommit(commit)) {
+            entry.dailyDiscovery[slot] += 1;
+            networkDiscovery[slot] += 1;
+          } else {
+            entry.dailyOss[slot] += 1;
+            networkOss[slot] += 1;
+          }
+        }
+      }
+    }
+
+    const activityIso = commit.mergedAt ?? commit.prCreatedAt ?? null;
+    if (activityIso) {
+      if (
+        !entry.lastActiveAt ||
+        Date.parse(activityIso) > Date.parse(entry.lastActiveAt)
+      ) {
+        entry.lastActiveAt = activityIso;
+      }
+    }
+
+    if (commit.repository) {
+      const existing = entry.topRepos.find((r) => r.name === commit.repository);
+      if (existing) existing.count += 1;
+      else entry.topRepos.push({ name: commit.repository, count: 1 });
+
+      let bucket = repoTotals.get(commit.repository);
+      if (!bucket) {
+        bucket = { count: 0, minerIds: new Set() };
+        repoTotals.set(commit.repository, bucket);
+      }
+      bucket.count += 1;
+      bucket.minerIds.add(githubId);
+    }
+
+    entry.reviewHits += inferReviewHits(commit.reviewQualityMultiplier);
+  }
+
+  for (const entry of index.values()) {
+    entry.topRepos.sort((a, b) => b.count - a.count);
+    if (entry.topRepos.length > topReposLimit) {
+      entry.topRepos.length = topReposLimit;
+    }
+  }
+
+  const last7 = networkDaily.slice(-7).reduce((a, b) => a + b, 0);
+  const prior7 =
+    lookbackDays >= 14
+      ? networkDaily.slice(-14, -7).reduce((a, b) => a + b, 0)
+      : 0;
+
+  const topRepos: NetworkRepoActivity[] = Array.from(repoTotals.entries())
+    .map(([name, bucket]) => ({
+      name,
+      count: bucket.count,
+      minerCount: bucket.minerIds.size,
+    }))
+    .sort((a, b) => b.count - a.count)
+    .slice(0, 5);
+
+  return {
+    index,
+    network: {
+      dailyMerged: networkDaily,
+      dailyOss: networkOss,
+      dailyDiscovery: networkDiscovery,
+      last7,
+      prior7,
+      topRepos,
+    },
+  };
+};
+
+const EMPTY_NETWORK: NetworkActivity = {
+  dailyMerged: [],
+  dailyOss: [],
+  dailyDiscovery: [],
+  last7: 0,
+  prior7: 0,
+  topRepos: [],
+};
+
+export const useMinerActivityIndex = (
+  options: Options = {},
+): {
+  index: MinerActivityIndex;
+  network: NetworkActivity;
+  isLoading: boolean;
+} => {
+  const { lookbackDays = 30, topReposLimit = 3, commitLimit = 500 } = options;
+
+  const { data, isLoading } = useRecentCommits(commitLimit);
+
+  const built = useMemo<BuildResult>(() => {
+    if (!data) return { index: new Map(), network: EMPTY_NETWORK };
+    return buildIndex(data, lookbackDays, topReposLimit);
+  }, [data, lookbackDays, topReposLimit]);
+
+  return {
+    index: built.index,
+    network: built.network,
+    isLoading,
+  };
+};

--- a/src/components/leaderboard/useRankSnapshot.ts
+++ b/src/components/leaderboard/useRankSnapshot.ts
@@ -1,0 +1,117 @@
+// Local snapshot of yesterday's ranks so we can render day-over-day movement without backend support.
+import { useEffect, useMemo, useRef, useState } from 'react';
+
+const STORAGE_KEY = 'gittensor.rank-snapshot.v1';
+
+interface Snapshot {
+  date: string;
+  ranks: Record<string, number>;
+}
+
+interface StoredShape {
+  today: Snapshot | null;
+  prev: Snapshot | null;
+}
+
+const EMPTY: StoredShape = { today: null, prev: null };
+
+const utcDateKey = (ms: number = Date.now()): string => {
+  const d = new Date(ms);
+  return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}-${String(d.getUTCDate()).padStart(2, '0')}`;
+};
+
+const isPlainObject = (v: unknown): v is Record<string, unknown> =>
+  typeof v === 'object' && v !== null && !Array.isArray(v);
+
+const parseSnapshot = (v: unknown): Snapshot | null => {
+  if (!isPlainObject(v)) return null;
+  const date = v.date;
+  const ranks = v.ranks;
+  if (typeof date !== 'string' || !isPlainObject(ranks)) return null;
+  const cleanRanks: Record<string, number> = {};
+  for (const [k, val] of Object.entries(ranks)) {
+    if (typeof val === 'number' && Number.isFinite(val)) cleanRanks[k] = val;
+  }
+  return { date, ranks: cleanRanks };
+};
+
+const readStored = (): StoredShape => {
+  if (typeof window === 'undefined') return EMPTY;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return EMPTY;
+    const parsed = JSON.parse(raw);
+    if (!isPlainObject(parsed)) return EMPTY;
+    return {
+      today: parseSnapshot(parsed.today),
+      prev: parseSnapshot(parsed.prev),
+    };
+  } catch {
+    return EMPTY;
+  }
+};
+
+const writeStored = (state: StoredShape): void => {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  } catch {
+    // Private mode / quota.
+  }
+};
+
+const toMap = (
+  ranks: Record<string, number> | undefined,
+): Map<string, number> => {
+  const map = new Map<string, number>();
+  if (!ranks) return map;
+  for (const [k, v] of Object.entries(ranks)) map.set(k, v);
+  return map;
+};
+
+interface UseRankSnapshot {
+  previousRanks: Map<string, number>;
+  isHydrated: boolean;
+}
+
+// Capture gated on `currentRanks.size > 0` so an empty baseline doesn't erase tomorrow's signal.
+export const useRankSnapshot = (
+  currentRanks: Map<string, number>,
+): UseRankSnapshot => {
+  const [previous, setPrevious] = useState<Map<string, number>>(new Map());
+  const [isHydrated, setIsHydrated] = useState(false);
+  const capturedRef = useRef(false);
+
+  useEffect(() => {
+    if (capturedRef.current) return;
+    if (currentRanks.size === 0) return;
+
+    const today = utcDateKey();
+    const stored = readStored();
+
+    if (stored.today && stored.today.date === today) {
+      setPrevious(toMap(stored.prev?.ranks));
+    } else {
+      // New UTC day — rotate today → prev, capture now.
+      const rotatedPrev = stored.today ?? stored.prev ?? null;
+      const ranksObj: Record<string, number> = {};
+      currentRanks.forEach((rank, id) => {
+        ranksObj[id] = rank;
+      });
+      const nextStored: StoredShape = {
+        today: { date: today, ranks: ranksObj },
+        prev: rotatedPrev,
+      };
+      writeStored(nextStored);
+      setPrevious(toMap(rotatedPrev?.ranks));
+    }
+
+    capturedRef.current = true;
+    setIsHydrated(true);
+  }, [currentRanks]);
+
+  return useMemo(
+    () => ({ previousRanks: previous, isHydrated }),
+    [previous, isHydrated],
+  );
+};

--- a/src/pages/LeaderboardPage.tsx
+++ b/src/pages/LeaderboardPage.tsx
@@ -1,0 +1,120 @@
+import React, { useCallback } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { Box } from '@mui/material';
+import { Page } from '../components/layout';
+import { SEO } from '../components';
+import {
+  LeaderboardInsights,
+  MinersLeaderTable,
+} from '../components/leaderboard';
+import {
+  parseCohortParam,
+  type CohortKey,
+} from '../components/leaderboard/eligibilityCohort';
+import { useAllMiners } from '../api';
+
+const REPO_PARAM = 'repo';
+const COHORT_PARAM = 'cohort';
+
+const LeaderboardPage: React.FC = () => {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const { data, isLoading } = useAllMiners();
+
+  const selectedRepo = searchParams.get(REPO_PARAM);
+  const selectedCohort = parseCohortParam(searchParams.get(COHORT_PARAM));
+
+  const handleSelectRepo = useCallback(
+    (repo: string | null) => {
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          if (repo === null) next.delete(REPO_PARAM);
+          else next.set(REPO_PARAM, repo);
+          // Reset pagination when filters change.
+          next.delete('page');
+          return next;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
+  );
+
+  const handleToggleRepo = useCallback(
+    (repo: string) => {
+      handleSelectRepo(selectedRepo === repo ? null : repo);
+    },
+    [handleSelectRepo, selectedRepo],
+  );
+
+  const handleSelectCohort = useCallback(
+    (cohort: CohortKey | null) => {
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          if (cohort === null) next.delete(COHORT_PARAM);
+          else next.set(COHORT_PARAM, cohort);
+          next.delete('page');
+          return next;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
+  );
+
+  const handleToggleCohort = useCallback(
+    (cohort: CohortKey) => {
+      handleSelectCohort(selectedCohort === cohort ? null : cohort);
+    },
+    [handleSelectCohort, selectedCohort],
+  );
+
+  return (
+    <Page title="Leaderboard">
+      <SEO
+        title="Miner Leaderboard"
+        description="Network-wide miner rankings — daily earnings, eligibility, and credibility for every active miner."
+        type="website"
+      />
+      <Box
+        sx={{
+          display: 'flex',
+          width: '100%',
+          justifyContent: 'center',
+          py: { xs: 2, sm: 3 },
+        }}
+      >
+        <Box
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 3,
+            width: '100%',
+            maxWidth: 1320,
+            px: { xs: 2, md: 0 },
+          }}
+        >
+          <LeaderboardInsights
+            miners={data}
+            isLoading={isLoading}
+            selectedRepo={selectedRepo}
+            onSelectRepo={handleToggleRepo}
+            selectedCohort={selectedCohort}
+            onSelectCohort={handleToggleCohort}
+          />
+          <MinersLeaderTable
+            miners={data ?? []}
+            isLoading={isLoading}
+            selectedRepo={selectedRepo}
+            onSelectRepo={handleSelectRepo}
+            selectedCohort={selectedCohort}
+            onClearCohort={() => handleSelectCohort(null)}
+          />
+        </Box>
+      </Box>
+    </Page>
+  );
+};
+
+export default LeaderboardPage;

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -17,6 +17,7 @@ const IssuesPage = React.lazy(() => import('./pages/IssuesPage'));
 const SearchPage = React.lazy(() => import('./pages/search/SearchPage'));
 const IssueDetailsPage = React.lazy(() => import('./pages/IssueDetailsPage'));
 const RepositoriesPage = React.lazy(() => import('./pages/RepositoriesPage'));
+const LeaderboardPage = React.lazy(() => import('./pages/LeaderboardPage'));
 const MinerDetailsPage = React.lazy(() => import('./pages/MinerDetailsPage'));
 const RepositoryDetailsPage = React.lazy(
   () => import('./pages/RepositoryDetailsPage'),
@@ -58,9 +59,15 @@ const routesArray: AppRoute[] = [
     element: <Navigate to="/repositories" replace />,
   },
   {
+    name: 'leaderboard',
+    path: '/leaderboard',
+    element: <LeaderboardPage />,
+    showGlobalSearch: true,
+  },
+  {
     name: 'top-miners-redirect',
     path: '/top-miners',
-    element: <Navigate to="/repositories" replace />,
+    element: <Navigate to="/leaderboard" replace />,
   },
   {
     name: 'watchlist',

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -56,15 +56,17 @@ export const LEADERBOARD_TRACK_COLORS = {
 } as const;
 
 // Keep in sync with `MinerStatusKind` in leaderboard/MinerStatus.tsx.
+// Collapsed onto a restrained, shared palette: positive momentum (green),
+// penalty (red), idle (grey), and descriptive traits (blue).
 export const MINER_STATUS_COLORS = {
-  penalized: '#ff7b72',
-  hot: '#ff7b72',
-  climbing: '#a78bfa',
-  rising: '#58a6ff',
-  dormant: 'rgba(255, 255, 255, 0.4)',
-  cooling: '#7dd3fc',
-  specialist: '#f59e0b',
-  dual: '#4ade80',
+  penalized: STATUS_COLORS.closed,
+  hot: STATUS_COLORS.merged,
+  climbing: STATUS_COLORS.merged,
+  rising: STATUS_COLORS.merged,
+  dormant: STATUS_COLORS.neutral,
+  cooling: STATUS_COLORS.neutral,
+  specialist: STATUS_COLORS.info,
+  dual: STATUS_COLORS.info,
 } as const;
 
 const RISK_COLORS = {

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -43,6 +43,30 @@ export const CREDIBILITY_COLORS = {
   poor: '#f87171', // Red - below 30%
 } as const;
 
+export const TOOLTIP_TONE_COLORS = {
+  positive: '#86efac',
+  caution: '#fcd34d',
+  negative: '#fca5a5',
+} as const;
+
+export const LEADERBOARD_TRACK_COLORS = {
+  oss: '#3fb950',
+  discovery: '#58a6ff',
+  dual: '#a371f7',
+} as const;
+
+// Keep in sync with `MinerStatusKind` in leaderboard/MinerStatus.tsx.
+export const MINER_STATUS_COLORS = {
+  penalized: '#ff7b72',
+  hot: '#ff7b72',
+  climbing: '#a78bfa',
+  rising: '#58a6ff',
+  dormant: 'rgba(255, 255, 255, 0.4)',
+  cooling: '#7dd3fc',
+  specialist: '#f59e0b',
+  dual: '#4ade80',
+} as const;
+
 const RISK_COLORS = {
   exceeded: 'rgba(248, 113, 113, 0.9)', // Red - threshold exceeded
   critical: 'rgba(251, 146, 60, 0.9)', // Orange - 1 away
@@ -247,7 +271,7 @@ export const tooltipSlotProps = {
       borderRadius: '6px',
       border: '1px solid',
       borderColor: 'border.light',
-      maxWidth: 220,
+      maxWidth: { xs: 'calc(100vw - 24px)', sm: 280 },
       width: 'max-content',
       minWidth: 0,
       lineHeight: 1.45,
@@ -257,6 +281,17 @@ export const tooltipSlotProps = {
     },
   },
   arrow: { sx: { color: 'surface.tooltip' } },
+  // `flip` alone doesn't clamp to the viewport; preventOverflow keeps long bodies on-screen.
+  popper: {
+    modifiers: [
+      {
+        name: 'preventOverflow',
+        enabled: true,
+        options: { boundary: 'viewport', padding: 8 },
+      },
+      { name: 'flip', enabled: true, options: { padding: 8 } },
+    ],
+  },
 };
 
 // Module Augmentation for Custom Theme Properties
@@ -570,7 +605,7 @@ const theme = createTheme({
     MuiTooltip: {
       defaultProps: {
         enterTouchDelay: 0,
-        leaveTouchDelay: 15000,
+        leaveTouchDelay: 1500,
       },
     },
     MuiAppBar: {


### PR DESCRIPTION
## Summary

Complete tear down and rebuild of the network Leaderboard, brought back at `/leaderboard` after the original page was deleted in [#1220](https://github.com/entrius/gittensor-ui/pull/1220). The new surface feels like a control room rather than a long card list. The top of the page frames the entire network at a glance with a four zone insights card (daily pool, 90/10 split, eligibility mix, top scorers, hottest repos). The dense table below presents nine sortable columns, seven behavior driven status badges, dual track eligibility pills with per repo counts, a stacked OSS vs Discovery sparkline that opens into a 1D/7D/30D analytics modal, an open PR risk pill that mirrors the validator's slot formula, and rank movement captured locally on a UTC rotation. Every cell traces back to a concrete validator field, every tooltip carries a title, a body, and a green action hint, and every piece of UI state (cohort, repo, view mode, page) round trips through the URL.

The page is held to the bar set by [#95](https://github.com/entrius/gittensor-ui/issues/95) and grounded in the policy that has shipped since the old page came down: repository scoped emissions ([gittensor#1235](https://github.com/entrius/gittensor/pull/1235)), per repo eligibility ([gittensor#1293](https://github.com/entrius/gittensor/pull/1293)), per repo scoring config ([gittensor#1300](https://github.com/entrius/gittensor/pull/1300)), the maintainer carve out and the penalized miner skip ([gittensor#1292](https://github.com/entrius/gittensor/pull/1292), [gittensor#1329](https://github.com/entrius/gittensor/pull/1329)), collateral inside repo allocation ([gittensor#1272](https://github.com/entrius/gittensor/pull/1272)), and per repo `min_token_score` on the PR scoring path ([gittensor#1330](https://github.com/entrius/gittensor/pull/1330)).

## Related Issues

Closes #1289
Refs #95

## Type of Change

* [ ] Bug fix
* [x] New feature
* [x] Refactor
* [ ] Documentation
* [ ] Other (describe below)

## Design Rationale

### Information Architecture

The page is structured around three stages of attention. Glance, scan, drill. Each stage owns one component, and the components are wired so a click in one collapses the next.

1. **Glance — `LeaderboardInsights`**. A single hero card with four zones, no chrome, no headers above it. `DailyPoolZone` shows the combined emissions pool in USD with live TAO and α74 spot prices, and a 90/10 split bar (miners vs issues treasury) driven by `OSS_EMISSION_SHARE` and `ISSUES_TREASURY_EMISSION_SHARE`. `CompositionZone` slices the network into five cohorts via `cohortOf`, with both the bar segments and the legend rows acting as filters into the table below. `PodiumZone` ranks the top three by `total_score + issue_discovery_score`, with avatar rails tinted in `RANK_COLORS`. `HotRepoZone` carries the hero repo plus three runners up over a rolling 30 day window, where the hero and runners up filter the table to that repo. The card is the entire "what is the network doing right now" answer.

2. **Scan — `MinersLeaderTable`**. Dense table, list and card view modes. Nine sortable fields (score, USD/day, credibility, volume, recent activity, rank movement, review hits, open PR risk, watchlist). Debounced search, cohort and eligibility chip filters, URL backed pagination, page index reset on filter change so the user never lands on an empty page. Every row carries an accent rail in the cohort color, a status badge driven by validator state, dual track eligibility pills with per repo counts, a stacked OSS + Discovery sparkline, an open PR risk pill, and a watchlist toggle.

3. **Drill — `SparklineDetailModal`**. Clicking a sparkline opens an ECharts modal in 1D, 7D, or 30D ranges, in stacked, bar, or line modes. 1D buckets hourly, 7D and 30D bucket daily. The modal reuses the same `/commits` query, so opening it costs nothing on the network.

### Why This Beats A Simpler Approach

* **No policy gap.** Every signal on the page maps to a validator field. The 90/10 bar is not a marketing diagram, it is `OSS_EMISSION_SHARE` and `ISSUES_TREASURY_EMISSION_SHARE`. The cohorts are not invented, they are the cross product of `is_eligible` and `is_issue_eligible`. The open PR risk pill computes its ceiling with the same formula the validator uses (`min(base + floor(token_score / per_slot), max)`). The page never invents a number it cannot trace.
* **One activity index, three consumers.** `useMinerActivityIndex` builds the per miner activity map and the network roll up in a single pass over `/commits`. The insights card, the table, and the `NetworkPulsePill` share one round trip via React Query deduping. Adding a future consumer costs nothing.
* **No drift between cohort, pill, dim state, and filter.** `eligibilityCohort.ts` is the single source of truth for "currently earning". Every component reads from `isOssEligibleNow`, `isDiscoveryEligibleNow`, `isAnyEligibleNow`, or `cohortOf`. There is no second helper that could disagree.
* **Local rank movement, no backend dependency.** `useRankSnapshot` rotates `today → prev` on each new UTC day, gated on `currentRanks.size > 0` so an empty load does not erase the next day's signal. Day over day deltas appear after the first 24 hours without any validator side change.
* **Status taxonomy that maps to behavior, not vibes.** Seven status kinds, each tied to a concrete rule on `MinerEvaluation` and `MinerActivity`. Tooltip carries the rule verbatim, so a miner who sees `Climbing` can read the threshold that put them there.
* **State that survives a refresh.** Cohort, repo, view mode, and page index all live in the URL. Reload the tab, paste the link, hit back, the table comes back exactly as it was.
* **Card sizes that divide cleanly.** Card view rows are `12 / 24 / 48`, list view rows are `10 / 25 / 50`. Every grid row at every breakpoint is full so the last row is never partial.

## Screenshots
Video:

[1.webm](https://github.com/user-attachments/assets/55327b09-0af3-496c-a428-0d28dc665b26)

[2.webm](https://github.com/user-attachments/assets/035e406b-33cc-4ed0-af60-cce79de7c828)


Desktop 1:
<img width="1364" height="906" alt="1" src="https://github.com/user-attachments/assets/b4e9b0b2-20e5-43a8-999b-1c0e61f4bbc7" />

Desktop 2:
<img width="1370" height="903" alt="2" src="https://github.com/user-attachments/assets/9012e9fd-d14a-43ff-bc43-ebb1edb1e874" />

Desktop 3:
<img width="1336" height="708" alt="3" src="https://github.com/user-attachments/assets/c731195b-e22b-4c50-af45-cfbd773ca47c" />

Desktop 4:
<img width="1375" height="899" alt="4" src="https://github.com/user-attachments/assets/354459a3-2064-42c9-bbae-21155ee8f956" />

Desktop 5:
<img width="1357" height="832" alt="5" src="https://github.com/user-attachments/assets/d6810ea0-f6ca-492e-9040-89f808799132" />

Mobile 1:
<img width="364" height="823" alt="m1" src="https://github.com/user-attachments/assets/115311d8-d8fa-4ae2-b44f-b824c5d9ecd0" />

Mobile 2:
<img width="363" height="822" alt="m2" src="https://github.com/user-attachments/assets/50ba9770-a5d8-479b-a8bf-04bcae709c93" />

Mobile 3:
<img width="363" height="822" alt="m3" src="https://github.com/user-attachments/assets/5025d027-e989-4be8-afa3-e7e0db06d9ec" />

Mobile 4:
<img width="368" height="818" alt="m4" src="https://github.com/user-attachments/assets/94b60d86-092f-4db6-8a95-3530f3266160" />


## Validator Policy Mapping

Every field on screen has a concrete source. The page never invents a number it cannot trace.

| What the page shows | Where it comes from |
| --- | --- |
| Daily emissions pool in USD | `parseNumber(m.usdPerDay)` summed across `EARNING_COHORTS` |
| 90/10 split bar | `OSS_EMISSION_SHARE`, `ISSUES_TREASURY_EMISSION_SHARE` |
| TAO + α74 spot prices | `usePrices()` |
| Eligibility cohort | `cohortOf(m)` over `is_eligible`, `is_issue_eligible`, `eligible_repo_count`, `issue_eligible_repo_count` |
| Top scorers podium | `parseNumber(m.totalScore) + parseNumber(m.issueDiscoveryScore)` |
| Hottest repos (30d) | `/commits` grouped by `commit.repository`, sorted by count |
| Penalized badge | `m.failedReason` (verbatim in tooltip) |
| Per track eligibility pills with repo count | `is_eligible`, `is_issue_eligible`, `eligible_repo_count`, `issue_eligible_repo_count` |
| OSS vs Discovery split sparkline | `/commits` + `isDiscoveryCommit` (mirrors `isIssueDiscoveryContributionPr`) |
| Open PR risk pill | `min(openPrSlotBase + floor(tokenScore / openPrSlotTokenScore), maxOpenPrSlots)`, defaults from `ELIGIBILITY_FIELD_DEFS` |
| Earnings split (OSS vs Discovery, tooltip) | `splitEarnings` mirrors the validator OSS/Discovery share split |
| Review hit count | `N = round((1 − review_quality_multiplier) / 0.15)`, `REVIEW_PENALTY_RATE = 0.15` |
| Day over day rank movement | `useRankSnapshot`, `localStorage[gittensor.rank-snapshot.v1]` rotated per UTC day |
| Network Pulse pill (7d vs prior 7d) | Network roll up from `useMinerActivityIndex` |

## Status Taxonomy

Seven status kinds plus `STATUS_NONE`. Order of resolution matches `deriveMinerStatus` in `MinerStatus.tsx`.

| Status | Trigger | Tone |
| --- | --- | --- |
| Penalized | `failed_reason` non empty | `MINER_STATUS_COLORS.penalized` |
| Hot | `≥ 3` merged in last 3d | `MINER_STATUS_COLORS.hot` |
| Climbing | Rank improved by `≥ 3` since the last UTC snapshot | `MINER_STATUS_COLORS.climbing` |
| Rising | Last 7d `≥ 3` merged and `≥ 1.5 ×` prior 7d | `MINER_STATUS_COLORS.rising` |
| Dormant | No merges in last 14d | `MINER_STATUS_COLORS.dormant` |
| Specialist | `≤ 2` unique repos and `≥ 5` merges | `MINER_STATUS_COLORS.specialist` |
| Dual | Eligible in both OSS and Discovery in at least one repo | `MINER_STATUS_COLORS.dual` |
| Cooling | Last 7d zero, prior 7d non zero | `MINER_STATUS_COLORS.cooling` |

## URL Contract

| Param | Driver | Behavior |
| --- | --- | --- |
| `?repo=<full_name>` | Hot repos card, repo column click | Clears `?page=` on change |
| `?cohort=<dual\|ossOnly\|discoveryOnly\|activeOnly\|inactive>` | Eligibility mix bar + legend, cohort chip | Validated via `parseCohortParam`, clears `?page=` |
| `?view=<list\|cards>` | View mode toggle | Mirrored to `localStorage[leaderboard:viewMode]` |
| `?page=<n>` | Pagination | Reset on any filter change |
| `?sort=<field>:<dir>` | Sortable column headers | Driven by the existing `useDataTableParams` hook |

## Testing

* [x] Manual testing performed against the test API
* [x] Tested on desktop viewport
* [x] Tested on mobile viewport (Chrome DevTools)
* [x] Empty network state checked (no scored miners, no merged PRs in the window)
* [x] Single miner state checked (podium collapses to one row, eligibility bar still renders)
* [x] Penalized row checked (badge present, tooltip carries `failed_reason` verbatim)
* [x] Cohort filter round trips through `?cohort=`, repo filter through `?repo=`, view mode through `?view=`, pagination through `?page=`
* [x] Rank snapshot rotates on a forced UTC day change (system clock advanced in dev)
* [x] Sparkline modal cycles 1D / 7D / 30D and stacked / bar / line without churn
* [x] Watchlist toggle keyboard focus state covered (`WatchlistButton` `focus-visible` outline)
* [x] Long tooltip body clamps to the viewport at `xs` (Network Pulse pill on a 320px wide screen)
* [x] `npm run build` passes
* [x] `npm run lint:fix` and `npm run format` clean

## Checklist

* [x] New components are modularized/separated where sensible
* [x] Uses predefined theme (`TOOLTIP_TONE_COLORS`, `LEADERBOARD_TRACK_COLORS`, `MINER_STATUS_COLORS`, `STATUS_COLORS`, `RANK_COLORS`, no hardcoded colors)
* [x] Responsive/mobile checked (`xs` stacked hero card, `sm` two by two zones, `lg` four across, card view rows divide evenly by 1/2/3 so the last grid row is never partial)
* [x] Tested against the test API
* [x] `npm run format` and `npm run lint:fix` have been run
* [x] `npm run build` passes
* [x] Screenshots included for any UI/visual changes

## Changes

### New Pages

* **LeaderboardPage** (`src/pages/LeaderboardPage.tsx`). Hosts the insights card and the table. Pipes `?repo=` and `?cohort=` into `useSearchParams`. Resets `?page=` whenever a filter changes so the user never lands on an empty page after narrowing the view.

### New Components

* **LeaderboardInsights** (`src/components/leaderboard/LeaderboardInsights.tsx`). Four zone hero card. `DailyPoolZone` carries the USD pool, the TAO/α74 ticker, the 90/10 emission split bar, and the top earners avatar stack. `CompositionZone` is the cohort bar plus an interactive legend that doubles as a filter. `PodiumZone` is the top three by combined score with rank tinted avatar rails. `HotRepoZone` is the hero repo plus three runners up, all clickable into the table filter.
* **MinersLeaderTable** (`src/components/leaderboard/MinersLeaderTable.tsx`). List and card view modes, nine sortable fields, cohort and eligibility chip filters, debounced search, URL backed pagination. Row accent rail in the cohort color, identity cell with status badge, dual track eligibility pills with repo counts, OSS and Discovery stat rows with a stacked sparkline trend, open PR risk pill, review hits cell, USD/day cell with a track split tooltip, watchlist toggle.
* **MinerStatus** (`src/components/leaderboard/MinerStatus.tsx`). Seven status kinds plus `STATUS_NONE`. `deriveMinerStatus` resolves them in priority order against `MinerEvaluation` and `MinerActivity`. `StatusBadge` renders the pill in the tone palette from `MINER_STATUS_COLORS`.
* **Sparkline** (`src/components/leaderboard/Sparkline.tsx`). Stacked bar sparkline (OSS bottom, Discovery on top), built from raw SVG to avoid pulling a chart library into the row hot path. Empty state collapses to a single dash so the row height stays stable.
* **SparklineDetailModal** (`src/components/leaderboard/SparklineDetailModal.tsx`). ECharts modal with 1D, 7D, 30D ranges and stacked / bar / line modes. Hourly bucketing on 1D, daily bucketing on 7D and 30D. Uses the shared gittensor ECharts theme so the modal matches the rest of the app.
* **NetworkPulsePill** (`src/components/leaderboard/NetworkPulsePill.tsx`). 7d vs prior 7d PR velocity. Low sample mode (`prior7 < 5`) renders raw counts instead of a misleading percentage.
* **GhIcons** (`src/components/leaderboard/GhIcons.tsx`). Inline GitHub PR and Issue SVG icons, sized for the dense row layout.

### New Modules

* **eligibilityCohort.ts** (`src/components/leaderboard/eligibilityCohort.ts`). Single source of truth for "currently earning". Exports `isOssEligibleNow`, `isDiscoveryEligibleNow`, `isAnyEligibleNow`, `isPenalized`, `cohortOf`, the cohort palette, labels, descriptions, and the `parseCohortParam` URL guard.
* **scoring.ts** (`src/components/leaderboard/scoring.ts`). Mirrors `gittensor/constants.py` and `validator/oss_contributions/scoring.py`. `resolveRepoThresholds` overlays `ELIGIBILITY_FIELD_DEFS` defaults. `openPrSlotsAllowed` mirrors `calculate_open_pr_threshold`. `splitEarnings` mirrors the OSS / Discovery share split.
* **useMinerActivityIndex.ts** (`src/components/leaderboard/useMinerActivityIndex.ts`). One pass over `/commits` builds the per miner activity map and the network roll up. Per miner: `dailyMerged`, `dailyOss`, `dailyDiscovery`, `topRepos`, `lastActiveAt`, `reviewHits`. Network: `dailyMerged`, `dailyOss`, `dailyDiscovery`, `last7`, `prior7`, `topRepos`.
* **useRankSnapshot.ts** (`src/components/leaderboard/useRankSnapshot.ts`). Rotates yesterday's ranks into `prev` on each new UTC day, gated on `currentRanks.size > 0` so an empty load does not erase tomorrow's signal. Stored under `localStorage[gittensor.rank-snapshot.v1]`.
* **leaderboardViewMode.ts** (`src/components/leaderboard/leaderboardViewMode.ts`). List and card view modes, persisted to `localStorage[leaderboard:viewMode]`, reflected in `?view=`. List rows are `10 / 25 / 50`, card rows are `12 / 24 / 48` so every grid row at every breakpoint is full.

### Refactored Components

* **WatchlistButton** (`src/components/common/WatchlistButton.tsx`). Picks up a `focus-visible` outline in the primary color so keyboard navigation has parity with hover. No regression on existing call sites.

### Modified Wiring

* **routes.tsx**. `/leaderboard` registered. `/top-miners` redirect repointed from `/repositories` to `/leaderboard` so existing external links land in the right place.
* **layout/Sidebar.tsx**. `leaderboard` nav item with the MUI `LeaderboardIcon`, sandwiched between `dashboard` and `repositories`.
* **api/DashboardApi.ts**. `useRecentCommits(limit = 500)` thin wrapper around the existing dashboard query helper, hits `/commits?page=1&limit=500`. React Query dedupes the request so the insights card and the table share one round trip.
* **theme.ts**. New palette tokens (`TOOLTIP_TONE_COLORS`, `LEADERBOARD_TRACK_COLORS`, `MINER_STATUS_COLORS`) move the cohort, status, and tooltip tones to one place. `tooltipSlotProps` picks up a `preventOverflow` popper modifier so long tooltip bodies clamp to the viewport on narrow screens, and `maxWidth` becomes responsive (`calc(100vw − 24px)` on `xs`, `280px` from `sm`).
* **leaderboard/index.ts**. New barrel exports for `LeaderboardInsights` and `MinersLeaderTable`.
* **.gitignore**. Adds `.verify` so local verification scratch directories do not get committed.

### Removed Components

None. The old `TopMinersPage` and its sidecars were already removed in [#1220](https://github.com/entrius/gittensor-ui/pull/1220) and are not resurrected.

### Bug Fixes

* None new. The rebuild starts from a clean slate, so there are no carryover bugs from the deleted page to chase.

### Known Gaps (Documented, Not Fixed Here)

* `/commits` represents OSS merges only. Discovery only activity is undercounted in the sparkline and in the Dormant / Cooling derivation until the activity feed includes solved issues. Cohort assignment itself is correct because it reads `is_eligible` and `is_issue_eligible` straight off `MinerEvaluation`.
* Per track `$/day` split and the structural vs leaf score breakdown are not surfaced yet. Both are blocked on validator data that is not on the public API. The combined `usdPerDay` is used everywhere a per row earning is shown.
