### PR TITLE
fix(ci): stop leaking GITHUB_TOKEN into published image metadata

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
     branches: [main, test]
 
+# Read-only token: the build step only uses it for public GitHub metadata
+# reads in the prebuild script.
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -6,6 +6,11 @@ on:
       - main
       - test
 
+# The GITHUB_TOKEN only reads public repo metadata in the prebuild script;
+# never let it carry write scopes into a job that pushes public images.
+permissions:
+  contents: read
+
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
@@ -42,5 +47,5 @@ jobs:
           file: Dockerfile
           push: true
           tags: ${{ steps.tags.outputs.tags }}
-          build-args: |
-            GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
+          secrets: |
+            github_token=${{ secrets.GITHUB_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 FROM node:20-alpine
 
 WORKDIR /app
@@ -12,8 +13,11 @@ EXPOSE 8080
 
 # Ephemeral CI token for scripts/fetch-repo-websites.mjs (prebuild); without
 # it the shared runner IP usually hits GitHub's unauthenticated rate limit
-# and the build falls back to the committed website snapshot.
-ARG GITHUB_TOKEN
-RUN GITHUB_TOKEN=$GITHUB_TOKEN npm run build
+# and the build falls back to the committed website snapshot. Mounted as a
+# BuildKit secret rather than an ARG: build args are recorded in the pushed
+# image's config (`docker history`), a secret mount never leaves this RUN.
+# Absent secret (local builds) resolves to empty — same fallback as before.
+RUN --mount=type=secret,id=github_token \
+    GITHUB_TOKEN="$(cat /run/secrets/github_token 2>/dev/null || true)" npm run build
 
 CMD [ "npm", "run", "preview" ]


### PR DESCRIPTION
## Problem

#1361 passes `secrets.GITHUB_TOKEN` to the Docker build via `build-args`. Build args consumed by a `RUN` are recorded in the image config — `docker history --no-trunc` on the public `entrius/gt-ui` image shows the token. The image is pushed **mid-job while the token is still valid**, and with no `permissions:` block the token carries the org default scopes (typically `contents: write`). Small window, public image, valid write token: worth closing properly.

## Fix

- **Dockerfile** — token now enters via a BuildKit secret mount (`RUN --mount=type=secret,id=github_token`). Secret mounts exist only for the duration of that `RUN`; nothing lands in layers or image config. When no secret is provided (local `docker build`), the value resolves to empty and `fetch-repo-websites.mjs` keeps its unauthenticated/snapshot fallback — verified both paths locally with a minimal test image.
- **docker-publish.yml** — `build-args:` → build-push-action's `secrets:` input; added `permissions: contents: read`.
- **build.yml** — added `permissions: contents: read` (its env-var usage doesn't persist anywhere, but the token has no reason to carry write scopes).

`# syntax=docker/dockerfile:1` added for older local engines; the buildx used by build-push-action needs nothing extra.

## Verification

- `docker build --check` clean; workflow YAML parses.
- Secret-mount semantics tested with a scratch image: secret provided → read correctly; secret absent → empty token, build succeeds (fail-safe preserved).
- After merge, confirm the freshly pushed `entrius/gt-ui:test` shows no token in `docker history --no-trunc`.