### PR TITLE
feat(repo): pin Discord link fallback for DPBG/Engram.AI

### DIFF
--- a/src/components/repositories/RepositorySocialLinks.tsx
+++ b/src/components/repositories/RepositorySocialLinks.tsx
@@ -82,6 +82,27 @@ const BLOCKED_HOSTS = [
 const BLOCKED_EXTENSIONS =
   /\.(?:png|jpe?g|gif|svg|webp|avif|ico|pdf)(?:$|[?#])/i;
 
+const LINK_ORDER: Record<LinkKind, number> = {
+  website: 0,
+  twitter: 1,
+  discord: 2,
+  telegram: 3,
+  linkedin: 4,
+  youtube: 5,
+};
+
+// Manual pins for repos whose README doesn't surface a link the auto-parser
+// can pick up. Only fills in a kind the live scan didn't already find.
+const FALLBACK_LINKS: Record<string, RepositoryLink[]> = {
+  'DPBG/Engram.AI': [
+    {
+      url: 'https://discord.com/channels/1504942454258798684/1523702741782888579',
+      label: 'Discord',
+      kind: 'discord',
+    },
+  ],
+};
+
 const markdownLinkPattern = /\[([^\]]+)\]\((https?:\/\/[^)\s]+)[^)]*\)/g;
 const htmlAnchorPattern =
   /<a\b[^>]*\bhref=["'](https?:\/\/[^"']+)["'][^>]*>(.*?)<\/a>/gis;
@@ -225,16 +246,9 @@ const buildRepositoryLinks = (
     });
   }
 
-  const order: Record<LinkKind, number> = {
-    website: 0,
-    twitter: 1,
-    discord: 2,
-    telegram: 3,
-    linkedin: 4,
-    youtube: 5,
-  };
-
-  return links.sort((a, b) => order[a.kind] - order[b.kind]).slice(0, 8);
+  return links
+    .sort((a, b) => LINK_ORDER[a.kind] - LINK_ORDER[b.kind])
+    .slice(0, 8);
 };
 
 const fetchRepositoryReadme = async (
@@ -298,15 +312,19 @@ const useRepositoryLinks = (repositoryFullName: string) => {
     retry: false,
   });
 
-  const links = useMemo(
-    () =>
-      buildRepositoryLinks(
-        repositoryFullName,
-        readmeQuery.data ?? '',
-        metaQuery.data,
-      ),
-    [metaQuery.data, readmeQuery.data, repositoryFullName],
-  );
+  const links = useMemo(() => {
+    const detected = buildRepositoryLinks(
+      repositoryFullName,
+      readmeQuery.data ?? '',
+      metaQuery.data,
+    );
+    const fallback = (FALLBACK_LINKS[repositoryFullName] ?? []).filter(
+      (link) => !detected.some((found) => found.kind === link.kind),
+    );
+    return [...detected, ...fallback].sort(
+      (a, b) => LINK_ORDER[a.kind] - LINK_ORDER[b.kind],
+    );
+  }, [metaQuery.data, readmeQuery.data, repositoryFullName]);
 
   return {
     links,


### PR DESCRIPTION
## Summary

The **Links** section on a repository detail page (e.g. `/miners/repository?name=DPBG%2FEngram.AI`, below the PR Activity chart) is built entirely by live-scanning the target repo's own `README.md` and GitHub `homepage` metadata (`RepositorySocialLinks.tsx`). For `DPBG/Engram.AI`, that scan didn't surface a Discord link, so no Discord button appeared even though the project has an active Discord.

This PR adds a small, per-repo `FALLBACK_LINKS` map that fills in a link kind (e.g. `discord`) only when the live README/homepage scan doesn't already find one — with `DPBG/Engram.AI` pinned to `https://discord.com/channels/1504942454258798684/1523702741782888579`. The kind-ordering table used to sort links (`LINK_ORDER`) was hoisted to module scope so both the live scan and the merged fallback list sort consistently.

Closes #1364.

## Motivation

Contributors and users landing on a project's repository page had no way to reach that project's Discord unless the maintainer happened to link it in a format the auto-parser recognizes. This lightweight fallback lets a specific repo's Discord (or other social link) be pinned without waiting on a README edit, while still preferring the maintainer's own README/homepage link whenever the live scan finds one.

Note: the pinned URL is a direct channel deep-link (`discord.com/channels/<guild>/<channel>`), not a public invite. Visitors who aren't already members of that server will hit an access-denied screen. It should be swapped for a public invite link (`https://discord.gg/XXXXXXX`) once one is available.
