### PR TITLE
[bug] Featured Discoverers view-all opens wrong route

### DIFF
--- a/src/pages/dashboard/DashboardPage.tsx
+++ b/src/pages/dashboard/DashboardPage.tsx
@@ -94,7 +94,7 @@ const DashboardFeaturePage: React.FC = () => {
               contributors={featuredDiscoveryContributors}
               isLoading={isLoading}
               mode="issues"
-              viewAllHref="/repositories"
+              viewAllHref="/leaderboard?cohort=discoveryOnly"
             />
 
             <DashboardFeaturedWorkSection


### PR DESCRIPTION
## Summary

Closes #1298.

Point Featured Discoverers “view all” at the discovery cohort on the leaderboard.

## Changes

- `viewAllHref="/leaderboard?cohort=discoveryOnly"` for the discoverers `DashboardTopContributors` block.

## Test plan

- [ ] Open dashboard → Featured Discoverers → view all → confirm discovery-only leaderboard.
