### PR TITLE
fix(ui): correct homepage repository detail links

### DIFF
--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1723,7 +1723,7 @@ const TopActiveReposPanel: React.FC<{
               return (
                 <LinkBox
                   key={`${row.repository}-${index}`}
-                  href={`/repositories/details?repo=${encodeURIComponent(row.repository)}`}
+                  href={`/miners/repository?name=${encodeURIComponent(row.repository)}`}
                   linkState={{ backLabel: 'Back to Home' }}
                   sx={(theme) => ({
                     display: 'grid',


### PR DESCRIPTION
## Summary

Closes #1296. Homepage “Most active repositories” links now use `/miners/repository?name=…` instead of the non-existent `/repositories/details?repo=…` route.

## Changes

- `src/pages/HomePage.tsx`: fix `TopActiveReposPanel` repository `LinkBox` href.

## Test plan

- [x] Manual: click a repo on the homepage → repository details page loads.
- [ ] `npm run build` (TypeScript + Vite)
