### PR TITLE
feat(repository-prs): add author to PR search filter

### DIFF
--- a/src/components/repositories/RepositoryPRsTable.tsx
+++ b/src/components/repositories/RepositoryPRsTable.tsx
@@ -490,7 +490,7 @@ const RepositoryPRsTable: React.FC<RepositoryPRsTableProps> = ({
       </Box>
       <TextField
         size="small"
-        placeholder="Search title, PR #, merged date…"
+        placeholder="Search title, PR #, author, merged date…"
         value={searchQuery}
         onChange={(e) => handleSearchChange(e.target.value)}
         InputProps={{

--- a/src/utils/prTable.ts
+++ b/src/utils/prTable.ts
@@ -54,6 +54,7 @@ export const filterPrs = <T extends CommitLog>(
   return filtered.filter(
     (pr) =>
       pr.pullRequestTitle?.toLowerCase().includes(normalizedQuery) ||
+      pr.author?.toLowerCase().includes(normalizedQuery) ||
       pr.repository.toLowerCase().includes(normalizedQuery) ||
       (includeNumber &&
         (String(pr.pullRequestNumber).includes(normalizedQuery) ||


### PR DESCRIPTION

## Summary

- Extend `filterPrs` so the PR search input matches author usernames (case-insensitive substring).
- Update the repository PR table search placeholder to include author.

## Motivation

The repository PR table already shows an **Author** column and a search field, but search only matched title, PR number, repository, and merged date. Users expect to type an author name in the search box the same way they can on the issues table.


## Related Issues

Closes #1334 

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Screenshots

### Before
<img width="1404" height="615" alt="image" src="https://github.com/user-attachments/assets/f97fdd33-36d7-4494-b28b-d4c8d6892fa5" />

### After
<img width="1404" height="615" alt="image" src="https://github.com/user-attachments/assets/4aab4f87-3c6f-4cf7-86b9-3a3ac581cd4c" />


## Checklist

- [ ] New components are modularized/separated where sensible
- [ ] Uses predefined theme (e.g. no hardcoded colors)
- [ ] Responsive/mobile checked
- [ ] Tested against the test API
- [x] `npm run format` and `npm run lint:fix` have been run
- [x] `npm run build` passes
- [x] Screenshots included for any UI/visual changes
