### PR TITLE
Fix repository social link clipping

### DIFF
--- a/src/components/leaderboard/RepositoryCard.tsx
+++ b/src/components/leaderboard/RepositoryCard.tsx
@@ -175,7 +175,7 @@ export const RepositoryCard: React.FC<RepositoryCardProps> = ({
             gap: 0.75,
             flex: 1,
             minWidth: 0,
-            overflow: 'hidden',
+            overflow: 'visible',
           }}
         >
           <Tooltip title={repo.repository || ''} placement="top" arrow>
@@ -189,7 +189,7 @@ export const RepositoryCard: React.FC<RepositoryCardProps> = ({
                 textOverflow: 'ellipsis',
                 whiteSpace: 'nowrap',
                 minWidth: 0,
-                flexShrink: 1,
+                flex: '1 1 auto',
               }}
             >
               {repo.repository}

--- a/src/components/leaderboard/TopRepositoriesTable.tsx
+++ b/src/components/leaderboard/TopRepositoriesTable.tsx
@@ -230,6 +230,7 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
               alignItems: 'center',
               gap: 1,
               minWidth: 0,
+              maxWidth: '100%',
               cursor: 'pointer',
               '&:hover': {
                 '& .MuiTypography-root': {
@@ -257,9 +258,10 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
                 display: 'flex',
                 alignItems: 'center',
                 gap: 0.75,
+                flex: '1 1 auto',
                 minWidth: 0,
                 maxWidth: '100%',
-                overflow: 'hidden',
+                overflow: 'visible',
               }}
             >
               <Typography
@@ -272,8 +274,8 @@ const TopRepositoriesTable: React.FC<TopRepositoriesTableProps> = ({
                   textOverflow: 'ellipsis',
                   whiteSpace: 'nowrap',
                   minWidth: 0,
-                  flexShrink: 1,
-                  display: 'inline-block',
+                  flex: '1 1 auto',
+                  display: 'block',
                 }}
               >
                 {truncateText(repo.repository || '', 40)}

--- a/src/components/repositories/RepositorySocialLinks.tsx
+++ b/src/components/repositories/RepositorySocialLinks.tsx
@@ -328,9 +328,9 @@ export const RepositorySocialLinksInline: React.FC<
         display: 'inline-flex',
         alignItems: 'center',
         gap: 0.5,
-        minWidth: 0,
-        maxWidth: '100%',
-        overflow: 'hidden',
+        flex: '0 0 auto',
+        minWidth: 'max-content',
+        overflow: 'visible',
       }}
       onClick={(event) => event.stopPropagation()}
       onMouseDown={(event) => event.stopPropagation()}


### PR DESCRIPTION
## Summary
- keep repository social link buttons from being clipped in compact repository rows
- let repository names flex and ellipsize while icons retain their tap target
- apply the same layout behavior to repository cards

## Verification
- npm run build
- npm run lint -- --quiet