### PR TITLE
Dashboard: flat single-layer design pass + honest all-time trends

### DIFF
--- a/src/pages/dashboard/dashboardData.ts
+++ b/src/pages/dashboard/dashboardData.ts
@@ -215,15 +215,21 @@ const isResolvedInWindow = (
   isResolvedMinerIssue(issue) &&
   isWithinWindow(toTimestamp(issue.solving_pr?.merged_at), window);
 
-const getUtcWeekStart = (timestamp: number) => {
-  const date = new Date(timestamp);
-  const dayOfWeek = date.getUTCDay();
-  const diffToMonday = (dayOfWeek + 6) % 7;
-  return Date.UTC(
-    date.getUTCFullYear(),
-    date.getUTCMonth(),
-    date.getUTCDate() - diffToMonday,
-  );
+// All-time buckets span a week, so the label carries the full range (and the
+// year, since the all-time window crosses a year boundary). The chart's x-axis
+// shows only the part before the dash; the tooltip shows the whole label.
+const formatWeekRangeLabel = (startMs: number, endMs: number) => {
+  const start = new Date(startMs);
+  const end = new Date(endMs - 1);
+  const monthDay = new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+  });
+  const sameMonth =
+    start.getFullYear() === end.getFullYear() &&
+    start.getMonth() === end.getMonth();
+  const endLabel = sameMonth ? String(end.getDate()) : monthDay.format(end);
+  return `${monthDay.format(start)} – ${endLabel}, ${end.getFullYear()}`;
 };
 
 const formatTrendBucketLabel = (timestamp: number, range: TrendTimeRange) => {
@@ -259,24 +265,24 @@ const buildTrendBuckets = (
     });
   }
 
-  const firstWeekStart = getUtcWeekStart(GITTENSOR_START_MS);
-  const currentWeekStart = getUtcWeekStart(now.getTime());
-  const endExclusive = currentWeekStart + WEEK_MS;
-  const buckets: Array<{ startMs: number; endMs: number; label: string }> = [];
+  // Anchor weekly buckets to *now* (rather than calendar weeks) so the last
+  // bucket always covers a full trailing 7 days. Calendar-aligned buckets end
+  // on a partial current week, which renders as a fake cliff at the right edge
+  // of every series.
+  const endMs = now.getTime();
+  const totalWeeks = Math.max(
+    1,
+    Math.ceil((endMs - GITTENSOR_START_MS) / WEEK_MS),
+  );
 
