### PR TITLE
fix(watchlist): keep at least one PR source filter active (#1312)

### DIFF
--- a/src/components/FilterButton.tsx
+++ b/src/components/FilterButton.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Button, Box } from '@mui/material';
+import { Button, Box, Tooltip } from '@mui/material';
 
 interface FilterButtonProps {
   label: string;
@@ -10,6 +10,10 @@ interface FilterButtonProps {
   activeTextColor?: string;
   /** When true, button stretches to fill its container (e.g. inside a grid cell). */
   fullWidth?: boolean;
+  /** When true, the button is non-interactive and dimmed. */
+  disabled?: boolean;
+  /** Optional hover hint (e.g. why the button is disabled). */
+  tooltip?: string;
 }
 
 const FilterButton: React.FC<FilterButtonProps> = ({
@@ -20,53 +24,79 @@ const FilterButton: React.FC<FilterButtonProps> = ({
   color,
   activeTextColor = 'text.primary',
   fullWidth = false,
-}) => (
-  <Button
-    size="small"
-    onClick={onClick}
-    fullWidth={fullWidth}
-    sx={{
-      display: 'inline-flex',
-      alignItems: 'center',
-      justifyContent: 'center',
-      gap: 0.75,
-      lineHeight: 1.2,
-      color: isActive ? activeTextColor : (t) => t.palette.text.secondary,
-      backgroundColor: isActive ? 'surface.light' : 'surface.transparent',
-      borderRadius: '6px',
-      px: { xs: 1.25, sm: 1.5 },
-      py: { xs: 0.5, sm: 0.65 },
-      minHeight: 32,
-      minWidth: fullWidth ? 0 : 'auto',
-      textTransform: 'none',
-      fontSize: { xs: '0.7rem', sm: '0.75rem' },
-      fontWeight: isActive ? 600 : 500,
-      border: isActive ? `1px solid ${color}` : '1px solid transparent',
-      whiteSpace: 'nowrap',
-      '&:hover': {
-        backgroundColor: 'border.light',
-      },
-    }}
-  >
-    <Box component="span" sx={{ display: 'inline-flex', alignItems: 'center' }}>
-      {label}
-    </Box>
-    {count !== undefined && (
+  disabled = false,
+  tooltip,
+}) => {
+  const button = (
+    <Button
+      size="small"
+      onClick={onClick}
+      disabled={disabled}
+      fullWidth={fullWidth}
+      sx={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 0.75,
+        lineHeight: 1.2,
+        color: isActive ? activeTextColor : (t) => t.palette.text.secondary,
+        backgroundColor: isActive ? 'surface.light' : 'surface.transparent',
+        borderRadius: '6px',
+        px: { xs: 1.25, sm: 1.5 },
+        py: { xs: 0.5, sm: 0.65 },
+        minHeight: 32,
+        minWidth: fullWidth ? 0 : 'auto',
+        textTransform: 'none',
+        fontSize: { xs: '0.7rem', sm: '0.75rem' },
+        fontWeight: isActive ? 600 : 500,
+        border: isActive ? `1px solid ${color}` : '1px solid transparent',
+        whiteSpace: 'nowrap',
+        // Keep the active styling readable while signalling non-interactivity.
+        '&.Mui-disabled': {
+          color: isActive ? activeTextColor : (t) => t.palette.text.secondary,
+          opacity: 0.6,
+          border: isActive ? `1px solid ${color}` : '1px solid transparent',
+        },
+        '&:hover': {
+          backgroundColor: 'border.light',
+        },
+      }}
+    >
       <Box
         component="span"
-        sx={{
-          display: 'inline-flex',
-          alignItems: 'center',
-          opacity: 0.72,
-          fontWeight: 600,
-          fontVariantNumeric: 'tabular-nums',
-          fontSize: 'inherit',
-        }}
+        sx={{ display: 'inline-flex', alignItems: 'center' }}
       >
-        {count}
+        {label}
       </Box>
-    )}
-  </Button>
-);
+      {count !== undefined && (
+        <Box
+          component="span"
+          sx={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            opacity: 0.72,
+            fontWeight: 600,
+            fontVariantNumeric: 'tabular-nums',
+            fontSize: 'inherit',
+          }}
+        >
+          {count}
+        </Box>
+      )}
+    </Button>
+  );
+
+  if (!tooltip) return button;
+
+  // Disabled MUI buttons swallow pointer events, so wrap in a span to keep
+  // the tooltip reachable on hover.
+  return (
+    <Tooltip title={tooltip} arrow>
+      <Box component="span" sx={{ display: 'inline-flex' }}>
+        {button}
+      </Box>
+    </Tooltip>
+  );
+};
 
 export default FilterButton;

--- a/src/hooks/usePrSourceFilter.ts
+++ b/src/hooks/usePrSourceFilter.ts
@@ -23,7 +23,10 @@ const parseSourceFilter = (raw: unknown): Set<WatchedPRSource> => {
   if (!Array.isArray(parsed)) return new Set(ALL_SOURCES);
   const next = new Set<WatchedPRSource>();
   for (const v of parsed) if (isSource(v)) next.add(v);
-  return next;
+  // An empty selection hides every PR with no obvious way to recover from the
+  // UI. Treat a stale/corrupt empty value as "all on" so reloading restores
+  // visibility instead of leaving the watchlist permanently blank.
+  return next.size > 0 ? next : new Set(ALL_SOURCES);
 };
 
 const sameSet = (
@@ -94,8 +97,14 @@ export const usePrSourceFilter = (): UsePrSourceFilter => {
 
   const toggle = useCallback((source: WatchedPRSource) => {
     const next = new Set(snapshot);
-    if (next.has(source)) next.delete(source);
-    else next.add(source);
+    if (next.has(source)) {
+      // Keep at least one source active — disabling the final one would
+      // empty the filter and hide every PR with no recovery in the UI.
+      if (next.size === 1) return;
+      next.delete(source);
+    } else {
+      next.add(source);
+    }
     write(next);
   }, []);
 

--- a/src/pages/WatchlistPage.tsx
+++ b/src/pages/WatchlistPage.tsx
@@ -3423,27 +3423,26 @@ const PRsList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
                     mx: 0.5,
                   }}
                 />
