### PR TITLE
fix(prs): keep time decay chart in sync with subnet multiplier

### DIFF
--- a/src/api/DashboardApi.ts
+++ b/src/api/DashboardApi.ts
@@ -30,8 +30,14 @@ export const useStats = () => useDashboardQuery<Stats>('useStats', '/stats');
 export const getReposQueryKey = () =>
   ['useReposAndWeights', '/dash/repos', undefined] as const;
 
-export const useReposAndWeights = () =>
-  useDashboardQuery<Repository[]>('useReposAndWeights', '/repos');
+export const useReposAndWeights = (enabled?: boolean) =>
+  useDashboardQuery<Repository[]>(
+    'useReposAndWeights',
+    '/repos',
+    undefined,
+    undefined,
+    enabled,
+  );
 
 export const useLanguagesAndWeights = () =>
   useDashboardQuery<LanguageWeight[]>('useLanguagesAndWeights', '/languages');

--- a/src/api/ReposApi.ts
+++ b/src/api/ReposApi.ts
@@ -1,5 +1,6 @@
 // Repository API hooks - uses /repos endpoints
 import { useApiQuery } from './ApiUtils';
+import { useReposAndWeights } from './DashboardApi';
 import { type RepositoryMaintainer, type RepositoryIssue } from './models';
 import { type Repository, type RepositoryMiner } from './models/Dashboard';
 
@@ -28,6 +29,22 @@ export const useRepositoryConfig = (repo: string) =>
     'useRepositoryConfig',
     `/${encodeURIComponent(repo)}`,
   );
+
+/**
+ * Repository config resolved case-insensitively. `/repos/{name}` matches the
+ * canonical casing only, while PR records may carry a lowercased repository
+ * name — on a direct miss this falls back to matching the full repositories
+ * list by lowercased name.
+ */
+export const useResolvedRepositoryConfig = (
+  repo: string,
+): Repository | null => {
+  const direct = useRepositoryConfig(repo);
+  const fallback = useReposAndWeights(direct.isError);
+  if (direct.data) return direct.data;
+  const lower = repo.toLowerCase();
+  return fallback.data?.find((r) => r.fullName.toLowerCase() === lower) ?? null;
+};
 
 /**
  * Get maintainers (assignees) for a specific repository

--- a/src/components/prs/PRTimeDecayChart.tsx
+++ b/src/components/prs/PRTimeDecayChart.tsx
@@ -2,7 +2,7 @@ import React, { useMemo } from 'react';
 import { Box, Typography, alpha, useTheme } from '@mui/material';
 import { type Theme } from '@mui/material/styles';
 import ReactECharts from 'echarts-for-react';
-import { useGeneralConfig, useRepositoryConfig } from '../../api';
+import { useGeneralConfig, useResolvedRepositoryConfig } from '../../api';
 import { STATUS_COLORS, TEXT_OPACITY } from '../../theme';
 import {
   echartsAxisTooltipChrome,
@@ -65,10 +65,10 @@ function buildGradient(opacities?: number[]) {
 function resolveNowMarker(projection: DecayProjection): NowMarker | null {
   if (!projection.isMerged || !projection.inWindow) return null;
   if (projection.daysSinceMerge == null) return null;
-  if (projection.chartNowMultiplier == null) return null;
+  if (projection.nowMultiplier == null) return null;
   return {
     day: +projection.daysSinceMerge.toFixed(2),
-    multiplier: projection.chartNowMultiplier,
+    multiplier: projection.nowMultiplier,
   };
 }
 
@@ -272,7 +272,7 @@ function PRTimeDecayChart({
 }: PRTimeDecayChartProps) {
   const theme = useTheme();
   const { data: generalConfig } = useGeneralConfig();
-  const { data: repoData } = useRepositoryConfig(repository);
+  const repoData = useResolvedRepositoryConfig(repository);
   const params = useMemo(
     () => resolveDecayParams(generalConfig, repoData?.config),
     [generalConfig, repoData],
@@ -347,7 +347,7 @@ function PRTimeDecayChart({
               </Typography>
             </Box>
           )}
-          {showNow && projection.chartNowMultiplier != null && (
+          {showNow && projection.nowMultiplier != null && (
             <Box sx={{ textAlign: 'right' }}>
               <Typography
                 sx={{
@@ -360,7 +360,7 @@ function PRTimeDecayChart({
                   lineHeight: 1.1,
                 }}
               >
-                {projection.chartNowMultiplier.toFixed(2)}×
+                {projection.nowMultiplier.toFixed(2)}×
               </Typography>
               <Typography sx={{ color: muted, fontSize: '0.65rem' }}>
                 multiplier

--- a/src/components/prs/prTimeDecayModel.ts
+++ b/src/components/prs/prTimeDecayModel.ts
@@ -34,9 +34,20 @@ export interface DecayProjection {
   chartNowMultiplier: number | null;
   /** Subnet-reported multiplier (used to back-derive pre-decay score). */
   currentMultiplier: number | null;
