### PR TITLE
style(landing): hero spacing rework into title+tagline and dial+grid groups

### DIFF
--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1134,6 +1134,26 @@ const HomePage: React.FC = () => {
           Gittensor
         </Typography>
 
+        <Typography
+          sx={(theme) => ({
+            mt: { xs: 1, md: 1.25 },
+            mx: 'auto',
+            maxWidth: 640,
+            color: alpha(theme.palette.text.primary, 0.45),
+            fontFamily: 'var(--font-accent)',
+            fontSize: '0.66rem',
+            letterSpacing: '0.16em',
+            textTransform: 'uppercase',
+            textAlign: 'center',
+            lineHeight: 1.7,
+            ...fadeUp(80),
+          })}
+        >
+          {timeline === 'repositories'
+            ? 'These are the open source projects built by Gittensor.'
+            : 'This is the work done by Gittensor miners.'}
+        </Typography>
+
         {/* Dial toggle: only the active timeline shows, flanked by arrows.
             Turning the dial slides the old word out and the new word in,
             both moving in the direction of travel. */}
@@ -1142,7 +1162,7 @@ const HomePage: React.FC = () => {
             display: 'flex',
             alignItems: 'center',
             gap: 1,
-            mt: { xs: 2.5, md: 3 },
+            mt: { xs: 1.25, md: 1.5 },
             mx: 'auto',
             py: 0.7,
             width: 'fit-content',
@@ -1224,27 +1244,9 @@ const HomePage: React.FC = () => {
 
         {timeline === 'repositories' ? (
           <>
-            <Typography
-              sx={(theme) => ({
-                mt: { xs: 1.25, md: 1.5 },
-                mx: 'auto',
-                maxWidth: 640,
-                color: alpha(theme.palette.text.primary, 0.45),
-                fontFamily: 'var(--font-accent)',
-                fontSize: '0.66rem',
-                letterSpacing: '0.16em',
-                textTransform: 'uppercase',
-                textAlign: 'center',
-                lineHeight: 1.7,
-                ...fadeUp(120),
-              })}
-            >
-              These are the open source projects built by Gittensor.
-            </Typography>
-
             <Box
               sx={{
-                mt: { xs: 5, md: 7 },
+                mt: { xs: 4, md: 5.5 },
                 display: 'grid',
                 gridTemplateColumns: {
                   xs: '1fr',
@@ -1314,23 +1316,6 @@ const HomePage: React.FC = () => {
           </>
         ) : (
           <Box>
-            <Typography
-              sx={(theme) => ({
-                mt: { xs: 1.25, md: 1.5 },
-                mx: 'auto',
-                maxWidth: 640,
-                color: alpha(theme.palette.text.primary, 0.45),
-                fontFamily: 'var(--font-accent)',
-                fontSize: '0.66rem',
-                letterSpacing: '0.16em',
-                textTransform: 'uppercase',
-                textAlign: 'center',
-                lineHeight: 1.7,
-                ...fadeUp(120),
-              })}
-            >
-              This is the work done by Gittensor miners.
-            </Typography>
             <React.Suspense
               fallback={
                 <Typography

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1108,7 +1108,7 @@ const HomePage: React.FC = () => {
           maxWidth: timeline === 'dashboard' ? 1680 : 1320,
           mx: 'auto',
           px: { xs: 1.5, sm: 3 },
-          py: { xs: 4, md: 7 },
+          py: { xs: 3, md: 5 },
           '@keyframes landingFadeUp': {
             '0%': { opacity: 0, transform: 'translateY(18px)' },
             '100%': { opacity: 1, transform: 'translateY(0)' },
@@ -1136,13 +1136,13 @@ const HomePage: React.FC = () => {
 
         <Typography
           sx={(theme) => ({
-            mt: { xs: 1, md: 1.25 },
+            mt: { xs: 0.75, md: 1 },
             mx: 'auto',
             maxWidth: 640,
             color: alpha(theme.palette.text.primary, 0.45),
             fontFamily: 'var(--font-accent)',
-            fontSize: '0.66rem',
-            letterSpacing: '0.16em',
+            fontSize: '0.7rem',
+            letterSpacing: '0.08em',
             textTransform: 'uppercase',
             textAlign: 'center',
             lineHeight: 1.7,
@@ -1162,7 +1162,7 @@ const HomePage: React.FC = () => {
             display: 'flex',
             alignItems: 'center',
             gap: 1,
-            mt: { xs: 1.25, md: 1.5 },
+            mt: { xs: 4, md: 5 },
             mx: 'auto',
             py: 0.7,
             width: 'fit-content',
@@ -1246,7 +1246,7 @@ const HomePage: React.FC = () => {
           <>
             <Box
               sx={{
-                mt: { xs: 4, md: 5.5 },
+                mt: { xs: 2.5, md: 3 },
                 display: 'grid',
                 gridTemplateColumns: {
                   xs: '1fr',


### PR DESCRIPTION
Follow-up polish to #1363: these two commits were pushed to the old branch after it merged, so they never landed in `test`.

## What changed

Hero spacing reworked from three floating strata into two visual groups:

- **Title + tagline** read as one header unit: the tagline moved above the timeline dial, sits 8px under the title, and its letter-spacing dropped from 0.16em to 0.08em (with a slightly larger 0.7rem size) so it reads as a quiet caption instead of a banner competing with the title's width.
- **Dial + grid** read as control plus content: the dial now sits just above the grid it switches, so it registers as the grid's tab bar instead of an orphaned element mid-hero.
- The duplicate dashboard-side tagline was consolidated into the single line under the title (it still swaps copy with the dial state).
- Page top padding reduced so the first row of cards starts on-screen.

![hero](https://raw.githubusercontent.com/entrius/gittensor-ui/pr-assets-landing-previews/final-grid.png)

## Verification

- `tsc -b` clean; eslint + prettier via lint-staged on commit.
- Verified in Chromium at 1440px: title/tagline gap 8px, tagline/dial ~40px, dial/grid 24px.
