### PR TITLE
[Bug]: Watchlist PR source filter can hide all PRs with no recovery

### DIFF
--- a/src/hooks/usePrSourceFilter.ts
+++ b/src/hooks/usePrSourceFilter.ts
@@ -94,8 +94,10 @@ export const usePrSourceFilter = (): UsePrSourceFilter => {
 
   const toggle = useCallback((source: WatchedPRSource) => {
     const next = new Set(snapshot);
-    if (next.has(source)) next.delete(source);
-    else next.add(source);
+    if (next.has(source)) {
+      if (next.size === 1) return;
+      next.delete(source);
+    } else next.add(source);
     write(next);
   }, []);
 


### PR DESCRIPTION
## Summary

Closes #1312.

Prevent toggling off the last active PR source filter on the watchlist.

## Changes

- `src/hooks/usePrSourceFilter.ts`: block empty filter set.

## Test plan

- [ ] Manual: cannot disable all source chips on watchlist PRs tab.
