### PR TITLE
feat(home): auto-generate repo website previews from GitHub metadata

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -7,6 +7,14 @@ module.exports = {
     'plugin:react-hooks/recommended',
   ],
   ignorePatterns: ['dist', '.eslintrc.cjs'],
+  overrides: [
+    {
+      // Build-time Node scripts, not browser code
+      files: ['scripts/**/*.mjs'],
+      env: { node: true },
+      rules: { 'no-console': 'off' },
+    },
+  ],
   parser: '@typescript-eslint/parser',
   parserOptions: {
     ecmaVersion: 'latest',

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,3 +26,5 @@ jobs:
 
       - name: Build project
         run: npm run build
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -42,3 +42,5 @@ jobs:
           file: Dockerfile
           push: true
           tags: ${{ steps.tags.outputs.tags }}
+          build-args: |
+            GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,10 @@ COPY . .
 
 EXPOSE 8080
 
-RUN npm run build
+# Ephemeral CI token for scripts/fetch-repo-websites.mjs (prebuild); without
+# it the shared runner IP usually hits GitHub's unauthenticated rate limit
+# and the build falls back to the committed website snapshot.
+ARG GITHUB_TOKEN
+RUN GITHUB_TOKEN=$GITHUB_TOKEN npm run build
 
 CMD [ "npm", "run", "preview" ]

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "prebuild": "node scripts/fetch-repo-websites.mjs",
     "build": "tsc -b && vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "lint:fix": "eslint . --ext ts,tsx --fix",

--- a/scripts/fetch-repo-websites.mjs
+++ b/scripts/fetch-repo-websites.mjs
@@ -1,0 +1,90 @@
+// Regenerates src/generated/repoWebsites.json: the homepage URL each
+// registry repo declares in its GitHub metadata, keyed by fullName. Runs as
+// the `prebuild` hook so every build ships whatever the projects currently
+// point their GitHub "website" field at — no hand-edited list to go stale.
+//
+// Fail-safe by design: any fetch problem (registry down, GitHub rate limit)
+// leaves the committed snapshot untouched and exits 0, so a build can never
+// break — worst case the previews are as fresh as the last successful run.
+// Set GITHUB_TOKEN (GitHub Actions' built-in token works) to lift the
+// unauthenticated 60 req/hr GitHub API limit shared by CI runner IPs.
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const OUT_PATH = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '..',
+  'src',
+  'generated',
+  'repoWebsites.json',
+);
+
+const API_BASE =
+  process.env.VITE_REACT_APP_BASE_URL || 'https://api.gittensor.io';
+
+const readSnapshot = () => {
+  try {
+    return JSON.parse(readFileSync(OUT_PATH, 'utf8'));
+  } catch {
+    return {};
+  }
+};
+
+const fetchJson = async (url, headers = {}) => {
+  const response = await fetch(url, { headers });
+  if (!response.ok) throw new Error(`${url} -> HTTP ${response.status}`);
+  return response.json();
+};
+
+const githubHeaders = process.env.GITHUB_TOKEN
+  ? { Authorization: `Bearer ${process.env.GITHUB_TOKEN}` }
+  : {};
+
+const snapshot = readSnapshot();
+
+let registry;
+try {
+  const payload = await fetchJson(`${API_BASE}/dash/repos`);
+  registry = Array.isArray(payload) ? payload : payload.repositories;
+  if (!Array.isArray(registry)) throw new Error('unexpected registry shape');
+} catch (error) {
+  console.warn(
+    `repo-websites: registry fetch failed, keeping snapshot (${error.message})`,
+  );
+  process.exit(0);
+}
+
+const websites = {};
+let failures = 0;
+for (const repo of registry) {
+  const fullName = repo.fullName;
+  if (!fullName) continue;
+  try {
+    const meta = await fetchJson(
+      `https://api.github.com/repos/${fullName}`,
+      githubHeaders,
+    );
+    const homepage = (meta.homepage || '').trim();
+    if (/^https?:\/\//i.test(homepage)) websites[fullName] = homepage;
+  } catch (error) {
+    failures += 1;
+    console.warn(`repo-websites: ${fullName} fetch failed (${error.message})`);
+    if (snapshot[fullName]) websites[fullName] = snapshot[fullName];
+  }
+}
+
+// A blanket failure (e.g. rate limit) must not wipe the snapshot wholesale.
+if (failures === registry.length) {
+  console.warn('repo-websites: every GitHub fetch failed, keeping snapshot');
+  process.exit(0);
+}
+
+const sorted = Object.fromEntries(
+  Object.entries(websites).sort(([a], [b]) => a.localeCompare(b)),
+);
+mkdirSync(dirname(OUT_PATH), { recursive: true });
+writeFileSync(OUT_PATH, `${JSON.stringify(sorted, null, 2)}\n`);
+console.log(
+  `repo-websites: wrote ${Object.keys(sorted).length} entries (${failures} fetch failures)`,
+);

--- a/src/generated/repoWebsites.json
+++ b/src/generated/repoWebsites.json
@@ -1,0 +1,17 @@
+{
+  "Autovara/kata": "https://dashboardking.ngrok.app/",
+  "Geniepod/genie-claw": "https://genieclaw.org",
+  "gittensor-ai-lab/sparkinfer": "https://gittensor-ai-lab.github.io/sparkinfer/dashboard/",
+  "gittensor-model-hub/SparkDistill": "https://gittensor-model-hub.github.io/SparkDistill/",
+  "gittensor-vanguard/vanguarstew": "https://gittensor-vanguard.github.io/vanguarstew/",
+  "imagent-ai/imagent": "https://tryimagent.com/",
+  "James-CUDA/Gittensor-TinyRouter": "https://james-cuda.github.io/Gittensor-TinyRouter/",
+  "JSONbored/awesome-claude": "https://heyclau.de",
+  "JSONbored/gittensory": "https://gittensory.aethereal.dev/",
+  "JSONbored/metagraphed": "https://metagraph.sh",
+  "mini-router/minirouter": "https://mini-router.github.io/minirouter/",
+  "phase-rs/phase": "http://preview.phase-rs.dev/",
+  "vouchdev/vouch": "https://vouchai.dev",
+  "we-promise/sure": "https://sure.am",
+  "zeokin/Cuda-Compute-OSS": "https://zeokin.github.io/Cuda-Compute-Dashboard/"
+}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -8,6 +8,7 @@ import { useReposAndWeights } from '../api';
 import { type Repository } from '../api/models/Dashboard';
 import { getRepositoryOwnerAvatarSrc } from '../utils/avatar';
 import { minerRepositoryPath, parseNumber } from '../utils';
+import repoWebsitesSnapshot from '../generated/repoWebsites.json';
 
 const fadeUp = (delayMs = 0) => ({
   opacity: 0,
@@ -23,28 +24,19 @@ const getRepoPreviewSrc = (fullName: string, attempt: number) =>
     attempt > 0 ? `?retry=${attempt}` : ''
   }`;
 
-// Experiment: show each project's own website in the card instead of the
-// GitHub OpenGraph card. Homepages come from the repos' GitHub metadata
-// (snapshotted 2026-07-09); repos without a website fall back to the OG image.
+// Show each project's own website in the card instead of the GitHub
+// OpenGraph card. Homepages come from the repos' GitHub metadata, snapshotted
+// into repoWebsites.json by scripts/fetch-repo-websites.mjs on every build
+// (the `prebuild` hook), so a project adding or changing its GitHub website
+// is picked up on the next deploy. Repos without one fall back to the OG
+// image.
 const REPO_WEBSITES: Record<string, string> = {
-  'gittensor-ai-lab/sparkinfer':
-    'https://gittensor-ai-lab.github.io/sparkinfer/dashboard/',
-  'JSONbored/metagraphed': 'https://metagraph.sh',
-  'gittensor-vanguard/vanguarstew':
-    'https://gittensor-vanguard.github.io/vanguarstew/',
+  ...repoWebsitesSnapshot,
   // The site you are on right now — mirror its live dashboard. A page cannot
-  // iframe its own URL (recursion protection), so point at /dashboard.
+  // iframe its own URL (recursion protection), so point at /dashboard. This
+  // stays in code (not the snapshot): the mirror must be same-origin on every
+  // deploy target, and it must win even if the repo sets a GitHub homepage.
   'entrius/gittensor': `${window.location.origin}/dashboard`,
-  'JSONbored/gittensory': 'https://gittensory.aethereal.dev/',
-  'Autovara/kata': 'https://dashboardking.ngrok.app/',
-  'Geniepod/genie-claw': 'https://genieclaw.org',
-  'vouchdev/vouch': 'https://vouchai.dev',
-  'phase-rs/phase': 'http://preview.phase-rs.dev/',
-  'imagent-ai/imagent': 'https://tryimagent.com/',
-  'mini-router/minirouter': 'https://mini-router.github.io/minirouter/',
-  'zeokin/Cuda-Compute-OSS': 'https://zeokin.github.io/Cuda-Compute-Dashboard/',
-  'JSONbored/awesome-claude': 'https://heyclau.de',
-  'we-promise/sure': 'https://sure.am',
 };
 
 // An https page cannot embed http content (browsers block it as mixed


### PR DESCRIPTION
## What

Replaces the hand-maintained `REPO_WEBSITES` map on the homepage with an auto-generated snapshot, so repo cards pick up each project's website without a code change. When a project registers or changes the website field on its GitHub repo, the next deploy shows it — no one has to re-edit the map (which is how SparkDistill and TinyRouter previews went missing, fixed manually in #1360).

## Before / after — homepage repositories section

Before (live gittensor.io, stale hand-curated map: SparkDistill falls back to the GitHub OG card):

![before-page](https://raw.githubusercontent.com/entrius/gittensor-ui/pr-assets-feat-auto-repo-website-previews/before-page.png)

After (this branch, map generated from GitHub metadata at build time: SparkDistill shows its live site; every other card renders identically to today):

![after-page](https://raw.githubusercontent.com/entrius/gittensor-ui/pr-assets-feat-auto-repo-website-previews/after-page.png)

## How

- `scripts/fetch-repo-websites.mjs` runs as the `prebuild` npm hook: it fetches the registry from `/dash/repos`, reads each repo's `homepage` from the GitHub API, and writes `src/generated/repoWebsites.json`.
- The snapshot is committed, and the script is fail-safe: registry unreachable, GitHub rate-limited, or all fetches failing -> it keeps the committed snapshot and exits 0, so a build can never break on this. Worst case previews are as fresh as the last successful run (i.e. exactly today's behavior).
- Per-repo fetch failures fall back to that repo's committed entry instead of dropping it.
- `HomePage.tsx` spreads the generated snapshot; the only code-level entry left is `entrius/gittensor`, which must stay same-origin (`/dashboard` mirror) on every deploy target.
- CI plumbing: `GITHUB_TOKEN` passed to the build in `build.yml` and as a Docker build-arg in `docker-publish.yml` (the default Actions token; read-only public metadata) so runner IPs don't hit the unauthenticated 60 req/hr GitHub limit.
- eslint override for `scripts/**/*.mjs` (Node env, console allowed).

The generated snapshot reproduces the previous hand-curated map exactly (verified entry by entry), plus the two repos that had gone stale.

## Validation

- `npm run build` (with prebuild) and `npm run lint` pass.
- Fallback tested: with an unreachable registry the script exits 0 and leaves the snapshot byte-identical.
- Close-up of a card rendering from the generated snapshot on the dev server:

![sparkdistill-json-driven](https://raw.githubusercontent.com/entrius/gittensor-ui/pr-assets-feat-auto-repo-website-previews/json-driven-SparkDistill.png)

## Note

Supersedes the map entries added in #1360; if that merges first this branch needs a trivial rebase of `HomePage.tsx`.