### PR TITLE
fix(leaderboard): align sparkline totals with contributions column

### DIFF
--- a/src/components/leaderboard/MinersLeaderTable.tsx
+++ b/src/components/leaderboard/MinersLeaderTable.tsx
@@ -2477,8 +2477,28 @@ const MinersLeaderTable: React.FC<MinersLeaderTableProps> = ({
 }) => {
   const navigate = useNavigate();
   const { isWatched, count: watchedCount } = useWatchlist('miners');
+  const activityGithubIds = useMemo(
+    () => miners.map((m) => m.githubId).filter(Boolean),
+    [miners],
+  );
+  // `/dash/commits` carries hotkey + author login but NOT githubId, so the
+  // OSS/merged series can't be attributed without this identity bridge.
+  const minerIdentities = useMemo(
+    () =>
+      miners.map((m) => ({
+        githubId: m.githubId,
+        hotkey: m.hotkey,
+        login: m.githubUsername,
+      })),
+    [miners],
+  );
   const { index: activityIndex, isLoading: isLoadingActivity } =
-    useMinerActivityIndex({ lookbackDays: 30, topReposLimit: 2 });
+    useMinerActivityIndex({
+      lookbackDays: 30,
+      topReposLimit: 2,
+      githubIds: activityGithubIds,
+      identities: minerIdentities,
+    });
 
   const [searchParams, setSearchParams] = useSearchParams();
   const initialViewMode = useMemo<LeaderboardViewMode>(() => {

--- a/src/components/leaderboard/Sparkline.tsx
+++ b/src/components/leaderboard/Sparkline.tsx
@@ -100,7 +100,7 @@ const Sparkline: React.FC<SparklineProps> = ({
 
   const defaultTooltip: React.ReactNode = (() => {
     if (total === 0 && totalSecondary === 0) {
-      return `No PR activity in the last ${values.length} days`;
+      return `No activity in the last ${values.length} days`;
     }
     if (!hasSecondary) {
       return `${total} ${primaryLabel} in ${values.length}d · ${last7} in the last 7d${trendText}`;

--- a/src/components/leaderboard/SparklineDetailModal.tsx
+++ b/src/components/leaderboard/SparklineDetailModal.tsx
@@ -29,8 +29,12 @@ import {
   echartsMutedCartesianAxisColors,
   echartsTransparentBackground,
 } from '../../utils/echarts/gittensorChartTheme';
-import { useRecentCommits } from '../../api';
-import { isDiscoveryCommit } from './useMinerActivityIndex';
+import {
+  useRecentCommits,
+  useMinerIssues,
+  MINER_ISSUES_FULL_HISTORY_SINCE_ISO,
+} from '../../api';
+import { minerSolvedIssueAt } from './useMinerActivityIndex';
 
 interface SparklineDetailModalProps {
   open: boolean;
@@ -283,8 +287,14 @@ const SparklineDetailModal: React.FC<SparklineDetailModalProps> = ({
   const [mode, setMode] = useState<ChartMode>('stack');
   const [range, setRange] = useState<RangeKey>('30d');
 
-  // 1D view re-buckets raw commits into 3-hour slots; daily props can't do it.
+  // 1D view re-buckets raw commits + solved issues into 3-hour slots; the daily
+  // props can't be re-sliced that finely. Only fetched while the modal is open.
   const { data: recentCommits } = useRecentCommits(500);
+  const { data: minerIssues } = useMinerIssues(
+    githubId ?? '',
+    open && !!githubId,
+    MINER_ISSUES_FULL_HISTORY_SINCE_ISO,
+  );
 
   const activeRange = useMemo(
     () => RANGE_OPTIONS.find((r) => r.key === range) ?? RANGE_OPTIONS[2],
@@ -304,8 +314,16 @@ const SparklineDetailModal: React.FC<SparklineDetailModalProps> = ({
         if (!Number.isFinite(t)) continue;
         const slot = buckets.findIndex((b) => t >= b.startMs && t < b.endMs);
         if (slot < 0) continue;
-        if (isDiscoveryCommit(c)) disc[slot] += 1;
-        else oss[slot] += 1;
+        oss[slot] += 1;
+      }
+      for (const issue of minerIssues ?? []) {
+        const solvedAt = minerSolvedIssueAt(issue, githubId ?? '');
+        if (solvedAt === null) continue;
+        const slot = buckets.findIndex(
+          (b) => solvedAt >= b.startMs && solvedAt < b.endMs,
+        );
+        if (slot < 0) continue;
+        disc[slot] += 1;
       }
       return {
         labels: buckets.map((b) => b.label),
@@ -327,6 +345,7 @@ const SparklineDetailModal: React.FC<SparklineDetailModalProps> = ({
     range,
     activeRange,
     recentCommits,
+    minerIssues,
     githubId,
     primaryValues,
     secondaryValues,
@@ -537,7 +556,13 @@ const SparklineDetailModal: React.FC<SparklineDetailModalProps> = ({
             }}
           >
             Activity · {activeRange.label} window ·{' '}
-            {grandTotal.toLocaleString()} merged PR{grandTotal === 1 ? '' : 's'}
+            {totalPrimary.toLocaleString()} merged PR
+            {totalPrimary === 1 ? '' : 's'}
+            {totalSecondary > 0
+              ? ` · ${totalSecondary.toLocaleString()} issue${
+                  totalSecondary === 1 ? '' : 's'
+                } solved`
+              : ''}
           </Typography>
         </Box>
         <IconButton
@@ -560,7 +585,7 @@ const SparklineDetailModal: React.FC<SparklineDetailModalProps> = ({
           <StatTile
             label={secondaryLabel}
             value={totalSecondary.toLocaleString()}
-            caption="merged PRs"
+            caption="issues solved"
             accentColor={LEADERBOARD_TRACK_COLORS.discovery}
           />
           <StatTile
@@ -658,7 +683,7 @@ const SparklineDetailModal: React.FC<SparklineDetailModalProps> = ({
                   color: alpha(theme.palette.text.primary, 0.7),
                 }}
               >
-                No PR activity in this window
+                No activity in this window
               </Typography>
               <Typography
                 sx={{

--- a/src/components/leaderboard/useMinerActivityIndex.ts
+++ b/src/components/leaderboard/useMinerActivityIndex.ts
@@ -1,10 +1,22 @@
 import { useMemo } from 'react';
-import { useRecentCommits, type CommitLog } from '../../api';
+import {
+  useAllPrs,
+  useMinersIssues,
+  useReposAndWeights,
+  MINER_ISSUES_FULL_HISTORY_SINCE_ISO,
+  type CommitLog,
+  type MinerIssue,
+} from '../../api';
 import { parseNumber } from '../../utils/ExplorerUtils';
 
 export interface MinerActivity {
+  // Merged PRs/day, from the `/prs` scored feed. Each scored PR is an OSS-track
+  // contribution, so `dailyOss` mirrors `dailyMerged`.
   dailyMerged: number[];
   dailyOss: number[];
+  // Issue-discovery track: solved issues/day, keyed by the solving PR's merge
+  // date. Sourced from the mirror issues feed (the `/prs` feed carries no
+  // discovery signal). Only populated when `githubIds` is supplied.
   dailyDiscovery: number[];
   topRepos: { name: string; count: number }[];
   lastActiveAt: string | null;
@@ -28,10 +40,26 @@ export interface NetworkActivity {
   topRepos: NetworkRepoActivity[];
 }
 
+// Maps a PR back to a miner. `/prs` rows carry `githubId` directly; the
+// identity maps (hotkey→id, login→id) are only a fallback for any row missing
+// it, built from the leaderboard rows.
+export interface MinerIdentity {
+  githubId: string;
+  hotkey?: string | null;
+  login?: string | null;
+}
+
 interface Options {
   lookbackDays?: number;
   topReposLimit?: number;
-  commitLimit?: number;
+  // GitHub IDs to source the issue-discovery (solved-issues) series for. One
+  // mirror fetch per id, so only pass the miners actually rendered. Omit to
+  // skip discovery entirely (e.g. network-only consumers).
+  githubIds?: string[];
+  // Identity bridge for the OSS/merged series. `/prs` rows carry `githubId`
+  // directly, so this is now only a fallback for rows missing it (attributed
+  // by hotkey, then author login).
+  identities?: MinerIdentity[];
 }
 
 const MS_PER_DAY = 86_400_000;
@@ -52,19 +80,59 @@ const emptyMiner = (lookbackDays: number): MinerActivity => ({
   reviewHits: 0,
 });
 
-// Mirrors `isIssueDiscoveryContributionPr` in `utils/ExplorerUtils.ts`.
-export const isDiscoveryCommit = (commit: CommitLog): boolean => {
-  const im = commit.issueMultiplier;
-  if (im !== undefined && im !== null && String(im).trim() !== '') {
-    if (parseNumber(im) > 0) return true;
+// A miner's issue-discovery "solve": an issue THIS miner authored (discovered)
+// that a merged PR resolved. The discovery track is credited when the solving
+// PR merges, so we key off `solving_pr.merged_at`. Returns that time in ms, or
+// null when the issue isn't a solved discovery by this miner.
+//
+// The gates below mirror the validator's `_classify_issue`
+// (gittensor/validator/issue_discovery/scan.py) so the sparkline's daily counts
+// sum to the leaderboard CONTRIBUTIONS column (`totalSolvedIssues`) rather than
+// the looser author+merged-PR heuristic this used before, which over-counted.
+// We match `total_solved_issues` (the broad count the column shows): we do NOT
+// apply the token-score "valid" gate and do NOT apply the cross-miner
+// one-issue-per-PR dedupe — do not "fix" that by adding them.
+//
+// Two `_classify_issue` gates can't be applied client-side and are the only
+// expected residual drift: branch-eligibility on the solving PR (the feed
+// carries `head_sha`/`base_sha` but not `base_ref`/`head_ref` names), and any
+// repo-config nuance beyond scored-repo membership.
+export const minerSolvedIssueAt = (
+  issue: MinerIssue,
+  githubId: string,
+  // Lower-cased `repo_full_name`s in the active scored set. When provided,
+  // issues outside it are excluded (the column only counts scored repos).
+  scoredRepos?: Set<string>,
+): number | null => {
+  // author present AND authored by this miner
+  if (!githubId || String(issue.author_github_id ?? '') !== githubId) {
+    return null;
   }
-  if (commit.labelMultiplier !== undefined && commit.labelMultiplier !== null) {
-    if (parseNumber(commit.labelMultiplier) > 0) return true;
+  // scored-repo scope
+  if (scoredRepos && !scoredRepos.has(issue.repo_full_name.toLowerCase())) {
+    return null;
   }
-  if (commit.label !== undefined && commit.label !== null) {
-    if (String(commit.label).trim() !== '') return true;
+  // not transferred
+  if (issue.is_transferred) return null;
+  // closed as completed (not NOT_PLANNED, not null)
+  if (issue.state !== 'CLOSED') return null;
+  if ((issue.state_reason ?? '').toUpperCase() !== 'COMPLETED') return null;
+  // solved by a populated, existing solving PR
+  if (!issue.solved_by_pr || !issue.solving_pr) return null;
+  const sp = issue.solving_pr;
+  // solving PR merged and not edited after merge
+  if ((sp.state ?? '').toUpperCase() !== 'MERGED') return null;
+  if (sp.edited_after_merge) return null;
+  const mergedAt = sp.merged_at;
+  if (!mergedAt) return null;
+  const t = Date.parse(mergedAt);
+  if (!Number.isFinite(t)) return null;
+  // anti spec-rewrite: issue not edited after the solving PR merged
+  if (issue.last_edited_at) {
+    const edited = Date.parse(issue.last_edited_at);
+    if (Number.isFinite(edited) && edited > t) return null;
   }
-  return false;
+  return t;
 };
 
 // multiplier = max(0, 1 - 0.15 × N), so N = round((1 - m) / 0.15).
@@ -80,11 +148,52 @@ interface BuildResult {
   network: NetworkActivity;
 }
 
+export interface MinerSolvedIssues {
+  githubId: string;
+  issues: MinerIssue[];
+}
+
+// Resolve a PR to a numeric githubId. `/prs` rows usually carry `githubId`; for
+// any row missing it, fall back to the hotkey→id map (exact match, casing-safe)
+// and finally the author-login→id map. Returns undefined when unattributable.
+const resolveCommitGithubId = (
+  commit: CommitLog,
+  byHotkey: Map<string, string>,
+  byLogin: Map<string, string>,
+): string | undefined => {
+  const direct = commit.githubId?.trim();
+  if (direct) return direct;
+  const hotkey = commit.hotkey?.trim();
+  if (hotkey) {
+    const viaHotkey = byHotkey.get(hotkey);
+    if (viaHotkey) return viaHotkey;
+  }
+  const login = commit.author?.trim().toLowerCase();
+  if (login) {
+    const viaLogin = byLogin.get(login);
+    if (viaLogin) return viaLogin;
+  }
+  return undefined;
+};
+
 const buildIndex = (
   commits: CommitLog[],
   lookbackDays: number,
   topReposLimit: number,
+  solvedIssues?: MinerSolvedIssues[],
+  identities?: MinerIdentity[],
+  scoredRepos?: Set<string>,
 ): BuildResult => {
+  const byHotkey = new Map<string, string>();
+  const byLogin = new Map<string, string>();
+  for (const id of identities ?? []) {
+    if (!id.githubId) continue;
+    const hotkey = id.hotkey?.trim();
+    if (hotkey) byHotkey.set(hotkey, id.githubId);
+    const login = id.login?.trim().toLowerCase();
+    if (login) byLogin.set(login, id.githubId);
+  }
+
   const today = startOfUtcDay(Date.now());
   const windowStart = today - (lookbackDays - 1) * MS_PER_DAY;
   const index = new Map<string, MinerActivity>();
@@ -97,7 +206,7 @@ const buildIndex = (
   >();
 
   for (const commit of commits) {
-    const githubId = commit.githubId?.trim();
+    const githubId = resolveCommitGithubId(commit, byHotkey, byLogin);
     if (!githubId) continue;
 
     let entry = index.get(githubId);
@@ -112,15 +221,13 @@ const buildIndex = (
         const day = startOfUtcDay(mergedAt);
         const slot = Math.round((day - windowStart) / MS_PER_DAY);
         if (slot >= 0 && slot < lookbackDays) {
+          // Every PR in the `/prs` scored feed is an OSS-track contribution; the
+          // feed carries no issue-discovery signal. Discovery is overlaid below
+          // from solved issues.
           entry.dailyMerged[slot] += 1;
+          entry.dailyOss[slot] += 1;
           networkDaily[slot] += 1;
-          if (isDiscoveryCommit(commit)) {
-            entry.dailyDiscovery[slot] += 1;
-            networkDiscovery[slot] += 1;
-          } else {
-            entry.dailyOss[slot] += 1;
-            networkOss[slot] += 1;
-          }
+          networkOss[slot] += 1;
         }
       }
     }
@@ -150,6 +257,27 @@ const buildIndex = (
     }
 
     entry.reviewHits += inferReviewHits(commit.reviewQualityMultiplier);
+  }
+
+  // Overlay the issue-discovery track: one count per solved issue, bucketed by
+  // the solving PR's merge day. A miner may have solved issues without any
+  // recent PRs, so create entries on demand.
+  for (const { githubId, issues } of solvedIssues ?? []) {
+    if (!githubId || issues.length === 0) continue;
+    let entry = index.get(githubId);
+    for (const issue of issues) {
+      const solvedAt = minerSolvedIssueAt(issue, githubId, scoredRepos);
+      if (solvedAt === null || solvedAt < windowStart) continue;
+      const slot = Math.round(
+        (startOfUtcDay(solvedAt) - windowStart) / MS_PER_DAY,
+      );
+      if (slot < 0 || slot >= lookbackDays) continue;
+      if (!entry) {
+        entry = emptyMiner(lookbackDays);
+        index.set(githubId, entry);
+      }
+      entry.dailyDiscovery[slot] += 1;
+    }
   }
 
   for (const entry of index.values()) {
@@ -203,18 +331,76 @@ export const useMinerActivityIndex = (
   network: NetworkActivity;
   isLoading: boolean;
 } => {
-  const { lookbackDays = 30, topReposLimit = 3, commitLimit = 500 } = options;
+  const {
+    lookbackDays = 30,
+    topReposLimit = 3,
+    githubIds,
+    identities,
+  } = options;
 
-  const { data, isLoading } = useRecentCommits(commitLimit);
+  // OSS/merged track: the full `/prs` scored feed (every scored PR, with
+  // `githubId`), NOT the global `/dash/commits` recent-N slice. With ~110
+  // miners that slice only spanned ~1–2 weeks, so in-window PRs older than the
+  // cut were missing and the sparkline under-counted vs the CONTRIBUTIONS
+  // column. `/prs` is the same gated set the column's `totalMergedPrs` counts,
+  // so per-miner merged-PR buckets now sum to it (within the display window).
+  const { data, isLoading } = useAllPrs();
+
+  // Active scored-repo set — discovery is only credited in scored repos, so we
+  // scope the solve gate to it to match `totalSolvedIssues`. Lower-cased for
+  // case-insensitive `repo_full_name` matching.
+  const { data: repos } = useReposAndWeights();
+
+  // One mirror call per miner; `since` must be set or the feed returns
+  // OPEN-only rows (we need solved/closed issues). Gated so network-only
+  // callers (no githubIds) fire nothing.
+  const wantsIssues = (githubIds?.length ?? 0) > 0;
+  const issueQueries = useMinersIssues(
+    githubIds ?? [],
+    wantsIssues,
+    MINER_ISSUES_FULL_HISTORY_SINCE_ISO,
+  );
 
   const built = useMemo<BuildResult>(() => {
-    if (!data) return { index: new Map(), network: EMPTY_NETWORK };
-    return buildIndex(data, lookbackDays, topReposLimit);
-  }, [data, lookbackDays, topReposLimit]);
+    const solvedIssues: MinerSolvedIssues[] | undefined = wantsIssues
+      ? githubIds!.map((githubId, i) => ({
+          githubId,
+          issues: issueQueries[i]?.data ?? [],
+        }))
+      : undefined;
+    // Pass the scope only once loaded; an empty set would wrongly exclude every
+    // solve while repos are still fetching, so fall back to unscoped until then.
+    const scoredRepos =
+      repos && repos.length
+        ? new Set(repos.map((r) => r.fullName.toLowerCase()))
+        : undefined;
+    if (!data && !solvedIssues) {
+      return { index: new Map(), network: EMPTY_NETWORK };
+    }
+    return buildIndex(
+      data ?? [],
+      lookbackDays,
+      topReposLimit,
+      solvedIssues,
+      identities,
+      scoredRepos,
+    );
+  }, [
+    data,
+    lookbackDays,
+    topReposLimit,
+    githubIds,
+    identities,
+    wantsIssues,
+    issueQueries,
+    repos,
+  ]);
+
+  const issuesLoading = wantsIssues && issueQueries.some((q) => q.isLoading);
 
   return {
     index: built.index,
     network: built.network,
-    isLoading,
+    isLoading: isLoading || issuesLoading,
   };
 };


### PR DESCRIPTION
## Summary

The miners leaderboard 30 day sparkline now agrees with the CONTRIBUTIONS column on both tracks. All changes live in `src/components/leaderboard/useMinerActivityIndex.ts`.

OSS track:

- The merged PR series now reads the full scored pull request feed (`/prs`) instead of the global recent commits feed (`/dash/commits`, capped at 500 rows). The capped feed only covered one to two weeks once spread across every miner, so merged PRs that were still inside the window went missing and the total fell short of `totalMergedPrs`. The `/prs` feed is the same gated set the column counts and carries the GitHub id directly, so attribution no longer depends on the hotkey or login fallback.

Discovery track:

- The solved issue gate now mirrors the validator classification: closed as completed, solved by a merged PR that was not edited after merge, issue not transferred, and issue not edited after the solving PR merged. It is also scoped to the active scored repositories. The previous version counted any authored issue that had a merged solving PR, which overcounted against `totalSolvedIssues`.

The broad `total_solved_issues` semantics are matched on purpose. The token score valid gate and the one issue per PR dedupe are intentionally left out, since those are not what the column shows, and a code comment records this so the gate set is not "corrected" by mistake later. Branch eligibility is the only validator gate that cannot run client side, because the issue payload does not include the base and head branch names.

## Related Issues

Fixes #1318 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

Before: 
<img width="1357" height="882" alt="before" src="https://github.com/user-attachments/assets/ea7b3a73-6ef0-4912-800e-cc74024ac706" />

After: 
<img width="1345" height="870" alt="after" src="https://github.com/user-attachments/assets/855361de-88e5-4eca-9305-5167efaa7544" />


## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
