### PR TITLE
One-page UI: single landing with repositories/dashboard timelines

### DIFF
--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -112,22 +112,20 @@ const AppLayout: React.FC = () => {
           title="Back to home"
           sx={{
             position: 'fixed',
-            top: 14,
-            left: 16,
+            top: 16,
+            left: 18,
             zIndex: 1200,
             display: 'flex',
             alignItems: 'center',
-            gap: 1,
-            px: 1.25,
-            py: 0.75,
-            borderRadius: 1.5,
-            border: `1px solid ${theme.palette.border.light}`,
-            backgroundColor: alpha(theme.palette.common.black, 0.72),
-            backdropFilter: 'blur(8px)',
-            transition: 'border-color 0.15s ease, transform 0.15s ease',
+            transition: 'transform 0.2s ease',
+            '& img': {
+              transition: 'filter 0.2s ease',
+            },
             '&:hover': {
-              borderColor: alpha(theme.palette.common.white, 0.35),
-              transform: 'translateY(-1px)',
+              transform: 'scale(1.12)',
+            },
+            '&:hover img': {
+              filter: `brightness(0) invert(1) drop-shadow(0 0 12px ${alpha(theme.palette.common.white, 1)})`,
             },
           }}
         >
@@ -135,9 +133,9 @@ const AppLayout: React.FC = () => {
             src="/gt-logo.svg"
             alt="Gittensor home"
             style={{
-              height: 20,
+              height: 24,
               width: 'auto',
-              filter: `brightness(0) invert(1) drop-shadow(0 0 6px ${alpha(theme.palette.common.white, 0.8)})`,
+              filter: `brightness(0) invert(1) drop-shadow(0 0 6px ${alpha(theme.palette.common.white, 0.7)})`,
             }}
           />
         </LinkBox>

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -5,6 +5,7 @@ import { LoadingPage } from '../../pages';
 import useOnNavigate from '../../hooks/useOnNavigate';
 import { useKeyboardShortcuts } from '../../hooks/useKeyboardShortcuts';
 import ErrorBoundary from '../ErrorBoundary';
+import { LinkBox } from '../common/linkBehavior';
 import GlobalSearchBar from './GlobalSearchBar';
 import ShortcutsHelpDialog from './ShortcutsHelpDialog';
 import theme, { scrollbarSx } from '../../theme';
@@ -60,7 +61,7 @@ const Footer: React.FC = () => (
             underline="none"
             sx={{
               color: theme.palette.text.primary,
-              fontFamily: 'var(--font-mono)',
+              fontFamily: 'var(--font-accent)',
               fontSize: '0.78rem',
               transition: 'color 0.15s ease',
               '&:hover': { color: theme.palette.status.merged },
@@ -74,7 +75,7 @@ const Footer: React.FC = () => (
     <Typography
       sx={{
         color: alpha(theme.palette.text.primary, 0.38),
-        fontFamily: 'var(--font-mono)',
+        fontFamily: 'var(--font-accent)',
         fontSize: '0.7rem',
       }}
     >
@@ -91,6 +92,7 @@ const AppLayout: React.FC = () => {
   const shouldShowGlobalSearch = Boolean(
     getRouteForPathname(location.pathname)?.showGlobalSearch,
   );
+  const isLandingPage = location.pathname === '/';
 
   return (
     <Box
@@ -103,6 +105,44 @@ const AppLayout: React.FC = () => {
         justifyContent: 'center', // Center for ultra-wide screens
       }}
     >
+      {/* One-click return to the landing page from anywhere */}
+      {!isLandingPage && (
+        <LinkBox
+          href="/"
+          title="Back to home"
+          sx={{
+            position: 'fixed',
+            top: 14,
+            left: 16,
+            zIndex: 1200,
+            display: 'flex',
+            alignItems: 'center',
+            gap: 1,
+            px: 1.25,
+            py: 0.75,
+            borderRadius: 1.5,
+            border: `1px solid ${theme.palette.border.light}`,
+            backgroundColor: alpha(theme.palette.common.black, 0.72),
+            backdropFilter: 'blur(8px)',
+            transition: 'border-color 0.15s ease, transform 0.15s ease',
+            '&:hover': {
+              borderColor: alpha(theme.palette.common.white, 0.35),
+              transform: 'translateY(-1px)',
+            },
+          }}
+        >
+          <img
+            src="/gt-logo.svg"
+            alt="Gittensor home"
+            style={{
+              height: 20,
+              width: 'auto',
+              filter: `brightness(0) invert(1) drop-shadow(0 0 6px ${alpha(theme.palette.common.white, 0.8)})`,
+            }}
+          />
+        </LinkBox>
+      )}
+
       {/* Main Content Area - Constrained for ultra-wide screens */}
       <Box
         ref={mainRef}

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -1,45 +1,96 @@
-import React, { Suspense, useRef, useState } from 'react';
-import {
-  Box,
-  useMediaQuery,
-  Drawer,
-  IconButton,
-  AppBar,
-  Toolbar,
-  alpha,
-} from '@mui/material';
+import React, { Suspense, useRef } from 'react';
+import { Box, Link, Stack, Typography, alpha } from '@mui/material';
 import { Outlet, useLocation } from 'react-router-dom';
-import MenuIcon from '@mui/icons-material/Menu';
 import { LoadingPage } from '../../pages';
 import useOnNavigate from '../../hooks/useOnNavigate';
 import { useKeyboardShortcuts } from '../../hooks/useKeyboardShortcuts';
-import { Sidebar } from '..';
 import ErrorBoundary from '../ErrorBoundary';
 import GlobalSearchBar from './GlobalSearchBar';
 import ShortcutsHelpDialog from './ShortcutsHelpDialog';
 import theme, { scrollbarSx } from '../../theme';
 import { getRouteForPathname } from '../../routes';
 
-const SIDEBAR_WIDTH = 240;
-const MOBILE_APP_BAR_HEIGHT = 56;
-const SIDEBAR_COLLAPSED_WIDTH = 72;
+const FOOTER_LINKS: ReadonlyArray<{ label: string; href: string }> = [
+  { label: 'Docs', href: 'https://docs.gittensor.io' },
+  {
+    label: 'Community',
+    href: 'https://docs.learnbittensor.org/resources/community-links',
+  },
+  { label: 'Github', href: 'https://github.com/entrius/gittensor' },
+  { label: 'X', href: 'https://x.com/gittensor_io' },
+];
+
+const Footer: React.FC = () => (
+  <Box
+    component="footer"
+    sx={{
+      mt: 'auto',
+      width: '100%',
+      py: 3,
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+      gap: 1,
+      borderTop: `1px solid ${theme.palette.border.light}`,
+    }}
+  >
+    <Stack
+      direction="row"
+      spacing={1}
+      alignItems="center"
+      sx={{ flexWrap: 'wrap', justifyContent: 'center' }}
+    >
+      {FOOTER_LINKS.map((link, index) => (
+        <React.Fragment key={link.href}>
+          {index > 0 && (
+            <Box
+              component="span"
+              sx={{
+                color: alpha(theme.palette.text.primary, 0.2),
+                fontSize: '0.72rem',
+              }}
+            >
+              |
+            </Box>
+          )}
+          <Link
+            href={link.href}
+            target="_blank"
+            rel="noopener noreferrer"
+            underline="none"
+            sx={{
+              color: theme.palette.text.primary,
+              fontFamily: 'var(--font-mono)',
+              fontSize: '0.78rem',
+              transition: 'color 0.15s ease',
+              '&:hover': { color: theme.palette.status.merged },
+            }}
+          >
+            {link.label}
+          </Link>
+        </React.Fragment>
+      ))}
+    </Stack>
+    <Typography
+      sx={{
+        color: alpha(theme.palette.text.primary, 0.38),
+        fontFamily: 'var(--font-mono)',
+        fontSize: '0.7rem',
+      }}
+    >
+      © Gittensor 2026
+    </Typography>
+  </Box>
+);
 
 const AppLayout: React.FC = () => {
   const mainRef = useRef<HTMLElement>(null);
   const location = useLocation();
   useOnNavigate(() => mainRef.current?.scrollTo(0, 0));
-  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
-  const isCompactDesktop = useMediaQuery(theme.breakpoints.down('lg'));
-  const isDesktopSidebarCollapsed = !isMobile && isCompactDesktop;
-  const [mobileOpen, setMobileOpen] = useState(false);
   const { isHelpOpen, closeHelp, shortcuts } = useKeyboardShortcuts();
   const shouldShowGlobalSearch = Boolean(
     getRouteForPathname(location.pathname)?.showGlobalSearch,
   );
-
-  const handleDrawerToggle = () => {
-    setMobileOpen(!mobileOpen);
-  };
 
   return (
     <Box
@@ -52,87 +103,6 @@ const AppLayout: React.FC = () => {
         justifyContent: 'center', // Center for ultra-wide screens
       }}
     >
-      {/* Mobile Header with Hamburger Menu */}
-      {isMobile && (
-        <AppBar
-          position="fixed"
-          sx={{
-            backgroundColor: 'background.default',
-            borderBottom: '1px solid',
-            borderColor: 'divider',
-          }}
-          elevation={0}
-        >
-          <Toolbar sx={{ minHeight: `${MOBILE_APP_BAR_HEIGHT}px !important` }}>
-            <IconButton
-              color="inherit"
-              aria-label="open drawer"
-              edge="start"
-              onClick={handleDrawerToggle}
-              sx={{ mr: 2 }}
-            >
-              <MenuIcon />
-            </IconButton>
-            <img
-              src="/gt-logo.svg"
-              alt="Gittensor"
-              style={{
-                height: '32px',
-                width: 'auto',
-                filter: `brightness(0) invert(1) drop-shadow(0 0 6px ${alpha(theme.palette.common.white, 0.8)})`,
-              }}
-            />
-          </Toolbar>
-        </AppBar>
-      )}
-
-      {/* Mobile Drawer */}
-      {isMobile && (
-        <Drawer
-          variant="temporary"
-          open={mobileOpen}
-          onClose={handleDrawerToggle}
-          ModalProps={{
-            keepMounted: true, // Better mobile performance
-          }}
-          sx={{
-            display: { xs: 'block', md: 'none' },
-            '& .MuiDrawer-paper': {
-              boxSizing: 'border-box',
-              width: { xs: '100%', sm: 320 },
-              backgroundColor: 'background.default',
-              backgroundImage: `linear-gradient(${alpha(theme.palette.common.white, 0.05)}, ${alpha(theme.palette.common.white, 0.05)})`,
-              borderRight: `1px solid ${theme.palette.border.light}`,
-            },
-            '& .MuiBackdrop-root': {
-              backgroundColor: alpha(theme.palette.common.black, 0.7),
-            },
-          }}
-        >
-          <Sidebar onNavigate={() => setMobileOpen(false)} />
-        </Drawer>
-      )}
-
-      {/* Desktop Sidebar — auto-collapses by breakpoint (no manual toggle). */}
-      {!isMobile && (
-        <Box
-          sx={{
-            flexShrink: 0,
-            width: isDesktopSidebarCollapsed
-              ? `${SIDEBAR_COLLAPSED_WIDTH}px`
-              : `${SIDEBAR_WIDTH}px`,
-            minWidth: isDesktopSidebarCollapsed
-              ? `${SIDEBAR_COLLAPSED_WIDTH}px`
-              : `${SIDEBAR_WIDTH}px`,
-            borderRight: `1px solid ${theme.palette.border.light}`,
-            overflow: 'hidden',
-            transition: 'width 0.2s ease, min-width 0.2s ease',
-          }}
-        >
-          <Sidebar collapsed={isDesktopSidebarCollapsed} />
-        </Box>
-      )}
-
       {/* Main Content Area - Constrained for ultra-wide screens */}
       <Box
         ref={mainRef}
@@ -141,11 +111,7 @@ const AppLayout: React.FC = () => {
           flexGrow: 1,
           maxWidth: '1920px', // Max content width for ultra-wide screens
           width: '100%',
-          height: {
-            xs: `calc(100dvh - ${MOBILE_APP_BAR_HEIGHT}px)`,
-            sm: '100dvh',
-          },
-          mt: { xs: `${MOBILE_APP_BAR_HEIGHT}px`, sm: 0 },
+          height: '100dvh',
           overflowY: 'auto',
           overflowX: 'hidden',
           display: 'flex',
@@ -183,8 +149,7 @@ const AppLayout: React.FC = () => {
                 width: '100%',
                 maxWidth: '100%',
                 minWidth: 0,
-                minHeight: 0,
-                flex: '1 1 auto',
+                flex: '1 0 auto',
                 display: 'flex',
                 flexDirection: 'column',
               }}
@@ -192,6 +157,7 @@ const AppLayout: React.FC = () => {
               <Outlet />
             </Box>
           </ErrorBoundary>
+          <Footer />
         </Suspense>
       </Box>
       <ShortcutsHelpDialog

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -11,13 +11,7 @@ import {
 } from '@mui/material';
 import { useLocation } from 'react-router-dom';
 import DashboardIcon from '@mui/icons-material/Dashboard';
-import LeaderboardIcon from '@mui/icons-material/Leaderboard';
-import VisibilityIcon from '@mui/icons-material/Visibility';
-import BugReportIcon from '@mui/icons-material/BugReport';
-import FolderCopyIcon from '@mui/icons-material/FolderCopy';
-import SchoolIcon from '@mui/icons-material/School';
 import { useLinkBehavior } from '../common/linkBehavior';
-import { useWatchlistTotalCount } from '../../hooks/useWatchlist';
 
 const LOGO_IMG_FILTER =
   'brightness(0) invert(1) drop-shadow(0 0 8px rgba(255, 255, 255, 0.8))';
@@ -81,21 +75,13 @@ const GittensorLogoImg: React.FC<{ heightPx: number }> = ({ heightPx }) => (
 
 const Sidebar: React.FC<SidebarProps> = ({ onNavigate, collapsed = false }) => {
   const location = useLocation();
-  const watchlistCount = useWatchlistTotalCount();
 
-  const navItems = [
-    { label: 'dashboard', path: '/dashboard', icon: <DashboardIcon /> },
-    { label: 'leaderboard', path: '/leaderboard', icon: <LeaderboardIcon /> },
-    { label: 'repositories', path: '/repositories', icon: <FolderCopyIcon /> },
-    {
-      label: 'watchlist',
-      path: '/watchlist',
-      badge: watchlistCount > 0 ? String(watchlistCount) : undefined,
-      icon: <VisibilityIcon />,
-    },
-    { label: 'bounties', path: '/bounties', icon: <BugReportIcon /> },
-    { label: 'onboard', path: '/onboard', icon: <SchoolIcon /> },
-  ];
+  const navItems: Array<{
+    label: string;
+    path: string;
+    icon: React.ReactNode;
+    badge?: string;
+  }> = [{ label: 'dashboard', path: '/dashboard', icon: <DashboardIcon /> }];
 
   const logoLink = (
     <SidebarLogoLink onNavigate={onNavigate} collapsed={collapsed}>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -111,7 +111,7 @@ const SiteOverlay: React.FC<{ host: string; live: boolean }> = ({
         borderRadius: 0.75,
         backgroundColor: alpha(theme.palette.common.black, 0.55),
         color: alpha(theme.palette.common.white, 0.78),
-        fontFamily: 'var(--font-mono)',
+        fontFamily: 'var(--font-accent)',
         fontSize: '0.58rem',
         letterSpacing: '0.06em',
         whiteSpace: 'nowrap',
@@ -275,7 +275,7 @@ const RepoCard: React.FC<{ repo: Repository; index: number }> = ({
               display: 'grid',
               placeItems: 'center',
               color: alpha(theme.palette.text.primary, 0.3),
-              fontFamily: 'var(--font-heading)',
+              fontFamily: 'var(--font-accent)',
               fontSize: '1.4rem',
               fontWeight: 900,
             })}
@@ -327,7 +327,7 @@ const RepoCard: React.FC<{ repo: Repository; index: number }> = ({
         <Box sx={{ minWidth: 0 }}>
           <Typography
             sx={{
-              fontFamily: 'var(--font-heading)',
+              fontFamily: 'var(--font-accent)',
               fontWeight: 900,
               fontSize: '1.02rem',
               lineHeight: 1.2,
@@ -341,7 +341,7 @@ const RepoCard: React.FC<{ repo: Repository; index: number }> = ({
           <Typography
             sx={(theme) => ({
               color: theme.palette.text.secondary,
-              fontFamily: 'var(--font-mono)',
+              fontFamily: 'var(--font-accent)',
               fontSize: '0.64rem',
               letterSpacing: '0.08em',
               textTransform: 'uppercase',
@@ -444,7 +444,7 @@ const HomePage: React.FC = () => {
         <Typography
           component="h1"
           sx={{
-            fontFamily: 'var(--font-heading)',
+            fontFamily: 'var(--font-accent)',
             fontWeight: 900,
             fontSize: { xs: '2.1rem', sm: '2.7rem' },
             textAlign: 'center',
@@ -476,7 +476,7 @@ const HomePage: React.FC = () => {
                 px: 2.25,
                 py: 0.7,
                 cursor: 'pointer',
-                fontFamily: 'var(--font-mono)',
+                fontFamily: 'var(--font-accent)',
                 fontSize: '0.68rem',
                 fontWeight: 700,
                 letterSpacing: '0.1em',
@@ -512,7 +512,7 @@ const HomePage: React.FC = () => {
                 mx: 'auto',
                 maxWidth: 640,
                 color: alpha(theme.palette.text.primary, 0.55),
-                fontFamily: 'var(--font-mono)',
+                fontFamily: 'var(--font-accent)',
                 fontSize: '0.72rem',
                 letterSpacing: '0.14em',
                 textTransform: 'uppercase',
@@ -552,7 +552,7 @@ const HomePage: React.FC = () => {
                 sx={(theme) => ({
                   mt: 6,
                   color: theme.palette.text.secondary,
-                  fontFamily: 'var(--font-mono)',
+                  fontFamily: 'var(--font-accent)',
                   fontSize: '0.72rem',
                   letterSpacing: '0.14em',
                   textTransform: 'uppercase',
@@ -573,7 +573,7 @@ const HomePage: React.FC = () => {
                   sx={(theme) => ({
                     mt: 6,
                     color: theme.palette.text.secondary,
-                    fontFamily: 'var(--font-mono)',
+                    fontFamily: 'var(--font-accent)',
                     fontSize: '0.72rem',
                     letterSpacing: '0.14em',
                     textTransform: 'uppercase',

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -462,7 +462,7 @@ const HomePage: React.FC = () => {
             mt: { xs: 2.5, md: 3.5 },
             mx: 'auto',
             width: 'fit-content',
-            borderRadius: 3,
+            borderRadius: 1,
             overflow: 'hidden',
             border: `1px solid ${theme.palette.border.light}`,
             ...fadeUp(100),

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -506,24 +506,6 @@ const HomePage: React.FC = () => {
 
         {timeline === 'repositories' ? (
           <>
-            <Typography
-              sx={(theme) => ({
-                mt: { xs: 3, md: 4.5 },
-                mx: 'auto',
-                maxWidth: 640,
-                color: alpha(theme.palette.text.primary, 0.55),
-                fontFamily: 'var(--font-accent)',
-                fontSize: '0.72rem',
-                letterSpacing: '0.14em',
-                textTransform: 'uppercase',
-                textAlign: 'center',
-                lineHeight: 1.9,
-                ...fadeUp(120),
-              })}
-            >
-              These are the open source projects built by Gittensor.
-            </Typography>
-
             <Box
               sx={{
                 mt: { xs: 4, md: 6 },

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -506,6 +506,24 @@ const HomePage: React.FC = () => {
 
         {timeline === 'repositories' ? (
           <>
+            <Typography
+              sx={(theme) => ({
+                mt: { xs: 3, md: 4.5 },
+                mx: 'auto',
+                maxWidth: 640,
+                color: alpha(theme.palette.text.primary, 0.55),
+                fontFamily: 'var(--font-accent)',
+                fontSize: '0.72rem',
+                letterSpacing: '0.14em',
+                textTransform: 'uppercase',
+                textAlign: 'center',
+                lineHeight: 1.9,
+                ...fadeUp(120),
+              })}
+            >
+              These are the open source projects built by Gittensor.
+            </Typography>
+
             <Box
               sx={{
                 mt: { xs: 4, md: 6 },

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -521,9 +521,7 @@ const HomePage: React.FC = () => {
                 ...fadeUp(120),
               })}
             >
-              These are the open source projects tracked by Gittensor. Miners,
-              increasingly AI agents, continuously improve them; validators
-              score the merged work and emissions follow.
+              These are the open source projects built by Gittensor.
             </Typography>
 
             <Box

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -565,6 +565,23 @@ const HomePage: React.FC = () => {
           </>
         ) : (
           <Box sx={{ mt: { xs: 2, md: 3 } }}>
+            <Typography
+              sx={(theme) => ({
+                mt: { xs: 1, md: 1.5 },
+                mx: 'auto',
+                maxWidth: 640,
+                color: alpha(theme.palette.text.primary, 0.55),
+                fontFamily: 'var(--font-accent)',
+                fontSize: '0.72rem',
+                letterSpacing: '0.14em',
+                textTransform: 'uppercase',
+                textAlign: 'center',
+                lineHeight: 1.9,
+                ...fadeUp(120),
+              })}
+            >
+              This is the work done by Gittensor miners.
+            </Typography>
             <React.Suspense
               fallback={
                 <Typography

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
-import { Avatar, Box, Typography } from '@mui/material';
+import { Avatar, Box, Stack, Typography } from '@mui/material';
 import { alpha } from '@mui/material/styles';
 import { Page } from '../components/layout';
 import { SEO } from '../components';
@@ -407,8 +407,14 @@ const RepoCardSkeleton: React.FC<{ index: number }> = ({ index }) => (
   </Box>
 );
 
+const DashboardTimeline = React.lazy(() => import('./dashboard/DashboardPage'));
+
+type Timeline = 'repositories' | 'dashboard';
+const TIMELINES: readonly Timeline[] = ['repositories', 'dashboard'];
+
 const HomePage: React.FC = () => {
   const reposQuery = useReposAndWeights();
+  const [timeline, setTimeline] = useState<Timeline>('repositories');
 
   const repos = useMemo(
     () => sortByEmissionShare(reposQuery.data ?? []),
@@ -425,7 +431,7 @@ const HomePage: React.FC = () => {
       <Box
         sx={{
           width: '100%',
-          maxWidth: 1180,
+          maxWidth: timeline === 'dashboard' ? 1680 : 1180,
           mx: 'auto',
           px: { xs: 1.5, sm: 3 },
           py: { xs: 4, md: 7 },
@@ -440,71 +446,147 @@ const HomePage: React.FC = () => {
           sx={{
             fontFamily: 'var(--font-heading)',
             fontWeight: 900,
-            fontSize: { xs: '1.9rem', sm: '2.4rem' },
+            fontSize: { xs: '2.1rem', sm: '2.7rem' },
             textAlign: 'center',
             lineHeight: 1.1,
             ...fadeUp(40),
           }}
         >
-          Gittensor Repositories
+          Gittensor
         </Typography>
-        <Typography
+
+        <Stack
+          direction="row"
+          spacing={0}
           sx={(theme) => ({
-            mt: { xs: 3, md: 4.5 },
+            mt: { xs: 2.5, md: 3.5 },
             mx: 'auto',
-            maxWidth: 640,
-            color: alpha(theme.palette.text.primary, 0.55),
-            fontFamily: 'var(--font-mono)',
-            fontSize: '0.72rem',
-            letterSpacing: '0.14em',
-            textTransform: 'uppercase',
-            textAlign: 'center',
-            lineHeight: 1.9,
-            ...fadeUp(120),
+            width: 'fit-content',
+            borderRadius: 3,
+            overflow: 'hidden',
+            border: `1px solid ${theme.palette.border.light}`,
+            ...fadeUp(100),
           })}
         >
-          These are the open source projects tracked by Gittensor. Miners,
-          increasingly AI agents, continuously improve them; validators score
-          the merged work and emissions follow.
-        </Typography>
+          {TIMELINES.map((tab) => (
+            <Box
+              key={tab}
+              onClick={() => setTimeline(tab)}
+              sx={(theme) => ({
+                px: 2.25,
+                py: 0.7,
+                cursor: 'pointer',
+                fontFamily: 'var(--font-mono)',
+                fontSize: '0.68rem',
+                fontWeight: 700,
+                letterSpacing: '0.1em',
+                textTransform: 'uppercase',
+                whiteSpace: 'nowrap',
+                transition: 'all 0.25s ease',
+                backgroundColor:
+                  timeline === tab
+                    ? alpha(theme.palette.status.merged, 0.15)
+                    : 'transparent',
+                color:
+                  timeline === tab
+                    ? theme.palette.status.merged
+                    : alpha(theme.palette.text.primary, 0.4),
+                '&:hover': {
+                  backgroundColor:
+                    timeline === tab
+                      ? alpha(theme.palette.status.merged, 0.15)
+                      : alpha(theme.palette.text.primary, 0.06),
+                },
+              })}
+            >
+              {tab}
+            </Box>
+          ))}
+        </Stack>
 
-        <Box
-          sx={{
-            mt: { xs: 5, md: 8 },
-            display: 'grid',
-            gridTemplateColumns: {
-              xs: '1fr',
-              sm: 'repeat(2, minmax(0, 1fr))',
-              md: 'repeat(3, minmax(0, 1fr))',
-            },
-            gap: { xs: 2, md: 2.5 },
-          }}
-        >
-          {reposQuery.isLoading
-            ? Array.from({ length: 9 }, (_, index) => (
-                <RepoCardSkeleton key={index} index={index} />
-              ))
-            : repos.map((repo, index) => (
-                <RepoCard key={repo.fullName} repo={repo} index={index} />
-              ))}
-        </Box>
+        {timeline === 'repositories' ? (
+          <>
+            <Typography
+              sx={(theme) => ({
+                mt: { xs: 3, md: 4.5 },
+                mx: 'auto',
+                maxWidth: 640,
+                color: alpha(theme.palette.text.primary, 0.55),
+                fontFamily: 'var(--font-mono)',
+                fontSize: '0.72rem',
+                letterSpacing: '0.14em',
+                textTransform: 'uppercase',
+                textAlign: 'center',
+                lineHeight: 1.9,
+                ...fadeUp(120),
+              })}
+            >
+              These are the open source projects tracked by Gittensor. Miners,
+              increasingly AI agents, continuously improve them; validators
+              score the merged work and emissions follow.
+            </Typography>
 
-        {!reposQuery.isLoading && repos.length === 0 && (
-          <Typography
-            sx={(theme) => ({
-              mt: 6,
-              color: theme.palette.text.secondary,
-              fontFamily: 'var(--font-mono)',
-              fontSize: '0.72rem',
-              letterSpacing: '0.14em',
-              textTransform: 'uppercase',
-              textAlign: 'center',
-            })}
-          >
-            {reposQuery.isError
-              ? 'Repository list is unavailable right now.'
-              : 'No tracked repositories returned.'}
-          </Typography>
+            <Box
+              sx={{
+                mt: { xs: 4, md: 6 },
+                display: 'grid',
+                gridTemplateColumns: {
+                  xs: '1fr',
+                  sm: 'repeat(2, minmax(0, 1fr))',
+                  md: 'repeat(3, minmax(0, 1fr))',
+                },
+                gap: { xs: 2, md: 2.5 },
+              }}
+            >
+              {reposQuery.isLoading
+                ? Array.from({ length: 9 }, (_, index) => (
+                    <RepoCardSkeleton key={index} index={index} />
+                  ))
+                : repos.map((repo, index) => (
+                    <RepoCard key={repo.fullName} repo={repo} index={index} />
+                  ))}
+            </Box>
+
+            {!reposQuery.isLoading && repos.length === 0 && (
+              <Typography
+                sx={(theme) => ({
+                  mt: 6,
+                  color: theme.palette.text.secondary,
+                  fontFamily: 'var(--font-mono)',
+                  fontSize: '0.72rem',
+                  letterSpacing: '0.14em',
+                  textTransform: 'uppercase',
+                  textAlign: 'center',
+                })}
+              >
+                {reposQuery.isError
+                  ? 'Repository list is unavailable right now.'
+                  : 'No tracked repositories returned.'}
+              </Typography>
+            )}
+          </>
+        ) : (
+          <Box sx={{ mt: { xs: 2, md: 3 } }}>
+            <React.Suspense
+              fallback={
+                <Typography
+                  sx={(theme) => ({
+                    mt: 6,
+                    color: theme.palette.text.secondary,
+                    fontFamily: 'var(--font-mono)',
+                    fontSize: '0.72rem',
+                    letterSpacing: '0.14em',
+                    textTransform: 'uppercase',
+                    textAlign: 'center',
+                  })}
+                >
+                  Loading dashboard…
+                </Typography>
+              }
+            >
+              <DashboardTimeline />
+            </React.Suspense>
+          </Box>
         )}
       </Box>
     </Page>

--- a/src/pages/dashboard/DashboardPage.tsx
+++ b/src/pages/dashboard/DashboardPage.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { Box, useMediaQuery } from '@mui/material';
 import { Page } from '../../components/layout';
 import { SEO } from '../../components';
-import theme, { scrollbarSx } from '../../theme';
+import theme from '../../theme';
 import { type TrendTimeRange } from './dashboardData';
 import useDashboardData from './useDashboardData';
 import ActiveNetwork from './views/ActiveNetwork';
@@ -59,11 +59,10 @@ const DashboardFeaturePage: React.FC = () => {
         <Box
           sx={{
             width: '100%',
-            height: showSidebarRight ? 'calc(100vh - 64px)' : 'auto',
             display: 'flex',
             flexDirection: showSidebarRight ? 'row' : 'column',
+            alignItems: showSidebarRight ? 'stretch' : 'normal',
             gap: { xs: 1.5, sm: 1.5, md: 1.75, lg: 2 },
-            overflow: 'hidden',
           }}
         >
           <Box
@@ -72,11 +71,7 @@ const DashboardFeaturePage: React.FC = () => {
               display: 'flex',
               flexDirection: 'column',
               gap: { xs: 1.35, sm: 1.15, md: 1.25 },
-              minHeight: 0,
-              overflow: showSidebarRight ? 'auto' : 'visible',
               minWidth: 0,
-              pr: showSidebarRight ? 0.75 : 0,
-              ...scrollbarSx,
             }}
           >
             <ActiveNetwork

--- a/src/pages/dashboard/views/LiveSidebar.tsx
+++ b/src/pages/dashboard/views/LiveSidebar.tsx
@@ -11,12 +11,39 @@ const LiveSidebar: React.FC<LiveSidebarProps> = ({
   showSidebarRight,
   sidebarWidth,
 }) => {
+  // When docked right, the sidebar stretches to the height of the main
+  // column without contributing height of its own: the row's stretch sets
+  // the outer Box height, and the feed absolutely fills it.
+  if (showSidebarRight) {
+    return (
+      <Box
+        sx={{
+          width: sidebarWidth,
+          flexShrink: 0,
+          position: 'relative',
+          alignSelf: 'stretch',
+        }}
+      >
+        <Box
+          sx={{
+            position: 'absolute',
+            inset: 0,
+            display: 'flex',
+            flexDirection: 'column',
+          }}
+        >
+          <LiveCommitLog />
+        </Box>
+      </Box>
+    );
+  }
+
   return (
     <Box
       sx={{
-        width: showSidebarRight ? sidebarWidth : '100%',
-        height: showSidebarRight ? '100%' : '700px',
-        maxHeight: showSidebarRight ? '100%' : '700px',
+        width: '100%',
+        height: '700px',
+        maxHeight: '700px',
         flexShrink: 0,
         display: 'flex',
         flexDirection: 'column',


### PR DESCRIPTION
## What

Builds on the landing redesign merged in #1351. The app becomes a single page with two timelines:

- **No left sidebar.** The nav rail, mobile drawer, and hamburger header are removed; content spans the full width. The footer links (Docs, Community, Github, X) and copyright move to a centered footer at the bottom of the page.
- **One landing page.** A centered `Gittensor` title with a chip-style toggle underneath switches between two timelines: **repositories** (the explore grid from #1351) and **dashboard** (the full dashboard rendered inline). Each timeline has a one-line blurb: "These are the open source projects built by Gittensor." / "This is the work done by Gittensor miners."
- **Dashboard flows as one page.** The viewport-locked layout with separate scrollboxes is gone; the main column flows naturally and the Live Activity sidebar stretches to exactly the main column's height.
- **One-click home.** Every page except the landing shows a fixed Gittensor logo top-left (no chip outline, glow+scale on hover) that returns to `/`.
- **Font consistency.** Landing and footer text use the site's JetBrains Mono accent font; the previous code referenced `var(--font-mono)`, which doesn't exist, and was silently falling back to Inter.

Other routes (/leaderboard, /watchlist, /bounties, /onboard) still exist by URL; they're just no longer in a nav. The unused Sidebar component is left in place for now.

## Before (test after #1351)

![before](https://raw.githubusercontent.com/entrius/gittensor-ui/pr-assets-one-page-ui/before.png)

## After — repositories timeline

![after](https://raw.githubusercontent.com/entrius/gittensor-ui/pr-assets-one-page-ui/after.png)

## After — dashboard timeline

![after-dashboard](https://raw.githubusercontent.com/entrius/gittensor-ui/pr-assets-one-page-ui/after-dashboard.png)

## Validation

- `tsc --noEmit`, eslint, prettier pass (lint-staged on every commit).
- Verified in the browser: both timelines render (screenshots above), footer sits below content, home logo appears on subpages and returns to the landing, dashboard columns end at the same height.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
