### PR TITLE
fix(file-tree): show full file name in a tooltip on hover

### DIFF
--- a/src/components/prs/PRFilesChanged.tsx
+++ b/src/components/prs/PRFilesChanged.tsx
@@ -457,41 +457,42 @@ const FileTreeItem: React.FC<{
         >
           {getIcon()}
         </ListItemIcon>
-
-        <ListItemText
-          primary={
-            <Box
-              component="span"
-              sx={{ display: 'flex', alignItems: 'center', gap: 1 }}
-            >
-              {node.name}
-              {node.hasChanges && !open && hasChildren && (
-                <Box
-                  sx={{
-                    width: 6,
-                    height: 6,
-                    borderRadius: '50%',
-                    bgcolor: 'status.warning',
-                  }}
-                />
-              )}
-            </Box>
-          }
-          primaryTypographyProps={{
-            sx: {
-              fontSize: '12px',
-              color: isSelected
-                ? 'text.primary'
-                : node.file || node.hasChanges
-                  ? 'text.tertiary'
-                  : 'status.open',
-              whiteSpace: 'nowrap',
-              overflow: 'hidden',
-              textOverflow: 'ellipsis',
-              fontWeight: isSelected || node.hasChanges ? 600 : 400,
-            },
-          }}
-        />
+        <Tooltip title={node.name} arrow>
+          <ListItemText
+            primary={
+              <Box
+                component="span"
+                sx={{ display: 'flex', alignItems: 'center', gap: 1 }}
+              >
+                {node.name}
+                {node.hasChanges && !open && hasChildren && (
+                  <Box
+                    sx={{
+                      width: 6,
+                      height: 6,
+                      borderRadius: '50%',
+                      bgcolor: 'status.warning',
+                    }}
+                  />
+                )}
+              </Box>
+            }
+            primaryTypographyProps={{
+              sx: {
+                fontSize: '12px',
+                color: isSelected
+                  ? 'text.primary'
+                  : node.file || node.hasChanges
+                    ? 'text.tertiary'
+                    : 'status.open',
+                whiteSpace: 'nowrap',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                fontWeight: isSelected || node.hasChanges ? 600 : 400,
+              },
+            }}
+          />
+        </Tooltip>
       </ListItemButton>
       {hasChildren && (
         <Collapse in={open} timeout="auto" unmountOnExit>


### PR DESCRIPTION
## Summary

Long file names in the PR **Files Changed** file-tree sidebar were truncated with an ellipsis and could not be read in full — there was no tooltip, no horizontal scroll, and the panel isn't resizable, so the hidden part of the name was unreachable.

This wraps the file-name `ListItemText` in `FileTreeItem` with an MUI `<Tooltip title={node.name} arrow>`, so hovering reveals the complete name. It matches the tooltip pattern already used across the codebase (e.g. `IssuesList.tsx` → `title={issue.solverHotkey} arrow`, `RepositoryMaintainers.tsx` → `title={maintainer.login} arrow`).

No layout change: `ListItemText` renders exactly as before, it's only wrapped so the full name is reachable on hover. `Tooltip` was already imported in the file, so there's no new import.

## Related Issues

Fixes #1310 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

Before change
<img width="1311" height="647" alt="Screenshot 2026-06-01 040402" src="https://github.com/user-attachments/assets/2e1b97e3-25d8-4588-bdeb-96af18007a53" />

After change:

<img width="1439" height="678" alt="Screenshot 2026-06-01 040436" src="https://github.com/user-attachments/assets/afeeb370-7487-4959-b3d3-d27204995eb1" />

## Checklist

- [x] New components are modularized/separated where sensible (no new components)
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [ ] Responsive/mobile checked
- [ ] Tested against the test API
- [ ] `npm run format` and `npm run lint:fix` have been run
- [ ] `npm run build` passes
- [ ] Screenshots included for any UI/visual changes