### PR TITLE
feat(miner): add card view for pull requests on miner details page

### DIFF
--- a/src/components/common/TablePagination.tsx
+++ b/src/components/common/TablePagination.tsx
@@ -61,10 +61,12 @@ export function parseMinerExplorerPageParam(raw: string | null): number {
   return Number.isFinite(parsed) && parsed >= 0 ? parsed : 0;
 }
 
+export type MinerExplorerPageSize = MinerExplorerRowsOption | number;
+
 export function getMinerExplorerPaging<T>(
   items: readonly T[],
   page: number,
-  rows: MinerExplorerRowsOption,
+  rows: MinerExplorerPageSize,
 ): {
   totalPages: number;
   safePage: number;
@@ -88,11 +90,14 @@ export function getMinerExplorerPaging<T>(
 type UseMinerExplorerPaginationOptions = {
   resetKey?: string;
   totalItemCount: number;
+  /** Page size used for clamping (e.g. card view uses a larger size than URL rows). */
+  pageSizeForClamp?: MinerExplorerPageSize;
 };
 
 export function useMinerExplorerPagination({
   resetKey,
   totalItemCount,
+  pageSizeForClamp,
 }: UseMinerExplorerPaginationOptions) {
   const [searchParams, setSearchParams] = useSearchParams();
 
@@ -156,13 +161,19 @@ export function useMinerExplorerPagination({
     setPageRef.current(0);
   }, [resetKey]);
 
+  const clampRows = pageSizeForClamp ?? rowsPerPage;
+
   useEffect(() => {
-    const isAll = rowsPerPage === 'all';
-    const size = isAll ? Math.max(totalItemCount, 1) : rowsPerPage;
+    const isAll = clampRows === 'all';
+    const size = isAll
+      ? Math.max(totalItemCount, 1)
+      : typeof clampRows === 'number'
+        ? clampRows
+        : clampRows;
     const totalPages = Math.max(1, Math.ceil(totalItemCount / size));
     const last = totalPages - 1;
     if (page > last) setPageRef.current(last);
-  }, [totalItemCount, rowsPerPage, page]);
+  }, [totalItemCount, clampRows, page]);
 
   return {
     page,

--- a/src/components/miners/MinerPRsTable.tsx
+++ b/src/components/miners/MinerPRsTable.tsx
@@ -5,6 +5,7 @@ import React, {
   useEffect,
   useRef,
 } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import {
   Avatar,
   Box,
@@ -12,7 +13,10 @@ import {
   Chip,
   CircularProgress,
   Collapse,
+  IconButton,
   InputAdornment,
+  MenuItem,
+  Select,
   TextField,
   Tooltip,
   Typography,
@@ -20,13 +24,18 @@ import {
   useTheme,
 } from '@mui/material';
 import {
+  ArrowDownward as ArrowDownwardIcon,
+  ArrowUpward as ArrowUpwardIcon,
   ExpandLess as ExpandLessIcon,
   ExpandMore as ExpandMoreIcon,
   Search as SearchIcon,
+  ViewList as ViewListIcon,
+  ViewModule as ViewModuleIcon,
 } from '@mui/icons-material';
 import { useMinerPRs, type CommitLog } from '../../api';
 import {
   filterPrs,
+  getMinerPrEffectiveScore,
   getRepositoryOwnerAvatarSrc,
   getPrStatusCounts,
   isOutsideScoringWindow,
@@ -50,11 +59,20 @@ import MinerTableRowsSelect from './MinerTableRowsSelect';
 import TablePagination, {
   getMinerExplorerPaging,
   MINER_EXPLORER_PAGE_PARAM,
+  MINER_EXPLORER_ROWS_PARAM,
+  parseMinerExplorerRowsParam,
   useMinerExplorerPagination,
 } from '../common/TablePagination';
 import { formatDate } from '../../utils/format';
 import { tooltipSlotProps } from '../../theme';
 import MinerPrScoreDetail from './MinerPrScoreDetail';
+import MinerPrCard from './MinerPrCard';
+import {
+  readStoredMinerPrsViewMode,
+  resolveMinerPrsPageSize,
+  writeStoredMinerPrsViewMode,
+  type MinerPrsViewMode,
+} from './minerPrsViewMode';
 
 type PrSortField =
   | 'number'
@@ -83,17 +101,6 @@ const DEFAULT_SORT_DIR: Record<PrSortField, SortDir> = {
   watch: 'desc',
 };
 
-// Mirrors the Score cell's render logic so clicking the Score header
-// sorts by what users actually see: merged → score, open → collateral,
-// closed-unmerged → treated as zero.
-const getEffectiveScore = (pr: CommitLog): number => {
-  if (pr.prState === 'CLOSED' && !pr.mergedAt) return 0;
-  if (!pr.mergedAt && pr.collateralScore) {
-    return parseFloat(pr.collateralScore || '0');
-  }
-  return parseFloat(pr.score || '0');
-};
-
 const getScoreTooltip = (pr: CommitLog): string | null => {
   const base = parseFloat(pr.baseScore || '0');
   if (!pr.mergedAt || base <= 0) return null;
@@ -108,6 +115,75 @@ const getScoreTooltip = (pr: CommitLog): string | null => {
 const isPrStatusFilter = (value: string | null): value is PrStatusFilter =>
   value !== null && (PR_STATUS_FILTERS as readonly string[]).includes(value);
 
+const CARD_SORT_OPTIONS: { value: PrSortField; label: string }[] = [
+  { value: 'date', label: 'Date' },
+  { value: 'score', label: 'Score' },
+  { value: 'number', label: 'PR #' },
+  { value: 'repository', label: 'Repository' },
+  { value: 'lines', label: 'Lines' },
+  { value: 'watch', label: 'Watchlist' },
+];
+
+const MinerPrsViewModeToggle: React.FC<{
+  viewMode: MinerPrsViewMode;
+  onChange: (mode: MinerPrsViewMode) => void;
+}> = ({ viewMode, onChange }) => {
+  const options: {
+    value: MinerPrsViewMode;
+    label: string;
+    Icon: typeof ViewListIcon;
+  }[] = [
+    { value: 'list', label: 'List view', Icon: ViewListIcon },
+    { value: 'cards', label: 'Card view', Icon: ViewModuleIcon },
+  ];
+
+  return (
+    <Box
+      sx={(t) => ({
+        display: 'inline-flex',
+        alignItems: 'center',
+        borderRadius: 2,
+        border: '1px solid',
+        borderColor: t.palette.border.light,
+        overflow: 'hidden',
+        flexShrink: 0,
+      })}
+      role="group"
+      aria-label="Toggle view mode"
+    >
+      {options.map(({ value, label, Icon }) => {
+        const isActive = viewMode === value;
+        return (
+          <Tooltip key={value} title={label} placement="top" arrow>
+            <IconButton
+              onClick={() => onChange(value)}
+              size="small"
+              aria-label={label}
+              aria-pressed={isActive}
+              sx={(t) => ({
+                borderRadius: 0,
+                padding: '6px 10px',
+                color: isActive
+                  ? t.palette.primary.main
+                  : t.palette.text.tertiary,
+                backgroundColor: isActive
+                  ? alpha(t.palette.primary.main, 0.12)
+                  : 'transparent',
+                '&:hover': {
+                  backgroundColor: alpha(t.palette.primary.main, 0.18),
+                  color: t.palette.primary.main,
+                },
+              })}
+            >
+              <Icon fontSize="small" />
+            </IconButton>
+          </Tooltip>
+        );
+      })}
+    </Box>
+  );
+};
+
 // Stable per-PR key — shared by the DataTable row key and the expanded-row
 // tracking set so the two never drift.
 const prRowKey = (pr: CommitLog): string =>
@@ -119,6 +195,7 @@ interface MinerPRsTableProps {
 
 const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
   const theme = useTheme();
+  const [searchParams] = useSearchParams();
   const { data: prs, isLoading } = useMinerPRs(githubId);
   const { isWatched } = useWatchlist('prs');
   const [selectedAuthor, setSelectedAuthor] = useState<string | null>(null);
@@ -128,6 +205,10 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
   const [expandedKeys, setExpandedKeys] = useState<Set<string>>(
     () => new Set(),
   );
+  const [viewMode, setViewMode] = useState<MinerPrsViewMode>(
+    readStoredMinerPrsViewMode,
+  );
+  const [isSortMenuOpen, setIsSortMenuOpen] = useState(false);
 
   const filtersConfig = useMemo(
     () => ({
@@ -194,7 +275,7 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
           if (cmp === 0) cmp = a.pullRequestNumber - b.pullRequestNumber;
           break;
         case 'score':
-          cmp = getEffectiveScore(a) - getEffectiveScore(b);
+          cmp = getMinerPrEffectiveScore(a) - getMinerPrEffectiveScore(b);
           break;
         case 'lines':
           cmp = a.additions + a.deletions - (b.additions + b.deletions);
@@ -214,15 +295,42 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
     return sorted;
   }, [filteredPRs, sortField, sortDir, isWatched]);
 
+  const tableRows = useMemo(
+    () =>
+      parseMinerExplorerRowsParam(searchParams.get(MINER_EXPLORER_ROWS_PARAM)),
+    [searchParams],
+  );
+
+  const effectivePageSize = useMemo(
+    () => resolveMinerPrsPageSize(tableRows, viewMode),
+    [tableRows, viewMode],
+  );
+
   const { page, setPage, rowsPerPage, setRowsPerPage } =
     useMinerExplorerPagination({
       resetKey: githubId,
       totalItemCount: sortedPRs.length,
+      pageSizeForClamp: effectivePageSize,
     });
 
+  const handleViewModeChange = useCallback(
+    (next: MinerPrsViewMode) => {
+      setViewMode(next);
+      writeStoredMinerPrsViewMode(next);
+      setPage(0);
+      setExpandedKeys(new Set());
+    },
+    [setPage],
+  );
+
+  const toggleSortDir = useCallback(() => {
+    setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
+    setPage(0);
+  }, [setPage]);
+
   const paging = useMemo(
-    () => getMinerExplorerPaging(sortedPRs, page, rowsPerPage),
-    [sortedPRs, page, rowsPerPage],
+    () => getMinerExplorerPaging(sortedPRs, page, effectivePageSize),
+    [sortedPRs, page, effectivePageSize],
   );
 
   const { slice: pagedPRs, totalPages, safePage, showPageNav } = paging;
@@ -621,7 +729,7 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
           display: 'flex',
           flexDirection: 'row',
           alignItems: 'center',
-          flexWrap: 'nowrap',
+          flexWrap: 'wrap',
           gap: 2,
           width: '100%',
           minWidth: 0,
@@ -631,6 +739,7 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
           value={rowsPerPage}
           onChange={setRowsPerPage}
           id="miner-prs-rows"
+          cardView={viewMode === 'cards'}
         />
         <DebouncedSearchInput
           initialDraft={searchQuery}
@@ -678,6 +787,94 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
             />
           )}
         </DebouncedSearchInput>
+
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 1,
+            flexShrink: 0,
+            ml: { xs: 0, sm: 'auto' },
+            flexWrap: 'wrap',
+          }}
+        >
+          {viewMode === 'cards' && (
+            <>
+              <Typography sx={{ fontSize: '0.8rem', color: 'text.secondary' }}>
+                Sort by
+              </Typography>
+              <Select
+                size="small"
+                value={sortField}
+                onOpen={() => setIsSortMenuOpen(true)}
+                onClose={() => setIsSortMenuOpen(false)}
+                onChange={(e) => handleSort(e.target.value as PrSortField)}
+                MenuProps={{
+                  PaperProps: {
+                    sx: (t) => ({
+                      mt: 0.75,
+                      borderRadius: 2,
+                      border: `1px solid ${t.palette.border.light}`,
+                      backgroundColor: t.palette.background.default,
+                      backgroundImage: 'none',
+                    }),
+                  },
+                }}
+                sx={{
+                  color: 'text.primary',
+                  backgroundColor: isSortMenuOpen
+                    ? (t) => alpha(t.palette.text.primary, 0.06)
+                    : 'background.default',
+                  fontSize: '0.8rem',
+                  height: 32,
+                  minWidth: 120,
+                  borderRadius: 2,
+                  '& .MuiOutlinedInput-notchedOutline': {
+                    borderColor: isSortMenuOpen
+                      ? 'border.medium'
+                      : 'border.light',
+                  },
+                  '& .MuiSelect-select': { py: 0.5, fontWeight: 600 },
+                }}
+              >
+                {CARD_SORT_OPTIONS.map((opt) => (
+                  <MenuItem key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </MenuItem>
+                ))}
+              </Select>
+              <IconButton
+                onClick={toggleSortDir}
+                size="small"
+                aria-label={
+                  sortDir === 'asc' ? 'Sort descending' : 'Sort ascending'
+                }
+                sx={{
+                  color: 'text.primary',
+                  border: '1px solid',
+                  borderColor: 'border.light',
+                  borderRadius: 2,
+                  width: 32,
+                  height: 32,
+                  '&:hover': {
+                    backgroundColor: 'surface.light',
+                    borderColor: 'border.medium',
+                  },
+                }}
+              >
+                {sortDir === 'asc' ? (
+                  <ArrowUpwardIcon sx={{ fontSize: '1rem' }} />
+                ) : (
+                  <ArrowDownwardIcon sx={{ fontSize: '1rem' }} />
+                )}
+              </IconButton>
+            </>
+          )}
+          <MinerPrsViewModeToggle
+            viewMode={viewMode}
+            onChange={handleViewModeChange}
+          />
+        </Box>
       </Box>
     </Box>
   );
@@ -686,6 +883,27 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
   const emptyMessage = noDataAtAll
     ? 'No PRs found'
     : 'No PRs found for the selected filters';
+
+  const paginationFooter = showPageNav ? (
+    <TablePagination
+      page={safePage}
+      totalPages={totalPages}
+      onPageChange={setPage}
+    />
+  ) : null;
+
+  const emptyState = (
+    <Box sx={{ textAlign: 'center', py: 8 }}>
+      <Typography
+        sx={{
+          color: (t) => alpha(t.palette.text.primary, 0.5),
+          fontSize: '0.9rem',
+        }}
+      >
+        {emptyMessage}
+      </Typography>
+    </Box>
+  );
 
   return (
     <Card
@@ -697,59 +915,84 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
       }}
       elevation={0}
     >
-      <DataTable<CommitLog, PrSortField>
-        columns={columns}
-        rows={pagedPRs}
-        getRowKey={prRowKey}
-        minWidth="760px"
-        stickyHeader
-        size="medium"
-        header={headerToolbar}
-        emptyState={
-          <Box sx={{ textAlign: 'center', py: 8 }}>
-            <Typography
+      {headerToolbar}
+      {viewMode === 'list' ? (
+        <DataTable<CommitLog, PrSortField>
+          columns={columns}
+          rows={pagedPRs}
+          getRowKey={prRowKey}
+          minWidth="760px"
+          stickyHeader
+          size="medium"
+          emptyState={emptyState}
+          onRowClick={toggleExpanded}
+          renderExpandedRow={(pr) => {
+            const open = expandedKeys.has(prRowKey(pr));
+            return (
+              <Collapse in={open} timeout="auto" unmountOnExit>
+                <MinerPrScoreDetail pr={pr} expanded={open} />
+              </Collapse>
+            );
+          }}
+          getRowSx={(pr) => {
+            if (pr.mergedAt && isOutsideScoringWindow(pr.mergedAt)) {
+              return { opacity: 0.4, filter: 'grayscale(0.5)' };
+            }
+            if (expandedKeys.has(prRowKey(pr))) {
+              return { backgroundColor: 'surface.subtle' };
+            }
+            return {};
+          }}
+          sort={{
+            field: sortField,
+            order: sortDir,
+            onChange: handleSort,
+          }}
+          pagination={paginationFooter}
+        />
+      ) : pagedPRs.length === 0 ? (
+        emptyState
+      ) : (
+        <Box
+          sx={{
+            px: { xs: 2, sm: 2.5 },
+            pt: { xs: 2, sm: 2.5 },
+            pb: 1,
+            display: 'grid',
+            gap: 2,
+            width: '100%',
+            alignItems: 'start',
+            gridTemplateColumns: {
+              xs: 'minmax(0, 1fr)',
+              sm: 'repeat(2, minmax(0, 1fr))',
+              md: 'repeat(3, minmax(0, 1fr))',
+            },
+          }}
+        >
+          {pagedPRs.map((pr) => (
+            <Box
+              key={prRowKey(pr)}
               sx={{
-                color: (t) => alpha(t.palette.text.primary, 0.5),
-                fontSize: '0.9rem',
+                display: 'flex',
+                flexDirection: 'column',
+                minWidth: 0,
               }}
             >
-              {emptyMessage}
-            </Typography>
-          </Box>
-        }
-        onRowClick={toggleExpanded}
-        renderExpandedRow={(pr) => {
-          const open = expandedKeys.has(prRowKey(pr));
-          return (
-            <Collapse in={open} timeout="auto" unmountOnExit>
-              <MinerPrScoreDetail pr={pr} expanded={open} />
-            </Collapse>
-          );
-        }}
-        getRowSx={(pr) => {
-          if (pr.mergedAt && isOutsideScoringWindow(pr.mergedAt)) {
-            return { opacity: 0.4, filter: 'grayscale(0.5)' };
-          }
-          if (expandedKeys.has(prRowKey(pr))) {
-            return { backgroundColor: 'surface.subtle' };
-          }
-          return {};
-        }}
-        sort={{
-          field: sortField,
-          order: sortDir,
-          onChange: handleSort,
-        }}
-        pagination={
-          showPageNav ? (
-            <TablePagination
-              page={safePage}
-              totalPages={totalPages}
-              onPageChange={setPage}
-            />
-          ) : null
-        }
-      />
+              <MinerPrCard pr={pr} />
+            </Box>
+          ))}
+        </Box>
+      )}
+      {viewMode === 'cards' ? (
+        <Box
+          sx={{
+            borderTop: showPageNav ? '1px solid' : 'none',
+            borderColor: 'border.light',
+          }}
+        >
+          {paginationFooter}
+        </Box>
+      ) : null}
     </Card>
   );
 };

--- a/src/components/miners/MinerPrCard.tsx
+++ b/src/components/miners/MinerPrCard.tsx
@@ -1,0 +1,554 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  Avatar,
+  Box,
+  Card,
+  Chip,
+  IconButton,
+  Tooltip,
+  Typography,
+  alpha,
+  type Theme,
+} from '@mui/material';
+import {
+  CalendarToday as CalendarTodayIcon,
+  ExpandLess as ExpandLessIcon,
+  ExpandMore as ExpandMoreIcon,
+  GitHub as GitHubIcon,
+} from '@mui/icons-material';
+import { usePullRequestDetails } from '../../api';
+import type { CommitLog } from '../../api/models/Dashboard';
+import { WatchlistButton } from '../common';
+import { linkResetSx, useLinkBehavior } from '../common/linkBehavior';
+import { serializePRKey } from '../../hooks/useWatchlist';
+import { STATUS_COLORS } from '../../theme';
+import {
+  formatMinerPrScoreDisplay,
+  getMinerPrCardDisplayDate,
+  getMinerPrEffectiveScore,
+  getPrStatusChipMeta,
+  getRepositoryOwnerAvatarSrc,
+  isClosedUnmergedPr,
+  isMergedPr,
+  isOutsideScoringWindow,
+  minerPrPath,
+} from '../../utils';
+import {
+  buildMinerPrCardBadges,
+  type MinerPrCardBadge,
+} from '../../utils/multiplierDefs';
+
+const IMPACT_EPSILON = 0.0001;
+const COLLAPSED_LABEL_COUNT = 2;
+const HEADER_ACTION_SIZE = 22;
+const LABEL_GRID_SX = {
+  display: 'grid',
+  gridTemplateColumns: 'repeat(2, minmax(0, 1fr))',
+  gap: 0.5,
+} as const;
+
+const headerActionSx = {
+  width: HEADER_ACTION_SIZE,
+  height: HEADER_ACTION_SIZE,
+  minWidth: HEADER_ACTION_SIZE,
+  minHeight: HEADER_ACTION_SIZE,
+  p: 0,
+};
+
+const statusChipSx = (statusColor: string) => ({
+  color: statusColor,
+  borderColor: alpha(statusColor, 0.35),
+  backgroundColor: alpha(statusColor, 0.12),
+  height: HEADER_ACTION_SIZE,
+  minHeight: HEADER_ACTION_SIZE,
+  flexShrink: 0,
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  '& .MuiChip-label': {
+    fontSize: '0.65rem',
+    fontWeight: 600,
+    lineHeight: 1,
+    px: 1,
+    py: 0,
+    display: 'flex',
+    alignItems: 'center',
+  },
+});
+
+const labelToggleSx = {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  flexShrink: 0,
+  width: 28,
+  minWidth: 28,
+  minHeight: 28,
+  borderRadius: 1,
+  border: '1px solid',
+  borderColor: 'border.light',
+  backgroundColor: (t: Theme) => alpha(t.palette.common.white, 0.03),
+  cursor: 'pointer',
+  p: 0,
+  color: 'text.tertiary',
+  transition: 'background-color 0.15s, border-color 0.15s, color 0.15s',
+  '&:hover': {
+    color: 'text.primary',
+    backgroundColor: 'surface.light',
+    borderColor: 'border.medium',
+  },
+  '&:focus-visible': {
+    outline: '2px solid',
+    outlineColor: 'primary.main',
+    outlineOffset: 2,
+  },
+};
+
+const footerLineSx = {
+  fontSize: '0.7rem',
+  fontWeight: 200,
+  fontVariantNumeric: 'tabular-nums',
+  lineHeight: 1,
+  whiteSpace: 'nowrap',
+} as const;
+
+const footerScoreSx = {
+  fontSize: '0.8rem',
+  fontWeight: 700,
+  fontVariantNumeric: 'tabular-nums',
+  lineHeight: 1,
+  whiteSpace: 'nowrap',
+} as const;
+
+const stopNav =
+  (fn: () => void) => (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    fn();
+  };
+
+const isImpactMultiplier = (value: number): boolean =>
+  Math.abs(value - 1) > IMPACT_EPSILON;
+
+const pickCollapsedBadges = (
+  badges: MinerPrCardBadge[],
+): MinerPrCardBadge[] => {
+  if (badges.length <= COLLAPSED_LABEL_COUNT) return badges;
+  const impacts = badges.filter((b) => isImpactMultiplier(b.value));
+  const rest = badges.filter((b) => !isImpactMultiplier(b.value));
+  return [...impacts, ...rest].slice(0, COLLAPSED_LABEL_COUNT);
+};
+
+const cardLeftBorderColor = (pr: CommitLog): string => {
+  if (isMergedPr(pr)) return STATUS_COLORS.merged;
+  if (isClosedUnmergedPr(pr)) return STATUS_COLORS.closed;
+  return '#ffffff';
+};
+
+const badgeAccent = (value: number): string =>
+  value === 1
+    ? STATUS_COLORS.neutral
+    : value > 1
+      ? STATUS_COLORS.success
+      : STATUS_COLORS.warningOrange;
+
+const BadgeCell: React.FC<{ badge: MinerPrCardBadge }> = ({ badge }) => (
+  <Box
+    sx={{
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      gap: 0.5,
+      px: 0.75,
+      py: 0.4,
+      borderRadius: 1,
+      border: '1px solid',
+      borderColor: 'border.light',
+      backgroundColor: (t) => alpha(t.palette.common.white, 0.03),
+      minWidth: 0,
+      height: '100%',
+    }}
+  >
+    <Typography
+      sx={{
+        fontSize: '0.58rem',
+        fontWeight: 600,
+        color: 'text.secondary',
+        letterSpacing: '0.04em',
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+        whiteSpace: 'nowrap',
+      }}
+    >
+      {badge.label}
+    </Typography>
+    <Typography
+      sx={{
+        fontSize: '0.68rem',
+        fontWeight: 700,
+        color: badgeAccent(badge.value),
+        flexShrink: 0,
+      }}
+    >
+      ×{badge.value.toFixed(2)}
+    </Typography>
+  </Box>
+);
+
+const LabelTailRow: React.FC<{
+  badges: MinerPrCardBadge[];
+  expanded: boolean;
+  onToggle: (e: React.MouseEvent<HTMLButtonElement>) => void;
+}> = ({ badges, expanded, onToggle }) => (
+  <Box sx={{ display: 'flex', alignItems: 'stretch', gap: 0.5 }}>
+    {badges.map((badge) => (
+      <Box key={badge.key} sx={{ flex: 1, minWidth: 0 }}>
+        <BadgeCell badge={badge} />
+      </Box>
+    ))}
+    <Box
+      component="button"
+      type="button"
+      aria-label={expanded ? 'Show fewer multipliers' : 'Show all multipliers'}
+      onClick={onToggle}
+      sx={{ ...labelToggleSx, alignSelf: 'stretch' }}
+    >
+      {expanded ? (
+        <ExpandLessIcon sx={{ fontSize: '1.15rem', color: 'inherit' }} />
+      ) : (
+        <ExpandMoreIcon sx={{ fontSize: '1.15rem', color: 'inherit' }} />
+      )}
+    </Box>
+  </Box>
+);
+
+const LabelSection: React.FC<{
+  badges: MinerPrCardBadge[];
+  expanded: boolean;
+  setExpanded: (v: boolean) => void;
+}> = ({ badges, expanded, setExpanded }) => {
+  const canExpand = badges.length > COLLAPSED_LABEL_COUNT;
+  if (!canExpand) {
+    return (
+      <Box sx={LABEL_GRID_SX}>
+        {badges.map((badge) => (
+          <BadgeCell key={badge.key} badge={badge} />
+        ))}
+      </Box>
+    );
+  }
+  if (expanded) {
+    const head = badges.slice(0, -2);
+    return (
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+        {head.length > 0 && (
+          <Box sx={LABEL_GRID_SX}>
+            {head.map((badge) => (
+              <BadgeCell key={badge.key} badge={badge} />
+            ))}
+          </Box>
+        )}
+        <LabelTailRow
+          badges={badges.slice(-2)}
+          expanded
+          onToggle={stopNav(() => setExpanded(false))}
+        />
+      </Box>
+    );
+  }
+  return (
+    <LabelTailRow
+      badges={pickCollapsedBadges(badges)}
+      expanded={false}
+      onToggle={stopNav(() => setExpanded(true))}
+    />
+  );
+};
+
+const CONVENTIONAL_COMMIT_RE = /^(\w+)(?:\([^)]+\))?!:\s+/;
+
+const PrTitle: React.FC<{
+  pullRequestNumber: number;
+  title: string;
+}> = ({ pullRequestNumber, title }) => {
+  const titleSx = {
+    fontSize: '0.85rem',
+    fontWeight: 600,
+    lineHeight: 1.35,
+    display: '-webkit-box',
+    WebkitLineClamp: 2,
+    WebkitBoxOrient: 'vertical' as const,
+    overflow: 'hidden',
+  };
+  const numberPrefix = (
+    <Box
+      component="span"
+      sx={{ color: 'text.primary', fontFamily: '"JetBrains Mono", monospace' }}
+    >
+      #{pullRequestNumber}{' '}
+    </Box>
+  );
+  const colonIdx = title.indexOf(':');
+  const match = title.match(CONVENTIONAL_COMMIT_RE);
+  if (!match || colonIdx < 0) {
+    return (
+      <Typography component="div" sx={titleSx}>
+        {numberPrefix}
+        <Box component="span" sx={{ color: 'text.primary' }}>
+          {title}
+        </Box>
+      </Typography>
+    );
+  }
+  return (
+    <Typography component="div" sx={titleSx}>
+      {numberPrefix}
+      <Box component="span" sx={{ color: 'primary.main' }}>
+        {title.slice(0, colonIdx + 1)}
+      </Box>
+      {title.slice(colonIdx + 1).trimStart() ? (
+        <Box component="span" sx={{ color: 'text.primary' }}>
+          {' '}
+          {title.slice(colonIdx + 1).trimStart()}
+        </Box>
+      ) : null}
+    </Typography>
+  );
+};
+
+interface MinerPrCardProps {
+  pr: CommitLog;
+}
+
+const MinerPrCard: React.FC<MinerPrCardProps> = ({ pr }) => {
+  const { label: statusLabel, color: statusColor } = getPrStatusChipMeta(pr);
+  const isMerged = isMergedPr(pr);
+  const isStale = !!pr.mergedAt && isOutsideScoringWindow(pr.mergedAt);
+  const isCollateral =
+    !pr.mergedAt && !!pr.collateralScore && pr.prState !== 'CLOSED';
+  const score = getMinerPrEffectiveScore(pr);
+  const leftBorderColor = cardLeftBorderColor(pr);
+  const repoOwner = pr.repository.split('/')[0] ?? '';
+
+  const { data: prDetails } = usePullRequestDetails(
+    pr.repository,
+    pr.pullRequestNumber,
+    isMerged,
+  );
+  const badges = useMemo(
+    () => buildMinerPrCardBadges(pr, prDetails),
+    [pr, prDetails],
+  );
+  const [labelsExpanded, setLabelsExpanded] = useState(false);
+
+  useEffect(() => {
+    setLabelsExpanded(false);
+  }, [pr.repository, pr.pullRequestNumber]);
+
+  const prLinkProps = useLinkBehavior<HTMLAnchorElement>(
+    minerPrPath(pr.repository, pr.pullRequestNumber),
+  );
+  const githubHref = `https://github.com/${pr.repository}/pull/${pr.pullRequestNumber}`;
+  const showLabels = badges.length > 0;
+
+  return (
+    <Card
+      component="a"
+      {...prLinkProps}
+      elevation={0}
+      aria-label={`PR #${pr.pullRequestNumber}: ${pr.pullRequestTitle}`}
+      sx={(t) => ({
+        ...linkResetSx,
+        p: 1.5,
+        width: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 0,
+        borderRadius: 2,
+        border: '1px solid',
+        borderColor: 'border.light',
+        borderLeft: '2px solid',
+        borderLeftColor: alpha(leftBorderColor, 0.4),
+        backgroundColor: t.palette.background.default,
+        cursor: 'pointer',
+        textDecoration: 'none',
+        transition:
+          'background-color 0.2s, border-color 0.2s, transform 0.2s, box-shadow 0.2s',
+        ...(isStale && { opacity: 0.4, filter: 'grayscale(0.5)' }),
+        '&:hover': {
+          backgroundColor: t.palette.surface.elevated,
+          borderColor: t.palette.border.medium,
+          borderLeftColor: alpha(leftBorderColor, 0.65),
+          transform: 'translateY(-2px)',
+          boxShadow: `0 8px 24px -6px ${alpha(t.palette.common.black, 0.45)}`,
+          textDecoration: 'none',
+        },
+        '&:focus-visible': {
+          outline: '2px solid',
+          outlineColor: 'primary.main',
+          outlineOffset: 2,
+        },
+      })}
+    >
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+        <Box
+          sx={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            gap: 1,
+          }}
+        >
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 0.75,
+              minWidth: 0,
+              flex: 1,
+            }}
+          >
+            <Avatar
+              src={getRepositoryOwnerAvatarSrc(repoOwner)}
+              alt={repoOwner}
+              sx={{
+                width: 20,
+                height: 20,
+                flexShrink: 0,
+                border: '1px solid',
+                borderColor: 'border.medium',
+              }}
+            />
+            <Typography
+              noWrap
+              sx={{ fontSize: '0.72rem', color: 'text.secondary' }}
+            >
+              {pr.repository}
+            </Typography>
+          </Box>
+          <Box
+            sx={{ display: 'flex', alignItems: 'center', flexShrink: 0 }}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <Chip
+              variant="status"
+              label={statusLabel}
+              size="small"
+              sx={statusChipSx(statusColor)}
+            />
+            <Box
+              sx={{ display: 'flex', alignItems: 'center', gap: 0.25, ml: 0.5 }}
+            >
+              <Tooltip title="Open on GitHub" arrow placement="top">
+                <IconButton
+                  size="small"
+                  aria-label="Open on GitHub"
+                  onClick={stopNav(() =>
+                    window.open(githubHref, '_blank', 'noopener,noreferrer'),
+                  )}
+                  sx={{
+                    ...headerActionSx,
+                    color: 'text.tertiary',
+                    '&:hover': {
+                      color: 'text.primary',
+                      backgroundColor: 'transparent',
+                    },
+                  }}
+                >
+                  <GitHubIcon sx={{ fontSize: '0.95rem' }} />
+                </IconButton>
+              </Tooltip>
+              <WatchlistButton
+                category="prs"
+                itemKey={serializePRKey(pr.repository, pr.pullRequestNumber)}
+                size="small"
+                sx={headerActionSx}
+              />
+            </Box>
+          </Box>
+        </Box>
+
+        <PrTitle
+          pullRequestNumber={pr.pullRequestNumber}
+          title={pr.pullRequestTitle}
+        />
+
+        {showLabels && (
+          <LabelSection
+            badges={badges}
+            expanded={labelsExpanded}
+            setExpanded={setLabelsExpanded}
+          />
+        )}
+      </Box>
+
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          gap: 0.75,
+          flexWrap: 'nowrap',
+          width: '100%',
+          flexShrink: 0,
+          mt: showLabels ? 1.5 : 1.25,
+        }}
+      >
+        <Box
+          sx={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 0.35,
+            minWidth: 0,
+            flex: 1,
+          }}
+        >
+          <CalendarTodayIcon
+            sx={{ fontSize: '0.7rem', color: 'text.tertiary', flexShrink: 0 }}
+          />
+          <Typography
+            component="span"
+            noWrap
+            sx={{ fontSize: '0.68rem', lineHeight: 1, color: 'text.tertiary' }}
+          >
+            {getMinerPrCardDisplayDate(pr)}
+          </Typography>
+        </Box>
+        <Box
+          sx={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            flexWrap: 'nowrap',
+            gap: 0.5,
+            flexShrink: 0,
+          }}
+        >
+          <Box
+            component="span"
+            sx={{ ...footerLineSx, color: 'diff.additions' }}
+          >
+            +{pr.additions}
+          </Box>
+          <Box
+            component="span"
+            sx={{ ...footerLineSx, color: 'diff.deletions' }}
+          >
+            -{pr.deletions}
+          </Box>
+          <Box
+            component="span"
+            sx={{
+              ...footerScoreSx,
+              ml: 1,
+              color: isCollateral ? 'status.warningOrange' : 'text.primary',
+            }}
+          >
+            {formatMinerPrScoreDisplay(pr, score, isCollateral)}
+          </Box>
+        </Box>
+      </Box>
+    </Card>
+  );
+};
+
+export default MinerPrCard;

