### PR TITLE
compute pages: observed TTFT (ms) + decode tok/s, settled-score explanations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,6 @@ VITE_REACT_APP_MIRROR_BASE_URL=https://mirror.gittensor.io/api/v1
 
 # Web3Forms — repository registration form delivery
 VITE_WEB3FORMS_ACCESS_KEY=
+
+# Dev only: mock the /serving (compute) endpoints until das ships them
+VITE_SERVING_MOCK=false

--- a/src/api/ServingApi.ts
+++ b/src/api/ServingApi.ts
@@ -64,6 +64,7 @@ const MINER_NUMERIC_FIELDS: readonly (keyof ServingMiner)[] = [
 ];
 const MINER_NULLABLE_NUMERIC_FIELDS: readonly (keyof ServingMiner)[] = [
   'probeTps',
+  'estAlphaPerTempo',
   'estAlphaPerDay',
   'estUsdPerDay',
 ];
@@ -89,13 +90,13 @@ const STATUS_NUMERIC_FIELDS: readonly (keyof ServingStatus)[] = [
   'quarantined',
   'cardEquivalents',
   'poolShare',
-  'poolCap',
-  'gpuHourUsd',
   'roundsLast24h',
-  'retentionDays',
 ];
 const STATUS_NULLABLE_NUMERIC_FIELDS: readonly (keyof ServingStatus)[] = [
+  'poolCap',
+  'gpuHourUsd',
   'alphaPerHour',
+  'estAlphaPerCardTempo',
   'alphaUsd',
   'estAlphaPerCardDay',
   'estUsdPerCardDay',

--- a/src/api/ServingApi.ts
+++ b/src/api/ServingApi.ts
@@ -63,7 +63,8 @@ const MINER_NUMERIC_FIELDS: readonly (keyof ServingMiner)[] = [
   'rounds24h',
 ];
 const MINER_NULLABLE_NUMERIC_FIELDS: readonly (keyof ServingMiner)[] = [
-  'probeTps',
+  'ttftMs',
+  'decodeTps',
   'estAlphaPerTempo',
   'estAlphaPerDay',
   'estUsdPerDay',
@@ -125,7 +126,7 @@ export const normalizeServingMiner = (row: ServingMiner): ServingMiner =>
   coerceNumbers(row, MINER_NUMERIC_FIELDS, MINER_NULLABLE_NUMERIC_FIELDS);
 
 const normalizeServingRound = (row: ServingRound): ServingRound =>
-  coerceNumbers(row, ROUND_NUMERIC_FIELDS, ['probeTps']);
+  coerceNumbers(row, ROUND_NUMERIC_FIELDS, ['ttftMs', 'decodeTps']);
 
 const normalizeServingStatus = (row: ServingStatus): ServingStatus =>
   coerceNumbers(row, STATUS_NUMERIC_FIELDS, STATUS_NULLABLE_NUMERIC_FIELDS);

--- a/src/api/ServingApi.ts
+++ b/src/api/ServingApi.ts
@@ -1,0 +1,215 @@
+// Serving (compute) API hooks — one validator's snapshot of the RTX 5090
+// serving pool. Uses `/serving` endpoints on the main das API.
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import axios, { type AxiosError } from 'axios';
+import { useApiQuery } from './ApiUtils';
+import type {
+  ServingMiner,
+  ServingMinerDetail,
+  ServingRound,
+  ServingStatus,
+} from './models/Serving';
+
+/** Audit rounds are 5 min; a minute keeps the page fresh without hammering. */
+export const SERVING_REFETCH_MS = 60_000;
+
+// Dev-only fixtures while the das endpoints are being built. The mock module
+// is imported lazily so it never ships in the production bundle.
+const USE_SERVING_MOCK =
+  import.meta.env.DEV && import.meta.env.VITE_SERVING_MOCK === 'true';
+
+const notFound = (): AxiosError =>
+  new axios.AxiosError('Not Found', '404', undefined, undefined, {
+    status: 404,
+    statusText: 'Not Found',
+    data: null,
+    headers: {},
+    config: {} as never,
+  });
+
+const useServingMockQuery = <T>(
+  queryName: string,
+  url: string,
+  queryParams: Record<string, string | number | undefined> | undefined,
+  resolve: (mock: typeof import('./mocks/servingMock')) => T | null | undefined,
+  enabled = true,
+) =>
+  useQuery<T, AxiosError>({
+    queryKey: [queryName, url, queryParams],
+    queryFn: async () => {
+      const mock = await import('./mocks/servingMock');
+      const data = resolve(mock);
+      if (data === null || data === undefined) throw notFound();
+      return data;
+    },
+    retry: false,
+    enabled,
+    refetchInterval: SERVING_REFETCH_MS,
+  });
+
+// Numeric columns arrive as strings when TypeORM hands back postgres
+// `numeric`; coerce so callers can sort / format without runtime surprises.
+const MINER_NUMERIC_FIELDS: readonly (keyof ServingMiner)[] = [
+  'uid',
+  'windowMean',
+  'windowN',
+  'served',
+  'credit',
+  'capacity',
+  'roundScore',
+  'settledScore',
+  'readyRounds24h',
+  'rounds24h',
+];
+const MINER_NULLABLE_NUMERIC_FIELDS: readonly (keyof ServingMiner)[] = [
+  'probeTps',
+  'estAlphaPerDay',
+  'estUsdPerDay',
+];
+const ROUND_NUMERIC_FIELDS: readonly (keyof ServingRound)[] = [
+  'windowMean',
+  'windowN',
+  'credit',
+  'capacity',
+  'roundScore',
+  'settledScore',
+  'served',
+];
+const STATUS_NUMERIC_FIELDS: readonly (keyof ServingStatus)[] = [
+  'served',
+  'gateway',
+  'baseline',
+  'passes',
+  'misses',
+  'strikes',
+  'neutral',
+  'ready',
+  'probation',
+  'quarantined',
+  'cardEquivalents',
+  'poolShare',
+  'poolCap',
+  'gpuHourUsd',
+  'roundsLast24h',
+  'retentionDays',
+];
+const STATUS_NULLABLE_NUMERIC_FIELDS: readonly (keyof ServingStatus)[] = [
+  'alphaPerHour',
+  'alphaUsd',
+  'estAlphaPerCardDay',
+  'estUsdPerCardDay',
+];
+
+const coerceNumbers = <T extends object>(
+  row: T,
+  fields: readonly (keyof T)[],
+  nullableFields: readonly (keyof T)[] = [],
+): T => {
+  const next = { ...row } as Record<string, unknown>;
+  for (const field of fields) next[field as string] = Number(row[field]) || 0;
+  for (const field of nullableFields) {
+    const raw = row[field];
+    if (raw === null || raw === undefined || raw === '') {
+      next[field as string] = null;
+    } else {
+      const parsed = Number(raw);
+      next[field as string] = Number.isFinite(parsed) ? parsed : null;
+    }
+  }
+  return next as T;
+};
+
+export const normalizeServingMiner = (row: ServingMiner): ServingMiner =>
+  coerceNumbers(row, MINER_NUMERIC_FIELDS, MINER_NULLABLE_NUMERIC_FIELDS);
+
+const normalizeServingRound = (row: ServingRound): ServingRound =>
+  coerceNumbers(row, ROUND_NUMERIC_FIELDS, ['probeTps']);
+
+const normalizeServingStatus = (row: ServingStatus): ServingStatus =>
+  coerceNumbers(row, STATUS_NUMERIC_FIELDS, STATUS_NULLABLE_NUMERIC_FIELDS);
+
+/** Pool-level snapshot for the latest audit round. 404 → no rounds yet. */
+export const useServingStatus = () => {
+  const live = useApiQuery<ServingStatus>(
+    'useServingStatus',
+    '/serving/status',
+    SERVING_REFETCH_MS,
+    undefined,
+    !USE_SERVING_MOCK,
+  );
+  const mock = useServingMockQuery<ServingStatus>(
+    'useServingStatus',
+    '/serving/status',
+    undefined,
+    (m) => m.mockServingStatus(),
+    USE_SERVING_MOCK,
+  );
+  const query = USE_SERVING_MOCK ? mock : live;
+  const data = useMemo(
+    () => (query.data ? normalizeServingStatus(query.data) : query.data),
+    [query.data],
+  );
+  return { ...query, data };
+};
+
+/** Latest round row per live (uid, hotkey). */
+export const useServingMiners = () => {
+  const live = useApiQuery<ServingMiner[]>(
+    'useServingMiners',
+    '/serving/miners',
+    SERVING_REFETCH_MS,
+    undefined,
+    !USE_SERVING_MOCK,
+  );
+  const mock = useServingMockQuery<ServingMiner[]>(
+    'useServingMiners',
+    '/serving/miners',
+    undefined,
+    (m) => m.mockServingMiners(),
+    USE_SERVING_MOCK,
+  );
+  const query = USE_SERVING_MOCK ? mock : live;
+  const data = useMemo(
+    () => query.data?.map(normalizeServingMiner),
+    [query.data],
+  );
+  return { ...query, data };
+};
+
+/** Per-hotkey history. 404 → hotkey never seen by this validator. */
+export const useServingMinerDetail = (hotkey: string, hours = 24) => {
+  const enabled = hotkey.length > 0;
+  const params = { hours };
+  const url = `/serving/miners/${encodeURIComponent(hotkey)}`;
+  const live = useApiQuery<ServingMinerDetail>(
+    'useServingMinerDetail',
+    url,
+    SERVING_REFETCH_MS,
+    params,
+    enabled && !USE_SERVING_MOCK,
+  );
+  const mock = useServingMockQuery<ServingMinerDetail>(
+    'useServingMinerDetail',
+    url,
+    params,
+    (m) => m.mockServingMinerDetail(hotkey, hours),
+    enabled && USE_SERVING_MOCK,
+  );
+  const query = USE_SERVING_MOCK ? mock : live;
+  const data = useMemo<ServingMinerDetail | undefined>(() => {
+    const raw = query.data;
+    if (!raw) return raw;
+    return {
+      ...raw,
+      miner: raw.miner ? normalizeServingMiner(raw.miner) : null,
+      rounds: (raw.rounds ?? []).map(normalizeServingRound),
+      misses: raw.misses ?? [],
+    };
+  }, [query.data]);
+  return { ...query, data };
+};
+
+/** True when the error is a 404 from the API (no rounds / unknown hotkey). */
+export const isNotFoundError = (error: AxiosError | null | undefined) =>
+  error?.response?.status === 404;

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -9,5 +9,6 @@ export * from './MirrorDashboardApi';
 export * from './PrsApi';
 export * from './ReposApi';
 export * from './SearchApi';
+export * from './ServingApi';
 
 export * from './models';

--- a/src/api/mocks/servingMock.ts
+++ b/src/api/mocks/servingMock.ts
@@ -1,0 +1,182 @@
+// Dev-only fixtures for the /serving endpoints. Enabled via
+// `VITE_SERVING_MOCK=true` while the das endpoints are being built; loaded
+// lazily so nothing here reaches the production bundle.
+import type {
+  ServingMiner,
+  ServingMinerDetail,
+  ServingMinerStatus,
+  ServingRound,
+  ServingStatus,
+} from '../models/Serving';
+
+const VALIDATOR_HOTKEY = '5GroGYvJ9wYfM2ZV8N7nDgWcM4tYkr1yF3QpZbH6sLdKcE2v';
+const ROUND_MS = 5 * 60 * 1000;
+const ALPHA_USD = 0.31;
+
+const latestRoundTs = () =>
+  new Date(Math.floor(Date.now() / ROUND_MS) * ROUND_MS).toISOString();
+
+// Deterministic pseudo-random so the fleet is stable across refetches.
+const seeded = (seed: number) => {
+  let s = seed;
+  return () => {
+    s = (s * 1664525 + 1013904223) % 4294967296;
+    return s / 4294967296;
+  };
+};
+
+const hotkeyFor = (uid: number) =>
+  `5${uid.toString(36).padStart(3, 'a')}${'F7kQmZ2xNpLcT9vRbW4yHdG8sJ3eA6uC1oK5iM0nX'.slice(0, 44)}`;
+
+const FIXTURE_ROWS: Array<{
+  uid: number;
+  status: ServingMinerStatus;
+  username: string | null;
+  githubId: string | null;
+}> = [
+  { uid: 12, status: 'ready', username: 'gpu-octo', githubId: '583231' },
+  { uid: 47, status: 'ready', username: 'serverfarm', githubId: '1024' },
+  { uid: 88, status: 'probation', username: null, githubId: null },
+  { uid: 133, status: 'ready', username: 'blackwell-bob', githubId: '77' },
+  { uid: 160, status: 'quarantined', username: 'carlos4s', githubId: '9001' },
+  { uid: 201, status: 'probation', username: 'newrig', githubId: '5555' },
+];
+
+const buildMiner = (
+  row: (typeof FIXTURE_ROWS)[number],
+  roundTs: string,
+): ServingMiner => {
+  const rand = seeded(row.uid);
+  const ready = row.status === 'ready';
+  const quarantined = row.status === 'quarantined';
+  const windowN = quarantined ? 0 : ready ? 10 : 3 + Math.floor(rand() * 5);
+  const windowMean = quarantined
+    ? 0
+    : ready
+      ? 0.8 + rand() * 0.2
+      : 0.4 + rand() * 0.35;
+  const probeTps = quarantined ? null : 120 + rand() * 90;
+  const capacity = probeTps ? Math.min(probeTps / 180, 1.2) : 0;
+  const credit = ready ? 0.85 + rand() * 0.15 : 0.5 + rand() * 0.4;
+  const roundScore = ready ? credit * capacity : 0;
+  const settledScore = ready ? roundScore * (0.9 + rand() * 0.1) : 0;
+  const rounds24h = 280 + Math.floor(rand() * 8);
+  const readyRounds24h = ready
+    ? rounds24h - Math.floor(rand() * 20)
+    : Math.floor(rand() * 60);
+  const estAlphaPerDay = ready ? settledScore * 54.2 : 0;
+  return {
+    uid: row.uid,
+    hotkey: hotkeyFor(row.uid),
+    githubId: row.githubId,
+    username: row.username,
+    modelId: 'gpt-oss-20b',
+    status: row.status,
+    windowMean: Number(windowMean.toFixed(3)),
+    windowN,
+    windowPassed: ready,
+    quarantinedUntil: quarantined
+      ? new Date(Date.now() + 37 * 60 * 1000).toISOString()
+      : null,
+    served: ready ? 20 + Math.floor(rand() * 40) : 2,
+    credit: Number(credit.toFixed(3)),
+    probeTps: probeTps === null ? null : Number(probeTps.toFixed(1)),
+    capacity: Number(capacity.toFixed(3)),
+    roundScore: Number(roundScore.toFixed(3)),
+    settledScore: Number(settledScore.toFixed(3)),
+    lastMissReason: quarantined
+      ? 'WRONG: reference mismatch on baseline prompt 2'
+      : ready
+        ? null
+        : 'TIMEOUT: no response within 30s on gateway request',
+    roundTs,
+    readyRounds24h,
+    rounds24h,
+    estAlphaPerDay: Number(estAlphaPerDay.toFixed(2)),
+    estUsdPerDay: Number((estAlphaPerDay * ALPHA_USD).toFixed(2)),
+  };
+};
+
+export const mockServingMiners = (): ServingMiner[] => {
+  const roundTs = latestRoundTs();
+  return FIXTURE_ROWS.map((row) => buildMiner(row, roundTs));
+};
+
+export const mockServingStatus = (): ServingStatus => {
+  const miners = mockServingMiners();
+  const ready = miners.filter((m) => m.status === 'ready').length;
+  const cardEquivalents = miners.reduce((sum, m) => sum + m.settledScore, 0);
+  const alphaPerHour = 2.26;
+  return {
+    validatorHotkey: VALIDATOR_HOTKEY,
+    roundTs: latestRoundTs(),
+    served: miners.reduce((sum, m) => sum + m.served, 0),
+    gateway: 96,
+    baseline: 12,
+    passes: 91,
+    misses: 5,
+    strikes: 1,
+    neutral: 0,
+    ready,
+    probation: miners.filter((m) => m.status === 'probation').length,
+    quarantined: miners.filter((m) => m.status === 'quarantined').length,
+    cardEquivalents: Number(cardEquivalents.toFixed(2)),
+    poolShare: 0.0212,
+    poolCap: 0.035,
+    gpuHourUsd: 0.7,
+    alphaPerHour,
+    alphaUsd: ALPHA_USD,
+    estAlphaPerCardDay: Number((alphaPerHour * 24).toFixed(2)),
+    estUsdPerCardDay: Number((alphaPerHour * 24 * ALPHA_USD).toFixed(2)),
+    roundsLast24h: 287,
+    retentionDays: 7,
+  };
+};
+
+export const mockServingMinerDetail = (
+  hotkey: string,
+  hours: number,
+): ServingMinerDetail | null => {
+  const miner = mockServingMiners().find((m) => m.hotkey === hotkey);
+  if (!miner) return null;
+  const rand = seeded(miner.uid * 7);
+  const count = Math.floor((hours * 60) / 5);
+  const end = new Date(miner.roundTs).getTime();
+  const rounds: ServingRound[] = [];
+  for (let i = count - 1; i >= 0; i -= 1) {
+    const ts = new Date(end - i * ROUND_MS).toISOString();
+    const jitter = () => 0.92 + rand() * 0.16;
+    const probeTps =
+      miner.probeTps === null
+        ? null
+        : Number((miner.probeTps * jitter()).toFixed(1));
+    const capacity = probeTps
+      ? Number(Math.min(probeTps / 180, 1.2).toFixed(3))
+      : 0;
+    const credit = Number(Math.min(1, miner.credit * jitter()).toFixed(3));
+    const missed = rand() < 0.04;
+    const roundScore =
+      miner.status === 'ready' && !missed
+        ? Number((credit * capacity).toFixed(3))
+        : 0;
+    rounds.push({
+      roundTs: ts,
+      status: miner.status,
+      windowMean: miner.windowMean,
+      windowN: miner.windowN,
+      credit,
+      probeTps,
+      capacity,
+      roundScore,
+      settledScore: Number((roundScore * 0.95).toFixed(3)),
+      served: missed ? 0 : miner.served,
+      lastMissReason: missed ? 'TIMEOUT: gateway request exceeded 30s' : null,
+    });
+  }
+  const misses = rounds
+    .filter((r) => r.lastMissReason)
+    .slice(-20)
+    .reverse()
+    .map((r) => ({ roundTs: r.roundTs, reason: r.lastMissReason as string }));
+  return { validatorHotkey: VALIDATOR_HOTKEY, miner, rounds, misses };
+};

--- a/src/api/mocks/servingMock.ts
+++ b/src/api/mocks/servingMock.ts
@@ -57,8 +57,9 @@ const buildMiner = (
     : ready
       ? 0.8 + rand() * 0.2
       : 0.4 + rand() * 0.35;
-  const probeTps = quarantined ? null : 120 + rand() * 90;
-  const capacity = probeTps ? Math.min(probeTps / 180, 1.2) : 0;
+  const decodeTps = quarantined ? null : 300 + rand() * 160;
+  const ttftMs = quarantined ? null : 35 + rand() * 120;
+  const capacity = ready ? 1 : 0;
   const credit = ready ? 0.85 + rand() * 0.15 : 0.5 + rand() * 0.4;
   const roundScore = ready ? credit * capacity : 0;
   const settledScore = ready ? roundScore * (0.9 + rand() * 0.1) : 0;
@@ -82,8 +83,9 @@ const buildMiner = (
       : null,
     served: ready ? 20 + Math.floor(rand() * 40) : 2,
     credit: Number(credit.toFixed(3)),
-    probeTps: probeTps === null ? null : Number(probeTps.toFixed(1)),
-    capacity: Number(capacity.toFixed(3)),
+    ttftMs: ttftMs === null ? null : Number(ttftMs.toFixed(1)),
+    decodeTps: decodeTps === null ? null : Number(decodeTps.toFixed(1)),
+    capacity,
     roundScore: Number(roundScore.toFixed(3)),
     settledScore: Number(settledScore.toFixed(3)),
     lastMissReason: quarantined
@@ -158,13 +160,15 @@ export const mockServingMinerDetail = (
   for (let i = count - 1; i >= 0; i -= 1) {
     const ts = new Date(end - i * ROUND_MS).toISOString();
     const jitter = () => 0.92 + rand() * 0.16;
-    const probeTps =
-      miner.probeTps === null
+    const decodeTps =
+      miner.decodeTps === null
         ? null
-        : Number((miner.probeTps * jitter()).toFixed(1));
-    const capacity = probeTps
-      ? Number(Math.min(probeTps / 180, 1.2).toFixed(3))
-      : 0;
+        : Number((miner.decodeTps * jitter()).toFixed(1));
+    const ttftMs =
+      miner.ttftMs === null
+        ? null
+        : Number((miner.ttftMs * jitter()).toFixed(1));
+    const capacity = miner.capacity;
     const credit = Number(Math.min(1, miner.credit * jitter()).toFixed(3));
     const missed = rand() < 0.04;
     const roundScore =
@@ -177,7 +181,8 @@ export const mockServingMinerDetail = (
       windowMean: miner.windowMean,
       windowN: miner.windowN,
       credit,
-      probeTps,
+      ttftMs,
+      decodeTps,
       capacity,
       roundScore,
       settledScore: Number((roundScore * 0.95).toFixed(3)),

--- a/src/api/mocks/servingMock.ts
+++ b/src/api/mocks/servingMock.ts
@@ -25,8 +25,10 @@ const seeded = (seed: number) => {
   };
 };
 
+// 48-char ss58-shaped string so `looksLikeSs58Hotkey` accepts fixtures.
+const HOTKEY_TAIL = 'F7kQmZ2xNpLcT9vRbW4yHdG8sJ3eA6uC1oK5iM9nXvY2rTb';
 const hotkeyFor = (uid: number) =>
-  `5${uid.toString(36).padStart(3, 'a')}${'F7kQmZ2xNpLcT9vRbW4yHdG8sJ3eA6uC1oK5iM0nX'.slice(0, 44)}`;
+  `5${uid.toString(36).padStart(3, 'a')}${HOTKEY_TAIL.slice(0, 44)}`;
 
 const FIXTURE_ROWS: Array<{
   uid: number;
@@ -92,6 +94,7 @@ const buildMiner = (
     roundTs,
     readyRounds24h,
     rounds24h,
+    estAlphaPerTempo: Number((estAlphaPerDay / 20).toFixed(3)),
     estAlphaPerDay: Number(estAlphaPerDay.toFixed(2)),
     estUsdPerDay: Number((estAlphaPerDay * ALPHA_USD).toFixed(2)),
   };
@@ -124,12 +127,21 @@ export const mockServingStatus = (): ServingStatus => {
     poolShare: 0.0212,
     poolCap: 0.035,
     gpuHourUsd: 0.7,
+    pricingSource: 'validator',
     alphaPerHour,
     alphaUsd: ALPHA_USD,
+    estAlphaPerCardTempo: Number((alphaPerHour * 1.2).toFixed(3)),
     estAlphaPerCardDay: Number((alphaPerHour * 24).toFixed(2)),
     estUsdPerCardDay: Number((alphaPerHour * 24 * ALPHA_USD).toFixed(2)),
     roundsLast24h: 287,
-    retentionDays: 7,
+    release: {
+      modelId: 'gpt-oss-20b',
+      runtimePin: 'gittensor-ai-lab/sparkinfer@12954e6',
+      modelSha256:
+        '9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08',
+      modelFile: 'gpt-oss-20b-q8_0.gguf',
+      image: 'entrius/sparkinfer:12954e6',
+    },
   };
 };
 

--- a/src/api/models/Serving.ts
+++ b/src/api/models/Serving.ts
@@ -3,6 +3,20 @@
 
 export type ServingMinerStatus = 'ready' | 'probation' | 'quarantined';
 
+/** Where the alpha price used for USD estimates came from. */
+export type ServingPricingSource = 'validator' | 'taostats' | 'none';
+
+/** The model/runtime pin the validator currently enforces. */
+export interface ServingRelease {
+  modelId: string;
+  /** e.g. "gittensor-ai-lab/sparkinfer@12954e6" */
+  runtimePin: string;
+  modelSha256: string;
+  modelFile: string;
+  /** e.g. "entrius/sparkinfer:12954e6" */
+  image: string;
+}
+
 export interface ServingStatus {
   validatorHotkey: string;
   roundTs: string;
@@ -19,14 +33,18 @@ export interface ServingStatus {
   cardEquivalents: number;
   /** Fraction of subnet emissions flowing to the pool (≤ poolCap). */
   poolShare: number;
-  poolCap: number;
-  gpuHourUsd: number;
+  /** From the validator; null on rows written before the column existed. */
+  poolCap: number | null;
+  gpuHourUsd: number | null;
+  pricingSource: ServingPricingSource;
   alphaPerHour: number | null;
   alphaUsd: number | null;
+  /** Per 72-min tempo. */
+  estAlphaPerCardTempo: number | null;
   estAlphaPerCardDay: number | null;
   estUsdPerCardDay: number | null;
   roundsLast24h: number;
-  retentionDays: number;
+  release: ServingRelease | null;
 }
 
 export interface ServingMiner {
@@ -50,6 +68,7 @@ export interface ServingMiner {
   roundTs: string;
   readyRounds24h: number;
   rounds24h: number;
+  estAlphaPerTempo: number | null;
   estAlphaPerDay: number | null;
   estUsdPerDay: number | null;
 }

--- a/src/api/models/Serving.ts
+++ b/src/api/models/Serving.ts
@@ -59,10 +59,16 @@ export interface ServingMiner {
   windowPassed: boolean;
   quarantinedUntil: string | null;
   served: number;
+  /** Speed credit 0–1: TTFT band × decode band, mean over the round's served requests. */
   credit: number;
-  probeTps: number | null;
+  /** Validator-observed time to first token, mean over the round (ms). */
+  ttftMs: number | null;
+  /** Validator-observed decode rate on served traffic, mean over the round (tok/s). */
+  decodeTps: number | null;
+  /** 1 when this round's hardware attestation passed, else 0. */
   capacity: number;
   roundScore: number;
+  /** Trailing 12-round mean of roundScore — what the miner is paid on. */
   settledScore: number;
   lastMissReason: string | null;
   roundTs: string;
@@ -79,7 +85,8 @@ export interface ServingRound {
   windowMean: number;
   windowN: number;
   credit: number;
-  probeTps: number | null;
+  ttftMs: number | null;
+  decodeTps: number | null;
   capacity: number;
   roundScore: number;
   settledScore: number;

--- a/src/api/models/Serving.ts
+++ b/src/api/models/Serving.ts
@@ -1,0 +1,83 @@
+// Compute (serving) sub-mechanism — one validator's snapshot of the RTX 5090
+// serving pool. All figures are that validator's own audit, not consensus.
+
+export type ServingMinerStatus = 'ready' | 'probation' | 'quarantined';
+
+export interface ServingStatus {
+  validatorHotkey: string;
+  roundTs: string;
+  served: number;
+  gateway: number;
+  baseline: number;
+  passes: number;
+  misses: number;
+  strikes: number;
+  neutral: number;
+  ready: number;
+  probation: number;
+  quarantined: number;
+  cardEquivalents: number;
+  /** Fraction of subnet emissions flowing to the pool (≤ poolCap). */
+  poolShare: number;
+  poolCap: number;
+  gpuHourUsd: number;
+  alphaPerHour: number | null;
+  alphaUsd: number | null;
+  estAlphaPerCardDay: number | null;
+  estUsdPerCardDay: number | null;
+  roundsLast24h: number;
+  retentionDays: number;
+}
+
+export interface ServingMiner {
+  uid: number;
+  hotkey: string;
+  githubId: string | null;
+  username: string | null;
+  modelId: string;
+  status: ServingMinerStatus;
+  windowMean: number;
+  windowN: number;
+  windowPassed: boolean;
+  quarantinedUntil: string | null;
+  served: number;
+  credit: number;
+  probeTps: number | null;
+  capacity: number;
+  roundScore: number;
+  settledScore: number;
+  lastMissReason: string | null;
+  roundTs: string;
+  readyRounds24h: number;
+  rounds24h: number;
+  estAlphaPerDay: number | null;
+  estUsdPerDay: number | null;
+}
+
+export interface ServingRound {
+  roundTs: string;
+  status: ServingMinerStatus;
+  windowMean: number;
+  windowN: number;
+  credit: number;
+  probeTps: number | null;
+  capacity: number;
+  roundScore: number;
+  settledScore: number;
+  served: number;
+  lastMissReason: string | null;
+}
+
+export interface ServingMiss {
+  roundTs: string;
+  reason: string;
+}
+
+export interface ServingMinerDetail {
+  validatorHotkey: string;
+  miner: ServingMiner | null;
+  /** Ascending by time. */
+  rounds: ServingRound[];
+  /** Most recent ≤ 20, newest first. */
+  misses: ServingMiss[];
+}

--- a/src/api/models/index.ts
+++ b/src/api/models/index.ts
@@ -4,3 +4,4 @@ export * from './Issues';
 export * from './Miner';
 export * from './MirrorDashboard';
 export * from './Configurations';
+export * from './Serving';

--- a/src/components/KpiCard.tsx
+++ b/src/components/KpiCard.tsx
@@ -34,15 +34,16 @@ const KpiCard: React.FC<KpiCardProps> = ({
   const valueVariant = isLarge ? 'h2' : 'h4';
   const titleSize = isLarge ? (isMobile ? 14 : 16) : isMobile ? 12 : 14;
 
+  // Numbers (and numeric strings) get locale grouping; any other string —
+  // "$5", "2.12%", "54.2 α", "3 minutes ago" — is displayed as-is.
   const formattedValue =
-    value !== undefined && value !== null
-      ? typeof value === 'string' &&
-        (value.startsWith('$') || value.includes('ل') || value.includes(','))
-        ? value
-        : typeof value === 'number' || typeof value === 'string'
+    value === undefined || value === null
+      ? undefined
+      : typeof value === 'number'
+        ? value.toLocaleString()
+        : value.trim() !== '' && Number.isFinite(Number(value))
           ? Number(value).toLocaleString()
-          : value
-      : undefined;
+          : value;
 
   return (
     <Card

--- a/src/components/compute/ColumnHint.tsx
+++ b/src/components/compute/ColumnHint.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Box, Tooltip } from '@mui/material';
+import { tooltipSlotProps } from '../../theme';
+
+interface ColumnHintProps {
+  label: string;
+  hint: string;
+}
+
+/** Column / KPI label with an explanatory tooltip. */
+export const ColumnHint: React.FC<ColumnHintProps> = ({ label, hint }) => (
+  <Tooltip title={hint} arrow placement="top" slotProps={tooltipSlotProps}>
+    <Box
+      component="span"
+      sx={{
+        textDecoration: 'underline dotted',
+        textUnderlineOffset: 3,
+        cursor: 'help',
+      }}
+    >
+      {label}
+    </Box>
+  </Tooltip>
+);

--- a/src/components/compute/ComputeFleetTable.tsx
+++ b/src/components/compute/ComputeFleetTable.tsx
@@ -59,6 +59,8 @@ const sortValue = (miner: ServingMiner, key: FleetSortKey): number => {
 
 interface ComputeFleetTableProps {
   miners: ServingMiner[];
+  /** False when the validator had no alpha price — payouts render as "—". */
+  priced?: boolean;
   isLoading: boolean;
   isError: boolean;
   emptyState: React.ReactNode;
@@ -66,6 +68,7 @@ interface ComputeFleetTableProps {
 
 export const ComputeFleetTable: React.FC<ComputeFleetTableProps> = ({
   miners,
+  priced = true,
   isLoading,
   isError,
   emptyState,
@@ -128,7 +131,7 @@ export const ComputeFleetTable: React.FC<ComputeFleetTableProps> = ({
       {
         key: 'credit',
         header: 'TTFT credit',
-        width: 100,
+        width: 118,
         align: 'right',
         sortKey: 'credit',
         renderCell: (m) => formatFixed(m.credit, 2),
@@ -136,7 +139,7 @@ export const ComputeFleetTable: React.FC<ComputeFleetTableProps> = ({
       {
         key: 'capacity',
         header: 'Capacity',
-        width: 92,
+        width: 104,
         align: 'right',
         sortKey: 'capacity',
         renderCell: (m) => formatFixed(m.capacity, 2),
@@ -152,7 +155,7 @@ export const ComputeFleetTable: React.FC<ComputeFleetTableProps> = ({
       {
         key: 'uptime',
         header: 'Uptime 24h',
-        width: 100,
+        width: 118,
         align: 'right',
         sortKey: 'uptime',
         renderCell: (m) => formatPercent(uptimeFraction(m)),
@@ -160,10 +163,10 @@ export const ComputeFleetTable: React.FC<ComputeFleetTableProps> = ({
       {
         key: 'alpha',
         header: 'Est. α/day',
-        width: 104,
+        width: 118,
         align: 'right',
         sortKey: 'alpha',
-        renderCell: (m) => formatAlpha(m.estAlphaPerDay),
+        renderCell: (m) => (priced ? formatAlpha(m.estAlphaPerDay) : '—'),
       },
       {
         key: 'lastMiss',
@@ -199,7 +202,7 @@ export const ComputeFleetTable: React.FC<ComputeFleetTableProps> = ({
         },
       },
     ],
-    [muted, theme.palette.status.error],
+    [muted, priced, theme.palette.status.error],
   );
 
   return (
@@ -211,7 +214,7 @@ export const ComputeFleetTable: React.FC<ComputeFleetTableProps> = ({
       isError={isError}
       errorLabel="Could not load the compute fleet."
       emptyState={emptyState}
-      minWidth={1180}
+      minWidth={1280}
       onRowClick={(m) => navigate(computeMinerPath(m.hotkey))}
       sort={{ field: sortField, order: sortOrder, onChange: setSort }}
     />

--- a/src/components/compute/ComputeFleetTable.tsx
+++ b/src/components/compute/ComputeFleetTable.tsx
@@ -4,12 +4,15 @@ import type { ServingMiner } from '../../api';
 import { useDataTableParams } from '../../hooks/useDataTableParams';
 import { computeMinerPath } from '../../utils/paths';
 import { DataTable, type DataTableColumn } from '../common/DataTable';
+import { ColumnHint } from './ColumnHint';
 import { ComputeStatusBadge } from './ComputeStatusBadge';
 import { CopyableHotkey } from './CopyableHotkey';
 import { MissReasonText } from './MissReasonText';
 import {
+  COMPUTE_METRIC_HINTS,
   formatAlpha,
   formatFixed,
+  formatMs,
   formatPercent,
   uptimeFraction,
 } from './computeFormat';
@@ -18,8 +21,8 @@ const SORT_KEYS = [
   'uid',
   'status',
   'tps',
+  'ttft',
   'credit',
-  'capacity',
   'settled',
   'uptime',
   'alpha',
@@ -32,7 +35,7 @@ const STATUS_RANK = { ready: 0, probation: 1, quarantined: 2 } as const;
 const cellSx = { py: 0.75, px: 1, whiteSpace: 'nowrap' } as const;
 const headerSx = { px: 1 } as const;
 
-/** Probe-derived metrics only mean something once a miner is READY. */
+/** Payout only means something once a miner is READY. */
 const readyOnly = (
   miner: ServingMiner,
   render: (m: ServingMiner) => string,
@@ -45,11 +48,11 @@ const sortValue = (miner: ServingMiner, key: FleetSortKey): number => {
     case 'status':
       return STATUS_RANK[miner.status] ?? 3;
     case 'tps':
-      return miner.probeTps ?? -1;
+      return miner.decodeTps ?? -1;
+    case 'ttft':
+      return miner.ttftMs ?? Number.POSITIVE_INFINITY;
     case 'credit':
       return miner.credit;
-    case 'capacity':
-      return miner.capacity;
     case 'settled':
       return miner.settledScore;
     case 'uptime':
@@ -81,7 +84,7 @@ export const ComputeFleetTable: React.FC<ComputeFleetTableProps> = ({
   const { sortField, sortOrder, setSort } = useDataTableParams<FleetSortKey>({
     sortKeys: SORT_KEYS,
     defaultSortKey: 'settled',
-    defaultOrderOverrides: { uid: 'asc', status: 'asc' },
+    defaultOrderOverrides: { uid: 'asc', status: 'asc', ttft: 'asc' },
   });
 
   const rows = useMemo(() => {
@@ -122,37 +125,39 @@ export const ComputeFleetTable: React.FC<ComputeFleetTableProps> = ({
       },
       {
         key: 'tps',
-        header: 'tok/s',
+        header: <ColumnHint label="tok/s" hint={COMPUTE_METRIC_HINTS.tps} />,
         width: 76,
         align: 'right',
         sortKey: 'tps',
         cellSx,
         headerSx,
-        renderCell: (m) => readyOnly(m, (x) => formatFixed(x.probeTps, 0)),
+        renderCell: (m) => formatFixed(m.decodeTps, 0),
+      },
+      {
+        key: 'ttft',
+        header: <ColumnHint label="TTFT" hint={COMPUTE_METRIC_HINTS.ttft} />,
+        width: 84,
+        align: 'right',
+        sortKey: 'ttft',
+        cellSx,
+        headerSx,
+        renderCell: (m) => formatMs(m.ttftMs),
       },
       {
         key: 'credit',
-        header: 'TTFT',
+        header: <ColumnHint label="Speed" hint={COMPUTE_METRIC_HINTS.credit} />,
         width: 76,
         align: 'right',
         sortKey: 'credit',
         cellSx,
         headerSx,
-        renderCell: (m) => readyOnly(m, (x) => formatFixed(x.credit, 2)),
-      },
-      {
-        key: 'capacity',
-        header: 'Capacity',
-        width: 104,
-        align: 'right',
-        sortKey: 'capacity',
-        cellSx,
-        headerSx,
-        renderCell: (m) => readyOnly(m, (x) => formatFixed(x.capacity, 2)),
+        renderCell: (m) => formatFixed(m.credit, 2),
       },
       {
         key: 'settled',
-        header: 'Settled',
+        header: (
+          <ColumnHint label="Settled" hint={COMPUTE_METRIC_HINTS.settled} />
+        ),
         width: 86,
         align: 'right',
         sortKey: 'settled',

--- a/src/components/compute/ComputeFleetTable.tsx
+++ b/src/components/compute/ComputeFleetTable.tsx
@@ -1,25 +1,22 @@
 import React, { useMemo } from 'react';
-import { Box, Tooltip, Typography, alpha, useTheme } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
 import type { ServingMiner } from '../../api';
 import { useDataTableParams } from '../../hooks/useDataTableParams';
-import { TEXT_OPACITY, tooltipSlotProps } from '../../theme';
 import { computeMinerPath } from '../../utils/paths';
 import { DataTable, type DataTableColumn } from '../common/DataTable';
 import { ComputeStatusBadge } from './ComputeStatusBadge';
 import { CopyableHotkey } from './CopyableHotkey';
+import { MissReasonText } from './MissReasonText';
 import {
   formatAlpha,
   formatFixed,
   formatPercent,
-  formatWindow,
   uptimeFraction,
 } from './computeFormat';
 
 const SORT_KEYS = [
   'uid',
   'status',
-  'window',
   'tps',
   'credit',
   'capacity',
@@ -30,7 +27,16 @@ const SORT_KEYS = [
 type FleetSortKey = (typeof SORT_KEYS)[number];
 
 const STATUS_RANK = { ready: 0, probation: 1, quarantined: 2 } as const;
-const LAST_MISS_MAX_CHARS = 28;
+
+// Compact single-line rows; numeric cells right-aligned.
+const cellSx = { py: 0.75, px: 1, whiteSpace: 'nowrap' } as const;
+const headerSx = { px: 1 } as const;
+
+/** Probe-derived metrics only mean something once a miner is READY. */
+const readyOnly = (
+  miner: ServingMiner,
+  render: (m: ServingMiner) => string,
+): string => (miner.status === 'ready' ? render(miner) : '—');
 
 const sortValue = (miner: ServingMiner, key: FleetSortKey): number => {
   switch (key) {
@@ -38,8 +44,6 @@ const sortValue = (miner: ServingMiner, key: FleetSortKey): number => {
       return miner.uid;
     case 'status':
       return STATUS_RANK[miner.status] ?? 3;
-    case 'window':
-      return miner.windowMean;
     case 'tps':
       return miner.probeTps ?? -1;
     case 'credit':
@@ -73,7 +77,6 @@ export const ComputeFleetTable: React.FC<ComputeFleetTableProps> = ({
   isError,
   emptyState,
 }) => {
-  const theme = useTheme();
   const navigate = useNavigate();
   const { sortField, sortOrder, setSort } = useDataTableParams<FleetSortKey>({
     sortKeys: SORT_KEYS,
@@ -89,52 +92,53 @@ export const ComputeFleetTable: React.FC<ComputeFleetTableProps> = ({
     });
   }, [miners, sortField, sortOrder]);
 
-  const muted = alpha(theme.palette.common.white, TEXT_OPACITY.muted);
-
   const columns = useMemo<DataTableColumn<ServingMiner, FleetSortKey>[]>(
     () => [
       {
         key: 'uid',
         header: 'UID',
-        width: 64,
+        width: 60,
         sortKey: 'uid',
+        cellSx,
+        headerSx,
         renderCell: (m) => m.uid,
       },
       {
         key: 'hotkey',
         header: 'Hotkey',
-        width: 170,
+        width: 140,
+        cellSx,
+        headerSx,
         renderCell: (m) => <CopyableHotkey hotkey={m.hotkey} edge={5} />,
       },
       {
         key: 'status',
         header: 'Status',
-        width: 120,
+        width: 118,
         sortKey: 'status',
+        cellSx,
+        headerSx,
         renderCell: (m) => <ComputeStatusBadge status={m.status} />,
-      },
-      {
-        key: 'window',
-        header: 'Window',
-        width: 110,
-        sortKey: 'window',
-        renderCell: (m) => formatWindow(m),
       },
       {
         key: 'tps',
         header: 'tok/s',
-        width: 84,
+        width: 76,
         align: 'right',
         sortKey: 'tps',
-        renderCell: (m) => formatFixed(m.probeTps, 0),
+        cellSx,
+        headerSx,
+        renderCell: (m) => readyOnly(m, (x) => formatFixed(x.probeTps, 0)),
       },
       {
         key: 'credit',
-        header: 'TTFT credit',
-        width: 118,
+        header: 'TTFT',
+        width: 76,
         align: 'right',
         sortKey: 'credit',
-        renderCell: (m) => formatFixed(m.credit, 2),
+        cellSx,
+        headerSx,
+        renderCell: (m) => readyOnly(m, (x) => formatFixed(x.credit, 2)),
       },
       {
         key: 'capacity',
@@ -142,67 +146,50 @@ export const ComputeFleetTable: React.FC<ComputeFleetTableProps> = ({
         width: 104,
         align: 'right',
         sortKey: 'capacity',
-        renderCell: (m) => formatFixed(m.capacity, 2),
+        cellSx,
+        headerSx,
+        renderCell: (m) => readyOnly(m, (x) => formatFixed(x.capacity, 2)),
       },
       {
         key: 'settled',
         header: 'Settled',
-        width: 92,
+        width: 86,
         align: 'right',
         sortKey: 'settled',
+        cellSx,
+        headerSx,
         renderCell: (m) => formatFixed(m.settledScore, 3),
       },
       {
         key: 'uptime',
         header: 'Uptime 24h',
-        width: 118,
+        width: 120,
         align: 'right',
         sortKey: 'uptime',
+        cellSx,
+        headerSx,
         renderCell: (m) => formatPercent(uptimeFraction(m)),
       },
       {
         key: 'alpha',
         header: 'Est. α/day',
-        width: 118,
+        width: 120,
         align: 'right',
         sortKey: 'alpha',
-        renderCell: (m) => (priced ? formatAlpha(m.estAlphaPerDay) : '—'),
+        cellSx,
+        headerSx,
+        renderCell: (m) =>
+          priced ? readyOnly(m, (x) => formatAlpha(x.estAlphaPerDay)) : '—',
       },
       {
         key: 'lastMiss',
         header: 'Last miss',
-        width: 200,
-        renderCell: (m) => {
-          const reason = m.lastMissReason?.trim();
-          if (!reason) return <Box sx={{ color: muted }}>—</Box>;
-          const truncated =
-            reason.length > LAST_MISS_MAX_CHARS
-              ? `${reason.slice(0, LAST_MISS_MAX_CHARS)}…`
-              : reason;
-          return (
-            <Tooltip
-              title={reason}
-              arrow
-              placement="top"
-              slotProps={tooltipSlotProps}
-            >
-              <Typography
-                component="span"
-                sx={{
-                  fontSize: 'inherit',
-                  fontFamily: 'inherit',
-                  color: theme.palette.status.error,
-                  whiteSpace: 'nowrap',
-                }}
-              >
-                {truncated}
-              </Typography>
-            </Tooltip>
-          );
-        },
+        cellSx,
+        headerSx,
+        renderCell: (m) => <MissReasonText reason={m.lastMissReason} />,
       },
     ],
-    [muted, priced, theme.palette.status.error],
+    [priced],
   );
 
   return (
@@ -214,7 +201,6 @@ export const ComputeFleetTable: React.FC<ComputeFleetTableProps> = ({
       isError={isError}
       errorLabel="Could not load the compute fleet."
       emptyState={emptyState}
-      minWidth={1280}
       onRowClick={(m) => navigate(computeMinerPath(m.hotkey))}
       sort={{ field: sortField, order: sortOrder, onChange: setSort }}
     />

--- a/src/components/compute/ComputeFleetTable.tsx
+++ b/src/components/compute/ComputeFleetTable.tsx
@@ -1,0 +1,219 @@
+import React, { useMemo } from 'react';
+import { Box, Tooltip, Typography, alpha, useTheme } from '@mui/material';
+import { useNavigate } from 'react-router-dom';
+import type { ServingMiner } from '../../api';
+import { useDataTableParams } from '../../hooks/useDataTableParams';
+import { TEXT_OPACITY, tooltipSlotProps } from '../../theme';
+import { computeMinerPath } from '../../utils/paths';
+import { DataTable, type DataTableColumn } from '../common/DataTable';
+import { ComputeStatusBadge } from './ComputeStatusBadge';
+import { CopyableHotkey } from './CopyableHotkey';
+import {
+  formatAlpha,
+  formatFixed,
+  formatPercent,
+  formatWindow,
+  uptimeFraction,
+} from './computeFormat';
+
+const SORT_KEYS = [
+  'uid',
+  'status',
+  'window',
+  'tps',
+  'credit',
+  'capacity',
+  'settled',
+  'uptime',
+  'alpha',
+] as const;
+type FleetSortKey = (typeof SORT_KEYS)[number];
+
+const STATUS_RANK = { ready: 0, probation: 1, quarantined: 2 } as const;
+const LAST_MISS_MAX_CHARS = 28;
+
+const sortValue = (miner: ServingMiner, key: FleetSortKey): number => {
+  switch (key) {
+    case 'uid':
+      return miner.uid;
+    case 'status':
+      return STATUS_RANK[miner.status] ?? 3;
+    case 'window':
+      return miner.windowMean;
+    case 'tps':
+      return miner.probeTps ?? -1;
+    case 'credit':
+      return miner.credit;
+    case 'capacity':
+      return miner.capacity;
+    case 'settled':
+      return miner.settledScore;
+    case 'uptime':
+      return uptimeFraction(miner) ?? -1;
+    case 'alpha':
+      return miner.estAlphaPerDay ?? -1;
+    default:
+      return 0;
+  }
+};
+
+interface ComputeFleetTableProps {
+  miners: ServingMiner[];
+  isLoading: boolean;
+  isError: boolean;
+  emptyState: React.ReactNode;
+}
+
+export const ComputeFleetTable: React.FC<ComputeFleetTableProps> = ({
+  miners,
+  isLoading,
+  isError,
+  emptyState,
+}) => {
+  const theme = useTheme();
+  const navigate = useNavigate();
+  const { sortField, sortOrder, setSort } = useDataTableParams<FleetSortKey>({
+    sortKeys: SORT_KEYS,
+    defaultSortKey: 'settled',
+    defaultOrderOverrides: { uid: 'asc', status: 'asc' },
+  });
+
+  const rows = useMemo(() => {
+    const direction = sortOrder === 'asc' ? 1 : -1;
+    return [...miners].sort((a, b) => {
+      const diff = sortValue(a, sortField) - sortValue(b, sortField);
+      return diff !== 0 ? diff * direction : a.uid - b.uid;
+    });
+  }, [miners, sortField, sortOrder]);
+
+  const muted = alpha(theme.palette.common.white, TEXT_OPACITY.muted);
+
+  const columns = useMemo<DataTableColumn<ServingMiner, FleetSortKey>[]>(
+    () => [
+      {
+        key: 'uid',
+        header: 'UID',
+        width: 64,
+        sortKey: 'uid',
+        renderCell: (m) => m.uid,
+      },
+      {
+        key: 'hotkey',
+        header: 'Hotkey',
+        width: 170,
+        renderCell: (m) => <CopyableHotkey hotkey={m.hotkey} edge={5} />,
+      },
+      {
+        key: 'status',
+        header: 'Status',
+        width: 120,
+        sortKey: 'status',
+        renderCell: (m) => <ComputeStatusBadge status={m.status} />,
+      },
+      {
+        key: 'window',
+        header: 'Window',
+        width: 110,
+        sortKey: 'window',
+        renderCell: (m) => formatWindow(m),
+      },
+      {
+        key: 'tps',
+        header: 'tok/s',
+        width: 84,
+        align: 'right',
+        sortKey: 'tps',
+        renderCell: (m) => formatFixed(m.probeTps, 0),
+      },
+      {
+        key: 'credit',
+        header: 'TTFT credit',
+        width: 100,
+        align: 'right',
+        sortKey: 'credit',
+        renderCell: (m) => formatFixed(m.credit, 2),
+      },
+      {
+        key: 'capacity',
+        header: 'Capacity',
+        width: 92,
+        align: 'right',
+        sortKey: 'capacity',
+        renderCell: (m) => formatFixed(m.capacity, 2),
+      },
+      {
+        key: 'settled',
+        header: 'Settled',
+        width: 92,
+        align: 'right',
+        sortKey: 'settled',
+        renderCell: (m) => formatFixed(m.settledScore, 3),
+      },
+      {
+        key: 'uptime',
+        header: 'Uptime 24h',
+        width: 100,
+        align: 'right',
+        sortKey: 'uptime',
+        renderCell: (m) => formatPercent(uptimeFraction(m)),
+      },
+      {
+        key: 'alpha',
+        header: 'Est. α/day',
+        width: 104,
+        align: 'right',
+        sortKey: 'alpha',
+        renderCell: (m) => formatAlpha(m.estAlphaPerDay),
+      },
+      {
+        key: 'lastMiss',
+        header: 'Last miss',
+        width: 200,
+        renderCell: (m) => {
+          const reason = m.lastMissReason?.trim();
+          if (!reason) return <Box sx={{ color: muted }}>—</Box>;
+          const truncated =
+            reason.length > LAST_MISS_MAX_CHARS
+              ? `${reason.slice(0, LAST_MISS_MAX_CHARS)}…`
+              : reason;
+          return (
+            <Tooltip
+              title={reason}
+              arrow
+              placement="top"
+              slotProps={tooltipSlotProps}
+            >
+              <Typography
+                component="span"
+                sx={{
+                  fontSize: 'inherit',
+                  fontFamily: 'inherit',
+                  color: theme.palette.status.error,
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                {truncated}
+              </Typography>
+            </Tooltip>
+          );
+        },
+      },
+    ],
+    [muted, theme.palette.status.error],
+  );
+
+  return (
+    <DataTable<ServingMiner, FleetSortKey>
+      columns={columns}
+      rows={rows}
+      getRowKey={(m) => `${m.uid}-${m.hotkey}`}
+      isLoading={isLoading}
+      isError={isError}
+      errorLabel="Could not load the compute fleet."
+      emptyState={emptyState}
+      minWidth={1180}
+      onRowClick={(m) => navigate(computeMinerPath(m.hotkey))}
+      sort={{ field: sortField, order: sortOrder, onChange: setSort }}
+    />
+  );
+};

--- a/src/components/compute/ComputeMissesTable.tsx
+++ b/src/components/compute/ComputeMissesTable.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import type { ServingMiss } from '../../api';
+import { DataTable, type DataTableColumn } from '../common/DataTable';
+import { formatRoundTime } from './computeFormat';
+
+const columns: DataTableColumn<ServingMiss>[] = [
+  {
+    key: 'time',
+    header: 'Round',
+    width: 160,
+    renderCell: (miss) => formatRoundTime(miss.roundTs),
+  },
+  {
+    key: 'reason',
+    header: 'Reason',
+    renderCell: (miss) => miss.reason,
+    cellSx: { whiteSpace: 'normal', overflowWrap: 'anywhere' },
+  },
+];
+
+export const ComputeMissesTable: React.FC<{ misses: ServingMiss[] }> = ({
+  misses,
+}) => (
+  <DataTable<ServingMiss>
+    columns={columns}
+    rows={misses}
+    getRowKey={(miss) => `${miss.roundTs}-${miss.reason}`}
+    emptyLabel="No misses recorded in this window."
+    minWidth={480}
+  />
+);

--- a/src/components/compute/ComputeMissesTable.tsx
+++ b/src/components/compute/ComputeMissesTable.tsx
@@ -1,20 +1,26 @@
 import React from 'react';
 import type { ServingMiss } from '../../api';
 import { DataTable, type DataTableColumn } from '../common/DataTable';
+import { MissReasonText } from './MissReasonText';
 import { formatRoundTime } from './computeFormat';
+
+const cellSx = { py: 0.75, whiteSpace: 'nowrap' } as const;
 
 const columns: DataTableColumn<ServingMiss>[] = [
   {
     key: 'time',
     header: 'Round',
-    width: 160,
+    width: 170,
+    cellSx,
     renderCell: (miss) => formatRoundTime(miss.roundTs),
   },
   {
     key: 'reason',
     header: 'Reason',
-    renderCell: (miss) => miss.reason,
-    cellSx: { whiteSpace: 'normal', overflowWrap: 'anywhere' },
+    cellSx,
+    renderCell: (miss) => (
+      <MissReasonText reason={miss.reason} maxWidth="100%" />
+    ),
   },
 ];
 
@@ -26,6 +32,5 @@ export const ComputeMissesTable: React.FC<{ misses: ServingMiss[] }> = ({
     rows={misses}
     getRowKey={(miss) => `${miss.roundTs}-${miss.reason}`}
     emptyLabel="No misses recorded in this window."
-    minWidth={480}
   />
 );

--- a/src/components/compute/ComputeReleaseCard.tsx
+++ b/src/components/compute/ComputeReleaseCard.tsx
@@ -16,9 +16,8 @@ import type { ServingRelease } from '../../api';
 import { useClipboardCopy } from '../../hooks/useClipboardCopy';
 import { TEXT_OPACITY, scrollbarSx, tooltipSlotProps } from '../../theme';
 
-const LOADOUT_URL =
-  'https://github.com/entrius/gittensor/blob/main/gittensor/validator/weights/serving_loadout.json';
-const DOCKER_HUB_URL = 'https://hub.docker.com/r/entrius/sparkinfer/tags';
+// Images for every blessed runtime/model live under the entrius org; the release row says which one to pull.
+const DOCKER_HUB_URL = 'https://hub.docker.com/u/entrius';
 
 const MONO = '"JetBrains Mono", monospace';
 
@@ -206,10 +205,7 @@ export const ComputeReleaseCard: React.FC<{ release: ServingRelease }> = ({
       </Box>
 
       <Stack direction="row" flexWrap="wrap" gap={2} sx={{ mt: 1.5 }}>
-        {[
-          { label: 'serving_loadout.json', href: LOADOUT_URL },
-          { label: 'entrius/sparkinfer on Docker Hub', href: DOCKER_HUB_URL },
-        ].map((link) => (
+        {[{ label: 'Docker Hub', href: DOCKER_HUB_URL }].map((link) => (
           <Link
             key={link.href}
             href={link.href}

--- a/src/components/compute/ComputeReleaseCard.tsx
+++ b/src/components/compute/ComputeReleaseCard.tsx
@@ -191,11 +191,12 @@ export const ComputeReleaseCard: React.FC<{ release: ServingRelease }> = ({
             m: 0,
             flex: 1,
             minWidth: 0,
-            overflowX: 'auto',
+            overflowX: 'hidden',
             fontFamily: MONO,
             fontSize: '0.78rem',
             lineHeight: 1.5,
-            whiteSpace: 'pre',
+            whiteSpace: 'pre-wrap',
+            overflowWrap: 'anywhere',
             ...scrollbarSx,
           }}
         >

--- a/src/components/compute/ComputeReleaseCard.tsx
+++ b/src/components/compute/ComputeReleaseCard.tsx
@@ -1,0 +1,233 @@
+import React from 'react';
+import {
+  Box,
+  ButtonBase,
+  Link,
+  Stack,
+  Tooltip,
+  Typography,
+  alpha,
+  useTheme,
+} from '@mui/material';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import CheckIcon from '@mui/icons-material/Check';
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
+import type { ServingRelease } from '../../api';
+import { useClipboardCopy } from '../../hooks/useClipboardCopy';
+import { TEXT_OPACITY, scrollbarSx, tooltipSlotProps } from '../../theme';
+
+const LOADOUT_URL =
+  'https://github.com/entrius/gittensor/blob/main/gittensor/validator/weights/serving_loadout.json';
+const DOCKER_HUB_URL = 'https://hub.docker.com/r/entrius/sparkinfer/tags';
+
+const MONO = '"JetBrains Mono", monospace';
+
+/** The exact command miners run; kept in one place so docs can link here. */
+export const buildSparkinferRunCommand = (release: ServingRelease): string =>
+  `docker run -d --name sparkinfer --gpus all -p 8080:8080 -v sparkmodels:/opt/sparkinfer/models -e MODEL_SHA256=${release.modelSha256} -e SPARKINFER_DETERMINISTIC=1 ${release.image}`;
+
+const CopyButton: React.FC<{ text: string; label: string }> = ({
+  text,
+  label,
+}) => {
+  const { copied, copy, liveRegion } = useClipboardCopy({
+    copiedMessage: `${label} copied to clipboard`,
+  });
+  return (
+    <>
+      <Tooltip
+        title={copied ? 'Copied' : `Copy ${label}`}
+        arrow
+        placement="top"
+        slotProps={tooltipSlotProps}
+      >
+        <ButtonBase
+          onClick={() => void copy(text)}
+          aria-label={`Copy ${label}`}
+          sx={{
+            p: 0.5,
+            borderRadius: '4px',
+            color: (t) =>
+              copied
+                ? t.palette.status.success
+                : alpha(t.palette.text.primary, 0.55),
+            '&:hover': { color: (t) => t.palette.text.primary },
+            '&:focus-visible': {
+              outline: (t) => `2px solid ${t.palette.primary.main}`,
+            },
+          }}
+        >
+          {copied ? (
+            <CheckIcon sx={{ fontSize: '1rem' }} />
+          ) : (
+            <ContentCopyIcon sx={{ fontSize: '1rem' }} />
+          )}
+        </ButtonBase>
+      </Tooltip>
+      {liveRegion}
+    </>
+  );
+};
+
+const Field: React.FC<{
+  label: string;
+  value: string;
+  copyable?: boolean;
+}> = ({ label, value, copyable = false }) => {
+  const theme = useTheme();
+  return (
+    <Box sx={{ minWidth: 0 }}>
+      <Typography
+        variant="dataLabel"
+        sx={{
+          display: 'block',
+          color: alpha(theme.palette.common.white, TEXT_OPACITY.muted),
+          mb: 0.25,
+        }}
+      >
+        {label}
+      </Typography>
+      <Stack direction="row" alignItems="center" gap={0.5} sx={{ minWidth: 0 }}>
+        <Typography
+          component="span"
+          sx={{
+            fontFamily: MONO,
+            fontSize: '0.82rem',
+            overflowWrap: 'anywhere',
+            minWidth: 0,
+          }}
+        >
+          {value}
+        </Typography>
+        {copyable ? <CopyButton text={value} label={label} /> : null}
+      </Stack>
+    </Box>
+  );
+};
+
+/**
+ * The validator-enforced runtime/model pin. This is the canonical place
+ * miners get the pin and digest — docs link here — so nothing is hard-coded.
+ */
+export const ComputeReleaseCard: React.FC<{ release: ServingRelease }> = ({
+  release,
+}) => {
+  const theme = useTheme();
+  const command = buildSparkinferRunCommand(release);
+  const muted = alpha(theme.palette.common.white, TEXT_OPACITY.muted);
+  return (
+    <Box
+      component="section"
+      aria-labelledby="compute-release-title"
+      sx={{
+        borderRadius: 3,
+        border: `1px solid ${theme.palette.border.light}`,
+        px: { xs: 2, sm: 3 },
+        py: { xs: 2, sm: 2.5 },
+      }}
+    >
+      <Stack
+        direction="row"
+        alignItems="baseline"
+        justifyContent="space-between"
+        flexWrap="wrap"
+        gap={1}
+        sx={{ mb: 1.5 }}
+      >
+        <Typography
+          id="compute-release-title"
+          variant="sectionTitle"
+          component="h2"
+        >
+          Current release
+        </Typography>
+        <Typography variant="caption" sx={{ color: muted }}>
+          Enforced by the validator this round — pin exactly this.
+        </Typography>
+      </Stack>
+
+      <Box
+        sx={{
+          display: 'grid',
+          gap: { xs: 1.5, sm: 2 },
+          gridTemplateColumns: {
+            xs: '1fr',
+            sm: 'repeat(2, minmax(0, 1fr))',
+            lg: 'repeat(4, minmax(0, 1fr))',
+          },
+          mb: 2,
+        }}
+      >
+        <Field label="Model" value={release.modelId} />
+        <Field label="Runtime pin" value={release.runtimePin} copyable />
+        <Field label="Model file" value={release.modelFile} />
+        <Field label="Image" value={release.image} copyable />
+      </Box>
+      <Box sx={{ mb: 2 }}>
+        <Field label="Model SHA-256" value={release.modelSha256} copyable />
+      </Box>
+
+      <Typography
+        variant="dataLabel"
+        sx={{ display: 'block', color: muted, mb: 0.5 }}
+      >
+        Run it
+      </Typography>
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'flex-start',
+          gap: 1,
+          borderRadius: 2,
+          border: `1px solid ${theme.palette.border.light}`,
+          backgroundColor: theme.palette.surface.subtle,
+          px: 1.5,
+          py: 1,
+        }}
+      >
+        <Box
+          component="pre"
+          sx={{
+            m: 0,
+            flex: 1,
+            minWidth: 0,
+            overflowX: 'auto',
+            fontFamily: MONO,
+            fontSize: '0.78rem',
+            lineHeight: 1.5,
+            whiteSpace: 'pre',
+            ...scrollbarSx,
+          }}
+        >
+          <code>{command}</code>
+        </Box>
+        <CopyButton text={command} label="docker command" />
+      </Box>
+
+      <Stack direction="row" flexWrap="wrap" gap={2} sx={{ mt: 1.5 }}>
+        {[
+          { label: 'serving_loadout.json', href: LOADOUT_URL },
+          { label: 'entrius/sparkinfer on Docker Hub', href: DOCKER_HUB_URL },
+        ].map((link) => (
+          <Link
+            key={link.href}
+            href={link.href}
+            target="_blank"
+            rel="noopener noreferrer"
+            underline="hover"
+            sx={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 0.5,
+              fontSize: '0.8rem',
+              color: theme.palette.status.info,
+            }}
+          >
+            {link.label}
+            <OpenInNewIcon sx={{ fontSize: '0.85rem' }} aria-hidden />
+          </Link>
+        ))}
+      </Stack>
+    </Box>
+  );
+};

--- a/src/components/compute/ComputeRoundChart.tsx
+++ b/src/components/compute/ComputeRoundChart.tsx
@@ -1,0 +1,136 @@
+import React, { useMemo } from 'react';
+import { Box, Typography, alpha, useTheme } from '@mui/material';
+import ReactECharts from 'echarts-for-react';
+import { TEXT_OPACITY } from '../../theme';
+import {
+  echartsAxisTooltipChrome,
+  echartsFontFamily,
+  echartsGridLineChart,
+  echartsMutedCartesianAxisColors,
+  echartsTransparentBackground,
+} from '../../utils/echarts/gittensorChartTheme';
+import { ChartEmptyPanel } from '../common/ChartEmptyPanel';
+import { formatRoundTime } from './computeFormat';
+
+interface ComputeRoundChartProps {
+  title: string;
+  /** ISO round timestamps, ascending. */
+  timestamps: string[];
+  /** Same length as `timestamps`; null gaps break the line. */
+  values: (number | null)[];
+  color: string;
+  /** Fixed y-axis ceiling (e.g. 1 for scores); omit to auto-scale. */
+  yMax?: number;
+  decimals?: number;
+  emptyHint: string;
+  height?: number;
+}
+
+/** Small single-series line chart for one per-round metric. */
+export const ComputeRoundChart: React.FC<ComputeRoundChartProps> = ({
+  title,
+  timestamps,
+  values,
+  color,
+  yMax,
+  decimals = 2,
+  emptyHint,
+  height = 180,
+}) => {
+  const theme = useTheme();
+  const hasData = values.some((v) => v !== null && Number.isFinite(v));
+
+  const option = useMemo(() => {
+    const axis = echartsMutedCartesianAxisColors(theme);
+    const fontFamily = echartsFontFamily(theme);
+    return {
+      ...echartsTransparentBackground(),
+      grid: echartsGridLineChart(),
+      tooltip: {
+        trigger: 'axis',
+        ...echartsAxisTooltipChrome(theme),
+        axisPointer: { type: 'line', lineStyle: { color: axis.axisLineColor } },
+        formatter: (raw: unknown) => {
+          const point = (Array.isArray(raw) ? raw : [raw])[0] as
+            | { dataIndex?: number; value?: number | null }
+            | undefined;
+          if (!point || point.dataIndex === undefined) return '';
+          const value = point.value;
+          const label =
+            value === null || value === undefined
+              ? '—'
+              : Number(value).toFixed(decimals);
+          return `${formatRoundTime(timestamps[point.dataIndex])}<br/><b>${label}</b>`;
+        },
+      },
+      xAxis: {
+        type: 'category',
+        data: timestamps,
+        boundaryGap: false,
+        axisLine: { lineStyle: { color: axis.axisLineColor } },
+        axisTick: { show: false },
+        axisLabel: {
+          color: axis.labelColor,
+          fontSize: 10,
+          fontFamily,
+          hideOverlap: true,
+          formatter: (iso: string) =>
+            new Date(iso).toLocaleTimeString(undefined, {
+              hour: '2-digit',
+              minute: '2-digit',
+            }),
+        },
+      },
+      yAxis: {
+        type: 'value',
+        min: 0,
+        max: yMax,
+        axisLine: { show: false },
+        axisTick: { show: false },
+        axisLabel: { color: axis.labelColor, fontSize: 10, fontFamily },
+        splitLine: { lineStyle: { color: axis.splitLineColor } },
+      },
+      series: [
+        {
+          type: 'line',
+          data: values,
+          showSymbol: false,
+          smooth: false,
+          connectNulls: false,
+          lineStyle: { width: 2, color },
+          areaStyle: { color: alpha(color, 0.12) },
+        },
+      ],
+    };
+  }, [theme, timestamps, values, color, yMax, decimals]);
+
+  return (
+    <Box sx={{ minWidth: 0 }}>
+      <Typography
+        variant="monoSmall"
+        sx={{
+          display: 'block',
+          color: alpha(theme.palette.common.white, TEXT_OPACITY.muted),
+          mb: 0.75,
+        }}
+      >
+        {title}
+      </Typography>
+      <ChartEmptyPanel
+        empty={!hasData}
+        minHeight={height}
+        title="No rounds in range"
+        hint={emptyHint}
+      >
+        <Box sx={{ height, width: '100%' }}>
+          <ReactECharts
+            option={option}
+            notMerge
+            style={{ height: '100%', width: '100%' }}
+            opts={{ renderer: 'svg' }}
+          />
+        </Box>
+      </ChartEmptyPanel>
+    </Box>
+  );
+};

--- a/src/components/compute/ComputeRoundChart.tsx
+++ b/src/components/compute/ComputeRoundChart.tsx
@@ -45,6 +45,7 @@ export const ComputeRoundChart: React.FC<ComputeRoundChartProps> = ({
     const fontFamily = echartsFontFamily(theme);
     return {
       ...echartsTransparentBackground(),
+      animation: false,
       grid: echartsGridLineChart(),
       tooltip: {
         trigger: 'axis',

--- a/src/components/compute/ComputeStatusBadge.tsx
+++ b/src/components/compute/ComputeStatusBadge.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { Box, Tooltip, alpha } from '@mui/material';
+import type { ServingMinerStatus } from '../../api';
+import { tooltipSlotProps } from '../../theme';
+import { COMPUTE_STATUS_META } from './computeFormat';
+
+interface ComputeStatusBadgeProps {
+  status: ServingMinerStatus;
+  size?: 'small' | 'medium';
+}
+
+/** Pill for the serving status — ready / probation / quarantined. */
+export const ComputeStatusBadge: React.FC<ComputeStatusBadgeProps> = ({
+  status,
+  size = 'small',
+}) => {
+  const meta = COMPUTE_STATUS_META[status] ?? COMPUTE_STATUS_META.probation;
+  const isMedium = size === 'medium';
+  return (
+    <Tooltip
+      title={`${meta.label} · ${meta.hint}`}
+      arrow
+      placement="top"
+      slotProps={tooltipSlotProps}
+    >
+      <Box
+        component="span"
+        sx={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: '5px',
+          px: isMedium ? '10px' : '7px',
+          py: isMedium ? '4px' : '2px',
+          borderRadius: '999px',
+          backgroundColor: alpha(meta.color, 0.12),
+          border: `1px solid ${alpha(meta.color, 0.32)}`,
+          color: meta.color,
+          fontSize: isMedium ? '0.78rem' : '0.64rem',
+          fontWeight: 700,
+          letterSpacing: '0.4px',
+          lineHeight: 1,
+          textTransform: 'uppercase',
+          whiteSpace: 'nowrap',
+          flexShrink: 0,
+        }}
+      >
+        <Box
+          component="span"
+          aria-hidden
+          sx={{
+            width: isMedium ? 7 : 5,
+            height: isMedium ? 7 : 5,
+            borderRadius: '50%',
+            backgroundColor: meta.color,
+          }}
+        />
+        {meta.label}
+      </Box>
+    </Tooltip>
+  );
+};

--- a/src/components/compute/CopyableHotkey.tsx
+++ b/src/components/compute/CopyableHotkey.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { Box, ButtonBase, Tooltip, alpha } from '@mui/material';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import CheckIcon from '@mui/icons-material/Check';
+import { useClipboardCopy } from '../../hooks/useClipboardCopy';
+import { tooltipSlotProps } from '../../theme';
+import { shortHotkey } from './computeFormat';
+
+interface CopyableHotkeyProps {
+  hotkey: string;
+  /** Visible characters on each end of the truncated hotkey. */
+  edge?: number;
+  fontSize?: string;
+  label?: string;
+}
+
+/** Truncated hotkey with click-to-copy; full hotkey in the tooltip. */
+export const CopyableHotkey: React.FC<CopyableHotkeyProps> = ({
+  hotkey,
+  edge = 6,
+  fontSize = '0.8rem',
+  label = 'Copy hotkey',
+}) => {
+  const { copied, copy, liveRegion } = useClipboardCopy({
+    copiedMessage: 'Hotkey copied to clipboard',
+  });
+  if (!hotkey) return null;
+  return (
+    <>
+      <Tooltip
+        title={copied ? 'Copied' : hotkey}
+        arrow
+        placement="top"
+        slotProps={tooltipSlotProps}
+      >
+        <ButtonBase
+          onClick={(event) => {
+            event.stopPropagation();
+            void copy(hotkey);
+          }}
+          aria-label={label}
+          disableRipple
+          sx={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 0.5,
+            borderRadius: '4px',
+            fontFamily: '"JetBrains Mono", monospace',
+            fontSize,
+            color: (t) =>
+              copied ? t.palette.status.success : t.palette.text.primary,
+            transition: 'color 0.15s ease',
+            '&:hover': { color: (t) => t.palette.primary.light },
+            '&:focus-visible': {
+              outline: (t) => `2px solid ${t.palette.primary.main}`,
+              outlineOffset: '2px',
+            },
+          }}
+        >
+          <Box component="span">{shortHotkey(hotkey, edge)}</Box>
+          {copied ? (
+            <CheckIcon sx={{ fontSize: '0.9em' }} aria-hidden />
+          ) : (
+            <ContentCopyIcon
+              sx={{
+                fontSize: '0.85em',
+                color: (t) => alpha(t.palette.text.primary, 0.5),
+              }}
+              aria-hidden
+            />
+          )}
+        </ButtonBase>
+      </Tooltip>
+      {liveRegion}
+    </>
+  );
+};

--- a/src/components/compute/MissReasonText.tsx
+++ b/src/components/compute/MissReasonText.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { Box, Tooltip, useTheme } from '@mui/material';
+import { tooltipSlotProps } from '../../theme';
+import { classifyMissReason } from './computeFormat';
+
+interface MissReasonTextProps {
+  reason: string | null | undefined;
+  /** Clamp width; the full text lives in the tooltip. */
+  maxWidth?: number | string;
+}
+
+/** Single-line, clamped miss reason. Strikes red, everything else neutral. */
+export const MissReasonText: React.FC<MissReasonTextProps> = ({
+  reason,
+  maxWidth = 260,
+}) => {
+  const theme = useTheme();
+  const trimmed = reason?.trim();
+  if (!trimmed) {
+    return <Box sx={{ color: theme.palette.text.secondary }}>—</Box>;
+  }
+  const { label, severity } = classifyMissReason(trimmed);
+  return (
+    <Tooltip title={label} arrow placement="top" slotProps={tooltipSlotProps}>
+      <Box
+        component="span"
+        sx={{
+          display: 'block',
+          maxWidth,
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+          color:
+            severity === 'strike'
+              ? theme.palette.status.error
+              : theme.palette.text.secondary,
+        }}
+      >
+        {label}
+      </Box>
+    </Tooltip>
+  );
+};

--- a/src/components/compute/ValidatorSnapshotFootnote.tsx
+++ b/src/components/compute/ValidatorSnapshotFootnote.tsx
@@ -1,11 +1,19 @@
 import React from 'react';
 import { Box, Typography, alpha, useTheme } from '@mui/material';
 import { TEXT_OPACITY } from '../../theme';
+import type { ServingPricingSource } from '../../api';
 import { CopyableHotkey } from './CopyableHotkey';
 
 interface ValidatorSnapshotFootnoteProps {
   validatorHotkey: string | null | undefined;
+  pricingSource?: ServingPricingSource | null;
 }
+
+const PRICING_NOTES: Partial<Record<ServingPricingSource, string>> = {
+  taostats:
+    'USD figures are priced from a market feed (validator had no price).',
+  none: 'No alpha price available this round, so payouts are shown as "—".',
+};
 
 /**
  * Required on every compute page: the numbers are one validator's audit,
@@ -13,7 +21,8 @@ interface ValidatorSnapshotFootnoteProps {
  */
 export const ValidatorSnapshotFootnote: React.FC<
   ValidatorSnapshotFootnoteProps
-> = ({ validatorHotkey }) => {
+> = ({ validatorHotkey, pricingSource }) => {
+  const pricingNote = pricingSource ? PRICING_NOTES[pricingSource] : null;
   const theme = useTheme();
   const muted = alpha(theme.palette.common.white, TEXT_OPACITY.muted);
   return (
@@ -48,6 +57,7 @@ export const ValidatorSnapshotFootnote: React.FC<
         )}
         . Other validators run their own audits; scores and payouts shown here
         are estimates, not consensus.
+        {pricingNote ? ` ${pricingNote}` : ''}
       </Typography>
     </Box>
   );

--- a/src/components/compute/ValidatorSnapshotFootnote.tsx
+++ b/src/components/compute/ValidatorSnapshotFootnote.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { Box, Typography, alpha, useTheme } from '@mui/material';
+import { TEXT_OPACITY } from '../../theme';
+import { CopyableHotkey } from './CopyableHotkey';
+
+interface ValidatorSnapshotFootnoteProps {
+  validatorHotkey: string | null | undefined;
+}
+
+/**
+ * Required on every compute page: the numbers are one validator's audit,
+ * not subnet consensus.
+ */
+export const ValidatorSnapshotFootnote: React.FC<
+  ValidatorSnapshotFootnoteProps
+> = ({ validatorHotkey }) => {
+  const theme = useTheme();
+  const muted = alpha(theme.palette.common.white, TEXT_OPACITY.muted);
+  return (
+    <Box
+      component="footer"
+      sx={{
+        borderTop: `1px solid ${theme.palette.border.light}`,
+        pt: 1.5,
+        mt: 1,
+      }}
+    >
+      <Typography
+        variant="caption"
+        sx={{
+          display: 'flex',
+          flexWrap: 'wrap',
+          alignItems: 'center',
+          gap: 0.5,
+          color: muted,
+          lineHeight: 1.5,
+        }}
+      >
+        Snapshot as observed by validator{' '}
+        {validatorHotkey ? (
+          <CopyableHotkey
+            hotkey={validatorHotkey}
+            fontSize="0.72rem"
+            label="Copy validator hotkey"
+          />
+        ) : (
+          <Box component="span">(unknown)</Box>
+        )}
+        . Other validators run their own audits; scores and payouts shown here
+        are estimates, not consensus.
+      </Typography>
+    </Box>
+  );
+};

--- a/src/components/compute/computeFormat.ts
+++ b/src/components/compute/computeFormat.ts
@@ -70,6 +70,28 @@ export const formatUsd = (value: number | null | undefined): string =>
         maximumFractionDigits: 2,
       });
 
+export type MissSeverity = 'strike' | 'neutral';
+
+/**
+ * Only a wrong answer (strike) is an error; timeouts / unavailable /
+ * not-verified / empty completion are ordinary misses. A bare "Success"
+ * is a legacy validator string for an empty completion — never show it red.
+ */
+export const classifyMissReason = (
+  reason: string,
+): { label: string; severity: MissSeverity } => {
+  const trimmed = reason.trim();
+  if (/^success$/i.test(trimmed)) {
+    return { label: 'empty completion', severity: 'neutral' };
+  }
+  const lower = trimmed.toLowerCase();
+  const isStrike =
+    lower.startsWith('wrong') ||
+    lower.includes('reference mismatch') ||
+    lower.includes('wrong');
+  return { label: trimmed, severity: isStrike ? 'strike' : 'neutral' };
+};
+
 /** Payout estimates are meaningless without a price — render "—". */
 export const hasPricing = (
   source: ServingPricingSource | null | undefined,

--- a/src/components/compute/computeFormat.ts
+++ b/src/components/compute/computeFormat.ts
@@ -8,7 +8,19 @@ import type {
 
 export const WINDOW_SLOTS = 10;
 export const WINDOW_READY_MEAN = 0.8;
-export const CAPACITY_REFERENCE_TPS = 180;
+export const SETTLEMENT_ROUNDS = 12;
+
+/** Header tooltips for the fleet table / KPI cards. */
+export const COMPUTE_METRIC_HINTS = {
+  tps: 'Decode rate the validator observed on traffic it sent this miner (completion tokens ÷ time after first token), mean over the round.',
+  ttft: 'Time to first token the validator observed on traffic it sent this miner, mean over the round.',
+  credit:
+    'Speed credit 0–1: TTFT band × decode band against the blessed 5090 curve, mean over the round. Misses earn 0.',
+  attested:
+    'Hardware attestation this round: seeded VRAM fill + GEMM chain must match the reference runtime. Not attested = no pay this round.',
+  settled: `Mean round score over the trailing ${SETTLEMENT_ROUNDS} rounds (~1 h). 1.0 = one fully paid card; this is what the miner is paid on.`,
+  round: 'This round: window pass (0/1) × speed credit × attested (0/1).',
+} as const;
 
 export const COMPUTE_STATUS_META: Record<
   ServingMinerStatus,
@@ -46,6 +58,16 @@ export const formatFixed = (
   value === null || value === undefined || !Number.isFinite(value)
     ? '—'
     : value.toFixed(decimals);
+
+export const formatMs = (value: number | null | undefined): string =>
+  value === null || value === undefined || !Number.isFinite(value)
+    ? '—'
+    : `${Math.round(value)} ms`;
+
+export const formatTps = (value: number | null | undefined): string =>
+  value === null || value === undefined || !Number.isFinite(value)
+    ? '—'
+    : `${Math.round(value)} tok/s`;
 
 export const formatPercent = (
   fraction: number | null | undefined,
@@ -132,7 +154,7 @@ export const formatRelative = (iso: string | null | undefined): string => {
 export const describeMinerStatus = (miner: ServingMiner): string => {
   switch (miner.status) {
     case 'ready':
-      return `Serving. Window ${miner.windowN}/${WINDOW_SLOTS}, settled ${formatFixed(miner.settledScore, 2)}.`;
+      return `Serving. Window ${miner.windowN}/${WINDOW_SLOTS}, settled ${formatFixed(miner.settledScore, 2)} (${SETTLEMENT_ROUNDS}-round mean).`;
     case 'probation':
       return `Not READY yet — window ${miner.windowN}/${WINDOW_SLOTS} mean ${formatFixed(miner.windowMean, 2)}, needs ≥ ${WINDOW_READY_MEAN} (validator sends 2 baseline prompts per round).`;
     case 'quarantined':

--- a/src/components/compute/computeFormat.ts
+++ b/src/components/compute/computeFormat.ts
@@ -1,0 +1,112 @@
+import { formatDistanceToNowStrict } from 'date-fns';
+import { STATUS_COLORS } from '../../theme';
+import type { ServingMiner, ServingMinerStatus } from '../../api';
+
+export const WINDOW_SLOTS = 10;
+export const WINDOW_READY_MEAN = 0.8;
+export const CAPACITY_REFERENCE_TPS = 180;
+
+export const COMPUTE_STATUS_META: Record<
+  ServingMinerStatus,
+  { label: string; color: string; hint: string }
+> = {
+  ready: {
+    label: 'Ready',
+    color: STATUS_COLORS.success,
+    hint: `Serving and earning — rolling ${WINDOW_SLOTS}-slot window mean ≥ ${WINDOW_READY_MEAN}.`,
+  },
+  probation: {
+    label: 'Probation',
+    color: STATUS_COLORS.warning,
+    hint: `Not READY yet. The validator sends 2 baseline prompts per round so the miner can build a ${WINDOW_SLOTS}-slot window with mean ≥ ${WINDOW_READY_MEAN}.`,
+  },
+  quarantined: {
+    label: 'Quarantined',
+    color: STATUS_COLORS.error,
+    hint: 'A WRONG answer wiped the window and paused this miner for 1 hour.',
+  },
+};
+
+const HOTKEY_EDGE = 6;
+
+export const shortHotkey = (hotkey: string, edge = HOTKEY_EDGE): string => {
+  if (!hotkey) return '';
+  if (hotkey.length <= edge * 2 + 1) return hotkey;
+  return `${hotkey.slice(0, edge)}…${hotkey.slice(-edge)}`;
+};
+
+export const formatFixed = (
+  value: number | null | undefined,
+  decimals = 2,
+): string =>
+  value === null || value === undefined || !Number.isFinite(value)
+    ? '—'
+    : value.toFixed(decimals);
+
+export const formatPercent = (
+  fraction: number | null | undefined,
+  decimals = 0,
+): string =>
+  fraction === null || fraction === undefined || !Number.isFinite(fraction)
+    ? '—'
+    : `${(fraction * 100).toFixed(decimals)}%`;
+
+/** "12.34 α" — estimate marker is added by callers' labels. */
+export const formatAlpha = (value: number | null | undefined): string =>
+  value === null || value === undefined || !Number.isFinite(value)
+    ? '—'
+    : `${value.toFixed(2)} α`;
+
+export const formatUsd = (value: number | null | undefined): string =>
+  value === null || value === undefined || !Number.isFinite(value)
+    ? '—'
+    : value.toLocaleString('en-US', {
+        style: 'currency',
+        currency: 'USD',
+        maximumFractionDigits: 2,
+      });
+
+export const formatWindow = (miner: {
+  windowN: number;
+  windowMean: number;
+}): string =>
+  `${miner.windowN}/${WINDOW_SLOTS} · ${formatFixed(miner.windowMean, 2)}`;
+
+export const uptimeFraction = (miner: {
+  readyRounds24h: number;
+  rounds24h: number;
+}): number | null =>
+  miner.rounds24h > 0 ? miner.readyRounds24h / miner.rounds24h : null;
+
+export const formatRoundTime = (iso: string | null | undefined): string => {
+  if (!iso) return '—';
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return '—';
+  return date.toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+};
+
+export const formatRelative = (iso: string | null | undefined): string => {
+  if (!iso) return '—';
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return '—';
+  return `${formatDistanceToNowStrict(date)} ago`;
+};
+
+/** Plain-English "why" for the miner's current status. */
+export const describeMinerStatus = (miner: ServingMiner): string => {
+  switch (miner.status) {
+    case 'ready':
+      return `Serving. Window ${miner.windowN}/${WINDOW_SLOTS}, settled ${formatFixed(miner.settledScore, 2)}.`;
+    case 'probation':
+      return `Not READY yet — window ${miner.windowN}/${WINDOW_SLOTS} mean ${formatFixed(miner.windowMean, 2)}, needs ≥ ${WINDOW_READY_MEAN} (validator sends 2 baseline prompts per round).`;
+    case 'quarantined':
+      return `Quarantined until ${formatRoundTime(miner.quarantinedUntil)} after a wrong answer; window reset.`;
+    default:
+      return '';
+  }
+};

--- a/src/components/compute/computeFormat.ts
+++ b/src/components/compute/computeFormat.ts
@@ -1,6 +1,10 @@
 import { formatDistanceToNowStrict } from 'date-fns';
 import { STATUS_COLORS } from '../../theme';
-import type { ServingMiner, ServingMinerStatus } from '../../api';
+import type {
+  ServingMiner,
+  ServingMinerStatus,
+  ServingPricingSource,
+} from '../../api';
 
 export const WINDOW_SLOTS = 10;
 export const WINDOW_READY_MEAN = 0.8;
@@ -65,6 +69,11 @@ export const formatUsd = (value: number | null | undefined): string =>
         currency: 'USD',
         maximumFractionDigits: 2,
       });
+
+/** Payout estimates are meaningless without a price — render "—". */
+export const hasPricing = (
+  source: ServingPricingSource | null | undefined,
+): boolean => source !== 'none';
 
 export const formatWindow = (miner: {
   windowN: number;

--- a/src/components/compute/index.ts
+++ b/src/components/compute/index.ts
@@ -7,3 +7,4 @@ export * from './ComputeRoundChart';
 export * from './ComputeMissesTable';
 export * from './ComputeReleaseCard';
 export * from './MissReasonText';
+export * from './ColumnHint';

--- a/src/components/compute/index.ts
+++ b/src/components/compute/index.ts
@@ -6,3 +6,4 @@ export * from './ComputeFleetTable';
 export * from './ComputeRoundChart';
 export * from './ComputeMissesTable';
 export * from './ComputeReleaseCard';
+export * from './MissReasonText';

--- a/src/components/compute/index.ts
+++ b/src/components/compute/index.ts
@@ -5,3 +5,4 @@ export * from './ValidatorSnapshotFootnote';
 export * from './ComputeFleetTable';
 export * from './ComputeRoundChart';
 export * from './ComputeMissesTable';
+export * from './ComputeReleaseCard';

--- a/src/components/compute/index.ts
+++ b/src/components/compute/index.ts
@@ -1,0 +1,7 @@
+export * from './computeFormat';
+export * from './ComputeStatusBadge';
+export * from './CopyableHotkey';
+export * from './ValidatorSnapshotFootnote';
+export * from './ComputeFleetTable';
+export * from './ComputeRoundChart';
+export * from './ComputeMissesTable';

--- a/src/components/layout/GlobalSearchBar.tsx
+++ b/src/components/layout/GlobalSearchBar.tsx
@@ -25,14 +25,19 @@ import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 import { useSearchResults } from '../../pages/search/searchData';
 import { useLinkBehavior, linkResetSx } from '../common/linkBehavior';
 import { minerPrPath, minerRepositoryPath } from '../../utils';
-import { minerDetailsPath, bountyDetailsPath } from '../../utils/paths';
+import {
+  minerDetailsPath,
+  bountyDetailsPath,
+  computeMinerPath,
+  looksLikeSs58Hotkey,
+} from '../../utils/paths';
 
 const QUICK_RESULT_LIMIT = 3;
 const DROPDOWN_CLOSE_DELAY_MS = 150;
 const LISTBOX_ID = 'global-search-listbox';
 const itemIdFromKey = (key: string) => `global-search-item-${key}`;
 
-type NavItemKind = 'miner' | 'repo' | 'pr' | 'issue' | 'action';
+type NavItemKind = 'miner' | 'compute' | 'repo' | 'pr' | 'issue' | 'action';
 
 type NavItem = {
   key: string;
@@ -45,6 +50,7 @@ type NavItem = {
 
 const SECTION_LABELS: Record<Exclude<NavItemKind, 'action'>, string> = {
   miner: 'Miners',
+  compute: 'Compute',
   repo: 'Repositories',
   pr: 'Pull Requests',
   issue: 'Issues',
@@ -245,13 +251,14 @@ const GlobalSearchBar: React.FC = () => {
     datasets.prs.isLoading ||
     datasets.issues.isLoading;
 
+  const trimmedQuery = query.trim();
+
   const hasAnyResults =
+    looksLikeSs58Hotkey(trimmedQuery) ||
     minerResults.length > 0 ||
     repositoryResults.length > 0 ||
     prResults.length > 0 ||
     issueResults.length > 0;
-
-  const trimmedQuery = query.trim();
 
   // Sync URL query param on /search page.
   useEffect(() => {
@@ -317,6 +324,19 @@ const GlobalSearchBar: React.FC = () => {
         onSelect: () => navigateAndClose(href),
       });
     });
+    // An ss58 hotkey may belong to a compute miner the contribution
+    // datasets don't know about — always offer the compute lookup.
+    if (looksLikeSs58Hotkey(trimmedQuery)) {
+      const href = computeMinerPath(trimmedQuery);
+      items.push({
+        key: `compute-${trimmedQuery}`,
+        kind: 'compute',
+        title: `Compute miner ${trimmedQuery.slice(0, 8)}…${trimmedQuery.slice(-6)}`,
+        subtitle: 'Serving status as observed by the validator',
+        href,
+        onSelect: () => navigateAndClose(href),
+      });
+    }
     repositoryResults.forEach((repo) => {
       const href = minerRepositoryPath(repo.fullName);
       items.push({

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -11,6 +11,7 @@ import {
 } from '@mui/material';
 import { useLocation } from 'react-router-dom';
 import DashboardIcon from '@mui/icons-material/Dashboard';
+import MemoryIcon from '@mui/icons-material/Memory';
 import { useLinkBehavior } from '../common/linkBehavior';
 
 const LOGO_IMG_FILTER =
@@ -81,7 +82,10 @@ const Sidebar: React.FC<SidebarProps> = ({ onNavigate, collapsed = false }) => {
     path: string;
     icon: React.ReactNode;
     badge?: string;
-  }> = [{ label: 'dashboard', path: '/dashboard', icon: <DashboardIcon /> }];
+  }> = [
+    { label: 'dashboard', path: '/dashboard', icon: <DashboardIcon /> },
+    { label: 'compute', path: '/compute', icon: <MemoryIcon /> },
+  ];
 
   const logoLink = (
     <SidebarLogoLink onNavigate={onNavigate} collapsed={collapsed}>

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -3,6 +3,8 @@ interface ImportMetaEnv {
   readonly VITE_REACT_APP_BASE_URL: string;
   readonly VITE_REACT_APP_MIRROR_BASE_URL?: string;
   readonly VITE_WEB3FORMS_ACCESS_KEY?: string;
+  /** Dev only: serve /serving endpoints from local fixtures. */
+  readonly VITE_SERVING_MOCK?: string;
 }
 
 interface ImportMeta {

--- a/src/pages/ComputeMinerPage.tsx
+++ b/src/pages/ComputeMinerPage.tsx
@@ -29,7 +29,7 @@ import {
   type ServingRound,
 } from '../api';
 import { STATUS_COLORS, TEXT_OPACITY } from '../theme';
-import { computePath, minerDetailsPath } from '../utils/paths';
+import { computeViewPath, minerDetailsPath } from '../utils/paths';
 
 const HISTORY_HOURS = 24;
 
@@ -303,7 +303,7 @@ const ComputeMinerPage: React.FC = () => {
         >
           <Box>
             <BackButton
-              to={computePath()}
+              to={computeViewPath()}
               label="Back to Compute"
               variant="text"
             />

--- a/src/pages/ComputeMinerPage.tsx
+++ b/src/pages/ComputeMinerPage.tsx
@@ -1,0 +1,314 @@
+import React, { useMemo } from 'react';
+import { Link as RouterLink, useSearchParams } from 'react-router-dom';
+import { Box, Link, Stack, Typography, alpha, useTheme } from '@mui/material';
+import { Page } from '../components/layout';
+import { BackButton, SEO } from '../components';
+import KpiCard from '../components/KpiCard';
+import {
+  COMPUTE_STATUS_META,
+  ComputeMissesTable,
+  ComputeRoundChart,
+  ComputeStatusBadge,
+  CopyableHotkey,
+  ValidatorSnapshotFootnote,
+  describeMinerStatus,
+  formatAlpha,
+  formatFixed,
+  formatPercent,
+  formatRelative,
+  formatUsd,
+  shortHotkey,
+  uptimeFraction,
+} from '../components/compute';
+import {
+  isNotFoundError,
+  useServingMinerDetail,
+  type ServingMiner,
+  type ServingRound,
+} from '../api';
+import { STATUS_COLORS, TEXT_OPACITY } from '../theme';
+import { computePath, minerDetailsPath } from '../utils/paths';
+
+const HISTORY_HOURS = 24;
+
+const IdentityHeader: React.FC<{ miner: ServingMiner }> = ({ miner }) => {
+  const theme = useTheme();
+  const muted = alpha(theme.palette.common.white, TEXT_OPACITY.muted);
+  return (
+    <Box>
+      <Stack
+        direction="row"
+        alignItems="center"
+        flexWrap="wrap"
+        gap={1.5}
+        sx={{ mb: 0.5 }}
+      >
+        <Typography variant="h4" component="h1" sx={{ fontWeight: 700 }}>
+          UID {miner.uid}
+        </Typography>
+        <ComputeStatusBadge status={miner.status} size="medium" />
+      </Stack>
+      <Stack
+        direction="row"
+        alignItems="center"
+        flexWrap="wrap"
+        gap={2}
+        sx={{ color: muted, fontSize: '0.85rem' }}
+      >
+        <CopyableHotkey hotkey={miner.hotkey} edge={8} />
+        {miner.username ? (
+          miner.githubId ? (
+            <Link
+              component={RouterLink}
+              to={minerDetailsPath(miner.githubId)}
+              underline="hover"
+              sx={{ color: theme.palette.status.info }}
+            >
+              @{miner.username}
+            </Link>
+          ) : (
+            <span>@{miner.username}</span>
+          )
+        ) : null}
+        <Box
+          component="span"
+          sx={{ fontFamily: '"JetBrains Mono", monospace' }}
+        >
+          {miner.modelId}
+        </Box>
+      </Stack>
+    </Box>
+  );
+};
+
+const StatusCard: React.FC<{ miner: ServingMiner }> = ({ miner }) => {
+  const theme = useTheme();
+  const meta = COMPUTE_STATUS_META[miner.status];
+  return (
+    <Box
+      sx={{
+        borderRadius: 3,
+        border: `1px solid ${alpha(meta.color, 0.35)}`,
+        backgroundColor: alpha(meta.color, 0.06),
+        px: { xs: 2, sm: 3 },
+        py: { xs: 2, sm: 2.5 },
+      }}
+    >
+      <Typography
+        variant="dataLabel"
+        sx={{ display: 'block', color: meta.color, mb: 0.5 }}
+      >
+        {meta.label}
+      </Typography>
+      <Typography
+        variant="h6"
+        component="p"
+        sx={{ fontWeight: 600, lineHeight: 1.4 }}
+      >
+        {describeMinerStatus(miner)}
+      </Typography>
+      <Typography
+        variant="body2"
+        sx={{
+          mt: 1,
+          color: alpha(theme.palette.common.white, TEXT_OPACITY.muted),
+        }}
+      >
+        Last round {formatRelative(miner.roundTs)}
+        {miner.lastMissReason ? ` · last miss: ${miner.lastMissReason}` : ''}
+      </Typography>
+    </Box>
+  );
+};
+
+const MinerKpis: React.FC<{ miner: ServingMiner }> = ({ miner }) => {
+  const usd = formatUsd(miner.estUsdPerDay);
+  return (
+    <Box
+      sx={{
+        display: 'grid',
+        gap: { xs: 1, sm: 1.5 },
+        gridTemplateColumns: {
+          xs: 'repeat(2, minmax(0, 1fr))',
+          md: 'repeat(5, minmax(0, 1fr))',
+        },
+      }}
+    >
+      <KpiCard
+        title="Settled score"
+        value={formatFixed(miner.settledScore, 3)}
+        subtitle={`Round ${formatFixed(miner.roundScore, 3)}`}
+      />
+      <KpiCard
+        title="Est. α/day"
+        value={formatAlpha(miner.estAlphaPerDay)}
+        subtitle={usd === '—' ? 'Estimate' : `≈ ${usd}/day · est.`}
+      />
+      <KpiCard
+        title="tok/s"
+        value={formatFixed(miner.probeTps, 0)}
+        subtitle={`Capacity ${formatFixed(miner.capacity, 2)} (÷ 180)`}
+      />
+      <KpiCard title="TTFT credit" value={formatFixed(miner.credit, 2)} />
+      <KpiCard
+        title="Uptime 24h"
+        value={formatPercent(uptimeFraction(miner))}
+        subtitle={`${miner.readyRounds24h}/${miner.rounds24h} rounds READY`}
+      />
+    </Box>
+  );
+};
+
+const RoundCharts: React.FC<{ rounds: ServingRound[] }> = ({ rounds }) => {
+  const timestamps = useMemo(() => rounds.map((r) => r.roundTs), [rounds]);
+  const scores = useMemo(() => rounds.map((r) => r.roundScore), [rounds]);
+  const tps = useMemo(() => rounds.map((r) => r.probeTps), [rounds]);
+  const credits = useMemo(() => rounds.map((r) => r.credit), [rounds]);
+  const emptyHint = `No audit rounds for this miner in the last ${HISTORY_HOURS} h.`;
+  return (
+    <Box
+      sx={{
+        display: 'grid',
+        gap: { xs: 2, md: 3 },
+        gridTemplateColumns: { xs: '1fr', md: 'repeat(3, minmax(0, 1fr))' },
+      }}
+    >
+      <ComputeRoundChart
+        title="Round score"
+        timestamps={timestamps}
+        values={scores}
+        color={STATUS_COLORS.success}
+        decimals={3}
+        emptyHint={emptyHint}
+      />
+      <ComputeRoundChart
+        title="Probe tok/s"
+        timestamps={timestamps}
+        values={tps}
+        color={STATUS_COLORS.info}
+        decimals={0}
+        emptyHint={emptyHint}
+      />
+      <ComputeRoundChart
+        title="TTFT credit"
+        timestamps={timestamps}
+        values={credits}
+        color={STATUS_COLORS.warning}
+        yMax={1}
+        emptyHint={emptyHint}
+      />
+    </Box>
+  );
+};
+
+const ComputeMinerPage: React.FC = () => {
+  const [searchParams] = useSearchParams();
+  const hotkey = (searchParams.get('hotkey') ?? '').trim();
+  const query = useServingMinerDetail(hotkey, HISTORY_HOURS);
+  const theme = useTheme();
+
+  const notFound = isNotFoundError(query.error);
+  const miner = query.data?.miner ?? null;
+
+  let body: React.ReactNode;
+  if (!hotkey) {
+    body = (
+      <Typography color="text.secondary">
+        Add <code>?hotkey=</code> to the URL to look up a compute miner.
+      </Typography>
+    );
+  } else if (query.isLoading) {
+    body = <Typography color="text.secondary">Loading…</Typography>;
+  } else if (notFound || (query.isSuccess && !miner)) {
+    body = (
+      <Typography color="text.secondary">
+        This validator has not seen hotkey {shortHotkey(hotkey, 8)} in any
+        serving round.
+      </Typography>
+    );
+  } else if (query.isError) {
+    body = (
+      <Typography color="error">Could not load this compute miner.</Typography>
+    );
+  } else if (miner && query.data) {
+    body = (
+      <>
+        <IdentityHeader miner={miner} />
+        <StatusCard miner={miner} />
+        <MinerKpis miner={miner} />
+        <Box>
+          <Typography
+            variant="sectionTitle"
+            component="h2"
+            sx={{ display: 'block', mb: 1.25 }}
+          >
+            Last {HISTORY_HOURS} h of audit rounds
+          </Typography>
+          <RoundCharts rounds={query.data.rounds} />
+        </Box>
+        <Box>
+          <Typography
+            variant="sectionTitle"
+            component="h2"
+            sx={{ display: 'block', mb: 1.25 }}
+          >
+            Recent misses
+          </Typography>
+          <ComputeMissesTable misses={query.data.misses} />
+        </Box>
+      </>
+    );
+  }
+
+  return (
+    <Page title={miner ? `Compute UID ${miner.uid}` : 'Compute miner'}>
+      <SEO
+        title={miner ? `Compute miner UID ${miner.uid}` : 'Compute miner'}
+        description="Per-hotkey serving status, audit window, round history, and estimated payouts as observed by one validator."
+      />
+      <Box
+        sx={{
+          display: 'flex',
+          width: '100%',
+          justifyContent: 'center',
+          py: { xs: 2, sm: 3 },
+        }}
+      >
+        <Box
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 3,
+            width: '100%',
+            maxWidth: 1320,
+            px: { xs: 2, md: 0 },
+          }}
+        >
+          <Box>
+            <BackButton
+              to={computePath()}
+              label="Back to Compute"
+              variant="text"
+            />
+          </Box>
+          {body}
+          <Typography
+            variant="caption"
+            sx={{
+              color: alpha(theme.palette.common.white, TEXT_OPACITY.muted),
+            }}
+          >
+            Score = window pass × TTFT credit × capacity (probe tok/s ÷ 180),
+            settled over the trailing 12 rounds. A WRONG answer wipes the window
+            and quarantines the miner for 1 h.
+          </Typography>
+          <ValidatorSnapshotFootnote
+            validatorHotkey={query.data?.validatorHotkey}
+          />
+        </Box>
+      </Box>
+    </Page>
+  );
+};
+
+export default ComputeMinerPage;

--- a/src/pages/ComputeMinerPage.tsx
+++ b/src/pages/ComputeMinerPage.tsx
@@ -6,6 +6,7 @@ import { BackButton, SEO } from '../components';
 import KpiCard from '../components/KpiCard';
 import {
   COMPUTE_STATUS_META,
+  SETTLEMENT_ROUNDS,
   ComputeMissesTable,
   ComputeRoundChart,
   ComputeStatusBadge,
@@ -14,6 +15,7 @@ import {
   describeMinerStatus,
   formatAlpha,
   formatFixed,
+  formatMs,
   formatPercent,
   formatRelative,
   formatUsd,
@@ -151,7 +153,7 @@ const MinerKpis: React.FC<{ miner: ServingMiner; priced: boolean }> = ({
       <KpiCard
         title="Settled score"
         value={formatFixed(miner.settledScore, 3)}
-        subtitle={`Round ${formatFixed(miner.roundScore, 3)}`}
+        subtitle={`${SETTLEMENT_ROUNDS}-round mean · this round ${formatFixed(miner.roundScore, 3)}`}
       />
       <KpiCard
         title="Est. alpha/day"
@@ -159,11 +161,15 @@ const MinerKpis: React.FC<{ miner: ServingMiner; priced: boolean }> = ({
         subtitle={payoutSubtitle}
       />
       <KpiCard
-        title="tok/s"
-        value={formatFixed(miner.probeTps, 0)}
-        subtitle={`Capacity ${formatFixed(miner.capacity, 2)} (÷ 180)`}
+        title="Decode tok/s"
+        value={formatFixed(miner.decodeTps, 0)}
+        subtitle={`TTFT ${formatMs(miner.ttftMs)}`}
       />
-      <KpiCard title="TTFT credit" value={formatFixed(miner.credit, 2)} />
+      <KpiCard
+        title="Speed credit"
+        value={formatFixed(miner.credit, 2)}
+        subtitle={miner.capacity > 0 ? 'Attested' : 'Not attested'}
+      />
       <KpiCard
         title="Uptime 24h"
         value={formatPercent(uptimeFraction(miner))}
@@ -176,8 +182,8 @@ const MinerKpis: React.FC<{ miner: ServingMiner; priced: boolean }> = ({
 const RoundCharts: React.FC<{ rounds: ServingRound[] }> = ({ rounds }) => {
   const timestamps = useMemo(() => rounds.map((r) => r.roundTs), [rounds]);
   const scores = useMemo(() => rounds.map((r) => r.roundScore), [rounds]);
-  const tps = useMemo(() => rounds.map((r) => r.probeTps), [rounds]);
-  const credits = useMemo(() => rounds.map((r) => r.credit), [rounds]);
+  const tps = useMemo(() => rounds.map((r) => r.decodeTps), [rounds]);
+  const ttft = useMemo(() => rounds.map((r) => r.ttftMs), [rounds]);
   const emptyHint = `No audit rounds for this miner in the last ${HISTORY_HOURS} h.`;
   return (
     <Box
@@ -196,7 +202,7 @@ const RoundCharts: React.FC<{ rounds: ServingRound[] }> = ({ rounds }) => {
         emptyHint={emptyHint}
       />
       <ComputeRoundChart
-        title="Probe tok/s"
+        title="Decode tok/s"
         timestamps={timestamps}
         values={tps}
         color={STATUS_COLORS.info}
@@ -204,11 +210,11 @@ const RoundCharts: React.FC<{ rounds: ServingRound[] }> = ({ rounds }) => {
         emptyHint={emptyHint}
       />
       <ComputeRoundChart
-        title="TTFT credit"
+        title="TTFT (ms)"
         timestamps={timestamps}
-        values={credits}
+        values={ttft}
         color={STATUS_COLORS.warning}
-        yMax={1}
+        decimals={0}
         emptyHint={emptyHint}
       />
     </Box>
@@ -315,9 +321,11 @@ const ComputeMinerPage: React.FC = () => {
               color: alpha(theme.palette.common.white, TEXT_OPACITY.muted),
             }}
           >
-            Score = window pass × TTFT credit × capacity (probe tok/s ÷ 180),
-            settled over the trailing 12 rounds. A WRONG answer wipes the window
-            and quarantines the miner for 1 h.
+            Round score = window pass × speed credit (TTFT band × decode band
+            vs. the blessed 5090 curve, on traffic this validator sent) ×
+            hardware attestation. Settled = mean over the trailing{' '}
+            {SETTLEMENT_ROUNDS} rounds (~1 h) and is what the miner is paid on.
+            A WRONG answer wipes the window and quarantines the miner for 1 h.
           </Typography>
           <ValidatorSnapshotFootnote
             validatorHotkey={query.data?.validatorHotkey}

--- a/src/pages/ComputeMinerPage.tsx
+++ b/src/pages/ComputeMinerPage.tsx
@@ -17,12 +17,14 @@ import {
   formatPercent,
   formatRelative,
   formatUsd,
+  hasPricing,
   shortHotkey,
   uptimeFraction,
 } from '../components/compute';
 import {
   isNotFoundError,
   useServingMinerDetail,
+  useServingStatus,
   type ServingMiner,
   type ServingRound,
 } from '../api';
@@ -121,8 +123,20 @@ const StatusCard: React.FC<{ miner: ServingMiner }> = ({ miner }) => {
   );
 };
 
-const MinerKpis: React.FC<{ miner: ServingMiner }> = ({ miner }) => {
+const MinerKpis: React.FC<{ miner: ServingMiner; priced: boolean }> = ({
+  miner,
+  priced,
+}) => {
   const usd = formatUsd(miner.estUsdPerDay);
+  const tempo = formatAlpha(miner.estAlphaPerTempo);
+  const payoutSubtitle = !priced
+    ? 'No price this round'
+    : [
+        tempo === '—' ? null : `${tempo}/tempo`,
+        usd === '—' ? null : `≈ ${usd}/day`,
+      ]
+        .filter(Boolean)
+        .join(' · ') + ' · est.';
   return (
     <Box
       sx={{
@@ -140,9 +154,9 @@ const MinerKpis: React.FC<{ miner: ServingMiner }> = ({ miner }) => {
         subtitle={`Round ${formatFixed(miner.roundScore, 3)}`}
       />
       <KpiCard
-        title="Est. α/day"
-        value={formatAlpha(miner.estAlphaPerDay)}
-        subtitle={usd === '—' ? 'Estimate' : `≈ ${usd}/day · est.`}
+        title="Est. alpha/day"
+        value={priced ? formatAlpha(miner.estAlphaPerDay) : '—'}
+        subtitle={payoutSubtitle}
       />
       <KpiCard
         title="tok/s"
@@ -205,6 +219,9 @@ const ComputeMinerPage: React.FC = () => {
   const [searchParams] = useSearchParams();
   const hotkey = (searchParams.get('hotkey') ?? '').trim();
   const query = useServingMinerDetail(hotkey, HISTORY_HOURS);
+  // Pricing source lives on the pool snapshot, not the per-hotkey payload.
+  const statusQuery = useServingStatus();
+  const pricingSource = statusQuery.data?.pricingSource;
   const theme = useTheme();
 
   const notFound = isNotFoundError(query.error);
@@ -235,7 +252,7 @@ const ComputeMinerPage: React.FC = () => {
       <>
         <IdentityHeader miner={miner} />
         <StatusCard miner={miner} />
-        <MinerKpis miner={miner} />
+        <MinerKpis miner={miner} priced={hasPricing(pricingSource)} />
         <Box>
           <Typography
             variant="sectionTitle"
@@ -304,6 +321,7 @@ const ComputeMinerPage: React.FC = () => {
           </Typography>
           <ValidatorSnapshotFootnote
             validatorHotkey={query.data?.validatorHotkey}
+            pricingSource={pricingSource}
           />
         </Box>
       </Box>

--- a/src/pages/ComputePage.tsx
+++ b/src/pages/ComputePage.tsx
@@ -77,7 +77,7 @@ const ComputeKpis: React.FC<{ status: ServingStatus }> = ({ status }) => {
       <KpiCard
         title="Card-equivalents"
         value={status.cardEquivalents.toFixed(2)}
-        subtitle="Sum of settled scores"
+        subtitle="Σ settled scores · paid 5090s this round"
       />
       <KpiCard
         title="Est. alpha/day per card"

--- a/src/pages/ComputePage.tsx
+++ b/src/pages/ComputePage.tsx
@@ -1,0 +1,179 @@
+import React from 'react';
+import { Box, Typography, alpha, useTheme } from '@mui/material';
+import { Page } from '../components/layout';
+import { SEO } from '../components';
+import KpiCard from '../components/KpiCard';
+import {
+  ComputeFleetTable,
+  ValidatorSnapshotFootnote,
+  formatAlpha,
+  formatRelative,
+  formatRoundTime,
+  formatUsd,
+} from '../components/compute';
+import {
+  isNotFoundError,
+  useServingMiners,
+  useServingStatus,
+  type ServingStatus,
+} from '../api';
+import { TEXT_OPACITY } from '../theme';
+
+const POOL_EXPLAINER =
+  'The serving pool pays RTX 5090 miners an estimated $0.70 per verified GPU-hour inside a 3.5% emission cap. Every 5 minutes the validator audits served traffic against its reference GPU, keeps a rolling 10-slot window (READY at mean ≥ 0.8), and settles scores over the trailing 12 rounds.';
+
+const EMPTY_MESSAGE = 'No serving rounds recorded yet by this validator.';
+
+const formatPoolShare = (status: ServingStatus): string =>
+  `${(status.poolShare * 100).toFixed(2)}% of ${(status.poolCap * 100).toFixed(1)}% cap`;
+
+const ComputeKpis: React.FC<{ status: ServingStatus }> = ({ status }) => {
+  const perCardUsd = formatUsd(status.estUsdPerCardDay);
+  return (
+    <Box
+      sx={{
+        display: 'grid',
+        gap: { xs: 1, sm: 1.5 },
+        gridTemplateColumns: {
+          xs: 'repeat(2, minmax(0, 1fr))',
+          md: 'repeat(5, minmax(0, 1fr))',
+        },
+      }}
+    >
+      <KpiCard
+        title="Ready cards"
+        value={status.ready}
+        subtitle={`${status.probation} probation · ${status.quarantined} quarantined`}
+      />
+      <KpiCard
+        title="Pool share"
+        value={`${(status.poolShare * 100).toFixed(2)}%`}
+        subtitle={formatPoolShare(status)}
+      />
+      <KpiCard
+        title="Card-equivalents"
+        value={status.cardEquivalents.toFixed(2)}
+        subtitle="Sum of settled scores"
+      />
+      <KpiCard
+        title="Est. α/day per card"
+        value={formatAlpha(status.estAlphaPerCardDay)}
+        subtitle={
+          perCardUsd === '—'
+            ? 'Full card, estimate'
+            : `≈ ${perCardUsd}/day · est.`
+        }
+      />
+      <KpiCard
+        title="Last round"
+        value={formatRelative(status.roundTs)}
+        subtitle={`${formatRoundTime(status.roundTs)} · ${status.roundsLast24h} rounds in 24 h`}
+      />
+    </Box>
+  );
+};
+
+const ComputePage: React.FC = () => {
+  const theme = useTheme();
+  const statusQuery = useServingStatus();
+  const minersQuery = useServingMiners();
+
+  const noRoundsYet =
+    isNotFoundError(statusQuery.error) ||
+    (statusQuery.isSuccess && !statusQuery.data);
+  const statusError = statusQuery.isError && !noRoundsYet;
+  const miners = noRoundsYet ? [] : (minersQuery.data ?? []);
+  const minersError =
+    minersQuery.isError && !isNotFoundError(minersQuery.error);
+
+  const emptyState = (
+    <Box sx={{ p: 3 }}>
+      <Typography color="text.secondary">{EMPTY_MESSAGE}</Typography>
+    </Box>
+  );
+
+  return (
+    <Page title="Compute">
+      <SEO
+        title="Compute"
+        description="RTX 5090 serving pool — READY cards, pool share, and per-miner audit status as observed by one validator."
+        type="website"
+      />
+      <Box
+        sx={{
+          display: 'flex',
+          width: '100%',
+          justifyContent: 'center',
+          py: { xs: 2, sm: 3 },
+        }}
+      >
+        <Box
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 3,
+            width: '100%',
+            maxWidth: 1320,
+            px: { xs: 2, md: 0 },
+          }}
+        >
+          <Box>
+            <Typography
+              variant="h4"
+              component="h1"
+              sx={{ fontWeight: 700, mb: 0.75 }}
+            >
+              Compute
+            </Typography>
+            <Typography
+              variant="body2"
+              sx={{
+                color: alpha(
+                  theme.palette.common.white,
+                  TEXT_OPACITY.secondary,
+                ),
+                maxWidth: 860,
+                lineHeight: 1.55,
+              }}
+            >
+              {POOL_EXPLAINER}
+            </Typography>
+          </Box>
+
+          {statusQuery.data && !noRoundsYet ? (
+            <ComputeKpis status={statusQuery.data} />
+          ) : null}
+          {statusError ? (
+            <Typography color="error" variant="body2">
+              Could not load the pool snapshot.
+            </Typography>
+          ) : null}
+
+          <Box>
+            <Typography
+              variant="sectionTitle"
+              component="h2"
+              sx={{ display: 'block', mb: 1.25 }}
+            >
+              Fleet
+            </Typography>
+            <ComputeFleetTable
+              miners={miners}
+              isLoading={
+                !noRoundsYet && (minersQuery.isLoading || statusQuery.isLoading)
+              }
+              isError={minersError}
+              emptyState={emptyState}
+            />
+          </Box>
+
+          <ValidatorSnapshotFootnote
+            validatorHotkey={statusQuery.data?.validatorHotkey}
+          />
+        </Box>
+      </Box>
+    </Page>
+  );
+};
+
+export default ComputePage;

--- a/src/pages/ComputePage.tsx
+++ b/src/pages/ComputePage.tsx
@@ -5,7 +5,9 @@ import { SEO } from '../components';
 import KpiCard from '../components/KpiCard';
 import {
   ComputeFleetTable,
+  ComputeReleaseCard,
   ValidatorSnapshotFootnote,
+  hasPricing,
   formatAlpha,
   formatRelative,
   formatRoundTime,
@@ -19,16 +21,38 @@ import {
 } from '../api';
 import { TEXT_OPACITY } from '../theme';
 
-const POOL_EXPLAINER =
-  'The serving pool pays RTX 5090 miners an estimated $0.70 per verified GPU-hour inside a 3.5% emission cap. Every 5 minutes the validator audits served traffic against its reference GPU, keeps a rolling 10-slot window (READY at mean ≥ 0.8), and settles scores over the trailing 12 rounds.';
+const poolExplainer = (status: ServingStatus | undefined): string => {
+  const rate =
+    status?.gpuHourUsd != null
+      ? `an estimated $${status.gpuHourUsd.toFixed(2)} per verified GPU-hour`
+      : 'a validator-set USD rate per verified GPU-hour';
+  const cap =
+    status?.poolCap != null
+      ? `inside a ${(status.poolCap * 100).toFixed(1)}% emission cap`
+      : 'inside an emission cap set by the validator';
+  return `The serving pool pays RTX 5090 miners ${rate} ${cap}. Every 5 minutes the validator audits served traffic against its reference GPU, keeps a rolling 10-slot window (READY at mean ≥ 0.8), and settles scores over the trailing 12 rounds.`;
+};
 
 const EMPTY_MESSAGE = 'No serving rounds recorded yet by this validator.';
 
 const formatPoolShare = (status: ServingStatus): string =>
-  `${(status.poolShare * 100).toFixed(2)}% of ${(status.poolCap * 100).toFixed(1)}% cap`;
+  status.poolCap === null
+    ? 'Cap not reported this round'
+    : `of ${(status.poolCap * 100).toFixed(1)}% cap`;
+
+const formatPerCardSubtitle = (status: ServingStatus): string => {
+  if (!hasPricing(status.pricingSource)) return 'No price this round';
+  const tempo = formatAlpha(status.estAlphaPerCardTempo);
+  const usd = formatUsd(status.estUsdPerCardDay);
+  const parts = [
+    tempo === '—' ? null : `${tempo}/tempo`,
+    usd === '—' ? null : `≈ ${usd}/day`,
+  ].filter(Boolean);
+  return parts.length ? `${parts.join(' · ')} · est.` : 'Full card, estimate';
+};
 
 const ComputeKpis: React.FC<{ status: ServingStatus }> = ({ status }) => {
-  const perCardUsd = formatUsd(status.estUsdPerCardDay);
+  const priced = hasPricing(status.pricingSource);
   return (
     <Box
       sx={{
@@ -56,13 +80,9 @@ const ComputeKpis: React.FC<{ status: ServingStatus }> = ({ status }) => {
         subtitle="Sum of settled scores"
       />
       <KpiCard
-        title="Est. α/day per card"
-        value={formatAlpha(status.estAlphaPerCardDay)}
-        subtitle={
-          perCardUsd === '—'
-            ? 'Full card, estimate'
-            : `≈ ${perCardUsd}/day · est.`
-        }
+        title="Est. alpha/day per card"
+        value={priced ? formatAlpha(status.estAlphaPerCardDay) : '—'}
+        subtitle={formatPerCardSubtitle(status)}
       />
       <KpiCard
         title="Last round"
@@ -136,12 +156,15 @@ const ComputePage: React.FC = () => {
                 lineHeight: 1.55,
               }}
             >
-              {POOL_EXPLAINER}
+              {poolExplainer(statusQuery.data)}
             </Typography>
           </Box>
 
           {statusQuery.data && !noRoundsYet ? (
             <ComputeKpis status={statusQuery.data} />
+          ) : null}
+          {statusQuery.data?.release && !noRoundsYet ? (
+            <ComputeReleaseCard release={statusQuery.data.release} />
           ) : null}
           {statusError ? (
             <Typography color="error" variant="body2">
@@ -159,6 +182,7 @@ const ComputePage: React.FC = () => {
             </Typography>
             <ComputeFleetTable
               miners={miners}
+              priced={hasPricing(statusQuery.data?.pricingSource)}
               isLoading={
                 !noRoundsYet && (minersQuery.isLoading || statusQuery.isLoading)
               }
@@ -169,6 +193,7 @@ const ComputePage: React.FC = () => {
 
           <ValidatorSnapshotFootnote
             validatorHotkey={statusQuery.data?.validatorHotkey}
+            pricingSource={statusQuery.data?.pricingSource}
           />
         </Box>
       </Box>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -766,8 +766,26 @@ const RepoCardSkeleton: React.FC<{ index: number }> = ({ index }) => (
 );
 
 const DashboardTimeline = React.lazy(() => import('./dashboard/DashboardPage'));
+const ComputeTimeline = React.lazy(() => import('./ComputePage'));
 
-type Timeline = 'repositories' | 'dashboard';
+// The dial's positions, left to right. Turning right moves one step toward
+// the end of this list, turning left one step toward the start.
+const TIMELINES = ['repositories', 'dashboard', 'compute'] as const;
+type Timeline = (typeof TIMELINES)[number];
+
+const dialTarget = (
+  active: Timeline,
+  dir: 'left' | 'right',
+): Timeline | null => {
+  const index = TIMELINES.indexOf(active) + (dir === 'right' ? 1 : -1);
+  return TIMELINES[index] ?? null;
+};
+
+const TIMELINE_TAGLINE: Record<Timeline, string> = {
+  repositories: 'These are the open source projects built by Gittensor.',
+  dashboard: 'This is the work done by Gittensor miners.',
+  compute: 'This is the GPU fleet serving Gittensor models.',
+};
 
 // A left/right dial button; grayed out when the dial can't turn that way
 // (the word that direction is already showing).
@@ -776,8 +794,8 @@ const DialArrow: React.FC<{
   active: Timeline;
   onTurn: (dir: 'left' | 'right') => void;
 }> = ({ dir, active, onTurn }) => {
-  const target: Timeline = dir === 'right' ? 'dashboard' : 'repositories';
-  const enabled = target !== active;
+  const target = dialTarget(active, dir);
+  const enabled = target !== null;
   return (
     <Box
       component="span"
@@ -892,8 +910,8 @@ const HomePage: React.FC = () => {
   } | null>(null);
 
   const turnDial = (dir: 'left' | 'right') => {
-    const target: Timeline = dir === 'right' ? 'dashboard' : 'repositories';
-    if (target === timeline) return;
+    const target = dialTarget(timeline, dir);
+    if (target === null) return;
     setLeaving({ word: timeline, dir });
     setTimeline(target);
   };
@@ -1142,7 +1160,7 @@ const HomePage: React.FC = () => {
         className={curtain === 'shown' ? 'landing-hold' : undefined}
         sx={{
           width: '100%',
-          maxWidth: timeline === 'dashboard' ? 1680 : 1320,
+          maxWidth: timeline === 'repositories' ? 1320 : 1680,
           mx: 'auto',
           px: { xs: 1.5, sm: 3 },
           py: { xs: 3, md: 5 },
@@ -1186,9 +1204,7 @@ const HomePage: React.FC = () => {
             ...fadeUp(80),
           })}
         >
-          {timeline === 'repositories'
-            ? 'These are the open source projects built by Gittensor.'
-            : 'This is the work done by Gittensor miners.'}
+          {TIMELINE_TAGLINE[timeline]}
         </Typography>
 
         {/* Dial toggle: only the active timeline shows, flanked by arrows.
@@ -1366,11 +1382,15 @@ const HomePage: React.FC = () => {
                     textAlign: 'center',
                   })}
                 >
-                  Loading dashboard…
+                  Loading {timeline}…
                 </Typography>
               }
             >
-              <DashboardTimeline />
+              {timeline === 'dashboard' ? (
+                <DashboardTimeline />
+              ) : (
+                <ComputeTimeline />
+              )}
             </React.Suspense>
           </Box>
         )}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -770,7 +770,7 @@ const ComputeTimeline = React.lazy(() => import('./ComputePage'));
 
 // The dial's positions, left to right. Turning right moves one step toward
 // the end of this list, turning left one step toward the start.
-const TIMELINES = ['repositories', 'dashboard', 'compute'] as const;
+const TIMELINES = ['repositories', 'compute', 'dashboard'] as const;
 type Timeline = (typeof TIMELINES)[number];
 
 const dialTarget = (

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { Box, Typography } from '@mui/material';
 import { alpha } from '@mui/material/styles';
 import { Page } from '../components/layout';
@@ -781,6 +782,9 @@ const dialTarget = (
   return TIMELINES[index] ?? null;
 };
 
+const isTimeline = (value: string | null): value is Timeline =>
+  (TIMELINES as readonly string[]).includes(value ?? '');
+
 const TIMELINE_TAGLINE: Record<Timeline, string> = {
   repositories: 'These are the open source projects built by Gittensor.',
   dashboard: 'This is the work done by Gittensor miners.',
@@ -901,7 +905,18 @@ const Curtain: React.FC<{ leaving: boolean }> = ({ leaving }) => (
 
 const HomePage: React.FC = () => {
   const reposQuery = useReposAndWeights();
-  const [timeline, setTimeline] = useState<Timeline>('repositories');
+  // The dial position lives in the URL (`/?view=compute`) so a drilldown's
+  // back link, a refresh, or a shared link land on the same timeline.
+  const [searchParams, setSearchParams] = useSearchParams();
+  const viewParam = searchParams.get('view');
+  const [timeline, setTimeline] = useState<Timeline>(
+    isTimeline(viewParam) ? viewParam : 'repositories',
+  );
+  useEffect(() => {
+    if (isTimeline(viewParam) && viewParam !== timeline) setTimeline(viewParam);
+    // Follow browser back/forward between dial positions.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [viewParam]);
   // The word leaving the dial; rendered just long enough to slide out in
   // the direction of travel, then cleared by onAnimationEnd.
   const [leaving, setLeaving] = useState<{
@@ -914,6 +929,9 @@ const HomePage: React.FC = () => {
     if (target === null) return;
     setLeaving({ word: timeline, dir });
     setTimeline(target);
+    setSearchParams(target === 'repositories' ? {} : { view: target }, {
+      replace: false,
+    });
   };
 
   const repos = useMemo(

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -81,7 +81,7 @@ const routesArray: AppRoute[] = [
     name: 'compute-miner',
     path: '/compute/miner',
     element: <ComputeMinerPage />,
-    showGlobalSearch: true,
+    showGlobalSearch: false,
   },
   {
     name: 'watchlist',

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -19,6 +19,8 @@ const IssueDetailsPage = React.lazy(() => import('./pages/IssueDetailsPage'));
 const RepositoriesPage = React.lazy(() => import('./pages/RepositoriesPage'));
 const LeaderboardPage = React.lazy(() => import('./pages/LeaderboardPage'));
 const MinerDetailsPage = React.lazy(() => import('./pages/MinerDetailsPage'));
+const ComputePage = React.lazy(() => import('./pages/ComputePage'));
+const ComputeMinerPage = React.lazy(() => import('./pages/ComputeMinerPage'));
 const RepositoryDetailsPage = React.lazy(
   () => import('./pages/RepositoryDetailsPage'),
 );
@@ -68,6 +70,18 @@ const routesArray: AppRoute[] = [
     name: 'top-miners-redirect',
     path: '/top-miners',
     element: <Navigate to="/leaderboard" replace />,
+  },
+  {
+    name: 'compute',
+    path: '/compute',
+    element: <ComputePage />,
+    showGlobalSearch: true,
+  },
+  {
+    name: 'compute-miner',
+    path: '/compute/miner',
+    element: <ComputeMinerPage />,
+    showGlobalSearch: true,
   },
   {
     name: 'watchlist',

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -24,3 +24,12 @@ export const minerRepositoryPath = (
   const base = `/miners/repository?name=${encodeURIComponent(repositoryFullName)}`;
   return options?.tab ? `${base}&tab=${options.tab}` : base;
 };
+
+export const computePath = (): string => '/compute';
+
+export const computeMinerPath = (hotkey: string): string =>
+  `/compute/miner?hotkey=${encodeURIComponent(hotkey)}`;
+
+/** Loose ss58 check — 48 chars, starts with `5` (Bittensor hotkeys). */
+export const looksLikeSs58Hotkey = (value: string): boolean =>
+  /^5[1-9A-HJ-NP-Za-km-z]{47}$/.test(value);

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -26,6 +26,8 @@ export const minerRepositoryPath = (
 };
 
 export const computePath = (): string => '/compute';
+/** The landing page with the dial turned to compute — where the fleet actually lives in the UI. */
+export const computeViewPath = (): string => '/?view=compute';
 
 export const computeMinerPath = (hotkey: string): string =>
   `/compute/miner?hotkey=${encodeURIComponent(hotkey)}`;


### PR DESCRIPTION
Compute page fixes from watching soak 6:

- **TTFT** column shows the validator-recorded milliseconds (e.g. `48 ms`) instead of the 0–1 credit; the credit moves to its own **Speed** column.
- **tok/s** is the observed decode rate on served traffic (the old `probeTps` was never populated after #1722). Both show for probation miners too.
- **Settled** and every other metric header has a tooltip; miner page KPIs / charts / footer rewritten to the current mechanism (round = window pass × speed credit × attested; settled = 12-round mean, what the miner is paid on). Stale `capacity (probe tok/s ÷ 180)` copy removed.

Needs das-gittensor #94 (`ttftMs` / `decodeTps`). Includes the earlier compute-page commits on this branch.

https://claude.ai/code/session_01Md8Vw3LJe91aNwrsje1UBY