### PR TITLE
fix(code-browser): guard commit header against invalid commit date

### DIFF
--- a/src/components/repositories/RepositoryCodeBrowser.tsx
+++ b/src/components/repositories/RepositoryCodeBrowser.tsx
@@ -39,6 +39,19 @@ import { useQuery } from '@tanstack/react-query';
 import { RateLimitError, githubFetch } from '../../api';
 import { ClearSearchAdornment } from '../common/ClearSearchAdornment';
 
+/**
+ * date-fns `formatDistanceToNow` throws `RangeError: Invalid time value` on an
+ * Invalid Date, so a malformed/missing commit timestamp from the GitHub API
+ * would crash the code browser header. Render nothing for an unparseable date
+ * instead of throwing.
+ */
+const commitRelativeTime = (dateStr: string): string => {
+  const date = new Date(dateStr);
+  return Number.isNaN(date.getTime())
+    ? ''
+    : formatDistanceToNow(date, { addSuffix: true });
+};
+
 interface RepositoryCodeBrowserProps {
   repositoryFullName: string;
 }
@@ -886,9 +899,7 @@ const RepositoryCodeBrowser: React.FC<RepositoryCodeBrowserProps> = ({
                 <Typography
                   sx={{ fontSize: '13px', color: STATUS_COLORS.open }}
                 >
-                  {formatDistanceToNow(new Date(currentCommit.date), {
-                    addSuffix: true,
-                  })}
+                  {commitRelativeTime(currentCommit.date)}
                 </Typography>
               </Box>
             </>


### PR DESCRIPTION
## Summary

The repository code browser renders the current commit's relative time with `formatDistanceToNow(new Date(currentCommit.date), ...)`. date-fns throws `RangeError: Invalid time value` on an `Invalid Date`, so a malformed or missing commit timestamp from the GitHub API crashes the entire code-browser panel.

This routes the value through a small `commitRelativeTime` helper that returns `''` for an unparseable date instead of throwing, so the commit header degrades gracefully. (Companion to the `formatDate` hardening in the separate PR for `src/utils/format.ts`; this is the one direct `date-fns` call in the code browser that bypasses that util.)

## Related Issues

No issue filed; self-contained crash hardening on API-sourced data. Pure logic change — the only visible difference is on malformed input (where it previously crashed), so no before/after media applies per CONTRIBUTING ("Pure logic changes … are exempt").

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / Enhancement
- [ ] Documentation
- [ ] Other

## Testing

```
npm run lint    # eslint --max-warnings 0: clean
npm run build   # tsc -b && vite build: success
npx prettier --check src/components/repositories/RepositoryCodeBrowser.tsx   # clean
```

`commitRelativeTime('2026-06-14T00:00:00Z')` → "in N months" (valid, unchanged); `commitRelativeTime('N/A')` / missing → `''` (was: RangeError crash → now graceful).

## Checklist

- [x] Code follows repository style (eslint + prettier clean)
- [x] Self-reviewed the diff
- [x] No unrelated changes
- [x] Pure logic change — no UI/UX media required