-                <FilterButton
-                  label="Starred"
-                  count={sourceCounts.starred}
-                  color={SOURCE_META.starred.color}
-                  isActive={activeSources.has('starred')}
-                  onClick={() => toggleSource('starred')}
-                />
-                <FilterButton
-                  label="Miner"
-                  count={sourceCounts.miner}
-                  color={SOURCE_META.miner.color}
-                  isActive={activeSources.has('miner')}
-                  onClick={() => toggleSource('miner')}
-                />
-                <FilterButton
-                  label="Repo"
-                  count={sourceCounts.repo}
-                  color={SOURCE_META.repo.color}
-                  isActive={activeSources.has('repo')}
-                  onClick={() => toggleSource('repo')}
-                />
+                {(['starred', 'miner', 'repo'] as const).map((src) => {
+                  const isOnlyActive =
+                    activeSources.size === 1 && activeSources.has(src);
+                  return (
+                    <FilterButton
+                      key={src}
+                      label={SOURCE_META[src].label}
+                      count={sourceCounts[src]}
+                      color={SOURCE_META[src].color}
+                      isActive={activeSources.has(src)}
+                      disabled={isOnlyActive}
+                      tooltip={
+                        isOnlyActive
+                          ? 'At least one source must stay active'
+                          : undefined
+                      }
+                      onClick={() => toggleSource(src)}
+                    />
+                  );
+                })}
               </Box>
             }
             searchValue={draftValue}
@@ -4370,27 +4369,27 @@ const IssuesList: React.FC<{ minerIds: string[] }> = ({ minerIds }) => {
                     mx: 0.5,
                   }}
                 />
-                <FilterButton
-                  label="Starred"
-                  count={issueSourceCounts.starred}
-                  color={SOURCE_META.starred.color}
-                  isActive={issueActiveSources.has('starred')}
-                  onClick={() => toggleIssueSource('starred')}
-                />
-                <FilterButton
-                  label="Miner"
-                  count={issueSourceCounts.miner}
-                  color={SOURCE_META.miner.color}
-                  isActive={issueActiveSources.has('miner')}
-                  onClick={() => toggleIssueSource('miner')}
-                />
-                <FilterButton
-                  label="Repo"
-                  count={issueSourceCounts.repo}
-                  color={SOURCE_META.repo.color}
-                  isActive={issueActiveSources.has('repo')}
-                  onClick={() => toggleIssueSource('repo')}
-                />
+                {(['starred', 'miner', 'repo'] as const).map((src) => {
+                  const isOnlyActive =
+                    issueActiveSources.size === 1 &&
+                    issueActiveSources.has(src);
+                  return (
+                    <FilterButton
+                      key={src}
+                      label={SOURCE_META[src].label}
+                      count={issueSourceCounts[src]}
+                      color={SOURCE_META[src].color}
+                      isActive={issueActiveSources.has(src)}
+                      disabled={isOnlyActive}
+                      tooltip={
+                        isOnlyActive
+                          ? 'At least one source must stay active'
+                          : undefined
+                      }
+                      onClick={() => toggleIssueSource(src)}
+                    />
+                  );
+                })}
               </Box>
             }
             searchValue={draftValue}


### PR DESCRIPTION
Disabling all three watchlist source filters (Starred/Miner/Repo) left the active set empty, which hid every PR and issue with no recovery in the UI other than clearing localStorage.

- usePrSourceFilter: refuse to remove the final active source, and treat a stale/empty stored value as "all on" so existing broken state recovers on reload.
- FilterButton: add optional disabled/tooltip props (wrapped in a span so the tooltip stays reachable while disabled).
- WatchlistPage: render the sole-active source chip as disabled with an explanatory tooltip on both the PRs and Issues tabs.

## Summary
Disabling all three watchlist source filters (Starred / Miner / Repo) left the active filter set empty. With no source active, the watchlist hid every PR and issue, and there was no way to recover from the UI short of manually clearing localStorage.

This fixes the problem at the data layer (so both the PRs and Issues tabs benefit) and adds a visible cue so the guard isn't a silent no-op:

- usePrSourceFilter — refuse to remove the final active source (toggle no-ops when only one remains), and treat a stale/empty stored value as "all on" so any user already stuck in the broken state recovers on reload.
- FilterButton — add optional disabled/tooltip props (the disabled button is wrapped in a span so the tooltip stays reachable on hover); all existing usages are unaffected.
- WatchlistPage — render the sole-active source chip as disabled with the tooltip "At least one source must stay active" on both the PRs and Issues tabs.

Related Issues

Fixes #1312

Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

Screenshots

Before:

https://github.com/user-attachments/assets/b053fb39-885f-49b2-a569-6bb2e231b534

After:

https://github.com/user-attachments/assets/3eac55b9-b986-4451-8ab4-97957684f7a0

Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] npm run format and npm run lint:fix have been run
- [x] npm run build passes
- [x] Screenshots included for any UI/visual changes


