### PR TITLE
hotfix(watchlist): improve Earnings/day and activity column alignment

### DIFF
--- a/src/components/leaderboard/MinersList.tsx
+++ b/src/components/leaderboard/MinersList.tsx
@@ -75,9 +75,11 @@ export const MinersList: React.FC<MinersListProps> = ({
         {
           key: 'prs',
           header: 'PRs',
-          width: '11%',
+          width: '14%',
           align: 'right',
           sortKey: 'totalPRs',
+          headerSx: { pl: 2 },
+          cellSx: { pl: 2 },
           renderCell: (miner) => (
             <MinerActivitySegments
               miner={miner}
@@ -89,9 +91,11 @@ export const MinersList: React.FC<MinersListProps> = ({
         {
           key: 'issues',
           header: 'Issues',
-          width: '11%',
+          width: '13%',
           align: 'right',
           sortKey: 'totalIssues',
+          headerSx: { pl: 1.5 },
+          cellSx: { pl: 1.5 },
           renderCell: (miner) => (
             <MinerActivitySegments
               miner={miner}
@@ -125,7 +129,7 @@ export const MinersList: React.FC<MinersListProps> = ({
     {
       key: 'miner',
       header: 'Miner',
-      width: '25%',
+      width: isWatchlist ? '23%' : '25%',
       cellSx: { pl: 1.5 },
       sortKey: 'username',
       renderCell: (miner) => <MinerIdentityCell miner={miner} />,
@@ -133,9 +137,10 @@ export const MinersList: React.FC<MinersListProps> = ({
     {
       key: 'usdPerDay',
       header: 'Earnings/day',
-      width: '14%',
+      width: isWatchlist ? '10%' : '14%',
       align: 'right',
       sortKey: 'usdPerDay',
+      ...(isWatchlist ? { headerSx: { pr: 2 }, cellSx: { pr: 2 } } : {}),
       renderCell: (miner) => {
         const earningsHighlighted = isWatchlist
           ? watchlistAnyRewardEligible(miner)
@@ -353,7 +358,9 @@ const MinerActivitySegments: React.FC<MinerActivitySegmentsProps> = ({
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'flex-end',
-        gap: 1.25,
+        gap: 1,
+        minWidth: 0,
+        maxWidth: '100%',
         opacity: trackEligible ? 1 : TRACK_INACTIVE_OPACITY,
       }}
     >


### PR DESCRIPTION
## Summary

Fixes a layout issue in the Watchlist → Miners table where Earnings/day values and PR/Issue activity metrics appeared visually merged due to tight column spacing and activity segment overflow.

### Changes

* Add spacing between Earnings/day and activity columns
* Rebalance watchlist column widths for better alignment
* Prevent activity segments from overflowing into adjacent columns
* Improve readability of PR and Issue activity metrics

This change only affects the Watchlist miners table. Leaderboard and discovery views are unchanged.

## Related Issues

Fixes #1343

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Refactor
* [ ] Documentation
* [ ] Other (describe below)

## Screenshots

### Before

<img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/89959b41-1fef-465e-81e8-707cd10dfd7a" />

### After

<img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/93b545a3-e1e6-4151-ab46-4377969efd3c" />

## Checklist

* [x] Uses predefined theme (e.g. no hardcoded colors)
* [x] Responsive/mobile checked
* [x] Tested against the test API
* [x] npm run format and npm run lint:fix have been run
* [x] npm run build passes
* [x] Screenshots included for UI changes
