### PR TITLE
fix(home): add missing website previews for SparkDistill and TinyRouter

### DIFF
--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -25,10 +25,14 @@ const getRepoPreviewSrc = (fullName: string, attempt: number) =>
 
 // Experiment: show each project's own website in the card instead of the
 // GitHub OpenGraph card. Homepages come from the repos' GitHub metadata
-// (snapshotted 2026-07-09); repos without a website fall back to the OG image.
+// (snapshotted 2026-07-13); repos without a website fall back to the OG image.
 const REPO_WEBSITES: Record<string, string> = {
   'gittensor-ai-lab/sparkinfer':
     'https://gittensor-ai-lab.github.io/sparkinfer/dashboard/',
+  'gittensor-model-hub/SparkDistill':
+    'https://gittensor-model-hub.github.io/SparkDistill/',
+  'James-CUDA/Gittensor-TinyRouter':
+    'https://james-cuda.github.io/Gittensor-TinyRouter/',
   'JSONbored/metagraphed': 'https://metagraph.sh',
   'gittensor-vanguard/vanguarstew':
     'https://gittensor-vanguard.github.io/vanguarstew/',


### PR DESCRIPTION
## What

Adds two entries to the homepage `REPO_WEBSITES` preview map, which was snapshotted from GitHub metadata on 2026-07-09. Both repos set their GitHub homepage after that snapshot, so their cards were falling back to the GitHub OpenGraph image even though their sites are live:

- `gittensor-model-hub/SparkDistill` -> https://gittensor-model-hub.github.io/SparkDistill/
- `James-CUDA/Gittensor-TinyRouter` -> https://james-cuda.github.io/Gittensor-TinyRouter/

Both URLs verified live (HTTP 200), and both keys match the exact `fullName` casing returned by the live `/dash/repos` API. Swept all 19 registry repos: these were the only two with a live homepage missing from the map. Snapshot date comment bumped to 2026-07-13.

## Before / after

| Repo | Before (gittensor.io) | After (this branch) |
| --- | --- | --- |
| SparkDistill | ![before-sparkdistill](https://raw.githubusercontent.com/entrius/gittensor-ui/pr-assets-fix-homepage-missing-website-previews/before-SparkDistill.png) | ![after-sparkdistill](https://raw.githubusercontent.com/entrius/gittensor-ui/pr-assets-fix-homepage-missing-website-previews/after-SparkDistill.png) |
| Gittensor-TinyRouter | ![before-tinyrouter](https://raw.githubusercontent.com/entrius/gittensor-ui/pr-assets-fix-homepage-missing-website-previews/before-Gittensor_TinyRouter.png) | ![after-tinyrouter](https://raw.githubusercontent.com/entrius/gittensor-ui/pr-assets-fix-homepage-missing-website-previews/after-Gittensor_TinyRouter.png) |

## Validation

- `npm run build` passes
- Verified visually on the local dev server in Chromium: both cards render the live site embed