--- a/src/components/miners/MinerTableRowsSelect.tsx
+++ b/src/components/miners/MinerTableRowsSelect.tsx
@@ -3,20 +3,35 @@ import { Box, FormControl, MenuItem, Select, Typography } from '@mui/material';
 import {
   MINER_EXPLORER_ROWS_OPTIONS,
   MINER_EXPLORER_ROWS_SELECT_SX,
+  type MinerExplorerNumericRows,
   type MinerExplorerRowsOption,
 } from '../common/TablePagination';
+import { MINER_PRS_TABLE_TO_CARD_ROWS } from './minerPrsViewMode';
 
 export interface MinerTableRowsSelectProps {
   value: MinerExplorerRowsOption;
   onChange: (next: MinerExplorerRowsOption) => void;
   id?: string;
+  /** When true, menu and closed label show card grid sizes (6, 12, 24, 48). */
+  cardView?: boolean;
 }
+
+const formatRowsLabel = (
+  tableRows: MinerExplorerRowsOption,
+  cardView: boolean,
+): string => {
+  if (tableRows === 'all') return 'All';
+  return cardView
+    ? String(MINER_PRS_TABLE_TO_CARD_ROWS[tableRows])
+    : String(tableRows);
+};
 
 /** Rows-per-page control for the Miner PRs table header toolbar. */
 const MinerTableRowsSelect: React.FC<MinerTableRowsSelectProps> = ({
   value,
   onChange,
   id = 'miner-table-rows',
+  cardView = false,
 }) => (
   <FormControl size="small" sx={{ flexShrink: 0 }}>
     <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
@@ -30,6 +45,13 @@ const MinerTableRowsSelect: React.FC<MinerTableRowsSelectProps> = ({
         id={id}
         aria-label="Rows per page"
         value={value === 'all' ? 'all' : value}
+        renderValue={(selected) => {
+          const rows: MinerExplorerRowsOption =
+            selected === 'all'
+              ? 'all'
+              : (Number(selected) as MinerExplorerNumericRows);
+          return formatRowsLabel(rows, cardView);
+        }}
         onChange={(e) => {
           const v = e.target.value;
           onChange(
@@ -40,7 +62,7 @@ const MinerTableRowsSelect: React.FC<MinerTableRowsSelectProps> = ({
       >
         {MINER_EXPLORER_ROWS_OPTIONS.filter((o) => o !== 'all').map((n) => (
           <MenuItem key={n} value={n}>
-            {n}
+            {formatRowsLabel(n, cardView)}
           </MenuItem>
         ))}
         <MenuItem value="all">All</MenuItem>

--- a/src/components/miners/minerPrsViewMode.ts
+++ b/src/components/miners/minerPrsViewMode.ts
@@ -1,0 +1,39 @@
+import type {
+  MinerExplorerNumericRows,
+  MinerExplorerRowsOption,
+} from '../common/TablePagination';
+
+export type MinerPrsViewMode = 'cards' | 'list';
+
+export const MINER_PRS_TABLE_TO_CARD_ROWS: Record<
+  MinerExplorerNumericRows,
+  number
+> = { 5: 6, 10: 12, 20: 24, 50: 48 };
+
+export const resolveMinerPrsPageSize = (
+  tableRows: MinerExplorerRowsOption,
+  viewMode: MinerPrsViewMode,
+): number | 'all' => {
+  if (tableRows === 'all') return 'all';
+  return viewMode === 'cards'
+    ? MINER_PRS_TABLE_TO_CARD_ROWS[tableRows]
+    : tableRows;
+};
+
+const STORAGE_KEY = 'miner:prs:viewMode';
+
+export const readStoredMinerPrsViewMode = (): MinerPrsViewMode => {
+  try {
+    return localStorage.getItem(STORAGE_KEY) === 'list' ? 'list' : 'cards';
+  } catch {
+    return 'list';
+  }
+};
+
+export const writeStoredMinerPrsViewMode = (mode: MinerPrsViewMode): void => {
+  try {
+    localStorage.setItem(STORAGE_KEY, mode);
+  } catch {
+    // localStorage unavailable
+  }
+};

--- a/src/utils/multiplierDefs.ts
+++ b/src/utils/multiplierDefs.ts
@@ -1,5 +1,6 @@
-import type { PullRequestDetails } from '../api/models/Dashboard';
+import type { CommitLog, PullRequestDetails } from '../api/models/Dashboard';
 import { parseNumber } from './ExplorerUtils';
+import { isMergedPr } from './prStatus';
 
 interface MultiplierPillDef {
   key: string;
@@ -171,4 +172,63 @@ export function buildMultiplierGrid(
   const entries = configs.map((cfg) => buildGridEntry(pr, cfg));
   if (isOpen) entries.push({ label: 'Collateral %', value: '20%' });
   return appendOptionalEntries(entries, pr);
+}
+
+export type MinerPrCardBadge = {
+  key: string;
+  label: string;
+  value: number;
+};
+
+const MERGED_CARD_BADGE_FIELDS: Array<{
+  key: string;
+  label: string;
+  field: keyof PullRequestDetails;
+}> = [
+  { key: 'cred', label: 'CRED', field: 'credibilityMultiplier' },
+  { key: 'spam', label: 'SPAM', field: 'openPrSpamMultiplier' },
+  { key: 'issue', label: 'ISSUE', field: 'issueMultiplier' },
+  { key: 'decay', label: 'DECAY', field: 'timeDecayMultiplier' },
+  { key: 'review', label: 'REVI', field: 'reviewQualityMultiplier' },
+];
+
+function parseCardMultiplier(raw: string | number | null | undefined): number {
+  if (raw == null || raw === '') return 1;
+  const n = parseNumber(raw);
+  return Number.isFinite(n) ? n : 1;
+}
+
+function readCommitLogMultiplier(
+  pr: CommitLog,
+  field: keyof PullRequestDetails,
+): string | number | null | undefined {
+  if (field === 'labelMultiplier') return pr.labelMultiplier;
+  return pr[field as keyof CommitLog] as string | undefined;
+}
+
+/** Merged PR multiplier badges for miner card view (list data + optional /details). */
+export function buildMinerPrCardBadges(
+  pr: CommitLog,
+  details?: PullRequestDetails | null,
+): MinerPrCardBadge[] {
+  if (!isMergedPr(pr)) return [];
+  const source = details ?? null;
+  const read = (field: keyof PullRequestDetails) =>
+    parseCardMultiplier(
+      source ? source[field] : readCommitLogMultiplier(pr, field),
+    );
+  return [
+    ...MERGED_CARD_BADGE_FIELDS.map(({ key, label, field }) => ({
+      key,
+      label,
+      value: read(field),
+    })),
+    {
+      key: 'label',
+      label: 'LABEL',
+      value: parseCardMultiplier(
+        source ? source.labelMultiplier : pr.labelMultiplier,
+      ),
+    },
+  ];
 }

--- a/src/utils/prStatus.ts
+++ b/src/utils/prStatus.ts
@@ -1,6 +1,14 @@
-interface PrStatusLike {
+import { STATUS_COLORS } from '../theme';
+import { formatDate } from './format';
+
+export interface PrStatusLike {
   mergedAt?: string | null;
   prState?: string | null;
+}
+
+export interface PrScoreLike extends PrStatusLike {
+  collateralScore?: string | null;
+  score?: string | null;
 }
 
 export const isOpenPr = (pr: PrStatusLike): boolean =>
@@ -18,3 +26,43 @@ export const getPrStatusCounts = <T extends PrStatusLike>(prs: T[]) => ({
   merged: prs.filter(isMergedPr).length,
   closed: prs.filter(isClosedUnmergedPr).length,
 });
+
+export const getPrStatusChipMeta = (pr: PrStatusLike) => {
+  const merged = isMergedPr(pr);
+  const closed = isClosedUnmergedPr(pr);
+  return {
+    label: merged ? 'Merged' : closed ? 'Closed' : 'Open',
+    color: merged
+      ? STATUS_COLORS.merged
+      : closed
+        ? STATUS_COLORS.closed
+        : STATUS_COLORS.open,
+  };
+};
+
+/** Score used for sort/display: merged score, open collateral, closed-unmerged → 0. */
+export const getMinerPrEffectiveScore = (pr: PrScoreLike): number => {
+  if (pr.prState === 'CLOSED' && !pr.mergedAt) return 0;
+  if (!pr.mergedAt && pr.collateralScore) {
+    return parseFloat(pr.collateralScore || '0');
+  }
+  return parseFloat(pr.score || '0');
+};
+
+export const getMinerPrCardDisplayDate = (pr: PrStatusLike): string =>
+  pr.mergedAt
+    ? formatDate(pr.mergedAt)
+    : pr.prState === 'CLOSED'
+      ? 'Closed'
+      : 'Open';
+
+export const formatMinerPrScoreDisplay = (
+  pr: PrScoreLike,
+  score: number,
+  isCollateral: boolean,
+): string =>
+  pr.prState === 'CLOSED' && !pr.mergedAt
+    ? '—'
+    : isCollateral
+      ? score.toFixed(4)
+      : score.toFixed(2);


### PR DESCRIPTION
## Summary

Adds a **Card View** option to the Pull Requests section on the Miner Details page alongside the existing table view.

Users can switch between **List** and **Card** layouts from the toolbar, providing an alternative way to browse PR activity while preserving the existing table workflow.

Each card surfaces key PR information in a compact, visual format, including:

* Repository avatar and name
* PR status (Merged, Open, Closed)
* GitHub link and watchlist action
* PR number and title
* Date
* Added and removed line counts
* PR score

Merged PRs additionally display scoring multiplier badges with expand/collapse support, allowing users to inspect scoring factors without overwhelming the default card layout. Open and closed PRs omit multiplier badges when not applicable to reduce visual noise.

The card view uses a responsive grid layout optimized for different screen sizes while preserving existing search, filters, status tabs, pagination, watchlist actions, and navigation to PR details.

## Related Issues

Closes #1316

## Type of Change

* [ ] Bug fix
* [x] New feature
* [ ] Refactor
* [ ] Documentation
* [ ] Other (describe below)

## Screenshots

### Before

<img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/4236f2af-4d6b-4d4f-8590-994bf126831f" />

### After

[miner-cardview-after.webm](https://github.com/user-attachments/assets/c4ccd8ba-1b3d-4723-b038-0478aa12918f)

## Checklist

* [x] New components are modularized/separated where sensible
* [x] Uses predefined theme (e.g. no hardcoded colors)
* [x] Responsive/mobile checked
* [x] Tested against the test API
* [x] `npm run format` and `npm run lint:fix` have been run
* [x] `npm run build` passes
* [x] Screenshots included for any UI/visual changes
