### PR TITLE
fix(miners): align per-repository standings table headers at responsive breakpoints

### DIFF
--- a/src/components/common/DataTable.tsx
+++ b/src/components/common/DataTable.tsx
@@ -109,6 +109,9 @@ type DataTableProps<T, SortKey extends string = never> = {
 };
 
 const containerSx: SxProps<Theme> = {
+  width: '100%',
+  maxWidth: '100%',
+  minWidth: 0,
   overflowX: 'auto',
   ...scrollbarSx,
 };

--- a/src/components/miners/MinerRepoStandings.tsx
+++ b/src/components/miners/MinerRepoStandings.tsx
@@ -100,6 +100,19 @@ const CredibilityValue: React.FC<{ value: number }> = ({ value }) => (
   </Typography>
 );
 
+const rightSortHeaderSx = {
+  '& .MuiTableSortLabel-root': {
+    width: '100%',
+    justifyContent: 'flex-end',
+  },
+  '& .MuiTableSortLabel-icon': {
+    width: 0,
+    marginLeft: '2px',
+    marginRight: 0,
+    overflow: 'visible',
+  },
+} as const;
+
 const RepositoryCell: React.FC<{ repository: string }> = ({ repository }) => {
   const owner = repository.split('/')[0];
   return (
@@ -244,14 +257,14 @@ const MinerRepoStandings: React.FC<MinerRepoStandingsProps> = ({
     {
       key: 'repository',
       header: 'Repository',
-      width: '40%',
+      width: 220,
       sortKey: 'repository',
       renderCell: (r) => <RepositoryCell repository={r.repositoryFullName} />,
     },
     {
       key: 'eligible',
       header: 'PR eligibility',
-      width: '18%',
+      width: 132,
       sortKey: 'eligible',
       renderCell: (r) => (
         <EligibilityChip eligible={r.isEligible} reason={r.failedReason} />
@@ -260,25 +273,28 @@ const MinerRepoStandings: React.FC<MinerRepoStandingsProps> = ({
     {
       key: 'credibility',
       header: 'Credibility',
-      width: '14%',
+      width: 112,
       align: 'right',
       sortKey: 'credibility',
+      headerSx: rightSortHeaderSx,
       renderCell: (r) => <CredibilityValue value={r.credibility} />,
     },
     {
       key: 'merged',
       header: 'Merged PRs',
-      width: '14%',
+      width: 112,
       align: 'right',
       sortKey: 'merged',
+      headerSx: rightSortHeaderSx,
       renderCell: (r) => r.totalMergedPrs,
     },
     {
       key: 'score',
       header: 'Repo score',
-      width: '14%',
+      width: 112,
       align: 'right',
       sortKey: 'score',
+      headerSx: rightSortHeaderSx,
       renderCell: (r) => r.totalScore.toFixed(2),
     },
   ];
@@ -290,14 +306,14 @@ const MinerRepoStandings: React.FC<MinerRepoStandingsProps> = ({
     {
       key: 'repository',
       header: 'Repository',
-      width: '34%',
+      width: 200,
       sortKey: 'repository',
       renderCell: (r) => <RepositoryCell repository={r.repositoryFullName} />,
     },
     {
       key: 'issueEligible',
       header: 'Issue eligibility',
-      width: '18%',
+      width: 140,
       sortKey: 'issueEligible',
       renderCell: (r) => (
         <EligibilityChip eligible={r.isIssueEligible} reason={r.failedReason} />
@@ -306,33 +322,37 @@ const MinerRepoStandings: React.FC<MinerRepoStandingsProps> = ({
     {
       key: 'issueCredibility',
       header: 'Issue credibility',
-      width: '16%',
+      width: 132,
       align: 'right',
       sortKey: 'issueCredibility',
+      headerSx: rightSortHeaderSx,
       renderCell: (r) => <CredibilityValue value={r.issueCredibility} />,
     },
     {
       key: 'solved',
       header: 'Solved',
-      width: '10%',
+      width: 80,
       align: 'right',
       sortKey: 'solved',
+      headerSx: rightSortHeaderSx,
       renderCell: (r) => r.totalSolvedIssues,
     },
     {
       key: 'valid',
       header: 'Valid',
-      width: '10%',
+      width: 72,
       align: 'right',
       sortKey: 'valid',
+      headerSx: rightSortHeaderSx,
       renderCell: (r) => r.totalValidSolvedIssues,
     },
     {
       key: 'discoveryScore',
       header: 'Discovery score',
-      width: '12%',
+      width: 128,
       align: 'right',
       sortKey: 'discoveryScore',
+      headerSx: rightSortHeaderSx,
       renderCell: (r) => r.issueDiscoveryScore.toFixed(2),
     },
   ];
@@ -353,6 +373,8 @@ const MinerRepoStandings: React.FC<MinerRepoStandingsProps> = ({
         backgroundColor: 'transparent',
         p: 0,
         overflow: 'hidden',
+        minWidth: 0,
+        maxWidth: '100%',
       }}
       elevation={0}
     >
@@ -575,18 +597,20 @@ const MinerRepoStandings: React.FC<MinerRepoStandingsProps> = ({
           ))}
         </Box>
       ) : (
-        <DataTable<MinerRepositoryEvaluation, StandingsSortKey>
-          columns={isIssueMode ? issueColumns : prColumns}
-          rows={rows}
-          getRowKey={(r) => r.repositoryFullName}
-          getRowHref={(r) => repoMinersHref(r.repositoryFullName)}
-          minWidth="640px"
-          sort={{
-            field: sortField,
-            order: sortOrder,
-            onChange: handleSortChange,
-          }}
-        />
+        <Box sx={{ minWidth: 0, maxWidth: '100%' }}>
+          <DataTable<MinerRepositoryEvaluation, StandingsSortKey>
+            columns={isIssueMode ? issueColumns : prColumns}
+            rows={rows}
+            getRowKey={(r) => r.repositoryFullName}
+            getRowHref={(r) => repoMinersHref(r.repositoryFullName)}
+            minWidth={isIssueMode ? 752 : 688}
+            sort={{
+              field: sortField,
+              order: sortOrder,
+              onChange: handleSortChange,
+            }}
+          />
+        </Box>
       )}
     </Card>
   );


### PR DESCRIPTION
## Summary

Fixes responsive layout issues in the **Per-repository standings** table on the Miner Details page where headers could become misaligned, truncated, or overflow outside the standings card at medium viewport widths.

### Changes

* Constrain the shared `DataTable` scroll container so tables remain contained within their parent layout and scroll horizontally when necessary
* Replace percentage-based column widths in `MinerRepoStandings` with fixed widths to maintain header alignment
* Add right-aligned sortable header styling for numeric columns
* Prevent the standings table from overflowing into the identity sidebar
* Add table minimum widths to preserve single-line headers and consistent column sizing
* Preserve existing sorting behavior and interactions

## Related Issues

Fixes #1329

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Refactor
* [ ] Documentation
* [ ] Other (describe below)

## Screenshots

### Before

<img width="1047" height="760" alt="image" src="https://github.com/user-attachments/assets/e7e3fbdd-60e3-4e7f-8140-338dea29c943" />

### After

<img width="1047" height="760" alt="image" src="https://github.com/user-attachments/assets/4a65a9f9-1d6c-48f0-8e9f-f4108a3d997c" />

## Checklist

* [x] New components are modularized/separated where sensible
* [x] Uses predefined theme (e.g. no hardcoded colors)
* [x] Responsive/mobile checked
* [x] Tested against the test API
* [x] `npm run format` and `npm run lint:fix` have been run
* [x] `npm run build` passes
* [x] Screenshots included for any UI/visual changes
