### PR TITLE
feat(layout): add global scroll-to-top button to AppLayout

### DIFF
--- a/src/components/common/ScrollToTopButton.tsx
+++ b/src/components/common/ScrollToTopButton.tsx
@@ -1,0 +1,72 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { Box, Fade, IconButton, Tooltip } from '@mui/material';
+import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
+
+function getMainScrollContainer(): HTMLElement | null {
+  return document.querySelector('main');
+}
+
+interface ScrollToTopButtonProps {
+  threshold?: number;
+}
+
+export const ScrollToTopButton: React.FC<ScrollToTopButtonProps> = ({
+  threshold = 300,
+}) => {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const el = getMainScrollContainer();
+    if (!el) return;
+
+    const onScroll = () => {
+      setVisible(el.scrollTop > threshold);
+    };
+
+    onScroll();
+    el.addEventListener('scroll', onScroll, { passive: true });
+    return () => el.removeEventListener('scroll', onScroll);
+  }, [threshold]);
+
+  const scrollToTop = useCallback(() => {
+    getMainScrollContainer()?.scrollTo({ top: 0, behavior: 'smooth' });
+  }, []);
+
+  return (
+    <Fade in={visible} unmountOnExit>
+      <Box
+        sx={{
+          position: 'fixed',
+          bottom: { xs: 24, md: 32 },
+          right: { xs: 16, md: 32 },
+          zIndex: 1000,
+        }}
+      >
+        <Tooltip title="Scroll to top" placement="left" arrow>
+          <IconButton
+            onClick={scrollToTop}
+            aria-label="Scroll to top"
+            disableRipple
+            sx={(theme) => ({
+              width: 48,
+              height: 48,
+              borderRadius: '8px',
+              color: theme.palette.text.secondary,
+              backgroundColor: theme.palette.background.default,
+              border: `1px solid ${theme.palette.border.light}`,
+              transition: 'all 0.18s ease',
+              '&:hover': {
+                color: theme.palette.text.primary,
+                backgroundColor: theme.palette.surface.subtle,
+                borderColor: theme.palette.border.medium,
+                transform: 'translateY(-2px)',
+              },
+            })}
+          >
+            <KeyboardArrowUpIcon sx={{ fontSize: '1.75rem' }} />
+          </IconButton>
+        </Tooltip>
+      </Box>
+    </Fade>
+  );
+};

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -5,3 +5,4 @@ export * from './WatchlistButton';
 export * from './DataTable';
 export { default as ConversationTimeline } from './ConversationTimeline';
 export * from './ConversationTimeline';
+export * from './ScrollToTopButton';

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -17,6 +17,7 @@ import { Sidebar } from '..';
 import ErrorBoundary from '../ErrorBoundary';
 import GlobalSearchBar from './GlobalSearchBar';
 import ShortcutsHelpDialog from './ShortcutsHelpDialog';
+import { ScrollToTopButton } from '../common/ScrollToTopButton';
 import theme, { scrollbarSx } from '../../theme';
 import { getRouteForPathname } from '../../routes';
 
@@ -194,6 +195,7 @@ const AppLayout: React.FC = () => {
           </ErrorBoundary>
         </Suspense>
       </Box>
+      <ScrollToTopButton />
       <ShortcutsHelpDialog
         open={isHelpOpen}
         shortcuts={shortcuts}


### PR DESCRIPTION
## Summary

Adds a reusable `ScrollToTopButton` component and integrates it into `AppLayout`, providing a consistent way for users to quickly return to the top of long pages across the application.

The button:

- Appears after the user scrolls beyond a predefined threshold within the main content area
- Smoothly scrolls the page back to the top when clicked
- Is available across all pages that use `AppLayout`
- Uses existing theme tokens and styling patterns for visual consistency
- Includes fade-in/fade-out transitions for a polished user experience
- Supports accessibility through keyboard interaction, tooltip text, and appropriate ARIA labels
- Works across desktop, tablet, and mobile layouts

## Related Issues

Closes #1326

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

### Before

<img width="1552" height="755" alt="image" src="https://github.com/user-attachments/assets/0d80eb81-a151-4010-9571-151b380786c9" />

### After

[scroll.webm](https://github.com/user-attachments/assets/553fa23d-5a2c-4992-983a-125489e2053b)

## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes