### PR TITLE
fix(register): unblock repo registration by checking install status directly

### DIFF
--- a/src/api/MirrorApi.ts
+++ b/src/api/MirrorApi.ts
@@ -1,43 +1,44 @@
-// Mirror API — public health endpoint of das-github-mirror.
+// Mirror API — public endpoints of das-github-mirror.
 // Used to verify a repository has the Gittensor Mirror GitHub App installed
 // before letting registration submissions through.
 const MIRROR_BASE_URL = import.meta.env.VITE_REACT_APP_MIRROR_BASE_URL;
 
-interface MirrorHealthRepo {
+interface RepoInstallationResponse {
   repo_full_name: string;
-  last_event_at: string | null;
-  hours_ago: number | null;
-}
-
-interface MirrorHealthResponse {
-  status: 'ok' | 'error';
-  repos?: MirrorHealthRepo[];
+  installed: boolean;
 }
 
 /**
- * Fetches the mirror's public /health response. Throws on missing config,
- * non-2xx responses, or network/parse failure so callers can distinguish
- * "couldn't check" from a successful empty result.
+ * Returns true if the Gittensor Mirror GitHub App is installed on
+ * `repoFullName` ("owner/name"), independent of whether the repo is already
+ * registered — a repo is installed-but-unregistered while the user is still
+ * going through registration, which is exactly the state this check gates.
+ *
+ * Uses the mirror's per-repo installation-status endpoint rather than the
+ * /health repos list: /health only reports installed AND registered repos,
+ * so a freshly-installed repo would be (wrongly) reported as not installed.
+ *
+ * Throws on missing config or network/parse failure so callers can
+ * distinguish "couldn't check" from a definitive "not installed".
  */
-const fetchMirrorHealth = async (): Promise<MirrorHealthResponse> => {
+export const isRepoInstalled = async (
+  repoFullName: string,
+): Promise<boolean> => {
   if (!MIRROR_BASE_URL) {
     throw new Error('Mirror base URL is not configured.');
   }
-  const response = await fetch(`${MIRROR_BASE_URL}/health`);
-  if (!response.ok) {
-    throw new Error(`Mirror health check failed (${response.status}).`);
+  const [owner, repo] = repoFullName.split('/');
+  if (!owner || !repo) {
+    throw new Error(`Invalid repository full name: ${repoFullName}`);
   }
-  return (await response.json()) as MirrorHealthResponse;
-};
-
-/**
- * Returns true if `repoFullName` ("owner/name") is currently in the mirror's
- * tracked repos list. Match is case-insensitive. Throws on fetch failure.
- */
-export const isRepoTracked = async (repoFullName: string): Promise<boolean> => {
-  const data = await fetchMirrorHealth();
-  const tracked = new Set(
-    (data.repos ?? []).map((repo) => repo.repo_full_name.toLowerCase()),
+  const response = await fetch(
+    `${MIRROR_BASE_URL}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(
+      repo,
+    )}/installation`,
   );
-  return tracked.has(repoFullName.toLowerCase());
+  if (!response.ok) {
+    throw new Error(`Mirror installation check failed (${response.status}).`);
+  }
+  const data = (await response.json()) as RepoInstallationResponse;
+  return data.installed === true;
 };

--- a/src/pages/RepositoryRegistrationPage.tsx
+++ b/src/pages/RepositoryRegistrationPage.tsx
@@ -12,26 +12,26 @@ import {
 import { alpha } from '@mui/material/styles';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
-import { isRepoTracked } from '../api';
+import { isRepoInstalled } from '../api';
 import { useLinkBehavior } from '../components/common/linkBehavior';
 import { Page } from '../components/layout';
 import { SEO } from '../components';
 import { extractRepoFullName } from '../utils';
 
 type VerifyResult =
-  | { tracked: true }
-  | { tracked: false; reason: 'not-installed' | 'transient' | 'bad-url' };
+  | { installed: true }
+  | { installed: false; reason: 'not-installed' | 'transient' | 'bad-url' };
 
-const verifyRepoTracked = async (repoUrl: string): Promise<VerifyResult> => {
+const verifyRepoInstalled = async (repoUrl: string): Promise<VerifyResult> => {
   const fullName = extractRepoFullName(repoUrl);
-  if (!fullName) return { tracked: false, reason: 'bad-url' };
+  if (!fullName) return { installed: false, reason: 'bad-url' };
   try {
-    const tracked = await isRepoTracked(fullName);
-    return tracked
-      ? { tracked: true }
-      : { tracked: false, reason: 'not-installed' };
+    const installed = await isRepoInstalled(fullName);
+    return installed
+      ? { installed: true }
+      : { installed: false, reason: 'not-installed' };
   } catch {
-    return { tracked: false, reason: 'transient' };
+    return { installed: false, reason: 'transient' };
   }
 };
 
@@ -139,8 +139,8 @@ const RepositoryRegistrationPage: React.FC = () => {
       return;
     }
 
-    const verification = await verifyRepoTracked(repoUrl);
-    if (!verification.tracked) {
+    const verification = await verifyRepoInstalled(repoUrl);
+    if (!verification.installed) {
       setSubmitting(false);
       if (verification.reason === 'transient') {
         setSubmitError(


### PR DESCRIPTION
## Problem

On the repo registration page, Step 2 ("Tell us about the repo") verifies the Gittensor Mirror App is installed by looking the repo up in the mirror's `GET /health` `repos[]` list.

das-github-mirror #180 narrowed `/health` to repos that are **installed AND `registered = true`**. But a repo being registered is precisely what a user is trying to do on this page — a freshly-installed repo is `installed` but not yet `registered`, so it no longer appears in `/health`. Result: every new repo gets the false error *"We don't see the Gittensor Mirror App installed on this repository"* (see the screenshot for `Autovara/kata`).

It's a chicken-and-egg deadlock: `registered` only flips true via the admin register step, but the UI's install gate — which runs *before* registration — now requires the repo to already be registered. New repos can't get past Step 2.

## Fix

Switch the install check from scanning `/health` to the mirror's new per-repo endpoint:

```
GET /repos/:owner/:repo/installation  →  { repo_full_name, installed }
```

which reports install status independent of `registered`.

- `MirrorApi.ts`: replace `isRepoTracked` (whole-list `/health` scan) with `isRepoInstalled` (single per-repo lookup). Owner/repo are URL-encoded.
- `RepositoryRegistrationPage.tsx`: rename the verify helper and its result discriminant (`tracked` → `installed`) to match install-only semantics. Error-handling buckets (bad-url / transient / not-installed) are unchanged.

## Dependency

Requires the mirror endpoint: **das-github-mirror #203**. Merge/deploy that first.

## Testing

- `tsc -b` and `eslint` pass; `prettier --check` clean.
- `npm run build` succeeds.
