### PR TITLE
chore: remove per-PR credibility multiplier from PR scoring UI

### DIFF
--- a/src/api/models/Dashboard.ts
+++ b/src/api/models/Dashboard.ts
@@ -211,7 +211,6 @@ export type CommitLog = {
   issueMultiplier?: string;
   openPrSpamMultiplier?: string;
   timeDecayMultiplier?: string;
-  credibilityMultiplier?: string;
 
   // Token scoring fields
   totalNodesScored?: number;
@@ -408,7 +407,6 @@ export type PullRequestDetails = {
   issueMultiplier: string; // float returned as string
   openPrSpamMultiplier: string; // float returned as string
   timeDecayMultiplier: string; // float returned as string
-  credibilityMultiplier: string; // float returned as string
   reviewQualityMultiplier?: string; // float returned as string
   labelMultiplier: number;
   label: string | null;

--- a/src/components/miners/MinerPRsTable.tsx
+++ b/src/components/miners/MinerPRsTable.tsx
@@ -93,8 +93,6 @@ const getScoreTooltip = (pr: CommitLog): string | null => {
   const parts: string[] = [`Base: ${base.toFixed(2)}`];
   if (pr.tokenScore != null)
     parts.push(`Tokens: ${Number(pr.tokenScore).toFixed(2)}`);
-  if (pr.credibilityMultiplier != null)
-    parts.push(`Cred: ${Number(pr.credibilityMultiplier).toFixed(2)}×`);
   return parts.join(' · ');
 };
 

--- a/src/components/prs/PRDetailsCard.tsx
+++ b/src/components/prs/PRDetailsCard.tsx
@@ -353,8 +353,9 @@ const PRDetailsCard: React.FC<PRDetailsCardProps> = ({
                 : numeric < 1
                   ? STATUS_COLORS.warningOrange
                   : theme.palette.text.tertiary;
-            const chip = (
+            return (
               <Box
+                key={index}
                 sx={{
                   display: 'inline-flex',
                   alignItems: 'center',
@@ -364,7 +365,6 @@ const PRDetailsCard: React.FC<PRDetailsCardProps> = ({
                   borderRadius: 1.5,
                   border: `1px solid ${alpha(accent, 0.35)}`,
                   backgroundColor: alpha(accent, 0.1),
-                  cursor: m.isCredibility ? 'pointer' : 'default',
                 }}
               >
                 <Typography
@@ -390,42 +390,7 @@ const PRDetailsCard: React.FC<PRDetailsCardProps> = ({
                 >
                   {m.value}
                 </Typography>
-                {m.isCredibility && (
-                  <InfoOutlinedIcon
-                    sx={{ fontSize: '0.85rem', color: accent, opacity: 0.7 }}
-                  />
-                )}
               </Box>
-            );
-            return m.isCredibility ? (
-              <Tooltip
-                key={index}
-                title={
-                  <Box sx={{ p: 0.5 }}>
-                    <Typography
-                      sx={{ fontSize: '0.75rem', fontWeight: 600, mb: 1 }}
-                    >
-                      Credibility Multiplier
-                    </Typography>
-                    <Typography
-                      sx={{
-                        fontSize: '0.7rem',
-                        color: alpha(theme.palette.common.white, 0.9),
-                      }}
-                    >
-                      Based on your PR success rate, scaled to reward
-                      consistency.
-                    </Typography>
-                  </Box>
-                }
-                arrow
-                placement="top"
-                slotProps={tooltipSlotProps}
-              >
-                {chip}
-              </Tooltip>
-            ) : (
-              <React.Fragment key={index}>{chip}</React.Fragment>
             );
           })}
         </Box>

--- a/src/utils/multiplierDefs.ts
+++ b/src/utils/multiplierDefs.ts
@@ -13,7 +13,6 @@ interface MultiplierPillDef {
 interface MultiplierGridEntry {
   label: string;
   value: string;
-  isCredibility?: boolean;
 }
 
 interface PillConfig {
@@ -53,13 +52,6 @@ function resolvePillTooltip(pr: PullRequestDetails, cfg: PillConfig): string {
 }
 
 const PILL_CONFIGS: PillConfig[] = [
-  {
-    key: 'cred',
-    label: 'cred',
-    field: 'credibilityMultiplier',
-    title: 'Credibility',
-    desc: 'Based on your PR success rate, scaled to reward consistency.',
-  },
   {
     key: 'issue',
     label: 'issue',
@@ -117,7 +109,6 @@ export function buildMergedPillDefs(
 interface GridConfig {
   label: string;
   field: keyof PullRequestDetails;
-  isCredibility?: boolean;
 }
 
 function resolveGridLabel(
@@ -137,7 +128,6 @@ function buildGridEntry(
   return {
     label: resolveGridLabel(pr, cfg.field, cfg.label),
     value: fmtGrid(pr[cfg.field] ?? '0'),
-    ...(cfg.isCredibility ? { isCredibility: true } : {}),
   };
 }
 
@@ -147,7 +137,6 @@ const OPEN_GRID: GridConfig[] = [
 
 const MERGED_GRID: GridConfig[] = [
   { label: 'Issue Bonus', field: 'issueMultiplier' },
-  { label: 'Credibility', field: 'credibilityMultiplier', isCredibility: true },
   { label: 'Review Quality', field: 'reviewQualityMultiplier' },
   { label: 'Time Decay', field: 'timeDecayMultiplier' },
 ];


### PR DESCRIPTION
Credibility is now gate-only (gittensor #1340 / PR #1359). The per-PR credibility multiplier is removed validator-side and dropped from the das-gittensor API, so the UI should stop surfacing it.

- Drop `credibilityMultiplier` from the `CommitLog` and `PullRequestDetails` models.
- Remove the "Credibility" chip + its info tooltip from the PR-details score story, plus the now-dead `isCredibility` plumbing in `multiplierDefs`.
- Drop the `Cred:` segment from the miner PR-table score tooltip.

The eligibility-gate credibility shown on miner cards, the leaderboard, and repo standings is **unchanged** — only the per-PR multiplier display is removed. Order-independent vs the API/db PRs: the field simply becomes absent.