### PR TITLE
fix(miner): repo standing counts match PR table active rows

### DIFF
--- a/src/components/miners/MinerPRsTable.tsx
+++ b/src/components/miners/MinerPRsTable.tsx
@@ -23,15 +23,19 @@ import {
   ExpandMore as ExpandMoreIcon,
   Search as SearchIcon,
 } from '@mui/icons-material';
-import { useMinerPRs, type CommitLog } from '../../api';
+import { useMinerPRs, useReposAndWeights, type CommitLog } from '../../api';
 import {
   filterPrs,
   getRepositoryOwnerAvatarSrc,
   getPrStatusCounts,
-  isOutsideScoringWindow,
+  isOutsidePrLookbackWindow,
   isPrStatusFilter,
   type PrStatusFilter,
 } from '../../utils';
+import {
+  buildRepoLookbackDaysMap,
+  DEFAULT_PR_LOOKBACK_DAYS,
+} from '../../utils/repoConfig';
 import {
   DataTable,
   type DataTableColumn,
@@ -110,6 +114,7 @@ interface MinerPRsTableProps {
 const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
   const theme = useTheme();
   const { data: prs, isLoading } = useMinerPRs(githubId);
+  const { data: repos } = useReposAndWeights();
   const { isWatched } = useWatchlist('prs');
   const [selectedAuthor, setSelectedAuthor] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
@@ -117,6 +122,22 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
   const [sortDir, setSortDir] = useState<SortDir>('desc');
   const [expandedKeys, setExpandedKeys] = useState<Set<string>>(
     () => new Set(),
+  );
+
+  const repoLookbackDays = useMemo(
+    () => buildRepoLookbackDaysMap(repos ?? []),
+    [repos],
+  );
+
+  const isMergedOutsideLookback = useCallback(
+    (pr: CommitLog) => {
+      if (!pr.mergedAt) return false;
+      const lookback =
+        repoLookbackDays.get(pr.repository.toLowerCase()) ??
+        DEFAULT_PR_LOOKBACK_DAYS;
+      return isOutsidePrLookbackWindow(pr.mergedAt, lookback);
+    },
+    [repoLookbackDays],
   );
 
   const filtersConfig = useMemo(
@@ -713,7 +734,7 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
           );
         }}
         getRowSx={(pr) => {
-          if (pr.mergedAt && isOutsideScoringWindow(pr.mergedAt)) {
+          if (isMergedOutsideLookback(pr)) {
             return { opacity: 0.4, filter: 'grayscale(0.5)' };
           }
           if (expandedKeys.has(prRowKey(pr))) {

--- a/src/components/miners/MinerRepoStandingCard.tsx
+++ b/src/components/miners/MinerRepoStandingCard.tsx
@@ -12,6 +12,8 @@ type ViewMode = 'prs' | 'issues';
 interface MinerRepoStandingCardProps {
   repo: MinerRepositoryEvaluation;
   viewMode: ViewMode;
+  /** Resolved `scoring.pr_lookback_days` for this repo (PR mode). */
+  prLookbackDays?: number;
 }
 
 const FONT_MONO = '"JetBrains Mono", monospace';
@@ -139,6 +141,7 @@ const InlineStat: React.FC<{
 const MinerRepoStandingCard: React.FC<MinerRepoStandingCardProps> = ({
   repo,
   viewMode,
+  prLookbackDays,
 }) => {
   const isIssueMode = viewMode === 'issues';
   const linkProps = useLinkBehavior<HTMLAnchorElement>(
@@ -354,7 +357,13 @@ const MinerRepoStandingCard: React.FC<MinerRepoStandingCardProps> = ({
         }}
       >
         <Box>
-          <Overline>{isIssueMode ? 'Issue activity' : 'PR activity'}</Overline>
+          <Overline>
+            {isIssueMode
+              ? 'Issue activity'
+              : prLookbackDays != null
+                ? `PR activity · ${prLookbackDays}d lookback`
+                : 'PR activity'}
+          </Overline>
           <Box
             sx={{
               display: 'flex',

--- a/src/components/miners/MinerRepoStandings.tsx
+++ b/src/components/miners/MinerRepoStandings.tsx
@@ -20,12 +20,16 @@ import {
   GridView as GridViewIcon,
   TableRows as TableRowsIcon,
 } from '@mui/icons-material';
-import { useMinerStats } from '../../api';
+import { useMinerStats, useReposAndWeights } from '../../api';
 import type { MinerRepositoryEvaluation } from '../../api/models/Dashboard';
 import { STATUS_COLORS, tooltipSlotProps } from '../../theme';
 import { credibilityColor } from '../../utils/format';
 import { type SortOrder } from '../../utils/ExplorerUtils';
 import { getRepositoryOwnerAvatarSrc } from '../../utils/avatar';
+import {
+  buildRepoLookbackDaysMap,
+  DEFAULT_PR_LOOKBACK_DAYS,
+} from '../../utils/repoConfig';
 import { DataTable, type DataTableColumn } from '../common';
 import EmptyStateMessage from './EmptyStateMessage';
 import MinerRepoStandingCard, { repoMinersHref } from './MinerRepoStandingCard';
@@ -144,6 +148,11 @@ const MinerRepoStandings: React.FC<MinerRepoStandingsProps> = ({
   viewMode = 'prs',
 }) => {
   const { data: minerStats, isLoading } = useMinerStats(githubId);
+  const { data: repos } = useReposAndWeights();
+  const repoLookbackDays = useMemo(
+    () => buildRepoLookbackDaysMap(repos ?? []),
+    [repos],
+  );
   const [view, setView] = useState<StandingsView>('cards');
   const isIssueMode = viewMode === 'issues';
   const [sortField, setSortField] = useState<StandingsSortKey>(
@@ -571,6 +580,10 @@ const MinerRepoStandings: React.FC<MinerRepoStandingsProps> = ({
               key={repo.repositoryFullName}
               repo={repo}
               viewMode={viewMode}
+              prLookbackDays={
+                repoLookbackDays.get(repo.repositoryFullName.toLowerCase()) ??
+                DEFAULT_PR_LOOKBACK_DAYS
+              }
             />
           ))}
         </Box>

--- a/src/utils/ExplorerUtils.ts
+++ b/src/utils/ExplorerUtils.ts
@@ -2,7 +2,6 @@ import { type CommitLog, type MinerEvaluation, type Repository } from '../api';
 import { type IssueBounty } from '../api/models/Issues';
 import { getRepositoryOwnerAvatarSrc } from './avatar';
 import { isMergedPr } from './prStatus';
-import { DEFAULT_PR_LOOKBACK_DAYS } from './repoConfig';
 
 export const getGithubAvatarSrc = (username?: string | null) =>
   getRepositoryOwnerAvatarSrc(username);
@@ -46,10 +45,12 @@ const VALID_ISSUE_SOLVE_TOKEN_THRESHOLD = 5;
 // Scoring window staleness check
 // ---------------------------------------------------------------------------
 
+/** UI-wide staleness window (watchlist, issues, discovery fetch). */
+const SCORING_WINDOW_DAYS = 35;
+
 export const isOutsideScoringWindow = (
   date: string | null | undefined,
-  lookbackDays: number = DEFAULT_PR_LOOKBACK_DAYS,
-): boolean => isOutsidePrLookbackWindow(date, lookbackDays);
+): boolean => isOutsidePrLookbackWindow(date, SCORING_WINDOW_DAYS);
 
 /** Staleness check using a repo's `pr_lookback_days` scoring window. */
 export const isOutsidePrLookbackWindow = (
@@ -64,12 +65,11 @@ export const isOutsidePrLookbackWindow = (
   return parsed < cutoff;
 };
 
-/** ISO timestamp for the start of the PR lookback window (UTC). */
-export const getScoringWindowStartIso = (
-  lookbackDays: number = DEFAULT_PR_LOOKBACK_DAYS,
-): string => {
+/** ISO timestamp for the start of the 35-day scoring window (UTC, suitable for
+ *  GitHub Search `created:>=` qualifier and other since-style filters). */
+export const getScoringWindowStartIso = (): string => {
   const cutoff = new Date();
-  cutoff.setUTCDate(cutoff.getUTCDate() - lookbackDays);
+  cutoff.setUTCDate(cutoff.getUTCDate() - SCORING_WINDOW_DAYS);
   return cutoff.toISOString();
 };
 

--- a/src/utils/ExplorerUtils.ts
+++ b/src/utils/ExplorerUtils.ts
@@ -45,7 +45,8 @@ const VALID_ISSUE_SOLVE_TOKEN_THRESHOLD = 5;
 // Scoring window staleness check
 // ---------------------------------------------------------------------------
 
-const SCORING_WINDOW_DAYS = 35;
+/** Default PR scoring lookback — mirrors gittensor `PR_LOOKBACK_DAYS`. */
+const SCORING_WINDOW_DAYS = 30;
 
 export const isOutsideScoringWindow = (
   date: string | null | undefined,
@@ -56,7 +57,7 @@ export const isOutsideScoringWindow = (
   return new Date(date) < cutoff;
 };
 
-/** ISO timestamp for the start of the 35-day scoring window (UTC, suitable for
+/** ISO timestamp for the start of the scoring window (UTC, suitable for
  *  GitHub Search `created:>=` qualifier and other since-style filters). */
 export const getScoringWindowStartIso = (): string => {
   const cutoff = new Date();

--- a/src/utils/ExplorerUtils.ts
+++ b/src/utils/ExplorerUtils.ts
@@ -2,6 +2,7 @@ import { type CommitLog, type MinerEvaluation, type Repository } from '../api';
 import { type IssueBounty } from '../api/models/Issues';
 import { getRepositoryOwnerAvatarSrc } from './avatar';
 import { isMergedPr } from './prStatus';
+import { DEFAULT_PR_LOOKBACK_DAYS } from './repoConfig';
 
 export const getGithubAvatarSrc = (username?: string | null) =>
   getRepositoryOwnerAvatarSrc(username);
@@ -45,23 +46,30 @@ const VALID_ISSUE_SOLVE_TOKEN_THRESHOLD = 5;
 // Scoring window staleness check
 // ---------------------------------------------------------------------------
 
-/** Default PR scoring lookback — mirrors gittensor `PR_LOOKBACK_DAYS`. */
-const SCORING_WINDOW_DAYS = 30;
-
 export const isOutsideScoringWindow = (
   date: string | null | undefined,
+  lookbackDays: number = DEFAULT_PR_LOOKBACK_DAYS,
+): boolean => isOutsidePrLookbackWindow(date, lookbackDays);
+
+/** Staleness check using a repo's `pr_lookback_days` scoring window. */
+export const isOutsidePrLookbackWindow = (
+  date: string | null | undefined,
+  lookbackDays: number,
 ): boolean => {
-  if (!date) return false;
+  if (!date || lookbackDays <= 0) return false;
+  const parsed = new Date(date);
+  if (Number.isNaN(parsed.getTime())) return false;
   const cutoff = new Date();
-  cutoff.setDate(cutoff.getDate() - SCORING_WINDOW_DAYS);
-  return new Date(date) < cutoff;
+  cutoff.setDate(cutoff.getDate() - lookbackDays);
+  return parsed < cutoff;
 };
 
-/** ISO timestamp for the start of the scoring window (UTC, suitable for
- *  GitHub Search `created:>=` qualifier and other since-style filters). */
-export const getScoringWindowStartIso = (): string => {
+/** ISO timestamp for the start of the PR lookback window (UTC). */
+export const getScoringWindowStartIso = (
+  lookbackDays: number = DEFAULT_PR_LOOKBACK_DAYS,
+): string => {
   const cutoff = new Date();
-  cutoff.setUTCDate(cutoff.getUTCDate() - SCORING_WINDOW_DAYS);
+  cutoff.setUTCDate(cutoff.getUTCDate() - lookbackDays);
   return cutoff.toISOString();
 };
 

--- a/src/utils/repoConfig.ts
+++ b/src/utils/repoConfig.ts
@@ -9,7 +9,7 @@
  * No repo sets a `scoring` block yet, so until one does every field resolves
  * to the default below.
  */
-import type { RepositoryConfig } from '../api/models/Dashboard';
+import type { Repository, RepositoryConfig } from '../api/models/Dashboard';
 import { pluralize } from './format';
 
 type RepoConfigFormat =
@@ -98,6 +98,31 @@ export const SCORING_FIELD_DEFS: RepoConfigFieldDef[] = [
     format: 'score',
   },
 ];
+
+/** Validator default — mirrors gittensor `PR_LOOKBACK_DAYS`. */
+export const DEFAULT_PR_LOOKBACK_DAYS =
+  SCORING_FIELD_DEFS.find((d) => d.key === 'pr_lookback_days')?.default ?? 30;
+
+/** Per-repo rolling window for merged PR scoring (`scoring.pr_lookback_days`). */
+export function resolvePrLookbackDays(
+  config?: RepositoryConfig | null,
+): number {
+  const raw = config?.scoring?.pr_lookback_days;
+  if (typeof raw === 'number' && Number.isFinite(raw) && raw >= 1) {
+    return raw;
+  }
+  return DEFAULT_PR_LOOKBACK_DAYS;
+}
+
+export function buildRepoLookbackDaysMap(
+  repos: readonly Pick<Repository, 'fullName' | 'config'>[],
+): Map<string, number> {
+  const map = new Map<string, number>();
+  for (const repo of repos) {
+    map.set(repo.fullName.toLowerCase(), resolvePrLookbackDays(repo.config));
+  }
+  return map;
+}
 
 // --- Time-decay curve (nested scoring.time_decay) ---------------------------
 


### PR DESCRIPTION
## Summary

On the miner details page, per-repository standing cards display Merged and Closed PR counts from the API (`totalMergedPrs`, `totalClosedPrs`). These counts are calculated using each repository's configured `scoring.pr_lookback_days` window (default 30 days via gittensor's `PR_LOOKBACK_DAYS`, with repository-specific overrides supported).

The Pull Requests table previously used a fixed 35-day staleness window when determining whether merged PRs should appear active or dimmed. As a result, repositories with shorter lookback windows could display merged PRs as active in the table even though they were already excluded from standing counts, leading to inconsistencies between the table and repository standings.

This change aligns PR table staleness styling with repository-specific scoring windows by:

* Resolving `pr_lookback_days` from repository configuration (`/dash/repos`)
* Applying repository-specific lookback windows when determining stale merged PRs in `MinerPRsTable`
* Displaying the effective lookback period on repository standing cards (`PR activity · {n}d lookback`)
* Updating scoring window utilities to support configurable lookback periods instead of relying on a fixed 35-day threshold

This ensures repository standing counts and Pull Requests table highlighting are derived from the same scoring window logic.


## Related Issues

Fixes #1308

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

### Before
<img width="1920" height="3029" alt="image" src="https://github.com/user-attachments/assets/72f14c8b-6410-48c8-9f86-e7adeadf7136" />


### After
<img width="1920" height="2827" alt="image" src="https://github.com/user-attachments/assets/e53c71da-edd0-4b9c-bfa1-f69183f934e2" />

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes