### PR TITLE
feat(repo-config): surface saturation-scale knob, drop density + token cliff

### DIFF
--- a/src/api/models/Dashboard.ts
+++ b/src/api/models/Dashboard.ts
@@ -49,6 +49,7 @@ export type RepoScoringConfig = {
   review_penalty_rate?: number;
   standard_issue_multiplier?: number;
   maintainer_issue_multiplier?: number;
+  src_tok_saturation_scale?: number;
   time_decay?: RepoTimeDecayConfig;
 };
 

--- a/src/api/models/Dashboard.ts
+++ b/src/api/models/Dashboard.ts
@@ -18,7 +18,6 @@ export type RepoChanges = {
 export type RepoEligibilityConfig = {
   min_valid_merged_prs?: number;
   min_credibility?: number;
-  min_token_score_for_base_score?: number;
   excessive_pr_penalty_base_threshold?: number;
   open_pr_threshold_token_score?: number;
   max_open_pr_threshold?: number;
@@ -228,7 +227,6 @@ export type CommitLog = {
   // Label scoring
   labelMultiplier?: number;
   label?: string;
-  codeDensity?: number;
 
   // Payout predictions
   potentialScore?: number;
@@ -414,7 +412,6 @@ export type PullRequestDetails = {
   reviewQualityMultiplier?: string; // float returned as string
   labelMultiplier: number;
   label: string | null;
-  codeDensity: number;
   earnedScore: string; // float returned as string
   collateralScore: string; // float returned as string
   additions: number;

--- a/src/components/leaderboard/scoring.ts
+++ b/src/components/leaderboard/scoring.ts
@@ -9,7 +9,6 @@ const DEFAULT_THRESHOLDS: Record<string, number> = Object.fromEntries(
 export interface RepoThresholds {
   minValidMergedPrs: number;
   minCredibility: number;
-  minTokenScoreForBaseScore: number;
   minValidSolvedIssues: number;
   minIssueCredibility: number;
   openPrSlotBase: number;
@@ -35,9 +34,6 @@ export const resolveRepoThresholds = (
       DEFAULT_THRESHOLDS.min_valid_merged_prs,
     minCredibility:
       pickNumber(e, 'min_credibility') ?? DEFAULT_THRESHOLDS.min_credibility,
-    minTokenScoreForBaseScore:
-      pickNumber(e, 'min_token_score_for_base_score') ??
-      DEFAULT_THRESHOLDS.min_token_score_for_base_score,
     minValidSolvedIssues:
       pickNumber(e, 'min_valid_solved_issues') ??
       DEFAULT_THRESHOLDS.min_valid_solved_issues,

--- a/src/utils/multiplierDefs.ts
+++ b/src/utils/multiplierDefs.ts
@@ -95,14 +95,6 @@ const PILL_CONFIGS: PillConfig[] = [
     title: 'Label Multiplier',
     desc: 'Adjusts score based on PR classification.',
   },
-  {
-    key: 'density',
-    label: 'density',
-    field: 'codeDensity',
-    title: 'Code Density',
-    desc: 'Ratio of meaningful code changes to total diff size.',
-    format: 'value',
-  },
 ];
 
 export function buildMergedPillDefs(
@@ -149,14 +141,6 @@ function buildGridEntry(
   };
 }
 
-function buildDensityEntry(pr: PullRequestDetails): MultiplierGridEntry | null {
-  if (pr.codeDensity == null) return null;
-  return {
-    label: 'Code Density',
-    value: parseNumber(pr.codeDensity).toFixed(2),
-  };
-}
-
 const OPEN_GRID: GridConfig[] = [
   { label: 'Issue Bonus', field: 'issueMultiplier' },
 ];
@@ -176,8 +160,6 @@ function appendOptionalEntries(
     entries.push(
       buildGridEntry(pr, { label: 'Label', field: 'labelMultiplier' }),
     );
-  const density = buildDensityEntry(pr);
-  if (density) entries.push(density);
   return entries;
 }
 

--- a/src/utils/repoConfig.ts
+++ b/src/utils/repoConfig.ts
@@ -163,14 +163,6 @@ export const ELIGIBILITY_FIELD_DEFS: RepoConfigFieldDef[] = [
     format: 'percent',
   },
   {
-    key: 'min_token_score_for_base_score',
-    label: 'Min token score (PR)',
-    description: 'Token score a PR needs to receive any base score.',
-    default: 5,
-    min: 0,
-    format: 'score',
-  },
-  {
     key: 'excessive_pr_penalty_base_threshold',
     label: 'Excessive-PR penalty threshold',
     description:

--- a/src/utils/repoConfig.ts
+++ b/src/utils/repoConfig.ts
@@ -86,6 +86,16 @@ export const SCORING_FIELD_DEFS: RepoConfigFieldDef[] = [
     max: 5,
     format: 'multiplier',
   },
+  {
+    key: 'src_tok_saturation_scale',
+    label: 'Source-token saturation scale',
+    description:
+      'Source token score at which base score reaches ~63% of its max — higher values make the curve rise more slowly.',
+    default: 58,
+    min: 10,
+    max: 500,
+    format: 'score',
+  },
 ];
 
 // --- Time-decay curve (nested scoring.time_decay) ---------------------------


### PR DESCRIPTION
Aligns the UI with the new exponential-saturation base-scoring in gittensor#1352.

**Surface the new knob**
- Adds `src_tok_saturation_scale` to `SCORING_FIELD_DEFS` (default `58`, range `[10, 500]`) so it renders in the Scoring group on the Repository Hyperparameters page, plus `src_tok_saturation_scale?` on the `RepoScoringConfig` type. Rides the existing JSONB config passthrough — no API/DB change.

**Drop what #1352 removed**
- Removes the **Code Density** chip from the PR-details page (`multiplierDefs.ts`) — the validator no longer produces density, so it would show `0.00` for every newly-scored PR.
- Removes the dead `min_token_score_for_base_score` token-score cliff: the eligibility field def (`repoConfig.ts`), the unused `minTokenScoreForBaseScore` threshold (`scoring.ts`), and the `code_density`/`min_token_score_for_base_score` fields on the `Dashboard.ts` types.

das still returns `codeDensity` (harmless — now ignored); the column can be dropped server-side whenever convenient.

Lint + `tsc -b` + vite build all green.