### PR TITLE
fix(utils): strip .git suffix from GitHub repo URLs

### DIFF
--- a/src/utils/githubRepoUrl.ts
+++ b/src/utils/githubRepoUrl.ts
@@ -4,10 +4,14 @@ export const extractRepoFullName = (repoUrl: string): string | null => {
     if (!['http:', 'https:'].includes(url.protocol)) return null;
     if (url.hostname.toLowerCase() !== 'github.com') return null;
 
-    const [owner, repo] = url.pathname.split('/').filter(Boolean);
+    const [owner, rawRepo] = url.pathname.split('/').filter(Boolean);
     const ownerPattern = /^[a-z\d](?:[a-z\d-]{0,37}[a-z\d])?$/i;
     const repoPattern = /^[a-z\d._-]+$/i;
-    if (!owner || !repo) return null;
+    if (!owner || !rawRepo) return null;
+
+    const repo = rawRepo.toLowerCase().endsWith('.git')
+      ? rawRepo.slice(0, -4)
+      : rawRepo;
     if (!ownerPattern.test(owner) || !repoPattern.test(repo)) return null;
 
     return `${owner}/${repo}`;


### PR DESCRIPTION
## Summary

Strip a trailing `.git` suffix when parsing GitHub repository URLs so clone links resolve to the same `owner/repo` name the API uses.

## Related Issues

Closes #1293

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [ ] Responsive/mobile checked
- [ ] Tested against the test API
- [ ] `npm run format` and `npm run lint:fix` have been run
- [ ] `npm run build` passes
