### PR TITLE
Fix leaderboard activity sparklines

### DIFF
--- a/src/components/leaderboard/MinersLeaderTable.tsx
+++ b/src/components/leaderboard/MinersLeaderTable.tsx
@@ -187,6 +187,7 @@ const SparklineButton: React.FC<{
   primaryLabel?: string;
   secondaryLabel?: string;
   emphasis?: boolean;
+  activeRangeMinDays?: number;
 }> = ({
   username,
   githubId,
@@ -197,6 +198,7 @@ const SparklineButton: React.FC<{
   primaryLabel = 'OSS',
   secondaryLabel = 'Discovery',
   emphasis = false,
+  activeRangeMinDays,
 }) => {
   const [open, setOpen] = useState(false);
   const totalPrimary = primaryValues.reduce((a, b) => a + b, 0);
@@ -240,6 +242,7 @@ const SparklineButton: React.FC<{
           primaryLabel={primaryLabel}
           secondaryLabel={secondaryLabel}
           emphasis={emphasis}
+          activeRangeMinDays={activeRangeMinDays}
         />
       </Box>
       <SparklineDetailModal
@@ -266,6 +269,7 @@ const ResponsiveSparklineButton: React.FC<{
   primaryLabel?: string;
   secondaryLabel?: string;
   emphasis?: boolean;
+  activeRangeMinDays?: number;
 }> = ({
   username,
   githubId,
@@ -275,6 +279,7 @@ const ResponsiveSparklineButton: React.FC<{
   primaryLabel,
   secondaryLabel,
   emphasis,
+  activeRangeMinDays,
 }) => {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const [width, setWidth] = useState(0);
@@ -313,6 +318,7 @@ const ResponsiveSparklineButton: React.FC<{
           primaryLabel={primaryLabel}
           secondaryLabel={secondaryLabel}
           emphasis={emphasis}
+          activeRangeMinDays={activeRangeMinDays}
         />
       )}
     </Box>
@@ -1440,6 +1446,7 @@ const MobileMinerCard: React.FC<{
             primaryLabel="OSS"
             secondaryLabel="Discovery"
             emphasis
+            activeRangeMinDays={10}
           />
         </Box>
       </Box>
@@ -2831,6 +2838,7 @@ const MinersLeaderTable: React.FC<MinersLeaderTableProps> = ({
             primaryLabel="OSS"
             secondaryLabel="Discovery"
             emphasis
+            activeRangeMinDays={10}
           />
         </Box>
       ),

--- a/src/components/leaderboard/Sparkline.tsx
+++ b/src/components/leaderboard/Sparkline.tsx
@@ -13,6 +13,7 @@ interface SparklineProps {
   primaryLabel?: string;
   secondaryLabel?: string;
   emphasis?: boolean;
+  activeRangeMinDays?: number;
 }
 
 interface BarSpec {
@@ -58,6 +59,19 @@ const computeBars = (
 const sumLast = (values: readonly number[], n: number): number =>
   values.slice(-n).reduce((a, b) => a + b, 0);
 
+const getRenderWindowStart = (
+  primary: readonly number[],
+  secondary: readonly number[] | null,
+  minDays: number | undefined,
+): number => {
+  if (!minDays || primary.length <= minDays) return 0;
+  const firstActive = primary.findIndex(
+    (value, index) => value + (secondary?.[index] ?? 0) > 0,
+  );
+  if (firstActive <= 0) return 0;
+  return Math.min(firstActive, primary.length - minDays);
+};
+
 const Sparkline: React.FC<SparklineProps> = ({
   values,
   secondaryValues,
@@ -69,6 +83,7 @@ const Sparkline: React.FC<SparklineProps> = ({
   primaryLabel = 'merged',
   secondaryLabel = 'discovery',
   emphasis = false,
+  activeRangeMinDays,
 }) => {
   const primaryOpacity = emphasis ? 0.95 : 0.78;
   const secondaryOpacity = emphasis ? 0.95 : 0.78;
@@ -167,10 +182,22 @@ const Sparkline: React.FC<SparklineProps> = ({
     (v, i) => v + (hasSecondary ? (secondaryValues?.[i] ?? 0) : 0),
   );
   const scaleMax = Math.max(...stackedTotals, 0);
-
-  const bars = computeBars(
+  const renderStart = getRenderWindowStart(
     values,
     hasSecondary ? secondaryValues! : null,
+    activeRangeMinDays,
+  );
+  const renderValues = renderStart > 0 ? values.slice(renderStart) : values;
+  const renderSecondaryValues =
+    hasSecondary && renderStart > 0
+      ? secondaryValues!.slice(renderStart)
+      : hasSecondary
+        ? secondaryValues!
+        : null;
+
+  const bars = computeBars(
+    renderValues,
+    renderSecondaryValues,
     width,
     height,
     scaleMax,

--- a/src/components/leaderboard/SparklineDetailModal.tsx
+++ b/src/components/leaderboard/SparklineDetailModal.tsx
@@ -284,7 +284,7 @@ const SparklineDetailModal: React.FC<SparklineDetailModalProps> = ({
   const [range, setRange] = useState<RangeKey>('30d');
 
   // 1D view re-buckets raw commits into 3-hour slots; daily props can't do it.
-  const { data: recentCommits } = useRecentCommits(500);
+  const { data: recentCommits } = useRecentCommits(5000);
 
   const activeRange = useMemo(
     () => RANGE_OPTIONS.find((r) => r.key === range) ?? RANGE_OPTIONS[2],

--- a/src/components/leaderboard/useMinerActivityIndex.ts
+++ b/src/components/leaderboard/useMinerActivityIndex.ts
@@ -203,7 +203,7 @@ export const useMinerActivityIndex = (
   network: NetworkActivity;
   isLoading: boolean;
 } => {
-  const { lookbackDays = 30, topReposLimit = 3, commitLimit = 500 } = options;
+  const { lookbackDays = 30, topReposLimit = 3, commitLimit = 5000 } = options;
 
   const { data, isLoading } = useRecentCommits(commitLimit);
 


### PR DESCRIPTION
## Summary
- Fetch a larger recent commit window so leaderboard 30-day activity charts are based on enough production data
- Add compact sparkline rendering that trims empty leading days while preserving full 30-day totals/tooltips
- Apply the improved sparkline rendering to both table and card leaderboard views

## Screenshots

### Before
![Before: leaderboard activity sparklines compressed to the right edge](https://raw.githubusercontent.com/ventura-oss/gittensor-ui/pr-assets/1336-leaderboard-screenshot/pr-assets/1336/leaderboard-activity-sparklines-before.png)

### After
![After: leaderboard activity sparklines distributed across the chart](https://raw.githubusercontent.com/ventura-oss/gittensor-ui/pr-assets/1336-leaderboard-screenshot/pr-assets/1336/leaderboard-activity-sparklines.png)

## Testing
- npm run build