### PR TITLE
fix(prs): fit time decay curve through subnet-reported multiplier

### DIFF
--- a/src/components/prs/PRTimeDecayChart.tsx
+++ b/src/components/prs/PRTimeDecayChart.tsx
@@ -16,6 +16,7 @@ import {
   buildDecaySubline,
   type DecayParams,
   type DecayProjection,
+  fitCurveThroughPoint,
   resolveDecayParams,
 } from './prTimeDecayModel';
 
@@ -252,14 +253,18 @@ function buildChartOption(
   const fontFamily = echartsFontFamily(theme);
   const mutedHex = alpha(theme.palette.common.white, TEXT_OPACITY.tertiary);
   const marker = resolveNowMarker(projection);
-  const seriesData = injectNowPoint(buildDecayCurve(params), marker);
+  const curveParams =
+    projection.curveMismatch && marker
+      ? fitCurveThroughPoint(params, marker.day, marker.multiplier)
+      : params;
+  const seriesData = injectNowPoint(buildDecayCurve(curveParams), marker);
   return {
     ...echartsTransparentBackground(),
     grid: { left: 44, right: 16, top: 28, bottom: 36 },
     tooltip: buildTooltip(theme, projection.preDecayScore, mutedHex),
-    xAxis: buildXAxis(axis, fontFamily, params.lookbackDays),
+    xAxis: buildXAxis(axis, fontFamily, curveParams.lookbackDays),
     yAxis: buildYAxis(axis),
-    series: [buildSeries(theme, axis, params, seriesData, marker)],
+    series: [buildSeries(theme, axis, curveParams, seriesData, marker)],
   };
 }
 

--- a/src/components/prs/prTimeDecayModel.ts
+++ b/src/components/prs/prTimeDecayModel.ts
@@ -104,6 +104,31 @@ export function resolveDecayParams(
   };
 }
 
+/**
+ * Re-fit the sigmoid midpoint so the curve passes through the subnet-reported
+ * (day, multiplier) point. Repos can override decay hyperparameters without
+ * the API publishing them (`/repos/{name}` only exposes emission shares), so
+ * when the reported multiplier contradicts the resolved params the fitted
+ * curve is the closest available approximation of the repo's real schedule.
+ */
+export function fitCurveThroughPoint(
+  params: DecayParams,
+  day: number,
+  multiplier: number,
+): DecayParams {
+  if (!(multiplier > params.floor) || !(multiplier < 1) || day <= 0) {
+    return params;
+  }
+  const midpoint = day - Math.log(1 / multiplier - 1) / params.steepness;
+  return {
+    ...params,
+    midpoint,
+    // A reported multiplier below 1 means decay already started, so the
+    // grace period cannot extend past the merge age.
+    graceHours: Math.min(params.graceHours, day * 24),
+  };
+}
+
 function decayAt(days: number, params: DecayParams): number {
   if (days <= params.graceHours / 24) return 1;
   const sigmoid =
@@ -214,6 +239,6 @@ export function buildDecaySubline(projection: DecayProjection): string {
   }
   const base = `${projection.daysSinceMerge.toFixed(1)} day(s) since merge`;
   return projection.curveMismatch
-    ? `${base} · showing subnet-reported multiplier (curve is approximate)`
+    ? `${base} · curve fitted to subnet-reported multiplier (repo overrides decay params)`
     : base;
 }


### PR DESCRIPTION
## Problem

On PRs in repos that override `scoring.time_decay` hyperparameters, the time decay chart drew a V-notch: the curve was rendered from the global config params (sigmoid midpoint 10 days), while the Now marker used the subnet-reported multiplier, and the marker point was spliced into the line.

Example: [james-cuda/gittensor-tinyrouter #240](https://gittensor.io/miners/pr?repo=james-cuda%2Fgittensor-tinyrouter&number=240) — subnet reports 0.71× at 0.9 days since merge, but the default curve says ~0.97× there.

The UI can't resolve the repo's real decay params because `/repos/{name}` only publishes `emissionShare` and `issueDiscoveryShare` — no `scoring.time_decay` — so the per-repo override never reaches the chart.

## Fix

When the subnet-reported multiplier contradicts the resolved curve (beyond the existing 0.05 tolerance), re-solve the sigmoid midpoint so the drawn curve passes through the reported (days since merge, multiplier) point, and clamp the grace period below the merge age. The `50% @ midpoint` mark line follows the fitted midpoint, and the subline now reads "curve fitted to subnet-reported multiplier (repo overrides decay params)".

Repos without overrides are unaffected: the fit only activates on mismatch, and if the API later publishes per-repo `scoring.time_decay`, the resolved params win again with no fit needed.

## Before

![before](https://raw.githubusercontent.com/entrius/gittensor-ui/pr-assets-fix-pr-decay-curve-fit/before.png)

## After

![after](https://raw.githubusercontent.com/entrius/gittensor-ui/pr-assets-fix-pr-decay-curve-fit/after.png)
