### PR TITLE
fix(miners): improve mobile layout on Miner Details page

### DIFF
--- a/src/components/miners/MinerPRsTable.tsx
+++ b/src/components/miners/MinerPRsTable.tsx
@@ -579,12 +579,18 @@ const MinerPRsTable: React.FC<MinerPRsTableProps> = ({ githubId }) => {
           <Box
             sx={{
               display: 'flex',
-              gap: { xs: 0.75, sm: 0.5 },
-              flexWrap: 'wrap',
-              width: { xs: '100%', sm: 'auto' },
+              flexWrap: 'nowrap',
+              gap: 0.75,
+              width: '100%',
+              maxWidth: '100%',
+              minWidth: 0,
+              overflowX: 'auto',
+              WebkitOverflowScrolling: 'touch',
+              scrollbarWidth: 'none',
+              msOverflowStyle: 'none',
+              '&::-webkit-scrollbar': { display: 'none' },
               '& > .MuiButton-root': {
-                flex: { xs: 1, sm: 'none' },
-                minWidth: 0,
+                flexShrink: 0,
               },
             }}
           >

--- a/src/components/miners/MinerRepoStandingCard.tsx
+++ b/src/components/miners/MinerRepoStandingCard.tsx
@@ -86,14 +86,7 @@ const InlineStat: React.FC<{
   isLast: boolean;
   eligible: boolean;
 }> = ({ label, value, isLast, eligible }) => (
-  <Box
-    sx={{
-      display: 'inline-flex',
-      alignItems: 'baseline',
-      gap: 0.5,
-      flexShrink: 0,
-    }}
-  >
+  <Box sx={{ display: 'inline-flex', alignItems: 'baseline', gap: 0.5 }}>
     <Typography
       sx={(theme) => ({
         fontFamily: FONT_MONO,
@@ -102,7 +95,6 @@ const InlineStat: React.FC<{
         color: theme.palette.text.tertiary,
         textTransform: 'uppercase',
         letterSpacing: '0.1em',
-        whiteSpace: 'nowrap',
       })}
     >
       {label}
@@ -375,17 +367,10 @@ const MinerRepoStandingCard: React.FC<MinerRepoStandingCardProps> = ({
           <Box
             sx={{
               display: 'flex',
-              flexWrap: 'nowrap',
               alignItems: 'baseline',
               gap: 1,
               mt: 0.7,
-              width: '100%',
-              minWidth: 0,
-              overflowX: 'auto',
-              WebkitOverflowScrolling: 'touch',
-              scrollbarWidth: 'none',
-              msOverflowStyle: 'none',
-              '&::-webkit-scrollbar': { display: 'none' },
+              flexWrap: 'wrap',
             }}
           >
             {segments.map((segment, index) => (

--- a/src/components/miners/MinerRepoStandingCard.tsx
+++ b/src/components/miners/MinerRepoStandingCard.tsx
@@ -86,7 +86,14 @@ const InlineStat: React.FC<{
   isLast: boolean;
   eligible: boolean;
 }> = ({ label, value, isLast, eligible }) => (
-  <Box sx={{ display: 'inline-flex', alignItems: 'baseline', gap: 0.5 }}>
+  <Box
+    sx={{
+      display: 'inline-flex',
+      alignItems: 'baseline',
+      gap: 0.5,
+      flexShrink: 0,
+    }}
+  >
     <Typography
       sx={(theme) => ({
         fontFamily: FONT_MONO,
@@ -95,6 +102,7 @@ const InlineStat: React.FC<{
         color: theme.palette.text.tertiary,
         textTransform: 'uppercase',
         letterSpacing: '0.1em',
+        whiteSpace: 'nowrap',
       })}
     >
       {label}
@@ -367,10 +375,17 @@ const MinerRepoStandingCard: React.FC<MinerRepoStandingCardProps> = ({
           <Box
             sx={{
               display: 'flex',
+              flexWrap: 'nowrap',
               alignItems: 'baseline',
               gap: 1,
               mt: 0.7,
-              flexWrap: 'wrap',
+              width: '100%',
+              minWidth: 0,
+              overflowX: 'auto',
+              WebkitOverflowScrolling: 'touch',
+              scrollbarWidth: 'none',
+              msOverflowStyle: 'none',
+              '&::-webkit-scrollbar': { display: 'none' },
             }}
           >
             {segments.map((segment, index) => (

--- a/src/components/miners/MinerRepoStandings.tsx
+++ b/src/components/miners/MinerRepoStandings.tsx
@@ -389,14 +389,14 @@ const MinerRepoStandings: React.FC<MinerRepoStandingsProps> = ({
     >
       <Box
         sx={{
-          p: 3,
+          p: { xs: 2, sm: 3 },
           borderBottom: '1px solid',
           borderColor: 'border.light',
           display: 'flex',
-          alignItems: 'center',
+          flexDirection: { xs: 'column', sm: 'row' },
+          alignItems: { xs: 'stretch', sm: 'center' },
           justifyContent: 'space-between',
           gap: 2,
-          flexWrap: 'wrap',
         }}
       >
         <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.4 }}>
@@ -434,11 +434,30 @@ const MinerRepoStandings: React.FC<MinerRepoStandingsProps> = ({
         </Box>
 
         {rows.length > 0 && (
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 1,
+              width: { xs: '100%', sm: 'auto' },
+              minWidth: 0,
+              overflowX: 'auto',
+              flexWrap: 'nowrap',
+              WebkitOverflowScrolling: 'touch',
+              scrollbarWidth: 'none',
+              msOverflowStyle: 'none',
+              '&::-webkit-scrollbar': { display: 'none' },
+              '& > *': { flexShrink: 0 },
+            }}
+          >
             {view === 'cards' && (
               <>
                 <Typography
-                  sx={{ fontSize: '0.92rem', color: 'text.secondary' }}
+                  sx={{
+                    display: { xs: 'none', sm: 'block' },
+                    fontSize: '0.92rem',
+                    color: 'text.secondary',
+                  }}
                 >
                   Sort:
                 </Typography>
@@ -491,7 +510,7 @@ const MinerRepoStandings: React.FC<MinerRepoStandingsProps> = ({
                       : 'background.default',
                     fontSize: '0.8rem',
                     height: 32,
-                    minWidth: 156,
+                    minWidth: { xs: 120, sm: 156 },
                     borderRadius: 2,
                     '& .MuiOutlinedInput-notchedOutline': {
                       borderColor: isSortMenuOpen
@@ -551,6 +570,7 @@ const MinerRepoStandings: React.FC<MinerRepoStandingsProps> = ({
               size="small"
               aria-label="Standings view"
               sx={{
+                flexShrink: 0,
                 '& .MuiToggleButton-root': {
                   color: 'text.secondary',
                   borderColor: 'border.light',

--- a/src/pages/MinerDetailsPage.tsx
+++ b/src/pages/MinerDetailsPage.tsx
@@ -103,79 +103,17 @@ const MinerDetailsPage: React.FC = () => {
             px: { xs: 2, md: 0 },
           }}
         >
-          {/* ── Header: back · mode toggle · watch ─────────────── */}
-          <Box
-            sx={{
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'space-between',
-              gap: 2,
-              flexWrap: 'wrap',
-            }}
-          >
-            <BackButton to="/repositories" />
+          {/* ── Header: back + watch on one row; mode toggle below ─ */}
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
             <Box
               sx={{
                 display: 'flex',
                 alignItems: 'center',
-                gap: 1.5,
-                flexWrap: 'wrap',
+                justifyContent: 'space-between',
+                gap: 2,
               }}
             >
-              {/* Mode toggle — a real page-level axis, not a stat */}
-              <Box
-                sx={{
-                  display: 'flex',
-                  gap: 0.5,
-                  backgroundColor: 'surface.subtle',
-                  p: 0.5,
-                  borderRadius: 2,
-                }}
-              >
-                {(
-                  [
-                    { label: 'OSS Contributions', value: 'prs' as const },
-                    { label: 'Issue Discovery', value: 'issues' as const },
-                  ] as const
-                ).map((option) => {
-                  const isActive = viewMode === option.value;
-                  return (
-                    <LinkBox
-                      key={option.value}
-                      href={buildModeHref(option.value)}
-                      replace
-                      sx={{
-                        px: 2,
-                        py: 0.75,
-                        borderRadius: 1.5,
-                        cursor: 'pointer',
-                        backgroundColor: isActive
-                          ? 'surface.elevated'
-                          : 'transparent',
-                        color: isActive
-                          ? 'text.primary'
-                          : (t) => alpha(t.palette.text.primary, 0.5),
-                        transition: 'all 0.2s',
-                        '&:hover': {
-                          backgroundColor: 'surface.elevated',
-                          color: 'text.primary',
-                        },
-                      }}
-                    >
-                      <Typography
-                        sx={{
-                          fontSize: '0.8rem',
-                          fontWeight: 600,
-                          textAlign: 'center',
-                          whiteSpace: 'nowrap',
-                        }}
-                      >
-                        {option.label}
-                      </Typography>
-                    </LinkBox>
-                  );
-                })}
-              </Box>
+              <BackButton to="/repositories" />
               {minerExists && (
                 <WatchlistButton
                   category="miners"
@@ -183,6 +121,61 @@ const MinerDetailsPage: React.FC = () => {
                   size="medium"
                 />
               )}
+            </Box>
+            <Box
+              sx={{
+                display: 'flex',
+                gap: 0.5,
+                backgroundColor: 'surface.subtle',
+                p: 0.5,
+                borderRadius: 2,
+                alignSelf: { xs: 'stretch', sm: 'flex-start' },
+              }}
+            >
+              {(
+                [
+                  { label: 'OSS Contributions', value: 'prs' as const },
+                  { label: 'Issue Discovery', value: 'issues' as const },
+                ] as const
+              ).map((option) => {
+                const isActive = viewMode === option.value;
+                return (
+                  <LinkBox
+                    key={option.value}
+                    href={buildModeHref(option.value)}
+                    replace
+                    sx={{
+                      flex: 1,
+                      px: 2,
+                      py: 0.75,
+                      borderRadius: 1.5,
+                      cursor: 'pointer',
+                      backgroundColor: isActive
+                        ? 'surface.elevated'
+                        : 'transparent',
+                      color: isActive
+                        ? 'text.primary'
+                        : (t) => alpha(t.palette.text.primary, 0.5),
+                      transition: 'all 0.2s',
+                      '&:hover': {
+                        backgroundColor: 'surface.elevated',
+                        color: 'text.primary',
+                      },
+                    }}
+                  >
+                    <Typography
+                      sx={{
+                        fontSize: '0.8rem',
+                        fontWeight: 600,
+                        textAlign: 'center',
+                        whiteSpace: { xs: 'normal', sm: 'nowrap' },
+                      }}
+                    >
+                      {option.label}
+                    </Typography>
+                  </LinkBox>
+                );
+              })}
             </Box>
           </Box>
 


### PR DESCRIPTION
## Summary

Fixes several mobile responsiveness issues on the Miner Details page where controls and statistics wrapped, overlapped, or became difficult to use on narrow viewports.

### Header

* Keep the Back button and watchlist star aligned on a single row
* Move the OSS Contributions / Issue Discovery toggle to a dedicated row below the header actions
* Prevent unwanted wrapping and layout shifts on mobile

### Per-Repository Standings

* Hide the **"Sort:"** label on smaller screens to reduce horizontal space usage
* Keep the sort dropdown, sort-direction toggle, and view toggle on a single horizontally scrollable row
* Improve usability when controls exceed the viewport width

### Pull Requests

* Keep **All / Open / Merged / Closed** status filters on a single horizontally scrollable row
* Prevent filter buttons from wrapping or overlapping on small screens

## Related Issues

Fixes #1341

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Refactor
* [ ] Documentation
* [ ] Other (describe below)

## Screenshots

### Before

<img width="360" height="740" alt="image" src="https://github.com/user-attachments/assets/3a57fd84-69c3-46ec-a2c2-5096abafc9c5" />
<img width="360" height="740" alt="image" src="https://github.com/user-attachments/assets/514dae61-d8bf-4c78-ae8d-74777b1cd55b" />
<img width="360" height="740" alt="image" src="https://github.com/user-attachments/assets/3b518320-152f-4afd-ad6c-c120e31ae026" />


### After

<img width="360" height="740" alt="image" src="https://github.com/user-attachments/assets/c80c1737-d1e6-4aa2-8b87-8550e6d8a43c" />
<img width="360" height="740" alt="image" src="https://github.com/user-attachments/assets/6e049515-4ba4-4ad4-b1fe-10e53b37e0c6" />
<img width="360" height="740" alt="image" src="https://github.com/user-attachments/assets/9ed293b0-edf9-497f-8c83-a5361be7e006" />


## Checklist

* [x] New components are modularized/separated where sensible
* [x] Uses predefined theme (e.g. no hardcoded colors)
* [x] Responsive/mobile checked
* [x] Tested against the test API
* [x] npm run format and npm run lint:fix have been run
* [x] npm run build passes
* [x] Screenshots included for any UI/visual changes
