### PR TITLE
fix(format): guard formatDate against unparseable date strings

### DIFF
--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -53,7 +53,12 @@ export const truncateText = (text: string, maxLength: number): string => {
 
 export const formatDate = (dateStr: string | null | undefined): string => {
   if (!dateStr) return '-';
-  return format(new Date(dateStr), 'MMM d, yyyy');
+  // A non-empty but unparseable date makes an Invalid Date, and date-fns
+  // `format()` throws `RangeError: Invalid time value` on it — which would
+  // crash every table/card that renders the value. Fall back to '-' like the
+  // empty case instead of throwing.
+  const date = new Date(dateStr);
+  return Number.isNaN(date.getTime()) ? '-' : format(date, 'MMM d, yyyy');
 };
 
 export const formatUsdEstimate = (


### PR DESCRIPTION
## Summary

`formatDate()` returned `'-'` for `null`/empty input but passed any non-empty string straight to date-fns `format(new Date(dateStr), ...)`. A non-empty but **unparseable** value (a malformed or sentinel timestamp from the API) produces an `Invalid Date`, and date-fns `format()` throws `RangeError: Invalid time value` on it. `formatDate` is used in 12+ components (PR/issue tables, headers, timelines, repository check tab), so a single bad date string crashes the whole view that renders it.

This returns `'-'` for an invalid date too, matching the existing empty-input fallback, so a bad date degrades gracefully instead of throwing.

## Related Issues

No issue filed; self-contained utility hardening. Pure logic change (no rendered-UI/layout change), so no before/after media applies per CONTRIBUTING ("Pure logic changes … are exempt").

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / Enhancement
- [ ] Documentation
- [ ] Other

## Testing

`src/utils/format.ts` is a pure utility; verified the gate and the behavior locally (Node 22):

```
npm run lint    # eslint --max-warnings 0: clean
npm run build   # tsc -b && vite build: success
npx prettier --check src/utils/format.ts   # clean
```

Behavior of `formatDate`:

```
formatDate('2026-06-14') -> 'Jun 13, 2026'   (valid, unchanged)
formatDate('')           -> '-'              (unchanged)
formatDate(null)         -> '-'              (unchanged)
formatDate('N/A')        -> '-'              (was: RangeError crash → now graceful)
```

## Checklist

- [x] Code follows repository style (eslint + prettier clean)
- [x] Self-reviewed the diff
- [x] No unrelated changes
- [x] Pure logic change — no UI/UX media required
