### PR TITLE
Repo sidebar: always show activity chart and maintainers

### DIFF
--- a/src/components/repositories/RepositoryMaintainers.tsx
+++ b/src/components/repositories/RepositoryMaintainers.tsx
@@ -10,11 +10,27 @@ import {
   useTheme,
 } from '@mui/material';
 import { useRepositoryMaintainers } from '../../api';
+import { type RepositoryMaintainer } from '../../api/models';
 import { STATUS_COLORS } from '../../theme';
 
 interface RepositoryMaintainersProps {
   repositoryFullName: string;
 }
+
+// When the API lists no maintainers (or the request fails), fall back to the
+// repo owner so the section never disappears from the sidebar.
+const ownerFallback = (repositoryFullName: string): RepositoryMaintainer[] => {
+  const owner = repositoryFullName.split('/')[0];
+  if (!owner) return [];
+  return [
+    {
+      login: owner,
+      avatarUrl: `https://github.com/${owner}.png?size=80`,
+      htmlUrl: `https://github.com/${owner}`,
+      type: 'User',
+    },
+  ];
+};
 
 const RepositoryMaintainers: React.FC<RepositoryMaintainersProps> = ({
   repositoryFullName,
@@ -44,7 +60,12 @@ const RepositoryMaintainers: React.FC<RepositoryMaintainersProps> = ({
     );
   }
 
-  if (!maintainers || maintainers.length === 0) {
+  const displayMaintainers =
+    maintainers && maintainers.length > 0
+      ? maintainers
+      : ownerFallback(repositoryFullName);
+
+  if (displayMaintainers.length === 0) {
     return null;
   }
 
@@ -62,12 +83,12 @@ const RepositoryMaintainers: React.FC<RepositoryMaintainersProps> = ({
           component="span"
           sx={{ color: STATUS_COLORS.open, fontSize: '0.8em' }}
         >
-          ({maintainers.length})
+          ({displayMaintainers.length})
         </Typography>
       </Typography>
 
       <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1.5 }}>
-        {maintainers.map((maintainer) => (
+        {displayMaintainers.map((maintainer) => (
           <Tooltip key={maintainer.login} title={maintainer.login} arrow>
             <Link
               href={maintainer.htmlUrl}

--- a/src/pages/RepositoryDetailsPage.tsx
+++ b/src/pages/RepositoryDetailsPage.tsx
@@ -651,12 +651,10 @@ const RepositoryDetailsPage: React.FC = () => {
                 {/* Repository Stats */}
                 <RepositoryStats repositoryFullName={repo} />
 
-                {tabValue === 4 || tabValue === 5 ? (
-                  <RepositoryPrActivityChart
-                    repositoryFullName={repo}
-                    viewMode={tabValue === 4 ? 'issues' : 'prs'}
-                  />
-                ) : null}
+                <RepositoryPrActivityChart
+                  repositoryFullName={repo}
+                  viewMode={tabValue === 4 ? 'issues' : 'prs'}
+                />
 
                 <RepositorySocialLinks repositoryFullName={repo} />
 


### PR DESCRIPTION
## Problem

On repo detail pages (`/miners/repository?name=...`) the right sidebar was unstable:

- The PR/issue activity chart only rendered while the Issues or Pull Requests tab was active, so it seemed to randomly appear and disappear as you moved between tabs (it never showed on the default Readme tab).
- The maintainers section unmounted entirely whenever `/repos/:repo/maintainers` returned `[]`, which it currently does whenever the backend's GitHub call is rate limited (see entrius/das-gittensor#87). Users saw the loading skeleton circles flash and then vanish.

## Fix

- Render the activity chart on every tab: issue mode on the Issues tab, PR mode everywhere else.
- Fall back to the repo owner (avatar + GitHub profile link) when the API returns no maintainers, so the section is always present. Once das-gittensor#87 is deployed the API returns the real assignee list and the fallback only covers transient failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)