### PR TITLE
refactor(utils): centralize GitHub PR and issue URL building

### DIFF
--- a/src/components/miners/MinerOpenDiscoveryIssuesByRepo.tsx
+++ b/src/components/miners/MinerOpenDiscoveryIssuesByRepo.tsx
@@ -16,6 +16,7 @@ import { useNavigate } from 'react-router-dom';
 import { useMinerIssues } from '../../api';
 import type { MinerIssue } from '../../api/models/Dashboard';
 import {
+  buildIssueUrl,
   getRepositoryOwnerAvatarSrc,
   getScoringWindowStartIso,
   isOutsideScoringWindow,
@@ -217,7 +218,7 @@ const MinerOpenDiscoveryIssuesByRepo: React.FC<
       cellSx: { fontSize: { xs: '0.75rem', sm: '0.85rem' } },
       renderCell: (issue) => (
         <a
-          href={`https://github.com/${issue.repo_full_name}/issues/${issue.issue_number}`}
+          href={buildIssueUrl(issue.repo_full_name, issue.issue_number)}
           target="_blank"
           rel="noopener noreferrer"
           style={{

--- a/src/components/miners/MinerPrScoreDetail.tsx
+++ b/src/components/miners/MinerPrScoreDetail.tsx
@@ -18,7 +18,7 @@ import { usePullRequestDetails, type CommitLog } from '../../api';
 import { STATUS_COLORS, tooltipSlotProps } from '../../theme';
 import { parseNumber } from '../../utils/ExplorerUtils';
 import { buildMergedPillDefs } from '../../utils/multiplierDefs';
-import { minerPrPath } from '../../utils';
+import { buildPrUrl, minerPrPath } from '../../utils';
 
 const tipProps = {
   ...tooltipSlotProps,
@@ -295,7 +295,7 @@ const MinerPrScoreDetail: React.FC<MinerPrScoreDetailProps> = ({
           size="small"
           startIcon={<GitHubIcon sx={{ fontSize: '0.85rem' }} />}
           component="a"
-          href={`https://github.com/${pr.repository}/pull/${pr.pullRequestNumber}`}
+          href={buildPrUrl(pr.repository, pr.pullRequestNumber)}
           target="_blank"
           rel="noopener noreferrer"
           onClick={(e) => e.stopPropagation()}

--- a/src/components/prs/PRHeader.tsx
+++ b/src/components/prs/PRHeader.tsx
@@ -5,6 +5,7 @@ import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import EventAvailableIcon from '@mui/icons-material/EventAvailable';
 import { linkResetSx, useLinkBehavior } from '../common/linkBehavior';
 import {
+  buildPrUrl,
   formatDate,
   formatUsdEstimate,
   getRepositoryOwnerAvatarSrc,
@@ -33,7 +34,7 @@ const PRHeader: React.FC<PRHeaderProps> = ({
     `/miners/details?githubId=${prDetails.githubId ?? ''}`,
     { state: { backLabel: `Back to PR #${pullRequestNumber}` } },
   );
-  const githubPrUrl = `https://github.com/${repository}/pull/${pullRequestNumber}`;
+  const githubPrUrl = buildPrUrl(repository, pullRequestNumber);
   const mergedDateLabel = prDetails.mergedAt
     ? formatDate(prDetails.mergedAt)
     : null;

--- a/src/components/repositories/RepositoryIssuesTable.tsx
+++ b/src/components/repositories/RepositoryIssuesTable.tsx
@@ -23,7 +23,12 @@ import {
   DataTable,
   type DataTableColumn,
 } from '../../components/common/DataTable';
-import { formatTokenAmount, getLowerText } from '../../utils';
+import {
+  buildIssueUrl,
+  buildPrUrl,
+  formatTokenAmount,
+  getLowerText,
+} from '../../utils';
 import { formatDate } from '../../utils/format';
 import { ScrollAwareTooltip } from '../../components/common/ScrollAwareTooltip';
 import {
@@ -218,7 +223,7 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
     // Row navigates to GitHub in a new tab; using onRowClick (not getRowHref)
     // keeps nested <a> cells valid HTML.
     window.open(
-      `https://github.com/${issue.repositoryFullName}/issues/${issue.number}`,
+      buildIssueUrl(issue.repositoryFullName, issue.number),
       '_blank',
       'noopener,noreferrer',
     );
@@ -254,7 +259,7 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
       sortKey: 'number',
       renderCell: (issue) => (
         <a
-          href={`https://github.com/${issue.repositoryFullName}/issues/${issue.number}`}
+          href={buildIssueUrl(issue.repositoryFullName, issue.number)}
           target="_blank"
           rel="noopener noreferrer"
           style={{
@@ -322,7 +327,7 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
       renderCell: (issue) =>
         issue.prNumber ? (
           <a
-            href={`https://github.com/${issue.repositoryFullName}/pull/${issue.prNumber}`}
+            href={buildPrUrl(issue.repositoryFullName, issue.prNumber)}
             target="_blank"
             rel="noopener noreferrer"
             style={{

--- a/src/components/repositories/RepositoryPRsTable.tsx
+++ b/src/components/repositories/RepositoryPRsTable.tsx
@@ -31,6 +31,7 @@ import {
 import { useDataTableParams } from '../../hooks/useDataTableParams';
 import theme, { TEXT_OPACITY, scrollbarSx } from '../../theme';
 import {
+  buildPrUrl,
   filterPrs,
   getPrStatusCounts,
   minerPrPath,
@@ -310,7 +311,7 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
       renderCell: (pr) => (
         // Native <a> to GitHub — `onRowClick` (no row-as-anchor) keeps this valid HTML.
         <a
-          href={`https://github.com/${pr.repository}/pull/${pr.pullRequestNumber}`}
+          href={buildPrUrl(pr.repository, pr.pullRequestNumber)}
           target="_blank"
           rel="noopener noreferrer"
           style={{

--- a/src/pages/WatchlistPage.tsx
+++ b/src/pages/WatchlistPage.tsx
@@ -108,7 +108,7 @@ import { filterPrs, type PrStatusFilter } from '../utils/prTable';
 import { getIssueStatusMeta } from '../utils/issueStatus';
 import { formatDate, formatTokenAmount, formatWeight } from '../utils/format';
 import { getRepositoryOwnerAvatarSrc } from '../utils/avatar';
-import { minerPrPath, minerRepositoryPath } from '../utils';
+import { buildIssueUrl, minerPrPath, minerRepositoryPath } from '../utils';
 import theme, {
   CHART_COLORS,
   LABEL_COLORS,
@@ -3926,7 +3926,7 @@ const buildIssueColumns = (
 ];
 
 const getIssueHref = (issue: MinerIssue): string =>
-  `https://github.com/${issue.repo_full_name}/issues/${issue.issue_number}`;
+  buildIssueUrl(issue.repo_full_name, issue.issue_number);
 
 const IssueCard: React.FC<{
   issue: MinerIssue;

--- a/src/utils/githubRepoUrl.ts
+++ b/src/utils/githubRepoUrl.ts
@@ -1,3 +1,18 @@
+// Build & parse github.com URLs. Builders take positional (repo, number) args so
+// call sites stay one-liners regardless of the upstream field naming
+// (repository / repositoryFullName / repo_full_name and number / issue_number /
+// pullRequestNumber / prNumber).
+
+export const buildPrUrl = (
+  repoFullName: string,
+  number: number | string,
+): string => `https://github.com/${repoFullName}/pull/${number}`;
+
+export const buildIssueUrl = (
+  repoFullName: string,
+  number: number | string,
+): string => `https://github.com/${repoFullName}/issues/${number}`;
+
 export const extractRepoFullName = (repoUrl: string): string | null => {
   try {
     const url = new URL(repoUrl.trim());


### PR DESCRIPTION
## Summary

GitHub PR and issue links were built with inline template strings in six different files, and each site read the repository and number from differently named fields (`repository` / `repositoryFullName` / `repo_full_name`, and `number` / `issue_number` / `pullRequestNumber` / `prNumber`). This routes all eight of those builds through two shared helpers so the link shape lives in one place.

Two builders now sit alongside the existing parser in `src/utils/githubRepoUrl.ts`:

```ts
export const buildPrUrl = (repoFullName: string, number: number | string): string =>
  `https://github.com/${repoFullName}/pull/${number}`;

export const buildIssueUrl = (repoFullName: string, number: number | string): string =>
  `https://github.com/${repoFullName}/issues/${number}`;
```

The signatures stay positional, so each call site remains a single line and the varied upstream field names are confined to plain arguments instead of buried inside template strings.

Call sites updated (eight inline builds across six files):

- `src/components/prs/PRHeader.tsx`
- `src/components/miners/MinerPrScoreDetail.tsx`
- `src/components/repositories/RepositoryPRsTable.tsx`
- `src/components/miners/MinerOpenDiscoveryIssuesByRepo.tsx`
- `src/pages/WatchlistPage.tsx`
- `src/components/repositories/RepositoryIssuesTable.tsx` (issue link, row click handler, and linked PR link)

The builders are co-located with the existing `extractRepoFullName` parser so the build and parse helpers stay together, and the file keeps its original name to keep the diff clean. The generated URLs are unchanged, so this carries no behavior or visual difference.

## Related Issues

Closes #1320 

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

Not applicable. This is a pure logic change with no rendered UI difference.

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [ ] Screenshots included for any UI/visual changes
