### PR TITLE
fix(routes): finish paths.ts route builder migration

### DIFF
--- a/src/components/issues/BountySidebar.tsx
+++ b/src/components/issues/BountySidebar.tsx
@@ -27,6 +27,7 @@ import { StatRow } from '../leaderboard/ActivitySidebarCards';
 import { FONTS } from '../leaderboard/types';
 import { CHART_COLORS, CREDIBILITY_COLORS, STATUS_COLORS } from '../../theme';
 import { getGithubAvatarSrc, parseNumber } from '../../utils';
+import { minerDetailsPath } from '../../utils/paths';
 import { formatAlphaToUsd, formatTokenAmount } from '../../utils/format';
 import { usePrices } from '../../hooks/usePrices';
 import { useFiltersPanelOpenInUrl } from '../../hooks/useFiltersPanelUrlState';
@@ -606,7 +607,7 @@ const HunterRowItem: React.FC<{
       : '';
   const displayName = authorLogin || truncateHotkey(hotkey);
   const profileHref = authorGithubId
-    ? `/miners/details?githubId=${encodeURIComponent(authorGithubId)}`
+    ? minerDetailsPath(authorGithubId)
     : hotkey
       ? `/miners?hotkey=${encodeURIComponent(hotkey)}`
       : '/miners';

--- a/src/components/issues/IssueSubmissionsTable.tsx
+++ b/src/components/issues/IssueSubmissionsTable.tsx
@@ -16,6 +16,7 @@ import { IssueSubmission } from '../../api/models/Issues';
 import { STATUS_COLORS } from '../../theme';
 import { formatDate } from '../../utils/format';
 import { getGithubAvatarSrc, minerPrPath } from '../../utils';
+import { minerDetailsPath } from '../../utils/paths';
 import { LinkBox } from '../common/linkBehavior';
 import {
   DataTable,
@@ -94,7 +95,7 @@ const IssueSubmissionsTable: React.FC<IssueSubmissionsTableProps> = ({
             onKeyDown={(e) => e.stopPropagation()}
           >
             <LinkBox
-              href={`/miners/details?githubId=${submission.authorGithubId}`}
+              href={minerDetailsPath(submission.authorGithubId)}
               linkState={linkState}
               sx={{
                 fontSize: '0.85rem',
@@ -379,7 +380,7 @@ const IssueSubmissionsTable: React.FC<IssueSubmissionsTableProps> = ({
                           e.stopPropagation();
                           e.preventDefault();
                           navigate(
-                            `/miners/details?githubId=${winnerSubmission.authorGithubId}`,
+                            minerDetailsPath(winnerSubmission.authorGithubId),
                             { state: linkState },
                           );
                         }}
@@ -388,7 +389,7 @@ const IssueSubmissionsTable: React.FC<IssueSubmissionsTableProps> = ({
                           if (e.key === 'Enter' || e.key === ' ') {
                             e.preventDefault();
                             navigate(
-                              `/miners/details?githubId=${winnerSubmission.authorGithubId}`,
+                              minerDetailsPath(winnerSubmission.authorGithubId),
                               { state: linkState },
                             );
                           }

--- a/src/components/layout/GlobalSearchBar.tsx
+++ b/src/components/layout/GlobalSearchBar.tsx
@@ -25,6 +25,7 @@ import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 import { useSearchResults } from '../../pages/search/searchData';
 import { useLinkBehavior, linkResetSx } from '../common/linkBehavior';
 import { minerPrPath, minerRepositoryPath } from '../../utils';
+import { minerDetailsPath, bountyDetailsPath } from '../../utils/paths';
 
 const QUICK_RESULT_LIMIT = 3;
 const DROPDOWN_CLOSE_DELAY_MS = 150;
@@ -306,7 +307,7 @@ const GlobalSearchBar: React.FC = () => {
   const navItems: NavItem[] = useMemo(() => {
     const items: NavItem[] = [];
     minerResults.forEach((miner) => {
-      const href = `/miners/details?githubId=${encodeURIComponent(miner.githubId)}`;
+      const href = minerDetailsPath(miner.githubId);
       items.push({
         key: `miner-${miner.githubId}`,
         kind: 'miner',
@@ -339,7 +340,7 @@ const GlobalSearchBar: React.FC = () => {
       });
     });
     issueResults.forEach((issue) => {
-      const href = `/bounties/details?id=${issue.id}`;
+      const href = bountyDetailsPath(issue.id);
       items.push({
         key: `issue-${issue.id}`,
         kind: 'issue',

--- a/src/components/leaderboard/LeaderboardInsights.tsx
+++ b/src/components/leaderboard/LeaderboardInsights.tsx
@@ -22,6 +22,7 @@ import {
 } from '../../theme';
 import { getRepositoryOwnerAvatarSrc } from '../../utils/avatar';
 import { parseNumber } from '../../utils/ExplorerUtils';
+import { minerDetailsPath } from '../../utils/paths';
 import { LinkBox } from '../common/linkBehavior';
 import type { MinerEvaluation } from '../../api';
 import {
@@ -414,7 +415,7 @@ const DailyPoolZone: React.FC<{
                   slotProps={tooltipSlotProps}
                 >
                   <LinkBox
-                    href={`/miners/details?githubId=${e.githubId}`}
+                    href={minerDetailsPath(e.githubId)}
                     aria-label={`${e.username}, ranked ${rank}, ${fmtUsd(e.usdPerDay)} per day`}
                     sx={{
                       display: 'inline-flex',
@@ -751,7 +752,7 @@ const PodiumZone: React.FC<{
           return (
             <LinkBox
               key={row.githubId}
-              href={`/miners/details?githubId=${row.githubId}`}
+              href={minerDetailsPath(row.githubId)}
               sx={(t) => ({
                 display: 'grid',
                 gridTemplateColumns: '28px minmax(0, 1fr) auto',

--- a/src/components/leaderboard/MinersLeaderTable.tsx
+++ b/src/components/leaderboard/MinersLeaderTable.tsx
@@ -46,6 +46,7 @@ import theme, {
 import { getRepositoryOwnerAvatarSrc } from '../../utils/avatar';
 import { parseNumber } from '../../utils/ExplorerUtils';
 import { paginateItems } from '../../utils';
+import { minerDetailsPath } from '../../utils/paths';
 import { useDataTableParams } from '../../hooks/useDataTableParams';
 import { useWatchlist } from '../../hooks/useWatchlist';
 import type { MinerEvaluation } from '../../api';
@@ -1260,11 +1261,11 @@ const MobileMinerCard: React.FC<{
     <Box
       role="button"
       tabIndex={0}
-      onClick={() => navigate(`/miners/details?githubId=${row.miner.githubId}`)}
+      onClick={() => navigate(minerDetailsPath(row.miner.githubId))}
       onKeyDown={(event) => {
         if (event.key === 'Enter' || event.key === ' ') {
           event.preventDefault();
-          navigate(`/miners/details?githubId=${row.miner.githubId}`);
+          navigate(minerDetailsPath(row.miner.githubId));
         }
       }}
       sx={(t) => ({
@@ -3511,9 +3512,7 @@ const MinersLeaderTable: React.FC<MinersLeaderTableProps> = ({
         columns={columns}
         rows={paged}
         getRowKey={(row) => row.miner.githubId}
-        onRowClick={(row) =>
-          navigate(`/miners/details?githubId=${row.miner.githubId}`)
-        }
+        onRowClick={(row) => navigate(minerDetailsPath(row.miner.githubId))}
         getRowSx={(row) => {
           const ineligible = !isAnyEligibleNow(row.miner);
           return {

--- a/src/components/prs/PRHeader.tsx
+++ b/src/components/prs/PRHeader.tsx
@@ -8,6 +8,7 @@ import {
   formatDate,
   formatUsdEstimate,
   getRepositoryOwnerAvatarSrc,
+  minerDetailsPath,
   minerRepositoryPath,
 } from '../../utils';
 import { type PullRequestDetails } from '../../api/models/Dashboard';
@@ -30,7 +31,7 @@ const PRHeader: React.FC<PRHeaderProps> = ({
     { state: { backLabel: `Back to PR #${pullRequestNumber}` } },
   );
   const authorLinkProps = useLinkBehavior<HTMLAnchorElement>(
-    `/miners/details?githubId=${prDetails.githubId ?? ''}`,
+    minerDetailsPath(prDetails.githubId),
     { state: { backLabel: `Back to PR #${pullRequestNumber}` } },
   );
   const githubPrUrl = `https://github.com/${repository}/pull/${pullRequestNumber}`;

--- a/src/components/repositories/RepositoryIssuesTable.tsx
+++ b/src/components/repositories/RepositoryIssuesTable.tsx
@@ -24,6 +24,7 @@ import {
   type DataTableColumn,
 } from '../../components/common/DataTable';
 import { formatTokenAmount, getLowerText } from '../../utils';
+import { bountyDetailsPath } from '../../utils/paths';
 import { formatDate } from '../../utils/format';
 import { ScrollAwareTooltip } from '../../components/common/ScrollAwareTooltip';
 import {
@@ -466,7 +467,7 @@ const RepositoryIssuesTable: React.FC<RepositoryIssuesTableProps> = ({
               return (
                 <LinkBox
                   key={bounty.id}
-                  href={`/bounties/details?id=${bounty.id}`}
+                  href={bountyDetailsPath(bounty.id)}
                   linkState={{ backLabel: `Back to ${repositoryFullName}` }}
                   sx={{
                     display: 'flex',

--- a/src/components/repositories/RepositoryMinersTab.tsx
+++ b/src/components/repositories/RepositoryMinersTab.tsx
@@ -2,6 +2,7 @@ import React, { useMemo, useState } from 'react';
 import { alpha, Box, Tooltip, Typography } from '@mui/material';
 import { useRepositoryConfig, useRepositoryMiners } from '../../api';
 import { mapRepositoryMinersToStats } from '../../utils/minerMapper';
+import { minerDetailsPath } from '../../utils/paths';
 import { tooltipSlotProps } from '../../theme';
 import { TopMinersTable, type MinerStats } from '../leaderboard';
 
@@ -58,8 +59,8 @@ const RepositoryMinersTab: React.FC<RepositoryMinersTabProps> = ({
 
   const getMinerHref = (miner: MinerStats): string =>
     effectiveMode === 'discoveries'
-      ? `/miners/details?githubId=${miner.githubId}&mode=issues&tab=open-issues`
-      : `/miners/details?githubId=${miner.githubId}`;
+      ? minerDetailsPath(miner.githubId, { mode: 'issues', tab: 'open-issues' })
+      : minerDetailsPath(miner.githubId);
 
   const linkState = useMemo(
     () => ({ backLabel: `Back to ${repositoryFullName}` }),

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -23,7 +23,9 @@ import {
   getGithubAvatarSrc,
   getGithubUserAvatarSrcById,
   getPrStatusLabel,
+  minerDetailsPath,
   minerPrPath,
+  minerRepositoryPath,
   parseNumber,
 } from '../utils';
 import useDashboardData from './dashboard/useDashboardData';
@@ -1449,9 +1451,7 @@ const TopMinersPanel: React.FC<{
             return (
               <LinkBox
                 key={`${miner.githubId}-${index}`}
-                href={`/miners/details?githubId=${encodeURIComponent(
-                  miner.githubId,
-                )}`}
+                href={minerDetailsPath(miner.githubId)}
                 linkState={{ backLabel: 'Back to Home' }}
                 sx={(theme) => ({
                   display: 'grid',
@@ -1722,9 +1722,7 @@ const TopActiveReposPanel: React.FC<{
               return (
                 <LinkBox
                   key={`${row.repository}-${index}`}
-                  // TODO: this route does not exist — should be minerRepositoryPath(row.repository) (/miners/repository?name=...).
-                  // Left as-is to keep this PR a no-op extraction; fix in a follow-up.
-                  href={`/repositories/details?repo=${encodeURIComponent(row.repository)}`}
+                  href={minerRepositoryPath(row.repository)}
                   linkState={{ backLabel: 'Back to Home' }}
                   sx={(theme) => ({
                     display: 'grid',

--- a/src/pages/IssuesPage.tsx
+++ b/src/pages/IssuesPage.tsx
@@ -19,9 +19,10 @@ import {
 } from '../components/issues/IssuesList';
 import { useIssuesStats, useIssues } from '../api';
 import { useTwitterStickySidebar } from '../hooks/useTwitterStickySidebar';
+import { bountyDetailsPath } from '../utils/paths';
 
 const ISSUE_LINK_STATE = { backLabel: 'Back to Bounties' } as const;
-const getIssueHref = (id: number) => `/bounties/details?id=${id}`;
+const getIssueHref = (id: number) => bountyDetailsPath(id);
 
 const IssuesPage: React.FC = () => {
   const navigate = useNavigate();

--- a/src/pages/WatchlistPage.tsx
+++ b/src/pages/WatchlistPage.tsx
@@ -109,6 +109,7 @@ import { getIssueStatusMeta } from '../utils/issueStatus';
 import { formatDate, formatTokenAmount, formatWeight } from '../utils/format';
 import { getRepositoryOwnerAvatarSrc } from '../utils/avatar';
 import { minerPrPath, minerRepositoryPath } from '../utils';
+import { minerDetailsPath, bountyDetailsPath } from '../utils/paths';
 import theme, {
   CHART_COLORS,
   LABEL_COLORS,
@@ -1007,9 +1008,7 @@ const MinersList: React.FC<{ itemKeys: string[] }> = ({ itemKeys }) => {
       <TopMinersTable
         miners={minerStats}
         isLoading={isLoading}
-        getMinerHref={(m) =>
-          `/miners/details?githubId=${encodeURIComponent(m.githubId)}`
-        }
+        getMinerHref={(m) => minerDetailsPath(m.githubId)}
         linkState={{ backLabel: 'Back to Watchlist' }}
         variant="watchlist"
         showDualEligibilityBadges
@@ -2130,8 +2129,7 @@ const BOUNTY_STATUS_FILTERS: readonly BountyStatusFilter[] = [
 
 const bountyKey = (issue: IssueBounty) => String(issue.id);
 
-const getBountyHref = (issue: IssueBounty) =>
-  `/bounties/details?id=${issue.id}`;
+const getBountyHref = (issue: IssueBounty) => bountyDetailsPath(issue.id);
 
 const bountyDate = (issue: IssueBounty): string =>
   issue.completedAt ||

--- a/src/pages/dashboard/views/DashboardTopContributors.tsx
+++ b/src/pages/dashboard/views/DashboardTopContributors.tsx
@@ -9,6 +9,7 @@ import {
 import { alpha, useTheme } from '@mui/material/styles';
 import { useNavigate } from 'react-router-dom';
 import { getGithubAvatarSrc } from '../../../utils';
+import { minerDetailsPath } from '../../../utils/paths';
 import { type DashboardFeaturedContributor } from '../dashboardData';
 
 interface DashboardTopContributorsProps {
@@ -39,9 +40,8 @@ const DashboardTopContributors: React.FC<DashboardTopContributorsProps> = ({
   const monoFontFamily = theme.typography.fontFamily;
 
   const openContributor = (githubId: string) => {
-    const modeParam = mode !== 'prs' ? `&mode=${mode}` : '';
     navigate(
-      `/miners/details?githubId=${encodeURIComponent(githubId)}${modeParam}`,
+      minerDetailsPath(githubId, mode !== 'prs' ? { mode } : undefined),
       {
         state: { backTo: '/dashboard' },
       },

--- a/src/pages/search/SearchPage.tsx
+++ b/src/pages/search/SearchPage.tsx
@@ -10,6 +10,7 @@ import PullRequestsTab from './PullRequestsTab';
 import RepositoryTab from './RepositoryTab';
 import { MIN_SEARCH_QUERY_LENGTH, useSearchResults } from './searchData';
 import { minerPrPath, minerRepositoryPath } from '../../utils';
+import { minerDetailsPath, bountyDetailsPath } from '../../utils/paths';
 
 const ROWS_PER_PAGE_OPTIONS = [10, 25, 50];
 const SEARCH_TABS = ['miners', 'repositories', 'prs', 'issues'] as const;
@@ -168,7 +169,7 @@ const SearchPage: React.FC = () => {
   };
 
   const getMinerHref = (miner: { githubId: string }) =>
-    `/miners/details?githubId=${encodeURIComponent(miner.githubId)}`;
+    minerDetailsPath(miner.githubId);
 
   const getRepositoryHref = (repo: { fullName: string }) =>
     minerRepositoryPath(repo.fullName);
@@ -176,8 +177,7 @@ const SearchPage: React.FC = () => {
   const getPrHref = (pr: { repository: string; pullRequestNumber: number }) =>
     minerPrPath(pr.repository, pr.pullRequestNumber);
 
-  const getIssueHref = (issue: { id: number }) =>
-    `/bounties/details?id=${issue.id}`;
+  const getIssueHref = (issue: { id: number }) => bountyDetailsPath(issue.id);
 
   return (
     <Page title="Search">

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -1,3 +1,16 @@
+export const minerDetailsPath = (
+  githubId: string | number | null | undefined,
+  options?: { mode?: string; tab?: string },
+): string => {
+  let path = `/miners/details?githubId=${encodeURIComponent(githubId ?? '')}`;
+  if (options?.mode) path += `&mode=${options.mode}`;
+  if (options?.tab) path += `&tab=${options.tab}`;
+  return path;
+};
+
+export const bountyDetailsPath = (id: number | string): string =>
+  `/bounties/details?id=${id}`;
+
 export const minerPrPath = (
   repository: string,
   pullRequestNumber: number | string,


### PR DESCRIPTION
## Summary

Finishes the route builder migration started in `src/utils/paths.ts`. The module already held `minerPrPath` and `minerRepositoryPath`, but most navigation strings were still hardcoded across the app. This change adds `minerDetailsPath(githubId, { mode?, tab? })` and `bountyDetailsPath(id)`, then replaces every remaining hardcoded `/miners/details` and `/bounties/details` string with the shared builders.

Encoding of `githubId` previously lived at each call site, with some places using `encodeURIComponent` and others interpolating raw. The builder owns that decision now, so all links encode the same way. Since `githubId` is a numeric ID and the read side decodes through `searchParams.get`, generated URLs stay identical for existing data and navigation does not change.

The migration also resolves a broken link on the Home page. The top repositories list pointed each row at `/repositories/details?repo=`, a route that does not exist in `routes.tsx`, so clicking a row resolved to the 404 page. The rows now route through `minerRepositoryPath` (`/miners/repository?name=...`), which renders `RepositoryDetailsPage` and matches what the existing TODO called for. The stale TODO is removed.

With the path strings centralized, future route renames become a single edit in `paths.ts` instead of a sweep across many files.

## Related Issues

Closes #1322 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

Not applicable. This is a routing and utility change with no visual layout, styling, or component changes.

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked (no UI changes)
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [ ] Screenshots included for any UI/visual changes (not applicable)
