### PR TITLE
compute pages: observed TTFT (ms) + decode tok/s, settled-score explanations

### DIFF
--- a/src/api/ServingApi.ts
+++ b/src/api/ServingApi.ts
@@ -63,7 +63,8 @@ const MINER_NUMERIC_FIELDS: readonly (keyof ServingMiner)[] = [
   'rounds24h',
 ];
 const MINER_NULLABLE_NUMERIC_FIELDS: readonly (keyof ServingMiner)[] = [
-  'probeTps',
+  'ttftMs',
+  'decodeTps',
   'estAlphaPerTempo',
   'estAlphaPerDay',
   'estUsdPerDay',
@@ -125,7 +126,7 @@ export const normalizeServingMiner = (row: ServingMiner): ServingMiner =>
   coerceNumbers(row, MINER_NUMERIC_FIELDS, MINER_NULLABLE_NUMERIC_FIELDS);
 
 const normalizeServingRound = (row: ServingRound): ServingRound =>
-  coerceNumbers(row, ROUND_NUMERIC_FIELDS, ['probeTps']);
+  coerceNumbers(row, ROUND_NUMERIC_FIELDS, ['ttftMs', 'decodeTps']);
 
 const normalizeServingStatus = (row: ServingStatus): ServingStatus =>
   coerceNumbers(row, STATUS_NUMERIC_FIELDS, STATUS_NULLABLE_NUMERIC_FIELDS);

--- a/src/api/mocks/servingMock.ts
+++ b/src/api/mocks/servingMock.ts
@@ -57,8 +57,9 @@ const buildMiner = (
     : ready
       ? 0.8 + rand() * 0.2
       : 0.4 + rand() * 0.35;
-  const probeTps = quarantined ? null : 120 + rand() * 90;
-  const capacity = probeTps ? Math.min(probeTps / 180, 1.2) : 0;
+  const decodeTps = quarantined ? null : 300 + rand() * 160;
+  const ttftMs = quarantined ? null : 35 + rand() * 120;
+  const capacity = ready ? 1 : 0;
   const credit = ready ? 0.85 + rand() * 0.15 : 0.5 + rand() * 0.4;
   const roundScore = ready ? credit * capacity : 0;
   const settledScore = ready ? roundScore * (0.9 + rand() * 0.1) : 0;
@@ -82,8 +83,9 @@ const buildMiner = (
       : null,
     served: ready ? 20 + Math.floor(rand() * 40) : 2,
     credit: Number(credit.toFixed(3)),
-    probeTps: probeTps === null ? null : Number(probeTps.toFixed(1)),
-    capacity: Number(capacity.toFixed(3)),
+    ttftMs: ttftMs === null ? null : Number(ttftMs.toFixed(1)),
+    decodeTps: decodeTps === null ? null : Number(decodeTps.toFixed(1)),
+    capacity,
     roundScore: Number(roundScore.toFixed(3)),
     settledScore: Number(settledScore.toFixed(3)),
     lastMissReason: quarantined
@@ -158,13 +160,15 @@ export const mockServingMinerDetail = (
   for (let i = count - 1; i >= 0; i -= 1) {
     const ts = new Date(end - i * ROUND_MS).toISOString();
     const jitter = () => 0.92 + rand() * 0.16;
-    const probeTps =
-      miner.probeTps === null
+    const decodeTps =
+      miner.decodeTps === null
         ? null
-        : Number((miner.probeTps * jitter()).toFixed(1));
-    const capacity = probeTps
-      ? Number(Math.min(probeTps / 180, 1.2).toFixed(3))
-      : 0;
+        : Number((miner.decodeTps * jitter()).toFixed(1));
+    const ttftMs =
+      miner.ttftMs === null
+        ? null
+        : Number((miner.ttftMs * jitter()).toFixed(1));
+    const capacity = miner.capacity;
     const credit = Number(Math.min(1, miner.credit * jitter()).toFixed(3));
     const missed = rand() < 0.04;
     const roundScore =
@@ -177,7 +181,8 @@ export const mockServingMinerDetail = (
       windowMean: miner.windowMean,
       windowN: miner.windowN,
       credit,
-      probeTps,
+      ttftMs,
+      decodeTps,
       capacity,
       roundScore,
       settledScore: Number((roundScore * 0.95).toFixed(3)),

--- a/src/api/models/Serving.ts
+++ b/src/api/models/Serving.ts
@@ -59,10 +59,16 @@ export interface ServingMiner {
   windowPassed: boolean;
   quarantinedUntil: string | null;
   served: number;
+  /** Speed credit 0–1: TTFT band × decode band, mean over the round's served requests. */
   credit: number;
-  probeTps: number | null;
+  /** Validator-observed time to first token, mean over the round (ms). */
+  ttftMs: number | null;
+  /** Validator-observed decode rate on served traffic, mean over the round (tok/s). */
+  decodeTps: number | null;
+  /** 1 when this round's hardware attestation passed, else 0. */
   capacity: number;
   roundScore: number;
+  /** Trailing 12-round mean of roundScore — what the miner is paid on. */
   settledScore: number;
   lastMissReason: string | null;
   roundTs: string;
@@ -79,7 +85,8 @@ export interface ServingRound {
   windowMean: number;
   windowN: number;
   credit: number;
-  probeTps: number | null;
+  ttftMs: number | null;
+  decodeTps: number | null;
   capacity: number;
   roundScore: number;
   settledScore: number;

--- a/src/components/compute/ColumnHint.tsx
+++ b/src/components/compute/ColumnHint.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Box, Tooltip } from '@mui/material';
+import { tooltipSlotProps } from '../../theme';
+
+interface ColumnHintProps {
+  label: string;
+  hint: string;
+}
+
+/** Column / KPI label with an explanatory tooltip. */
+export const ColumnHint: React.FC<ColumnHintProps> = ({ label, hint }) => (
+  <Tooltip title={hint} arrow placement="top" slotProps={tooltipSlotProps}>
+    <Box
+      component="span"
+      sx={{
+        textDecoration: 'underline dotted',
+        textUnderlineOffset: 3,
+        cursor: 'help',
+      }}
+    >
+      {label}
+    </Box>
+  </Tooltip>
+);

--- a/src/components/compute/ComputeFleetTable.tsx
+++ b/src/components/compute/ComputeFleetTable.tsx
@@ -4,12 +4,15 @@ import type { ServingMiner } from '../../api';
 import { useDataTableParams } from '../../hooks/useDataTableParams';
 import { computeMinerPath } from '../../utils/paths';
 import { DataTable, type DataTableColumn } from '../common/DataTable';
+import { ColumnHint } from './ColumnHint';
 import { ComputeStatusBadge } from './ComputeStatusBadge';
 import { CopyableHotkey } from './CopyableHotkey';
 import { MissReasonText } from './MissReasonText';
 import {
+  COMPUTE_METRIC_HINTS,
   formatAlpha,
   formatFixed,
+  formatMs,
   formatPercent,
   uptimeFraction,
 } from './computeFormat';
@@ -18,8 +21,8 @@ const SORT_KEYS = [
   'uid',
   'status',
   'tps',
+  'ttft',
   'credit',
-  'capacity',
   'settled',
   'uptime',
   'alpha',
@@ -32,7 +35,7 @@ const STATUS_RANK = { ready: 0, probation: 1, quarantined: 2 } as const;
 const cellSx = { py: 0.75, px: 1, whiteSpace: 'nowrap' } as const;
 const headerSx = { px: 1 } as const;
 
-/** Probe-derived metrics only mean something once a miner is READY. */
+/** Payout only means something once a miner is READY. */
 const readyOnly = (
   miner: ServingMiner,
   render: (m: ServingMiner) => string,
@@ -45,11 +48,11 @@ const sortValue = (miner: ServingMiner, key: FleetSortKey): number => {
     case 'status':
       return STATUS_RANK[miner.status] ?? 3;
     case 'tps':
-      return miner.probeTps ?? -1;
+      return miner.decodeTps ?? -1;
+    case 'ttft':
+      return miner.ttftMs ?? Number.POSITIVE_INFINITY;
     case 'credit':
       return miner.credit;
-    case 'capacity':
-      return miner.capacity;
     case 'settled':
       return miner.settledScore;
     case 'uptime':
@@ -81,7 +84,7 @@ export const ComputeFleetTable: React.FC<ComputeFleetTableProps> = ({
   const { sortField, sortOrder, setSort } = useDataTableParams<FleetSortKey>({
     sortKeys: SORT_KEYS,
     defaultSortKey: 'settled',
-    defaultOrderOverrides: { uid: 'asc', status: 'asc' },
+    defaultOrderOverrides: { uid: 'asc', status: 'asc', ttft: 'asc' },
   });
 
   const rows = useMemo(() => {
@@ -122,37 +125,39 @@ export const ComputeFleetTable: React.FC<ComputeFleetTableProps> = ({
       },
       {
         key: 'tps',
-        header: 'tok/s',
+        header: <ColumnHint label="tok/s" hint={COMPUTE_METRIC_HINTS.tps} />,
         width: 76,
         align: 'right',
         sortKey: 'tps',
         cellSx,
         headerSx,
-        renderCell: (m) => readyOnly(m, (x) => formatFixed(x.probeTps, 0)),
+        renderCell: (m) => formatFixed(m.decodeTps, 0),
+      },
+      {
+        key: 'ttft',
+        header: <ColumnHint label="TTFT" hint={COMPUTE_METRIC_HINTS.ttft} />,
+        width: 84,
+        align: 'right',
+        sortKey: 'ttft',
+        cellSx,
+        headerSx,
+        renderCell: (m) => formatMs(m.ttftMs),
       },
       {
         key: 'credit',
-        header: 'TTFT',
+        header: <ColumnHint label="Speed" hint={COMPUTE_METRIC_HINTS.credit} />,
         width: 76,
         align: 'right',
         sortKey: 'credit',
         cellSx,
         headerSx,
-        renderCell: (m) => readyOnly(m, (x) => formatFixed(x.credit, 2)),
-      },
-      {
-        key: 'capacity',
-        header: 'Capacity',
-        width: 104,
-        align: 'right',
-        sortKey: 'capacity',
-        cellSx,
-        headerSx,
-        renderCell: (m) => readyOnly(m, (x) => formatFixed(x.capacity, 2)),
+        renderCell: (m) => formatFixed(m.credit, 2),
       },
       {
         key: 'settled',
-        header: 'Settled',
+        header: (
+          <ColumnHint label="Settled" hint={COMPUTE_METRIC_HINTS.settled} />
+        ),
         width: 86,
         align: 'right',
         sortKey: 'settled',

--- a/src/components/compute/computeFormat.ts
+++ b/src/components/compute/computeFormat.ts
@@ -8,7 +8,19 @@ import type {
 
 export const WINDOW_SLOTS = 10;
 export const WINDOW_READY_MEAN = 0.8;
-export const CAPACITY_REFERENCE_TPS = 180;
+export const SETTLEMENT_ROUNDS = 12;
+
+/** Header tooltips for the fleet table / KPI cards. */
+export const COMPUTE_METRIC_HINTS = {
+  tps: 'Decode rate the validator observed on traffic it sent this miner (completion tokens ÷ time after first token), mean over the round.',
+  ttft: 'Time to first token the validator observed on traffic it sent this miner, mean over the round.',
+  credit:
+    'Speed credit 0–1: TTFT band × decode band against the blessed 5090 curve, mean over the round. Misses earn 0.',
+  attested:
+    'Hardware attestation this round: seeded VRAM fill + GEMM chain must match the reference runtime. Not attested = no pay this round.',
+  settled: `Mean round score over the trailing ${SETTLEMENT_ROUNDS} rounds (~1 h). 1.0 = one fully paid card; this is what the miner is paid on.`,
+  round: 'This round: window pass (0/1) × speed credit × attested (0/1).',
+} as const;
 
 export const COMPUTE_STATUS_META: Record<
   ServingMinerStatus,
@@ -46,6 +58,16 @@ export const formatFixed = (
   value === null || value === undefined || !Number.isFinite(value)
     ? '—'
     : value.toFixed(decimals);
+
+export const formatMs = (value: number | null | undefined): string =>
+  value === null || value === undefined || !Number.isFinite(value)
+    ? '—'
+    : `${Math.round(value)} ms`;
+
+export const formatTps = (value: number | null | undefined): string =>
+  value === null || value === undefined || !Number.isFinite(value)
+    ? '—'
+    : `${Math.round(value)} tok/s`;
 
 export const formatPercent = (
   fraction: number | null | undefined,
@@ -132,7 +154,7 @@ export const formatRelative = (iso: string | null | undefined): string => {
 export const describeMinerStatus = (miner: ServingMiner): string => {
   switch (miner.status) {
     case 'ready':
-      return `Serving. Window ${miner.windowN}/${WINDOW_SLOTS}, settled ${formatFixed(miner.settledScore, 2)}.`;
+      return `Serving. Window ${miner.windowN}/${WINDOW_SLOTS}, settled ${formatFixed(miner.settledScore, 2)} (${SETTLEMENT_ROUNDS}-round mean).`;
     case 'probation':
       return `Not READY yet — window ${miner.windowN}/${WINDOW_SLOTS} mean ${formatFixed(miner.windowMean, 2)}, needs ≥ ${WINDOW_READY_MEAN} (validator sends 2 baseline prompts per round).`;
     case 'quarantined':

--- a/src/components/compute/index.ts
+++ b/src/components/compute/index.ts
@@ -7,3 +7,4 @@ export * from './ComputeRoundChart';
 export * from './ComputeMissesTable';
 export * from './ComputeReleaseCard';
 export * from './MissReasonText';
+export * from './ColumnHint';

--- a/src/pages/ComputeMinerPage.tsx
+++ b/src/pages/ComputeMinerPage.tsx
@@ -6,6 +6,7 @@ import { BackButton, SEO } from '../components';
 import KpiCard from '../components/KpiCard';
 import {
   COMPUTE_STATUS_META,
+  SETTLEMENT_ROUNDS,
   ComputeMissesTable,
   ComputeRoundChart,
   ComputeStatusBadge,
@@ -14,6 +15,7 @@ import {
   describeMinerStatus,
   formatAlpha,
   formatFixed,
+  formatMs,
   formatPercent,
   formatRelative,
   formatUsd,
@@ -151,7 +153,7 @@ const MinerKpis: React.FC<{ miner: ServingMiner; priced: boolean }> = ({
       <KpiCard
         title="Settled score"
         value={formatFixed(miner.settledScore, 3)}
-        subtitle={`Round ${formatFixed(miner.roundScore, 3)}`}
+        subtitle={`${SETTLEMENT_ROUNDS}-round mean · this round ${formatFixed(miner.roundScore, 3)}`}
       />
       <KpiCard
         title="Est. alpha/day"
@@ -159,11 +161,15 @@ const MinerKpis: React.FC<{ miner: ServingMiner; priced: boolean }> = ({
         subtitle={payoutSubtitle}
       />
       <KpiCard
-        title="tok/s"
-        value={formatFixed(miner.probeTps, 0)}
-        subtitle={`Capacity ${formatFixed(miner.capacity, 2)} (÷ 180)`}
+        title="Decode tok/s"
+        value={formatFixed(miner.decodeTps, 0)}
+        subtitle={`TTFT ${formatMs(miner.ttftMs)}`}
       />
-      <KpiCard title="TTFT credit" value={formatFixed(miner.credit, 2)} />
+      <KpiCard
+        title="Speed credit"
+        value={formatFixed(miner.credit, 2)}
+        subtitle={miner.capacity > 0 ? 'Attested' : 'Not attested'}
+      />
       <KpiCard
         title="Uptime 24h"
         value={formatPercent(uptimeFraction(miner))}
@@ -176,8 +182,8 @@ const MinerKpis: React.FC<{ miner: ServingMiner; priced: boolean }> = ({
 const RoundCharts: React.FC<{ rounds: ServingRound[] }> = ({ rounds }) => {
   const timestamps = useMemo(() => rounds.map((r) => r.roundTs), [rounds]);
   const scores = useMemo(() => rounds.map((r) => r.roundScore), [rounds]);
-  const tps = useMemo(() => rounds.map((r) => r.probeTps), [rounds]);
-  const credits = useMemo(() => rounds.map((r) => r.credit), [rounds]);
+  const tps = useMemo(() => rounds.map((r) => r.decodeTps), [rounds]);
+  const ttft = useMemo(() => rounds.map((r) => r.ttftMs), [rounds]);
   const emptyHint = `No audit rounds for this miner in the last ${HISTORY_HOURS} h.`;
   return (
     <Box
@@ -196,7 +202,7 @@ const RoundCharts: React.FC<{ rounds: ServingRound[] }> = ({ rounds }) => {
         emptyHint={emptyHint}
       />
       <ComputeRoundChart
-        title="Probe tok/s"
+        title="Decode tok/s"
         timestamps={timestamps}
         values={tps}
         color={STATUS_COLORS.info}
@@ -204,11 +210,11 @@ const RoundCharts: React.FC<{ rounds: ServingRound[] }> = ({ rounds }) => {
         emptyHint={emptyHint}
       />
       <ComputeRoundChart
-        title="TTFT credit"
+        title="TTFT (ms)"
         timestamps={timestamps}
-        values={credits}
+        values={ttft}
         color={STATUS_COLORS.warning}
-        yMax={1}
+        decimals={0}
         emptyHint={emptyHint}
       />
     </Box>
@@ -315,9 +321,11 @@ const ComputeMinerPage: React.FC = () => {
               color: alpha(theme.palette.common.white, TEXT_OPACITY.muted),
             }}
           >
-            Score = window pass × TTFT credit × capacity (probe tok/s ÷ 180),
-            settled over the trailing 12 rounds. A WRONG answer wipes the window
-            and quarantines the miner for 1 h.
+            Round score = window pass × speed credit (TTFT band × decode band
+            vs. the blessed 5090 curve, on traffic this validator sent) ×
+            hardware attestation. Settled = mean over the trailing{' '}
+            {SETTLEMENT_ROUNDS} rounds (~1 h) and is what the miner is paid on.
+            A WRONG answer wipes the window and quarantines the miner for 1 h.
           </Typography>
           <ValidatorSnapshotFootnote
             validatorHotkey={query.data?.validatorHotkey}

--- a/src/pages/ComputePage.tsx
+++ b/src/pages/ComputePage.tsx
@@ -77,7 +77,7 @@ const ComputeKpis: React.FC<{ status: ServingStatus }> = ({ status }) => {
       <KpiCard
         title="Card-equivalents"
         value={status.cardEquivalents.toFixed(2)}
-        subtitle="Sum of settled scores"
+        subtitle="Σ settled scores · paid 5090s this round"
       />
       <KpiCard
         title="Est. alpha/day per card"


### PR DESCRIPTION
Rebased replacement for #1371 (its base commits were already squash-merged as #1370).

- **TTFT** column shows the validator-recorded milliseconds (e.g. `48 ms`) instead of the 0–1 credit; the credit moves to its own **Speed** column.
- **tok/s** is the observed decode rate on served traffic (the old `probeTps` was never populated after gittensor #1722). Both show for probation miners too.
- **Settled** and every other metric header has a tooltip; miner page KPIs / charts / footer rewritten to the current mechanism (round = window pass × speed credit × attested; settled = 12-round mean, what the miner is paid on). Stale `capacity (probe tok/s ÷ 180)` copy removed.

Needs das-gittensor #94 (merged).

https://claude.ai/code/session_01Md8Vw3LJe91aNwrsje1UBY