-  for (
-    let bucketStart = firstWeekStart;
-    bucketStart < endExclusive;
-    bucketStart += WEEK_MS
-  ) {
-    buckets.push({
-      startMs: bucketStart,
-      endMs: bucketStart + WEEK_MS,
-      label: formatTrendBucketLabel(bucketStart, range),
-    });
-  }
-
-  return buckets;
+  return Array.from({ length: totalWeeks }, (_, index) => {
+    const bucketEnd = endMs - (totalWeeks - 1 - index) * WEEK_MS;
+    return {
+      startMs: bucketEnd - WEEK_MS,
+      endMs: bucketEnd,
+      label: formatWeekRangeLabel(bucketEnd - WEEK_MS, bucketEnd),
+    };
+  });
 };
 
 const bucketTimestamps = (

--- a/src/pages/dashboard/views/ActiveNetwork.tsx
+++ b/src/pages/dashboard/views/ActiveNetwork.tsx
@@ -35,15 +35,9 @@ const ActiveNetwork: React.FC<ActiveNetworkProps> = ({
   onCalendarMonthChange,
 }) => {
   return (
-    <Box
-      sx={{
-        width: '100%',
-        p: { xs: 1.45, sm: 1.65 },
-        borderRadius: 3,
-        border: (muiTheme) => `1px solid ${muiTheme.palette.border.light}`,
-        backgroundColor: 'transparent',
-      }}
-    >
+    // Section labels sit directly on the canvas; each subsection carries its
+    // own single card layer.
+    <Box sx={{ width: '100%' }}>
       <ContributionTrends
         range={range}
         labels={trendLabels}

--- a/src/pages/dashboard/views/ContributionCalendar.tsx
+++ b/src/pages/dashboard/views/ContributionCalendar.tsx
@@ -440,36 +440,23 @@ const ContributionCalendar: React.FC<ContributionCalendarProps> = ({
                             aria-pressed={isSelected}
                             aria-label={`Show ${formatMonthLabel(month)}`}
                             sx={{
+                              // No border or fill: the selected month is
+                              // marked by its text turning green, matching
+                              // the other dashboard controls.
                               appearance: 'none',
                               position: 'relative',
                               zIndex: 1,
-                              border: `1px solid ${
-                                isSelected
-                                  ? alpha(theme.palette.status.success, 0.85)
-                                  : alpha(theme.palette.border.light, 0.72)
-                              }`,
-                              borderRadius: 1,
-                              px: 1.05,
+                              border: 0,
+                              borderRadius: 999,
+                              px: 0.6,
                               py: 0.55,
-                              minWidth: { xs: 76, sm: 86 },
+                              backgroundColor: 'transparent',
                               color: isSelected
-                                ? theme.palette.text.primary
+                                ? theme.palette.status.success
                                 : alpha(
                                     theme.palette.text.primary,
                                     TEXT_OPACITY.secondary,
                                   ),
-                              backgroundColor: isSelected
-                                ? alpha(theme.palette.status.success, 0.22)
-                                : theme.palette.background.default,
-                              boxShadow: isSelected
-                                ? `0 0 0 1px ${alpha(
-                                    theme.palette.status.success,
-                                    0.32,
-                                  )}`
-                                : `0 0 0 1px ${alpha(
-                                    theme.palette.common.black,
-                                    0.45,
-                                  )}`,
                               cursor: isSelected ? 'default' : 'pointer',
                               fontFamily: monoFontFamily,
                               fontSize: { xs: '0.64rem', sm: '0.68rem' },
@@ -477,18 +464,11 @@ const ContributionCalendar: React.FC<ContributionCalendarProps> = ({
                               lineHeight: 1.1,
                               textAlign: 'center',
                               whiteSpace: 'nowrap',
-                              transition:
-                                'background-color 120ms ease, color 120ms ease, border-color 120ms ease, box-shadow 120ms ease',
+                              transition: 'color 120ms ease',
                               '&:hover': {
-                                color: theme.palette.text.primary,
-                                borderColor: alpha(
-                                  theme.palette.status.success,
-                                  0.5,
-                                ),
-                                backgroundColor: alpha(
-                                  theme.palette.status.success,
-                                  isSelected ? 0.22 : 0.09,
-                                ),
+                                color: isSelected
+                                  ? theme.palette.status.success
+                                  : theme.palette.text.primary,
                               },
                               '&:disabled': {
                                 opacity: 1,

--- a/src/pages/dashboard/views/ContributionTrends.tsx
+++ b/src/pages/dashboard/views/ContributionTrends.tsx
@@ -80,15 +80,6 @@ const TREND_LINE_AREA_GRADIENT_STOPS = [
   { offset: 1, opacity: 0 },
 ] as const;
 
-const CHART_MODE_TOGGLE_PADDING = 0.25;
-const CHART_MODE_TOGGLE_BORDER_OPACITY = 0.08;
-const CHART_MODE_TOGGLE_BACKGROUND_OPACITY = 0.035;
-const CHART_MODE_TOGGLE_SLIDER_INSET = 3;
-const CHART_MODE_TOGGLE_SLIDER_WIDTH = `calc(50% - ${CHART_MODE_TOGGLE_SLIDER_INSET}px)`;
-const CHART_MODE_TOGGLE_SLIDER_OPACITY = 0.95;
-const CHART_MODE_TOGGLE_SLIDER_SHADOW_OPACITY = 0.16;
-const CHART_MODE_TOGGLE_TRANSITION =
-  'transform 0.22s ease, box-shadow 0.22s ease, background-color 0.22s ease';
 const CHART_MODE_TOGGLE_BUTTON_SIZE = {
   width: 36,
   height: 26,
@@ -214,47 +205,12 @@ const getTrendBarShadowBlur = (seriesKey: TrendSeriesKey) =>
     ? TREND_BAR_PRIMARY_SHADOW_BLUR
     : TREND_BAR_SECONDARY_SHADOW_BLUR;
 
-const getChartModeSliderOffset = (chartMode: TrendChartMode) =>
-  chartMode === 'bar' ? 'translateX(100%)' : 'translateX(0)';
-
-const getBarLayoutSliderOffset = (barLayout: TrendBarLayout) =>
-  barLayout === 'grouped' ? 'translateX(100%)' : 'translateX(0)';
-
-const getChartModeToggleSx = (theme: Theme, chartMode: TrendChartMode) => ({
-  position: 'relative',
+// No container, border, or fill: the selected control is marked by its text
+// (or icon) turning green; unselected stays neutral. Matches the Live
+// Activity filter styling.
+const getChartModeToggleSx = (theme: Theme) => ({
   gap: 0,
-  p: CHART_MODE_TOGGLE_PADDING,
-  borderRadius: 999,
-  border: `1px solid ${alpha(
-    theme.palette.text.primary,
-    CHART_MODE_TOGGLE_BORDER_OPACITY,
-  )}`,
-  backgroundColor: alpha(
-    theme.palette.text.primary,
-    CHART_MODE_TOGGLE_BACKGROUND_OPACITY,
-  ),
-  overflow: 'hidden',
-  '&::before': {
-    content: '""',
-    position: 'absolute',
-    top: CHART_MODE_TOGGLE_SLIDER_INSET,
-    bottom: CHART_MODE_TOGGLE_SLIDER_INSET,
-    left: CHART_MODE_TOGGLE_SLIDER_INSET,
-    width: CHART_MODE_TOGGLE_SLIDER_WIDTH,
-    borderRadius: 999,
-    backgroundColor: alpha(
-      theme.palette.diff.additions,
-      CHART_MODE_TOGGLE_SLIDER_OPACITY,
-    ),
-    boxShadow: `0 8px 18px ${alpha(
-      theme.palette.diff.additions,
-      CHART_MODE_TOGGLE_SLIDER_SHADOW_OPACITY,
-    )}`,
-    transform: getChartModeSliderOffset(chartMode),
-    transition: CHART_MODE_TOGGLE_TRANSITION,
-  },
   '& .MuiToggleButtonGroup-grouped': {
-    zIndex: 1,
     border: 0,
     borderRadius: '999px !important',
     px: 0,
@@ -270,25 +226,19 @@ const getChartModeToggleSx = (theme: Theme, chartMode: TrendChartMode) => ({
     fontWeight: 700,
     letterSpacing: '0.05em',
     textTransform: 'uppercase',
+    backgroundColor: 'transparent',
     '&.Mui-selected': {
-      color: theme.palette.background.paper,
+      color: theme.palette.diff.additions,
       backgroundColor: 'transparent',
     },
     '&.Mui-selected:hover': {
+      color: theme.palette.diff.additions,
       backgroundColor: 'transparent',
     },
     '&:hover': {
       backgroundColor: 'transparent',
       color: theme.palette.text.primary,
     },
-  },
-});
-
-const getBarLayoutToggleSx = (theme: Theme, barLayout: TrendBarLayout) => ({
-  ...getChartModeToggleSx(theme, 'line'),
-  '&::before': {
-    ...getChartModeToggleSx(theme, 'line')['&::before'],
-    transform: getBarLayoutSliderOffset(barLayout),
   },
 });
 
@@ -357,6 +307,7 @@ const buildContributionTrendChartOption = ({
       formatter: (
         params: Array<{
           axisValueLabel: string;
+          name: string;
           seriesName: string;
           seriesIndex: number;
           value: number;
@@ -391,7 +342,7 @@ const buildContributionTrendChartOption = ({
 
         return `
           <div style="display:grid;gap:6px;font-family:${chartFontFamily};min-width:160px;">
-            <div style="color:${tooltipPrimaryColor};font-weight:700;">${params[0]?.axisValueLabel || ''}</div>
+            <div style="color:${tooltipPrimaryColor};font-weight:700;">${params[0]?.name || params[0]?.axisValueLabel || ''}</div>
             ${rows}
             ${totalRow}
           </div>
@@ -409,6 +360,12 @@ const buildContributionTrendChartOption = ({
         fontSize: TREND_CHART_AXIS_LABEL_FONT_SIZE,
         interval: labelInterval,
         hideOverlap: true,
+        // All-time labels are full week ranges ("Dec 14 – 20, 2025") for the
+        // tooltip; the axis only shows the week's start date.
+        formatter:
+          range === 'all'
+            ? (value: string) => value.split(' – ')[0]
+            : undefined,
       },
       axisLine: {
         lineStyle: {
@@ -650,7 +607,7 @@ const ContributionTrends: React.FC<ContributionTrendsProps> = ({
             }}
             size="small"
             aria-label="Contribution timeline chart mode"
-            sx={getChartModeToggleSx(theme, chartMode)}
+            sx={getChartModeToggleSx(theme)}
           >
             <ToggleButton
               value="line"
@@ -676,7 +633,7 @@ const ContributionTrends: React.FC<ContributionTrendsProps> = ({
               }}
               size="small"
               aria-label="Bar chart layout"
-              sx={getBarLayoutToggleSx(theme, barLayout)}
+              sx={getChartModeToggleSx(theme)}
             >
               <ToggleButton
                 value="stacked"
@@ -720,14 +677,16 @@ const ContributionTrends: React.FC<ContributionTrendsProps> = ({
                 letterSpacing: '0.05em',
                 textTransform: 'uppercase',
                 '&.Mui-selected': {
-                  color: theme.palette.background.paper,
-                  backgroundColor: alpha(theme.palette.diff.additions, 0.95),
+                  color: theme.palette.diff.additions,
+                  backgroundColor: 'transparent',
                 },
                 '&.Mui-selected:hover': {
-                  backgroundColor: alpha(theme.palette.diff.additions, 0.95),
+                  color: theme.palette.diff.additions,
+                  backgroundColor: 'transparent',
                 },
                 '&:hover': {
-                  backgroundColor: alpha(theme.palette.text.primary, 0.06),
+                  backgroundColor: 'transparent',
+                  color: theme.palette.text.primary,
                 },
               },
             }}
@@ -792,45 +751,29 @@ const ContributionTrends: React.FC<ContributionTrendsProps> = ({
                     tabIndex={0}
                     aria-pressed={!isHidden}
                     sx={{
-                      px: 0.95,
+                      // No chip chrome: the legend word carries its series
+                      // color; hidden series fall back to muted gray.
                       py: 0.48,
-                      borderRadius: 999,
-                      border: isHidden
-                        ? `1px solid ${theme.palette.border.subtle}`
-                        : `1px solid ${theme.palette.border.light}`,
-                      backgroundColor: isHidden
-                        ? 'transparent'
-                        : theme.palette.surface.subtle,
                       cursor: 'pointer',
+                      transition: 'opacity 0.18s ease, color 0.18s ease',
                       opacity: isHidden ? 0.55 : 1,
-                      transition:
-                        'opacity 0.18s ease, border-color 0.18s ease, background-color 0.18s ease',
                       '&:hover': {
-                        borderColor: alpha(seriesColor, 0.5),
-                        backgroundColor: alpha(seriesColor, 0.06),
+                        opacity: 1,
                       },
                       '&:focus-visible': {
                         outline: `2px solid ${alpha(seriesColor, 0.5)}`,
                         outlineOffset: '2px',
+                        borderRadius: 999,
                       },
                     }}
                   >
-                    <Box
-                      sx={{
-                        width: 10,
-                        height: 10,
-                        borderRadius: '50%',
-                        backgroundColor: seriesColor,
-                        boxShadow: `0 0 0 1px ${seriesColor}`,
-                        opacity: isHidden ? 0.35 : presentation.lineOpacity,
-                      }}
-                    />
                     <Typography
                       sx={{
                         color: isHidden
                           ? alpha(theme.palette.text.primary, 0.46)
-                          : alpha(theme.palette.text.primary, 0.72),
+                          : seriesColor,
                         fontSize: '0.72rem',
+                        fontWeight: 700,
                         lineHeight: 1,
                       }}
                     >

--- a/src/pages/dashboard/views/DashboardOverview.tsx
+++ b/src/pages/dashboard/views/DashboardOverview.tsx
@@ -1,5 +1,5 @@
 import React, { useRef } from 'react';
-import { Box, Card, CardContent, Grid, Stack, Typography } from '@mui/material';
+import { Box, Grid, Stack, Typography } from '@mui/material';
 import { alpha, type Theme, useTheme } from '@mui/material/styles';
 import ReactECharts from 'echarts-for-react';
 import KpiCard from '../../../components/KpiCard';
@@ -224,7 +224,7 @@ const PoolColumn: React.FC<PoolColumnProps> = ({
         border: `1px solid ${theme.palette.border.light}`,
       }}
     >
-      {/* Pool label — matches MinerCard eligibility badge style */}
+      {/* Pool label: plain colored word, no badge chrome */}
       <Typography
         sx={{
           fontFamily: monoFontFamily,
@@ -232,16 +232,9 @@ const PoolColumn: React.FC<PoolColumnProps> = ({
           fontWeight: 700,
           letterSpacing: '0.04em',
           alignSelf: 'flex-start',
-          borderRadius: 1,
-          px: 0.75,
-          py: 0.2,
-          border: `1px solid ${isEligible ? alpha(theme.palette.status.merged, 0.45) : theme.palette.border.subtle}`,
           color: isEligible
             ? theme.palette.status.merged
             : theme.palette.text.secondary,
-          backgroundColor: isEligible
-            ? alpha(theme.palette.status.merged, 0.08)
-            : theme.palette.surface.subtle,
         }}
       >
         {isEligible ? 'Eligible' : 'Ineligible'}
@@ -389,66 +382,51 @@ const DashboardOverview: React.FC<DashboardOverviewProps> = ({
         <Grid container spacing={{ xs: 1.5, md: 2 }}>
           {sections.map((section) => (
             <Grid item xs={12} lg={6} key={section.title}>
-              <Card
-                sx={{
-                  height: '100%',
-                  borderRadius: 3,
-                  border: `1px solid ${theme.palette.border.light}`,
-                  backgroundColor: 'transparent',
-                  overflow: 'visible',
-                }}
-                elevation={0}
-              >
-                <CardContent
-                  sx={{
-                    p: { xs: 1.35, sm: 1.5 },
-                    '&:last-child': { pb: { xs: 1.35, sm: 1.5 } },
-                  }}
-                >
-                  {/* Card header */}
-                  <Box sx={{ mb: 1.25 }}>
-                    <Typography
-                      sx={{
-                        color: theme.palette.text.primary,
-                        fontFamily: monoFontFamily,
-                        fontSize: { xs: '0.98rem', sm: '1.05rem' },
-                        fontWeight: 700,
-                      }}
-                    >
-                      {section.title}
-                    </Typography>
-                    <Typography
-                      sx={{
-                        mt: 0.18,
-                        color: 'text.secondary',
-                        fontFamily: monoFontFamily,
-                        fontSize: '0.7rem',
-                        letterSpacing: '0.02em',
-                      }}
-                    >
-                      {rangeDescription}
-                    </Typography>
-                  </Box>
+              {/* Section header sits directly on the canvas; the pool
+                  columns below are the only card layer. */}
+              <Box sx={{ height: '100%' }}>
+                <Box sx={{ mb: 1.25 }}>
+                  <Typography
+                    sx={{
+                      color: theme.palette.text.primary,
+                      fontFamily: monoFontFamily,
+                      fontSize: { xs: '0.98rem', sm: '1.05rem' },
+                      fontWeight: 700,
+                    }}
+                  >
+                    {section.title}
+                  </Typography>
+                  <Typography
+                    sx={{
+                      mt: 0.18,
+                      color: 'text.secondary',
+                      fontFamily: monoFontFamily,
+                      fontSize: '0.7rem',
+                      letterSpacing: '0.02em',
+                    }}
+                  >
+                    {rangeDescription}
+                  </Typography>
+                </Box>
 
-                  {/* Two pools side by side */}
-                  <Grid container spacing={1}>
-                    <Grid item xs={6}>
-                      <PoolColumn
-                        sectionTitle={section.title}
-                        pool={section.eligible}
-                        isEligible={true}
-                      />
-                    </Grid>
-                    <Grid item xs={6}>
-                      <PoolColumn
-                        sectionTitle={section.title}
-                        pool={section.ineligible}
-                        isEligible={false}
-                      />
-                    </Grid>
+                {/* Two pools side by side */}
+                <Grid container spacing={1}>
+                  <Grid item xs={6}>
+                    <PoolColumn
+                      sectionTitle={section.title}
+                      pool={section.eligible}
+                      isEligible={true}
+                    />
                   </Grid>
-                </CardContent>
-              </Card>
+                  <Grid item xs={6}>
+                    <PoolColumn
+                      sectionTitle={section.title}
+                      pool={section.ineligible}
+                      isEligible={false}
+                    />
+                  </Grid>
+                </Grid>
+              </Box>
             </Grid>
           ))}
         </Grid>

--- a/src/pages/dashboard/views/DashboardTopContributors.tsx
+++ b/src/pages/dashboard/views/DashboardTopContributors.tsx
@@ -49,15 +49,9 @@ const DashboardTopContributors: React.FC<DashboardTopContributorsProps> = ({
   };
 
   return (
-    <Box
-      sx={{
-        width: '100%',
-        p: { xs: 1.45, sm: 1.65 },
-        borderRadius: 3,
-        border: `1px solid ${theme.palette.border.light}`,
-        backgroundColor: 'transparent',
-      }}
-    >
+    // Section title sits directly on the canvas; the contributor cards
+    // inside are the only card layer.
+    <Box sx={{ width: '100%' }}>
       <Box
         sx={{
           mb: 1.35,

--- a/src/pages/dashboard/views/LiveCommitLog.tsx
+++ b/src/pages/dashboard/views/LiveCommitLog.tsx
@@ -6,8 +6,6 @@ import React, {
   useState,
 } from 'react';
 import {
-  Card,
-  CardContent,
   Typography,
   Box,
   Stack,
@@ -15,7 +13,6 @@ import {
   useMediaQuery,
   alpha,
   Avatar,
-  Chip,
   Tooltip,
 } from '@mui/material';
 import { formatDistanceToNow } from 'date-fns';
@@ -73,55 +70,13 @@ interface CommitLogEntry {
   score: string;
 }
 
-type CommitStatus = 'merged' | 'open' | 'closed';
-type CommitStatusFilter = 'all' | CommitStatus;
-
-const COMMIT_STATUS_META: Record<
-  CommitStatusFilter,
-  { filterLabel: string; badgeLabel: string; color: string }
-> = {
-  all: {
-    filterLabel: 'All',
-    badgeLabel: 'ALL',
-    color: theme.palette.text.secondary,
-  },
-  merged: {
-    filterLabel: 'Merged',
-    badgeLabel: 'MERGED',
-    color: theme.palette.status.merged,
-  },
-  open: {
-    filterLabel: 'Open',
-    badgeLabel: 'OPEN',
-    color: theme.palette.status.open,
-  },
-  closed: {
-    filterLabel: 'Closed',
-    badgeLabel: 'CLOSED',
-    color: theme.palette.status.closed,
-  },
-};
-
 /** Remaining scroll distance (px) at which the next page starts loading. */
 const SCROLL_BOTTOM_BUFFER_PX = 80;
 /** Debounce delay (ms) for the scroll handler to avoid hammering on fast scroll. */
 const SCROLL_DEBOUNCE_MS = 120;
 
-const COMMIT_STATUS_FILTERS: CommitStatusFilter[] = [
-  'all',
-  'merged',
-  'open',
-  'closed',
-];
-
 const getCommitId = (entry: CommitLogEntry) =>
   `${entry.repository}-${entry.pullRequestNumber}`;
-
-const getCommitStatus = (entry: CommitLogEntry): CommitStatus => {
-  if (entry.mergedAt || entry.prState === 'MERGED') return 'merged';
-  if (entry.prState === 'CLOSED') return 'closed';
-  return 'open';
-};
 
 const getCommitTimestamp = (entry: CommitLogEntry) => {
   const timestamp = entry.mergedAt || entry.prCreatedAt;
@@ -147,7 +102,7 @@ const CommitLogItem: React.FC<{
   const isMerged = !!entry.mergedAt;
   const isClosed = entry.prState === 'CLOSED' && !entry.mergedAt;
 
-  let status = { label: 'OPEN', color: theme.palette.status.neutral };
+  let status = { label: 'OPENED', color: theme.palette.status.neutral };
   if (isMerged)
     status = { label: 'MERGED', color: theme.palette.status.merged };
   else if (isClosed)
@@ -172,28 +127,16 @@ const CommitLogItem: React.FC<{
         borderColor: isNew
           ? theme.palette.secondary.main
           : theme.palette.border.light,
-        backgroundColor: theme.palette.surface.subtle,
-        backdropFilter: 'blur(8px)',
+        backgroundColor: 'transparent',
         transition: 'all 0.2s cubic-bezier(0.4, 0, 0.2, 1)',
         animation: isNew ? 'slideIn 0.5s ease-out' : undefined,
         cursor: 'pointer',
         position: 'relative',
         overflow: 'hidden',
-        '&::before': {
-          content: '""',
-          position: 'absolute',
-          top: 0,
-          left: 0,
-          right: 0,
-          bottom: 0,
-          background: `linear-gradient(90deg, ${alpha(status.color, 0.1)} 0%, transparent 100%)`,
-          opacity: 0.5,
-        },
         '&:hover': {
           borderColor: status.color,
           transform: 'translateX(4px)',
           boxShadow: `0 0 20px ${alpha(status.color, 0.1)}`,
-          '&::before': { opacity: 0.8 },
         },
         '@keyframes slideIn': {
           from: { opacity: 0, transform: 'translateX(-20px)' },
@@ -252,16 +195,17 @@ const CommitLogItem: React.FC<{
             spacing={1}
             sx={{ mb: 0.5 }}
           >
-            <Chip
-              variant="status"
-              label={status.label}
-              size="small"
+            <Typography
+              component="span"
+              variant="caption"
               sx={{
                 color: status.color,
-                borderColor: alpha(status.color, 0.3),
-                backgroundColor: alpha(status.color, 0.1),
+                fontWeight: 700,
+                letterSpacing: '0.04em',
               }}
-            />
+            >
+              {status.label}
+            </Typography>
             {timestampRaw ? (
               <Tooltip
                 title={formatUtcTimestamp(timestampRaw)}
@@ -389,7 +333,6 @@ const LiveCommitLog: React.FC = () => {
   const { data, isLoading, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useInfiniteCommitLog({ refetchInterval: 10000 });
 
-  const [statusFilter, setStatusFilter] = useState<CommitStatusFilter>('all');
   const [logEntries, setLogEntries] = useState<CommitLogEntry[]>([]);
   const [newEntryIds, setNewEntryIds] = useState<Set<string>>(new Set());
   const [, setRelativeTimeTick] = useState(0);
@@ -456,19 +399,15 @@ const LiveCommitLog: React.FC = () => {
 
   const visibleEntries = useMemo(
     () =>
-      [...logEntries]
-        .filter(
-          (entry) =>
-            statusFilter === 'all' || getCommitStatus(entry) === statusFilter,
-        )
-        .sort((a, b) => getCommitTimestamp(b) - getCommitTimestamp(a)),
-    [logEntries, statusFilter],
+      [...logEntries].sort(
+        (a, b) => getCommitTimestamp(b) - getCommitTimestamp(a),
+      ),
+    [logEntries],
   );
 
   const hasAnyEntries = logEntries.length > 0;
   const showInitialLoading = isLoading && !hasAnyEntries;
   const showWaitingForActivity = !showInitialLoading && !hasAnyEntries;
-  const showFilteredEmptyState = hasAnyEntries && visibleEntries.length === 0;
 
   // If the first page doesn't fill the container there is no scroll event to
   // trigger pagination. Check after each render and fetch the next page when
@@ -518,124 +457,41 @@ const LiveCommitLog: React.FC = () => {
   );
 
   return (
-    <Card
+    // Header sits directly on the canvas; the activity entries inside are
+    // the only card layer.
+    <Box
       sx={{
-        borderRadius: 3,
-        border: `1px solid ${theme.palette.border.light}`,
-        backgroundColor: 'transparent',
         height: '100%',
         display: 'flex',
         flexDirection: 'column',
       }}
-      elevation={0}
     >
-      <CardContent
+      <Box
         sx={{
           flex: 1,
-          p: isMobile ? 1.5 : isTablet ? 1.75 : 2,
-          '&:last-child': { pb: isMobile ? 1.5 : isTablet ? 1.75 : 2 },
+          // No vertical padding: the header lines up with the "Active
+          // Network" title and the feed's bottom edge lines up with the
+          // main column's bottom.
           display: 'flex',
           flexDirection: 'column',
           overflow: 'hidden',
           minHeight: 0,
         }}
       >
-        <Stack
-          spacing={0.5}
-          useFlexGap
-          sx={{ mb: isMobile ? 1 : 1.5, flexShrink: 0 }}
+        <Typography
+          variant="h6"
+          sx={{
+            // Matches the "Active Network" header metrics exactly so the
+            // first entry card's top lines up with the chart card's top.
+            fontSize: { xs: '1.02rem', sm: '1.1rem' },
+            fontWeight: 700,
+            lineHeight: 1.5,
+            mb: isMobile ? 1 : 1.1,
+            flexShrink: 0,
+          }}
         >
-          <Stack
-            direction="row"
-            alignItems="center"
-            justifyContent="space-between"
-          >
-            <Typography
-              variant="h6"
-              sx={{
-                fontSize: isMobile ? '0.9rem' : isTablet ? '0.95rem' : '1rem',
-                fontWeight: 500,
-              }}
-            >
-              Live Activity
-            </Typography>
-            <Box
-              sx={{
-                width: 8,
-                height: 8,
-                borderRadius: '50%',
-                backgroundColor: theme.palette.success.main,
-                animation: 'pulse 2s infinite',
-                '@keyframes pulse': {
-                  '0%, 100%': { opacity: 1 },
-                  '50%': { opacity: 0.5 },
-                },
-              }}
-            />
-          </Stack>
-          <Box
-            sx={{
-              mt: 0.5,
-              borderBottom: (t) => `1px solid ${t.palette.border.light}`,
-            }}
-          />
-          <Box
-            sx={(t) => ({
-              mt: 1,
-              mb: '1px',
-              display: 'inline-flex',
-              alignSelf: 'center',
-              gap: 0.5,
-              p: 0.5,
-              borderRadius: 2,
-              backgroundColor: t.palette.surface.light,
-            })}
-          >
-            {COMMIT_STATUS_FILTERS.map((filter) => {
-              const option = COMMIT_STATUS_META[filter];
-              const selected = statusFilter === filter;
-
-              return (
-                <Box
-                  key={filter}
-                  component="button"
-                  type="button"
-                  aria-pressed={selected}
-                  onClick={() => setStatusFilter(filter)}
-                  sx={(t) => ({
-                    px: isMobile ? 1.35 : 1.6,
-                    height: isMobile ? 22 : 24,
-                    display: 'flex',
-                    alignItems: 'center',
-                    border: 0,
-                    borderRadius: 1.5,
-                    backgroundColor: selected
-                      ? alpha(t.palette.text.primary, 0.15)
-                      : 'transparent',
-                    color: selected
-                      ? t.palette.text.primary
-                      : alpha(option.color, 0.82),
-                    cursor: 'pointer',
-                    fontSize: isMobile ? '0.68rem' : '0.72rem',
-                    fontWeight: selected ? 600 : 500,
-                    lineHeight: 1,
-                    transition: 'all 0.2s ease',
-                    '&:hover': {
-                      backgroundColor: alpha(t.palette.text.primary, 0.1),
-                      color: t.palette.text.primary,
-                    },
-                    '&:focus-visible': {
-                      outline: `1px solid ${option.color}`,
-                      outlineOffset: 1,
-                    },
-                  })}
-                >
-                  {option.filterLabel}
-                </Box>
-              );
-            })}
-          </Box>
-        </Stack>
+          Live Activity
+        </Typography>
 
         {showInitialLoading ? (
           <Box
@@ -672,22 +528,6 @@ const LiveCommitLog: React.FC = () => {
               >
                 <Typography variant="body2">Waiting for activity...</Typography>
               </Box>
-            ) : showFilteredEmptyState ? (
-              <Box
-                sx={{
-                  display: 'flex',
-                  justifyContent: 'center',
-                  alignItems: 'center',
-                  py: 8,
-                  color: 'text.secondary',
-                }}
-              >
-                <Typography variant="body2">
-                  No{' '}
-                  {COMMIT_STATUS_META[statusFilter].filterLabel.toLowerCase()}{' '}
-                  activity yet.
-                </Typography>
-              </Box>
             ) : (
               <Stack spacing={isMobile ? 1 : isTablet ? 1.25 : 1}>
                 {visibleEntries.map((entry) => {
@@ -708,8 +548,8 @@ const LiveCommitLog: React.FC = () => {
             )}
           </Box>
         )}
-      </CardContent>
-    </Card>
+      </Box>
+    </Box>
   );
 };
 

--- a/src/pages/dashboard/views/featuredWorkStyles.ts
+++ b/src/pages/dashboard/views/featuredWorkStyles.ts
@@ -3,14 +3,10 @@ import { type SxProps, type Theme, alpha } from '@mui/material/styles';
 type ThemeSxFactory = (theme: Theme) => SxProps<Theme>;
 type FontSxFactory = (theme: Theme, mono: string) => SxProps<Theme>;
 
-export const sectionContainerSx: ThemeSxFactory = (
-  theme: Theme,
-): SxProps<Theme> => ({
+// Section title sits directly on the canvas; the repo cards inside are the
+// only card layer.
+export const sectionContainerSx: ThemeSxFactory = (): SxProps<Theme> => ({
   width: '100%',
-  p: { xs: 1.45, sm: 1.65 },
-  borderRadius: 3,
-  border: `1px solid ${theme.palette.border.light}`,
-  backgroundColor: 'transparent',
 });
 
 export const sectionTitleSx: FontSxFactory = (


### PR DESCRIPTION
## What changed

### Design pass: one card layer on a black canvas
- Removed the outer wrapper cards around every dashboard section (Active Network, Contribution Calendar, OSS Contributions, Issue Discoveries, Featured Contributors/Discoverers/Work, Live Activity). Section labels now sit directly on the canvas with exactly one card layer beneath them.
- All controls speak one language: no pill fills, outlines, or sliders — only the selected item's text takes color. Applied to the chart mode toggle, the 1D/7D/35D/ALL range selector, and the calendar month selector.
- Chart legend chips are now plain series-colored words matching the lines on the chart; click-to-toggle and shift-to-solo behavior preserved.
- Status badges (OPENED/MERGED/CLOSED) and Eligible/Ineligible badges are plain colored words instead of chips.
- Live Activity: gray card fills and status gradient washes removed, filter row and pulse dot removed (feed always shows all activity), open PRs read OPENED, and the header/card edges align pixel-exact with the Active Network column top and bottom.

### Fix: all-time trend chart
- The all-time view's weekly buckets were calendar-aligned, so the last bucket was the partial current week and every series nosedived at the right edge. Buckets are now anchored to the current time, so the last point always covers a full trailing 7 days (verified against live API counts).
- All-time labels carry the full week range and year in the tooltip ("Dec 14 – 20, 2025") while the axis shows the compact start date, resolving the year ambiguity across the Dec–Jan boundary.

## Before / After

### Dashboard (35D default)
| Before | After |
|---|---|
| ![before 35d](https://raw.githubusercontent.com/entrius/gittensor-ui/pr-assets-dashboard-flat-design/pr_before_35d.png) | ![after 35d](https://raw.githubusercontent.com/entrius/gittensor-ui/pr-assets-dashboard-flat-design/pr_after_35d.png) |

### All-time range (note the fake right-edge cliff in Before)
| Before | After |
|---|---|
| ![before all](https://raw.githubusercontent.com/entrius/gittensor-ui/pr-assets-dashboard-flat-design/pr_before_all.png) | ![after all](https://raw.githubusercontent.com/entrius/gittensor-ui/pr-assets-dashboard-flat-design/pr_after_all.png) |

## Validation
- `npm run build` passes; lint-staged ran on commit.
- Screenshot-verified at desktop width: alignment, wrapping, and the all-time chart's right edge match the underlying data.