### PR TITLE
fix(leaderboard): explain global-rank gaps when filters are active

### DIFF
--- a/src/components/leaderboard/MinersLeaderTable.tsx
+++ b/src/components/leaderboard/MinersLeaderTable.tsx
@@ -25,6 +25,7 @@ import {
   ArrowDownward as ArrowDownwardIcon,
   ArrowUpward as ArrowUpwardIcon,
   Close as ClearIcon,
+  InfoOutlined as InfoOutlinedIcon,
   Search as SearchIcon,
   Sort as SortIcon,
   StarBorder as StarBorderIcon,
@@ -1901,6 +1902,15 @@ const Toolbar: React.FC<ToolbarProps> = ({
     total > 0
       ? `${counts.eligible.toLocaleString()} eligible · ${counts.ineligible.toLocaleString()} ineligible`
       : null;
+  // Any active filter hides rows from the globally-ranked list, so the # column
+  // shows non-consecutive numbers. Surface a note so those gaps read as
+  // "filtered out" rather than "buggy" (issue #1102).
+  const isFiltered =
+    filter !== 'all' ||
+    trackedOnly ||
+    Boolean(selectedRepo) ||
+    Boolean(selectedCohort) ||
+    search.trim().length > 0;
   return (
     <Box
       sx={{
@@ -2417,6 +2427,26 @@ const Toolbar: React.FC<ToolbarProps> = ({
           }}
         />
       </Box>
+      {isFiltered && (
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
+          <InfoOutlinedIcon
+            sx={{
+              fontSize: '0.95rem',
+              color: alpha(theme.palette.common.white, 0.45),
+            }}
+          />
+          <Typography
+            sx={{
+              fontSize: '0.72rem',
+              lineHeight: 1.35,
+              color: alpha(theme.palette.common.white, 0.55),
+            }}
+          >
+            Filtered view — the # column shows global rank across all miners, so
+            hidden miners leave gaps in the numbering.
+          </Typography>
+        </Box>
+      )}
     </Box>
   );
 };
@@ -2737,7 +2767,23 @@ const MinersLeaderTable: React.FC<MinersLeaderTableProps> = ({
   const columns: DataTableColumn<RankedMiner, SortField>[] = [
     {
       key: 'rank',
-      header: '#',
+      header: (
+        <Tooltip
+          arrow
+          placement="top"
+          slotProps={tooltipSlotProps}
+          title={
+            <RowTooltipContent
+              title="Global rank"
+              body="Position across all miners. When a filter is active, hidden miners leave gaps in the sequence."
+            />
+          }
+        >
+          <Box component="span" sx={{ cursor: 'help' }}>
+            #
+          </Box>
+        </Tooltip>
+      ),
       width: 48,
       sortKey: 'movement',
       renderCell: (row) => (


### PR DESCRIPTION
## Summary

The leaderboard `#` column shows each miner's **global** rank (position across all ~110 miners). When a filter is active — most visibly `Eligibility = Eligible` — the non-matching rows are hidden but the survivors keep their global rank numbers, so the column appears to "skip" (e.g. `… 21, 22, 33, 107`). The math is correct, but the gaps read as a bug.

This PR keeps the meaningful global rank and makes the gaps self-explanatory:

- Adds a one-line note above the table, shown only when a filter is active (eligibility tab, cohort, tracked-only, repo, or search): _"Filtered view — the # column shows global rank across all miners, so hidden miners leave gaps in the numbering."_
- Adds a tooltip on the `#` column header explaining the same.

Presentation-only — no sort/filter/ranking logic changed. The note lives in the shared toolbar, so it covers both list and card views. Implemented in `MinersLeaderTable.tsx` (the component rendered at `/leaderboard`); the issue's original reference to `TopMinersTable.tsx` / `/top-miners` is stale since that route now redirects to `/leaderboard`.

## Related Issues

Fixes #1102

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

**The gap (problem):** 
<img width="1023" height="1596" alt="ISSUE_1102_rank_gaps" src="https://github.com/user-attachments/assets/6c31776d-646e-4a39-8eaa-301d2b0d4992" />


**Before** — no explanation, gaps look like a bug:

<img width="2224" height="1200" alt="BEFORE_filtered_card" src="https://github.com/user-attachments/assets/0f869a94-ca2b-4047-beaf-9e614763f881" />


**After** — note added above the table explaining the global-rank gaps:

<img width="2224" height="1200" alt="AFTER_filtered_card" src="https://github.com/user-attachments/assets/1e971b40-99ff-49dc-8306-b2d7fd33746b" />


**After (no filter)** — note correctly hidden, ranks consecutive:

<img width="2224" height="1200" alt="AFTER_unfiltered_card" src="https://github.com/user-attachments/assets/3af7b829-0570-4e4d-8b47-d5ac4f35eb1f" />


## Checklist

- [x] New components are modularized/separated where sensible
- [x] Uses predefined theme (e.g. no hardcoded colors)
- [x] Responsive/mobile checked
- [x] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