+  /** Multiplier to display — the subnet value wins when the curve disagrees. */
+  nowMultiplier: number | null;
+  /** True when the subnet-reported multiplier contradicts the local curve. */
+  curveMismatch: boolean;
   preDecayScore: number | null;
   chartNowScore: number | null;
 }
+
+/**
+ * Subnet multipliers arrive rounded to 2dp, so small drift from the local
+ * curve is expected; beyond this the curve params must be wrong (e.g. the
+ * repo config failed to load) and the subnet value is authoritative.
+ */
+const NOW_MULTIPLIER_TOLERANCE = 0.05;
 
 const DEFAULT_PARAMS: DecayParams = {
   graceHours: 12,
@@ -176,6 +187,11 @@ export function buildDecayProjection(
     earned,
     currentMultiplier ?? chartNowMultiplier,
   );
+  const curveMismatch =
+    currentMultiplier != null &&
+    chartNowMultiplier != null &&
+    Math.abs(currentMultiplier - chartNowMultiplier) > NOW_MULTIPLIER_TOLERANCE;
+  const nowMultiplier = curveMismatch ? currentMultiplier : chartNowMultiplier;
   return {
     isMerged,
     inWindow: isWithinLookbackWindow(daysSinceMerge, params.lookbackDays),
@@ -183,8 +199,10 @@ export function buildDecayProjection(
     daysSinceMerge,
     chartNowMultiplier,
     currentMultiplier,
+    nowMultiplier,
+    curveMismatch,
     preDecayScore,
-    chartNowScore: applyMultiplier(preDecayScore, chartNowMultiplier),
+    chartNowScore: applyMultiplier(preDecayScore, nowMultiplier),
   };
 }
 
@@ -194,5 +212,8 @@ export function buildDecaySubline(projection: DecayProjection): string {
   if (projection.daysSinceMerge > projection.lookbackDays) {
     return `Outside ${projection.lookbackDays}-day scoring window.`;
   }
-  return `${projection.daysSinceMerge.toFixed(1)} day(s) since merge`;
+  const base = `${projection.daysSinceMerge.toFixed(1)} day(s) since merge`;
+  return projection.curveMismatch
+    ? `${base} · showing subnet-reported multiplier (curve is approximate)`
+    : base;
 }


### PR DESCRIPTION
## Problem

The Time Decay chart on the PR details page can directly contradict the subnet-reported multiplier shown in the Score Story chips. Example: `jsonbored/metagraphed` #4432 shows **TIME DECAY 0.11x** in the chip while the chart claims **Now 0.91x** on a 30-day default curve.

Root cause: the chart resolves per-repo decay hyperparameters via `/repos/{name}`, but that lookup is case-sensitive while PR records can carry a lowercased repository name (`jsonbored/metagraphed` vs canonical `JSONbored/metagraphed`). The config request 404s and the chart silently falls back to the default curve (midpoint 10, 30-day window), even though the validator scored the PR with the repo's override (midpoint 2, steepness 1, 5-day lookback).

## Fix

1. **Case-insensitive config resolution** (`useResolvedRepositoryConfig` in `ReposApi.ts`): try `/repos/{name}` as before; on a miss, fall back to a case-insensitive `fullName` match against the repositories list. The list fetch is only enabled after a direct-lookup error, and reuses the shared react-query cache.
2. **Subnet multiplier wins on disagreement** (`prTimeDecayModel.ts`): if the subnet-reported multiplier still disagrees with the locally computed curve beyond rounding tolerance (0.05), the Now marker, multiplier, and now-score display the subnet value and the subline notes the curve is approximate. The chart can no longer confidently contradict the chip.

## Before / after

`jsonbored/metagraphed` #4432 (merged ~4 days ago, repo overrides decay to midpoint 2 / 5-day lookback):

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/entrius/gittensor-ui/pr-assets-fix-pr-decay-repo-config/before-metagraphed.png) | ![after](https://raw.githubusercontent.com/entrius/gittensor-ui/pr-assets-fix-pr-decay-repo-config/after-metagraphed.png) |

`mini-router/minirouter` #97 (canonical-case repo, unaffected path stays correct):

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/entrius/gittensor-ui/pr-assets-fix-pr-decay-repo-config/before-minirouter.png) | ![after](https://raw.githubusercontent.com/entrius/gittensor-ui/pr-assets-fix-pr-decay-repo-config/after-minirouter.png) |

## Validation

- `npm run build` passes (tsc + vite), eslint clean on changed files.
- Verified in a live dev server against the production API with a headless browser: metagraphed #4432 now renders the override curve (5-day axis, Now 0.11x matching the chip); minirouter #97 unchanged and correct (7-day axis, Now 0.70x).

Note: the backend root cause is also worth fixing separately (make the `/repos/{name}` lookup case-insensitive or return canonical casing in PR payloads); this PR makes the UI robust either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
