### PR TITLE
[Bug]: Featured Contributors View all links to repositories instead of leaderboard

### DIFF
--- a/src/pages/dashboard/DashboardPage.tsx
+++ b/src/pages/dashboard/DashboardPage.tsx
@@ -86,7 +86,7 @@ const DashboardFeaturePage: React.FC = () => {
             <DashboardTopContributors
               contributors={featuredContributors}
               isLoading={isLoading}
-              viewAllHref="/repositories"
+              viewAllHref="/leaderboard"
             />
 
             <DashboardTopContributors


### PR DESCRIPTION
## Summary

Closes #1306.

Point Featured Contributors "View all" to `/leaderboard` instead of `/repositories`.

## Changes

- `src/pages/dashboard/DashboardPage.tsx`: `viewAllHref="/leaderboard"`.

## Test plan

- [ ] Manual: Contributors card "View all" opens leaderboard.
