### PR TITLE
Robust live previews: browser-verified embeds, layered fallbacks, browsable windows

### DIFF
--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -55,6 +55,16 @@ const toEmbedUrl = (url: string) => url.replace(/^http:\/\//i, 'https://');
 // Backstop for a live embed that fires neither load nor error.
 const EMBED_VERIFY_TIMEOUT_MS = 10000;
 
+// Cross-origin live embeds are Chromium-only. Chromium's <object> gives an
+// honest verdict (refused/unreachable documents fire error, rendered pages
+// fire load — verified empirically). WebKit fires load with a null
+// contentDocument for allowed and blocked frames alike, so there is no
+// client-side way to tell a live window from a blank refused one; Safari
+// gets the screenshot instead. Same-origin embeds are verifiable in every
+// browser (the document URL is readable), so the self-mirror stays live.
+const IS_CHROMIUM =
+  typeof (window as unknown as { chrome?: unknown }).chrome !== 'undefined';
+
 type EmbedState = 'checking' | 'ok' | 'failed';
 
 const getSiteHost = (url: string) => {
@@ -129,21 +139,43 @@ const RepoCard: React.FC<{ repo: Repository; index: number }> = ({
   repo,
   index,
 }) => {
+  const website = REPO_WEBSITES[repo.fullName];
+  const embedUrl = website ? toEmbedUrl(website) : '';
+  const websiteHost = website ? getSiteHost(embedUrl) : '';
+  const sameOrigin = Boolean(website) && websiteHost === window.location.host;
+  const canAttemptEmbed = Boolean(website) && (sameOrigin || IS_CHROMIUM);
+
   const [attempt, setAttempt] = useState(0);
   const [imageFailed, setImageFailed] = useState(false);
   const [shotTick, setShotTick] = useState(0);
   const [siteShotFailed, setSiteShotFailed] = useState(false);
-  const [embedState, setEmbedState] = useState<EmbedState>('checking');
+  const [embedState, setEmbedState] = useState<EmbedState>(
+    canAttemptEmbed ? 'checking' : 'failed',
+  );
   const [inView, setInView] = useState(false);
   const retryTimerRef = useRef<number | undefined>(undefined);
   const shotTimerRef = useRef<number | undefined>(undefined);
   const mediaRef = useRef<HTMLDivElement | null>(null);
+  const embedRef = useRef<HTMLObjectElement | null>(null);
 
-  const website = REPO_WEBSITES[repo.fullName];
-  const embedUrl = website ? toEmbedUrl(website) : '';
-  const websiteHost = website ? getSiteHost(embedUrl) : '';
   const embedLive = Boolean(website) && embedState === 'ok';
   const showSiteShot = Boolean(website) && !siteShotFailed;
+
+  // A load event proves rendering on Chromium. For the same-origin mirror
+  // the initial about:blank document also fires load, so require the real
+  // URL before going live there.
+  const handleEmbedLoad = () => {
+    if (!sameOrigin) {
+      setEmbedState('ok');
+      return;
+    }
+    try {
+      const doc = embedRef.current?.contentDocument;
+      if (doc && doc.URL !== 'about:blank') setEmbedState('ok');
+    } catch {
+      /* cross-origin surprise: leave it to the deadline */
+    }
+  };
 
   useEffect(
     () => () => {
@@ -156,7 +188,7 @@ const RepoCard: React.FC<{ repo: Repository; index: number }> = ({
   // Only mount the live embed once the card is near the viewport, so
   // verification timers don't start (and fail) for off-screen cards.
   useEffect(() => {
-    if (!website || inView) return;
+    if (!canAttemptEmbed || inView) return;
     const node = mediaRef.current;
     if (!node || typeof IntersectionObserver === 'undefined') {
       setInView(true);
@@ -173,7 +205,7 @@ const RepoCard: React.FC<{ repo: Repository; index: number }> = ({
     );
     observer.observe(node);
     return () => observer.disconnect();
-  }, [website, inView]);
+  }, [canAttemptEmbed, inView]);
 
   // The live window is an <object>, not an <iframe>, because the browser
   // gives <object> an honest verdict: a document refused by the site
@@ -184,12 +216,12 @@ const RepoCard: React.FC<{ repo: Repository; index: number }> = ({
   // a failure can never show a blank card. The timeout is a backstop for
   // an embed that never reports either way.
   useEffect(() => {
-    if (!website || !inView || embedState !== 'checking') return;
+    if (!canAttemptEmbed || !inView || embedState !== 'checking') return;
     const deadline = window.setTimeout(() => {
       setEmbedState((current) => (current === 'checking' ? 'failed' : current));
     }, EMBED_VERIFY_TIMEOUT_MS);
     return () => window.clearTimeout(deadline);
-  }, [website, inView, embedState]);
+  }, [canAttemptEmbed, inView, embedState]);
 
   // mshots serves a "generating" placeholder on the first request for a
   // site; re-render the image a couple of times so the real screenshot
@@ -324,7 +356,7 @@ const RepoCard: React.FC<{ repo: Repository; index: number }> = ({
 
         {/* Live window: mounted once near the viewport, revealed only after
             the browser confirms the site actually rendered in the frame. */}
-        {website && inView && embedState !== 'failed' && (
+        {canAttemptEmbed && inView && embedState !== 'failed' && (
           <Box
             className={embedLive ? 'repo-card-preview' : undefined}
             sx={{
@@ -340,11 +372,12 @@ const RepoCard: React.FC<{ repo: Repository; index: number }> = ({
           >
             <Box
               component="object"
+              ref={embedRef}
               type="text/html"
               data={embedUrl}
               aria-label={`${repo.fullName} website`}
               tabIndex={-1}
-              onLoad={() => setEmbedState('ok')}
+              onLoad={handleEmbedLoad}
               onError={() => setEmbedState('failed')}
               sx={{
                 width: '400%',

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -48,24 +48,67 @@ const REPO_WEBSITES: Record<string, string> = {
 };
 
 // An https page cannot embed http content (browsers block it as mixed
-// content), so embeds always upgrade to https. A site that cannot serve
-// https simply fails the live embed and falls back to a screenshot.
-const toEmbedUrl = (url: string) => url.replace(/^http:\/\//i, 'https://');
+// content), so on https embed URLs upgrade to https; a site that cannot
+// serve https then fails the live embed and falls back to a screenshot. On
+// an http origin (local dev) the original scheme is kept — http-in-http is
+// allowed, and upgrading would break the same-origin dashboard mirror.
+const toEmbedUrl = (url: string) =>
+  window.location.protocol === 'https:'
+    ? url.replace(/^http:\/\//i, 'https://')
+    : url;
 
-// Backstop for a live embed that fires neither load nor error.
-const EMBED_VERIFY_TIMEOUT_MS = 10000;
+// Backstop for an embed that fires neither load nor error (both are wired
+// natively below); generous so slow hosts still get to go live.
+const EMBED_VERIFY_TIMEOUT_MS = 30000;
 
-// Cross-origin live embeds are Chromium-only. Chromium's <object> gives an
-// honest verdict (refused/unreachable documents fire error, rendered pages
-// fire load — verified empirically). WebKit fires load with a null
-// contentDocument for allowed and blocked frames alike, so there is no
-// client-side way to tell a live window from a blank refused one; Safari
-// gets the screenshot instead. Same-origin embeds are verifiable in every
-// browser (the document URL is readable), so the self-mirror stays live.
-const IS_CHROMIUM =
-  typeof (window as unknown as { chrome?: unknown }).chrome !== 'undefined';
+// Live embeds are Blink-only. Blink's <object> gives an honest verdict
+// (refused/unreachable documents fire error, rendered pages fire load —
+// verified empirically). WebKit fires load with a null contentDocument for
+// allowed and blocked frames alike, so a live window is indistinguishable
+// from a blank refused one; it also crash-reloaded under a page of embeds.
+// Gecko is unverified, so it is excluded too; both get screenshots.
+// navigator.userAgentData only exists in Blink browsers — notably it is
+// absent in iOS Chrome, which is WebKit and would false-positive a
+// window.chrome sniff.
+const IS_CHROMIUM = Boolean(
+  (
+    navigator as Navigator & {
+      userAgentData?: { brands?: Array<{ brand: string }> };
+    }
+  ).userAgentData?.brands?.some((entry) => entry.brand === 'Chromium'),
+);
+
+// Once verified, the visible/interactive window is a sandboxed <iframe>
+// (no allow-top-navigation), so a listed site can never navigate the whole
+// app away; <object> cannot carry a sandbox, so it is used only as the
+// hidden verifier.
+const EMBED_IFRAME_SANDBOX =
+  'allow-scripts allow-same-origin allow-forms allow-popups';
+
+// The embed renders a desktop-ish viewport scaled down into the card.
+const EMBED_ZOOM = 0.25;
+const EMBED_SIZE = `${100 / EMBED_ZOOM}%`;
+
+// mshots returns a "generating…" placeholder on the first request for a
+// URL; remount the image a couple of times so the real shot swaps in.
+const SHOT_REFRESH_MAX = 2;
+const SHOT_REFRESH_BASE_MS = 5000;
+const SHOT_REFRESH_STAGGER_MS = 200;
 
 type EmbedState = 'checking' | 'ok' | 'failed';
+
+// Shared look for every card preview surface (screenshot, OG image, live
+// window): grayscale until the card is hovered.
+const PREVIEW_MEDIA_SX = {
+  position: 'absolute',
+  inset: 0,
+  width: '100%',
+  height: '100%',
+  objectFit: 'cover',
+  filter: 'grayscale(1)',
+  opacity: 0.88,
+  transition: 'filter 0.25s ease, opacity 0.25s ease',
+} as const;
 
 const getSiteHost = (url: string) => {
   try {
@@ -143,8 +186,6 @@ const RepoCard: React.FC<{ repo: Repository; index: number }> = ({
   const embedUrl = website ? toEmbedUrl(website) : '';
   const websiteHost = website ? getSiteHost(embedUrl) : '';
   const sameOrigin = Boolean(website) && websiteHost === window.location.host;
-  // Chromium-only across the board: WebKit can't verify embeds (see
-  // IS_CHROMIUM) and crash-reloads under the self-mirror's nested app.
   const canAttemptEmbed = Boolean(website) && IS_CHROMIUM;
 
   const [attempt, setAttempt] = useState(0);
@@ -160,24 +201,16 @@ const RepoCard: React.FC<{ repo: Repository; index: number }> = ({
   const mediaRef = useRef<HTMLDivElement | null>(null);
   const embedRef = useRef<HTMLObjectElement | null>(null);
 
-  const embedLive = Boolean(website) && embedState === 'ok';
-  const showSiteShot = Boolean(website) && !siteShotFailed;
-
-  // A load event proves rendering on Chromium. For the same-origin mirror
-  // the initial about:blank document also fires load, so require the real
-  // URL before going live there.
-  const handleEmbedLoad = () => {
-    if (!sameOrigin) {
-      setEmbedState('ok');
-      return;
-    }
-    try {
-      const doc = embedRef.current?.contentDocument;
-      if (doc && doc.URL !== 'about:blank') setEmbedState('ok');
-    } catch {
-      /* cross-origin surprise: leave it to the deadline */
-    }
-  };
+  const embedLive = embedState === 'ok';
+  // The screenshot is fetched only when it will actually be seen: right
+  // away in browsers that never attempt embeds, otherwise only after the
+  // embed failed — verified-live cards fire no mshots requests, and the
+  // screenshot always targets the site's declared URL (mshots fetches
+  // server-side, so the mixed-content upgrade is irrelevant to it).
+  const showSiteShot =
+    Boolean(website) &&
+    !siteShotFailed &&
+    (!canAttemptEmbed || embedState === 'failed');
 
   useEffect(
     () => () => {
@@ -209,33 +242,54 @@ const RepoCard: React.FC<{ repo: Repository; index: number }> = ({
     return () => observer.disconnect();
   }, [canAttemptEmbed, inView]);
 
-  // The live window is an <object>, not an <iframe>, because the browser
-  // gives <object> an honest verdict: a document refused by the site
-  // (X-Frame-Options / CSP frame-ancestors), blocked as mixed content, or
-  // unreachable fires the error event, while a rendered page fires load.
-  // An <iframe> deliberately reports all of those identically. Until the
-  // load verdict arrives the embed stays hidden behind the screenshot, so
-  // a failure can never show a blank card. The timeout is a backstop for
-  // an embed that never reports either way.
+  // Verdict listeners are attached natively: react-dom wires only the load
+  // event for <object>/<iframe>/<embed>, and error does not bubble, so an
+  // onError prop would silently never fire. A load event proves rendering
+  // (see IS_CHROMIUM); the same-origin mirror also fires load for its
+  // initial about:blank, so it must report a real document URL first. The
+  // deadline reaps embeds that never report either way.
   useEffect(() => {
     if (!canAttemptEmbed || !inView || embedState !== 'checking') return;
-    const deadline = window.setTimeout(() => {
-      setEmbedState((current) => (current === 'checking' ? 'failed' : current));
-    }, EMBED_VERIFY_TIMEOUT_MS);
-    return () => window.clearTimeout(deadline);
-  }, [canAttemptEmbed, inView, embedState]);
+    const node = embedRef.current;
+    if (!node) return;
 
-  // mshots serves a "generating" placeholder on the first request for a
-  // site; re-render the image a couple of times so the real screenshot
-  // replaces it without a manual reload. Stops once the live embed covers it.
+    const handleLoad = () => {
+      if (!sameOrigin) {
+        setEmbedState('ok');
+        return;
+      }
+      try {
+        const doc = node.contentDocument;
+        if (doc && doc.URL !== 'about:blank') setEmbedState('ok');
+      } catch {
+        /* unexpectedly cross-origin: let the deadline decide */
+      }
+    };
+    const handleError = () => setEmbedState('failed');
+
+    node.addEventListener('load', handleLoad);
+    node.addEventListener('error', handleError);
+    const deadline = window.setTimeout(
+      () => setEmbedState('failed'),
+      EMBED_VERIFY_TIMEOUT_MS,
+    );
+    return () => {
+      node.removeEventListener('load', handleLoad);
+      node.removeEventListener('error', handleError);
+      window.clearTimeout(deadline);
+    };
+  }, [canAttemptEmbed, inView, embedState, sameOrigin]);
+
+  // Remount the screenshot a couple of times so the real shot replaces the
+  // mshots "generating…" placeholder without a manual reload.
   useEffect(() => {
-    if (!showSiteShot || embedLive || shotTick >= 2) return;
+    if (!showSiteShot || shotTick >= SHOT_REFRESH_MAX) return;
     shotTimerRef.current = window.setTimeout(
       () => setShotTick(shotTick + 1),
-      5000 * (shotTick + 1) + index * 200,
+      SHOT_REFRESH_BASE_MS * (shotTick + 1) + index * SHOT_REFRESH_STAGGER_MS,
     );
     return () => window.clearTimeout(shotTimerRef.current);
-  }, [showSiteShot, embedLive, shotTick, index]);
+  }, [showSiteShot, shotTick, index]);
 
   const handleImageError = () => {
     if (attempt + 1 >= MAX_PREVIEW_ATTEMPTS) {
@@ -248,8 +302,7 @@ const RepoCard: React.FC<{ repo: Repository; index: number }> = ({
     );
   };
 
-  const showBackdropShot = showSiteShot && !embedLive;
-  const showBackdropOg = !embedLive && !showSiteShot;
+  const showBackdropOg = !embedLive && (!website || siteShotFailed);
 
   return (
     <LinkBox
@@ -277,9 +330,13 @@ const RepoCard: React.FC<{ repo: Repository; index: number }> = ({
         },
         // Hovering a live card hands the pointer to the embedded site so it
         // can be scrolled and browsed like a real window; the footer below
-        // the preview stays the link to the repo page.
-        '&:hover .repo-card-embed': {
-          pointerEvents: 'auto',
+        // the preview stays the link to the repo page. Mouse-like pointers
+        // only: on touch, sticky :hover would swallow the tap that should
+        // follow the card link.
+        '@media (hover: hover) and (pointer: fine)': {
+          '&:hover .repo-card-embed': {
+            pointerEvents: 'auto',
+          },
         },
         '&:focus-visible': {
           outline: `2px solid ${theme.palette.status.merged}`,
@@ -298,102 +355,104 @@ const RepoCard: React.FC<{ repo: Repository; index: number }> = ({
           overflow: 'hidden',
         })}
       >
-        {website && <SiteOverlay host={websiteHost} live={embedLive} />}
+        {website && (embedLive || showSiteShot) && (
+          <SiteOverlay host={websiteHost} live={embedLive} />
+        )}
 
         {/* Backdrop: website screenshot → GitHub OG card → repo name. The
-            verified live window covers it, so the card never renders blank. */}
-        {showBackdropShot ? (
+            verified live window covers it, so the card never renders blank.
+            While an embed is still being verified the neutral card
+            background shows instead — most verdicts land within seconds. */}
+        {!embedLive &&
+          (showSiteShot ? (
+            <Box
+              key={shotTick}
+              component="img"
+              className="repo-card-preview"
+              src={getSiteScreenshotSrc(website)}
+              alt={`${websiteHost} screenshot`}
+              loading="lazy"
+              onError={() => setSiteShotFailed(true)}
+              sx={{ ...PREVIEW_MEDIA_SX, objectPosition: 'top' }}
+            />
+          ) : showBackdropOg ? (
+            imageFailed ? (
+              <Box
+                sx={(theme) => ({
+                  position: 'absolute',
+                  inset: 0,
+                  display: 'grid',
+                  placeItems: 'center',
+                  color: alpha(theme.palette.text.primary, 0.3),
+                  fontFamily: 'var(--font-accent)',
+                  fontSize: '1.4rem',
+                  fontWeight: 900,
+                })}
+              >
+                {repo.name}
+              </Box>
+            ) : (
+              <Box
+                key={attempt}
+                component="img"
+                className="repo-card-preview"
+                src={getRepoPreviewSrc(repo.fullName, attempt)}
+                alt={`${repo.fullName} preview`}
+                loading="lazy"
+                onError={handleImageError}
+                sx={PREVIEW_MEDIA_SX}
+              />
+            )
+          ) : null)}
+
+        {/* Hidden verifier: mounted once near the viewport, unmounted as
+            soon as a verdict arrives (see the verification effect). */}
+        {canAttemptEmbed && inView && embedState === 'checking' && (
           <Box
-            key={shotTick}
-            component="img"
-            className="repo-card-preview"
-            src={getSiteScreenshotSrc(embedUrl)}
-            alt={`${websiteHost} screenshot`}
-            loading="lazy"
-            onError={() => setSiteShotFailed(true)}
+            component="object"
+            ref={embedRef}
+            type="text/html"
+            data={embedUrl}
+            aria-hidden
+            tabIndex={-1}
             sx={{
               position: 'absolute',
               inset: 0,
-              width: '100%',
-              height: '100%',
-              objectFit: 'cover',
-              objectPosition: 'top',
-              filter: 'grayscale(1)',
-              opacity: 0.88,
-              transition: 'filter 0.25s ease, opacity 0.25s ease',
+              border: 0,
+              opacity: 0,
+              pointerEvents: 'none',
             }}
           />
-        ) : showBackdropOg ? (
-          imageFailed ? (
-            <Box
-              sx={(theme) => ({
-                position: 'absolute',
-                inset: 0,
-                display: 'grid',
-                placeItems: 'center',
-                color: alpha(theme.palette.text.primary, 0.3),
-                fontFamily: 'var(--font-accent)',
-                fontSize: '1.4rem',
-                fontWeight: 900,
-              })}
-            >
-              {repo.name}
-            </Box>
-          ) : (
-            <Box
-              key={attempt}
-              component="img"
-              className="repo-card-preview"
-              src={getRepoPreviewSrc(repo.fullName, attempt)}
-              alt={`${repo.fullName} preview`}
-              loading="lazy"
-              onError={handleImageError}
-              sx={{
-                position: 'absolute',
-                inset: 0,
-                width: '100%',
-                height: '100%',
-                objectFit: 'cover',
-                filter: 'grayscale(1)',
-                opacity: 0.88,
-                transition: 'filter 0.25s ease, opacity 0.25s ease',
-              }}
-            />
-          )
-        ) : null}
+        )}
 
-        {/* Live window: mounted once near the viewport, revealed only after
-            the browser confirms the site actually rendered in the frame. */}
-        {canAttemptEmbed && inView && embedState !== 'failed' && (
+        {/* Live window: shown only after verification, as a sandboxed
+            iframe so the embedded site can never navigate the app away
+            (an <object> cannot carry a sandbox attribute). */}
+        {embedLive && (
           <Box
-            className={
-              embedLive ? 'repo-card-preview repo-card-embed' : undefined
-            }
+            className="repo-card-preview repo-card-embed"
             sx={{
               position: 'absolute',
               inset: 0,
               overflow: 'hidden',
               filter: 'grayscale(1)',
-              opacity: embedLive ? 0.88 : 0,
-              transition: 'filter 0.25s ease, opacity 0.4s ease',
-              backgroundColor: embedLive ? '#fff' : 'transparent',
+              opacity: 0.88,
+              transition: 'filter 0.25s ease, opacity 0.25s ease',
+              backgroundColor: '#fff',
               pointerEvents: 'none',
             }}
           >
             <Box
-              component="object"
-              ref={embedRef}
-              type="text/html"
-              data={embedUrl}
-              aria-label={`${repo.fullName} website`}
+              component="iframe"
+              src={embedUrl}
+              title={`${repo.fullName} website`}
+              sandbox={EMBED_IFRAME_SANDBOX}
               tabIndex={-1}
-              onLoad={handleEmbedLoad}
-              onError={() => setEmbedState('failed')}
               sx={{
-                width: '400%',
-                height: '400%',
+                width: EMBED_SIZE,
+                height: EMBED_SIZE,
                 border: 0,
-                transform: 'scale(0.25)',
+                transform: `scale(${EMBED_ZOOM})`,
                 transformOrigin: 'top left',
                 backgroundColor: '#fff',
               }}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -143,7 +143,9 @@ const RepoCard: React.FC<{ repo: Repository; index: number }> = ({
   const embedUrl = website ? toEmbedUrl(website) : '';
   const websiteHost = website ? getSiteHost(embedUrl) : '';
   const sameOrigin = Boolean(website) && websiteHost === window.location.host;
-  const canAttemptEmbed = Boolean(website) && (sameOrigin || IS_CHROMIUM);
+  // Chromium-only across the board: WebKit can't verify embeds (see
+  // IS_CHROMIUM) and crash-reloads under the self-mirror's nested app.
+  const canAttemptEmbed = Boolean(website) && IS_CHROMIUM;
 
   const [attempt, setAttempt] = useState(0);
   const [imageFailed, setImageFailed] = useState(false);

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -47,16 +47,15 @@ const REPO_WEBSITES: Record<string, string> = {
   'we-promise/sure': 'https://sure.am',
 };
 
-// These sites send X-Frame-Options / frame-ancestors and refuse to render in
-// an iframe, so they get a website screenshot (WordPress mshots) instead of a
-// live window.
-const FRAME_BLOCKED_HOSTS = new Set([
-  'metagraph.sh',
-  'gittensory.aethereal.dev',
-  'vouchai.dev',
-  'heyclau.de',
-  'sure.am',
-]);
+// An https page cannot embed http content (browsers block it as mixed
+// content), so embeds always upgrade to https. A site that cannot serve
+// https simply fails the live embed and falls back to a screenshot.
+const toEmbedUrl = (url: string) => url.replace(/^http:\/\//i, 'https://');
+
+// Backstop for a live embed that fires neither load nor error.
+const EMBED_VERIFY_TIMEOUT_MS = 10000;
+
+type EmbedState = 'checking' | 'ok' | 'failed';
 
 const getSiteHost = (url: string) => {
   try {
@@ -134,13 +133,17 @@ const RepoCard: React.FC<{ repo: Repository; index: number }> = ({
   const [imageFailed, setImageFailed] = useState(false);
   const [shotTick, setShotTick] = useState(0);
   const [siteShotFailed, setSiteShotFailed] = useState(false);
+  const [embedState, setEmbedState] = useState<EmbedState>('checking');
+  const [inView, setInView] = useState(false);
   const retryTimerRef = useRef<number | undefined>(undefined);
   const shotTimerRef = useRef<number | undefined>(undefined);
+  const mediaRef = useRef<HTMLDivElement | null>(null);
 
   const website = REPO_WEBSITES[repo.fullName];
-  const websiteHost = website ? getSiteHost(website) : '';
-  const canEmbed = Boolean(website) && !FRAME_BLOCKED_HOSTS.has(websiteHost);
-  const useSiteShot = Boolean(website) && !canEmbed && !siteShotFailed;
+  const embedUrl = website ? toEmbedUrl(website) : '';
+  const websiteHost = website ? getSiteHost(embedUrl) : '';
+  const embedLive = Boolean(website) && embedState === 'ok';
+  const showSiteShot = Boolean(website) && !siteShotFailed;
 
   useEffect(
     () => () => {
@@ -150,17 +153,55 @@ const RepoCard: React.FC<{ repo: Repository; index: number }> = ({
     [],
   );
 
+  // Only mount the live embed once the card is near the viewport, so
+  // verification timers don't start (and fail) for off-screen cards.
+  useEffect(() => {
+    if (!website || inView) return;
+    const node = mediaRef.current;
+    if (!node || typeof IntersectionObserver === 'undefined') {
+      setInView(true);
+      return;
+    }
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) {
+          setInView(true);
+          observer.disconnect();
+        }
+      },
+      { rootMargin: '200px' },
+    );
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [website, inView]);
+
+  // The live window is an <object>, not an <iframe>, because the browser
+  // gives <object> an honest verdict: a document refused by the site
+  // (X-Frame-Options / CSP frame-ancestors), blocked as mixed content, or
+  // unreachable fires the error event, while a rendered page fires load.
+  // An <iframe> deliberately reports all of those identically. Until the
+  // load verdict arrives the embed stays hidden behind the screenshot, so
+  // a failure can never show a blank card. The timeout is a backstop for
+  // an embed that never reports either way.
+  useEffect(() => {
+    if (!website || !inView || embedState !== 'checking') return;
+    const deadline = window.setTimeout(() => {
+      setEmbedState((current) => (current === 'checking' ? 'failed' : current));
+    }, EMBED_VERIFY_TIMEOUT_MS);
+    return () => window.clearTimeout(deadline);
+  }, [website, inView, embedState]);
+
   // mshots serves a "generating" placeholder on the first request for a
   // site; re-render the image a couple of times so the real screenshot
-  // replaces it without a manual reload.
+  // replaces it without a manual reload. Stops once the live embed covers it.
   useEffect(() => {
-    if (!useSiteShot || shotTick >= 2) return;
+    if (!showSiteShot || embedLive || shotTick >= 2) return;
     shotTimerRef.current = window.setTimeout(
       () => setShotTick(shotTick + 1),
       5000 * (shotTick + 1) + index * 200,
     );
     return () => window.clearTimeout(shotTimerRef.current);
-  }, [useSiteShot, shotTick, index]);
+  }, [showSiteShot, embedLive, shotTick, index]);
 
   const handleImageError = () => {
     if (attempt + 1 >= MAX_PREVIEW_ATTEMPTS) {
@@ -172,6 +213,9 @@ const RepoCard: React.FC<{ repo: Repository; index: number }> = ({
       1200 * (attempt + 1) + index * 150,
     );
   };
+
+  const showBackdropShot = showSiteShot && !embedLive;
+  const showBackdropOg = !embedLive && !showSiteShot;
 
   return (
     <LinkBox
@@ -204,6 +248,7 @@ const RepoCard: React.FC<{ repo: Repository; index: number }> = ({
       })}
     >
       <Box
+        ref={mediaRef}
         sx={(theme) => ({
           position: 'relative',
           width: '100%',
@@ -213,45 +258,16 @@ const RepoCard: React.FC<{ repo: Repository; index: number }> = ({
           overflow: 'hidden',
         })}
       >
-        {(canEmbed || useSiteShot) && (
-          <SiteOverlay host={websiteHost} live={canEmbed} />
-        )}
-        {canEmbed ? (
-          <Box
-            className="repo-card-preview"
-            sx={{
-              position: 'absolute',
-              inset: 0,
-              overflow: 'hidden',
-              filter: 'grayscale(1)',
-              opacity: 0.88,
-              transition: 'filter 0.25s ease, opacity 0.25s ease',
-              backgroundColor: '#fff',
-            }}
-          >
-            <Box
-              component="iframe"
-              src={website}
-              title={`${repo.fullName} website`}
-              loading="lazy"
-              tabIndex={-1}
-              sx={{
-                width: '400%',
-                height: '400%',
-                border: 0,
-                transform: 'scale(0.25)',
-                transformOrigin: 'top left',
-                pointerEvents: 'none',
-                backgroundColor: '#fff',
-              }}
-            />
-          </Box>
-        ) : useSiteShot ? (
+        {website && <SiteOverlay host={websiteHost} live={embedLive} />}
+
+        {/* Backdrop: website screenshot → GitHub OG card → repo name. The
+            verified live window covers it, so the card never renders blank. */}
+        {showBackdropShot ? (
           <Box
             key={shotTick}
             component="img"
             className="repo-card-preview"
-            src={getSiteScreenshotSrc(website)}
+            src={getSiteScreenshotSrc(embedUrl)}
             alt={`${websiteHost} screenshot`}
             loading="lazy"
             onError={() => setSiteShotFailed(true)}
@@ -267,41 +283,80 @@ const RepoCard: React.FC<{ repo: Repository; index: number }> = ({
               transition: 'filter 0.25s ease, opacity 0.25s ease',
             }}
           />
-        ) : imageFailed ? (
+        ) : showBackdropOg ? (
+          imageFailed ? (
+            <Box
+              sx={(theme) => ({
+                position: 'absolute',
+                inset: 0,
+                display: 'grid',
+                placeItems: 'center',
+                color: alpha(theme.palette.text.primary, 0.3),
+                fontFamily: 'var(--font-accent)',
+                fontSize: '1.4rem',
+                fontWeight: 900,
+              })}
+            >
+              {repo.name}
+            </Box>
+          ) : (
+            <Box
+              key={attempt}
+              component="img"
+              className="repo-card-preview"
+              src={getRepoPreviewSrc(repo.fullName, attempt)}
+              alt={`${repo.fullName} preview`}
+              loading="lazy"
+              onError={handleImageError}
+              sx={{
+                position: 'absolute',
+                inset: 0,
+                width: '100%',
+                height: '100%',
+                objectFit: 'cover',
+                filter: 'grayscale(1)',
+                opacity: 0.88,
+                transition: 'filter 0.25s ease, opacity 0.25s ease',
+              }}
+            />
+          )
+        ) : null}
+
+        {/* Live window: mounted once near the viewport, revealed only after
+            the browser confirms the site actually rendered in the frame. */}
+        {website && inView && embedState !== 'failed' && (
           <Box
-            sx={(theme) => ({
-              position: 'absolute',
-              inset: 0,
-              display: 'grid',
-              placeItems: 'center',
-              color: alpha(theme.palette.text.primary, 0.3),
-              fontFamily: 'var(--font-accent)',
-              fontSize: '1.4rem',
-              fontWeight: 900,
-            })}
-          >
-            {repo.name}
-          </Box>
-        ) : (
-          <Box
-            key={attempt}
-            component="img"
-            className="repo-card-preview"
-            src={getRepoPreviewSrc(repo.fullName, attempt)}
-            alt={`${repo.fullName} preview`}
-            loading="lazy"
-            onError={handleImageError}
+            className={embedLive ? 'repo-card-preview' : undefined}
             sx={{
               position: 'absolute',
               inset: 0,
-              width: '100%',
-              height: '100%',
-              objectFit: 'cover',
+              overflow: 'hidden',
               filter: 'grayscale(1)',
-              opacity: 0.88,
-              transition: 'filter 0.25s ease, opacity 0.25s ease',
+              opacity: embedLive ? 0.88 : 0,
+              transition: 'filter 0.25s ease, opacity 0.4s ease',
+              backgroundColor: embedLive ? '#fff' : 'transparent',
+              pointerEvents: 'none',
             }}
-          />
+          >
+            <Box
+              component="object"
+              type="text/html"
+              data={embedUrl}
+              aria-label={`${repo.fullName} website`}
+              tabIndex={-1}
+              onLoad={() => setEmbedState('ok')}
+              onError={() => setEmbedState('failed')}
+              sx={{
+                width: '400%',
+                height: '400%',
+                border: 0,
+                transform: 'scale(0.25)',
+                transformOrigin: 'top left',
+                pointerEvents: 'none',
+                backgroundColor: '#fff',
+              }}
+            />
+          </Box>
         )}
       </Box>
       <Box

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -275,6 +275,12 @@ const RepoCard: React.FC<{ repo: Repository; index: number }> = ({
           filter: 'grayscale(0)',
           opacity: 1,
         },
+        // Hovering a live card hands the pointer to the embedded site so it
+        // can be scrolled and browsed like a real window; the footer below
+        // the preview stays the link to the repo page.
+        '&:hover .repo-card-embed': {
+          pointerEvents: 'auto',
+        },
         '&:focus-visible': {
           outline: `2px solid ${theme.palette.status.merged}`,
           outlineOffset: 2,
@@ -360,7 +366,9 @@ const RepoCard: React.FC<{ repo: Repository; index: number }> = ({
             the browser confirms the site actually rendered in the frame. */}
         {canAttemptEmbed && inView && embedState !== 'failed' && (
           <Box
-            className={embedLive ? 'repo-card-preview' : undefined}
+            className={
+              embedLive ? 'repo-card-preview repo-card-embed' : undefined
+            }
             sx={{
               position: 'absolute',
               inset: 0,
@@ -387,7 +395,6 @@ const RepoCard: React.FC<{ repo: Repository; index: number }> = ({
                 border: 0,
                 transform: 'scale(0.25)',
                 transformOrigin: 'top left',
-                pointerEvents: 'none',
                 backgroundColor: '#fff',
               }}
             />


### PR DESCRIPTION
## What

Makes the repo-card previews robust to embed failures with zero hardcoded site lists, fixes the blank phase card on prod, and makes live windows browsable.

### How it works

- **Browser-verified embeds.** Each card mounts a hidden `<object type="text/html">` as a verifier: in Blink, refused documents (X-Frame-Options / CSP frame-ancestors), mixed-content blocks, and unreachable hosts fire `error`, rendered pages fire `load` (verified empirically against live sites — an `<iframe>` deliberately reports all of those identically, which is why the old blocklist existed; it is now deleted). Verdict listeners are attached natively because react-dom never delivers `error` for `<object>`.
- **Sandboxed live windows.** On a load verdict the verifier is unmounted and the visible window renders as a **sandboxed iframe** (no `allow-top-navigation`), so a listed third-party site can never navigate the app away. Hovering a live card hands it pointer events — you can scroll and browse the mini site; the footer stays the link to the repo page. Hover handoff is gated to `(hover: hover) and (pointer: fine)` so taps on touch devices still follow the card link.
- **Layered fallbacks, no blank state.** Live window → website screenshot (mshots, only requested when it will actually be seen) → GitHub OG card (with 429 retry) → repo name. A wrong assumption can only make a card less live, never broken.
- **Engine gating.** Live embeds are Blink-only via `navigator.userAgentData.brands` (absent in WebKit/Gecko — including iOS Chrome, where a `window.chrome` sniff would false-positive). Measured in Safari 26.5: `load` fires with null `contentDocument` for allowed and blocked frames alike, and a page of embeds crash-reloaded the tab — Safari/Firefox get screenshots everywhere.
- **Mixed-content fix (the prod phase bug).** Embed URLs upgrade `http://` → `https://` only when the page itself is https — this un-bricks the phase card on gittensor.io while keeping same-origin embeds (the dashboard self-mirror) working on http dev origins. The screenshot fallback targets the site's declared URL, since mshots fetches server-side.

### Review

The branch went through a multi-agent review (8 finder angles + verification) before this PR; 10 findings were confirmed and fixed in the final commit, including the react-dom `onError` dead code, the iOS-Chrome engine false positive, the https upgrade breaking the self-mirror on http origins, and the unsandboxed top-navigation vector.

### Known limitation / follow-up

`REPO_WEBSITES` is still a snapshot of repo homepages hardcoded in `HomePage.tsx`. The clean fix — serving homepage URLs (and optionally server-checked embeddability, which would unlock live windows in Safari) from das-github-mirror — is backend work deferred from this PR.

## Before (gittensor.io today — note the blank phase card)

![before](https://raw.githubusercontent.com/entrius/gittensor-ui/pr-assets-robust-live-previews/before.png)

## After (all 18 cards; live windows verified, blocked sites on screenshots, phase fixed)

![after](https://raw.githubusercontent.com/entrius/gittensor-ui/pr-assets-robust-live-previews/after.png)

## Validation

- `tsc --noEmit`, eslint, prettier pass (lint-staged on every commit).
- Empirical signal tests in Chromium and Safari against allowed / XFO DENY / CSP frame-ancestors / XFO SAMEORIGIN / dead-DNS targets.
- Full-page checks: Chromium shows 9 verified live windows (including the dashboard self-mirror) and screenshot fallbacks for the 5 frame-blocking sites; Safari shows screenshots everywhere with no crash; no blank or broken cards in either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)