### PR TITLE
compute: release card shows the attest image and both docker run lines

### DIFF
--- a/src/api/mocks/servingMock.ts
+++ b/src/api/mocks/servingMock.ts
@@ -143,6 +143,7 @@ export const mockServingStatus = (): ServingStatus => {
         '9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08',
       modelFile: 'gpt-oss-20b-q8_0.gguf',
       image: 'entrius/sparkinfer:12954e6',
+      attestImage: 'entrius/gt-attest:v1',
     },
   };
 };

--- a/src/api/models/Serving.ts
+++ b/src/api/models/Serving.ts
@@ -13,8 +13,10 @@ export interface ServingRelease {
   runtimePin: string;
   modelSha256: string;
   modelFile: string;
-  /** e.g. "entrius/sparkinfer:12954e6" */
+  /** e.g. "entrius/sparkinfer:7498736@sha256:…" — the runtime container */
   image: string;
+  /** e.g. "entrius/gt-attest:v1" — the attest container every box runs beside the runtime; null on older rounds */
+  attestImage: string | null;
 }
 
 export interface ServingStatus {
@@ -65,7 +67,7 @@ export interface ServingMiner {
   ttftMs: number | null;
   /** Validator-observed decode rate on served traffic, mean over the round (tok/s). */
   decodeTps: number | null;
-  /** 1 when this round's hardware attestation passed, else 0. */
+  /** GPUs that passed this round's hardware attestation (0 = not attested); each is a card-hour. */
   capacity: number;
   roundScore: number;
   /** Trailing 12-round mean of roundScore — what the miner is paid on. */

--- a/src/components/compute/ComputeReleaseCard.tsx
+++ b/src/components/compute/ComputeReleaseCard.tsx
@@ -21,9 +21,17 @@ const DOCKER_HUB_URL = 'https://hub.docker.com/u/entrius';
 
 const MONO = '"JetBrains Mono", monospace';
 
-/** The exact command miners run; kept in one place so docs can link here. */
+/** The exact commands miners run — the runtime and, beside it, the attest container that answers the validators'
+ *  hardware challenge on every GPU of the box. Kept in one place so docs can link here. */
 export const buildSparkinferRunCommand = (release: ServingRelease): string =>
-  `docker run -d --name sparkinfer --gpus all -p 8080:8080 -v sparkmodels:/opt/sparkinfer/models -e MODEL_SHA256=${release.modelSha256} -e SPARKINFER_DETERMINISTIC=1 ${release.image}`;
+  [
+    `docker run -d --name sparkinfer --gpus all --restart unless-stopped -p 127.0.0.1:8080:8080 -v sparkmodels:/opt/sparkinfer/models -e MODEL_SHA256=${release.modelSha256} -e SPARKINFER_DETERMINISTIC=1 ${release.image}`,
+    release.attestImage
+      ? `docker run -d --name gt-attest --gpus all --restart unless-stopped -p 127.0.0.1:8081:8081 ${release.attestImage}`
+      : null,
+  ]
+    .filter(Boolean)
+    .join('\n');
 
 const CopyButton: React.FC<{ text: string; label: string }> = ({
   text,
@@ -162,6 +170,11 @@ export const ComputeReleaseCard: React.FC<{ release: ServingRelease }> = ({
         <Field label="Model file" value={release.modelFile} />
         <Field label="Image" value={release.image} copyable />
       </Box>
+      {release.attestImage && (
+        <Box sx={{ mb: 2 }}>
+          <Field label="Attest image" value={release.attestImage} copyable />
+        </Box>
+      )}
       <Box sx={{ mb: 2 }}>
         <Field label="Model SHA-256" value={release.modelSha256} copyable />
       </Box>
@@ -201,7 +214,7 @@ export const ComputeReleaseCard: React.FC<{ release: ServingRelease }> = ({
         >
           <code>{command}</code>
         </Box>
-        <CopyButton text={command} label="docker command" />
+        <CopyButton text={command} label="docker commands" />
       </Box>
 
       <Stack direction="row" flexWrap="wrap" gap={2} sx={{ mt: 1.5 }}>


### PR DESCRIPTION
Pairs with das `serving/attest-image` (`attestImage` on the release) and entrius/gittensor#1727. Card gets an "Attest image" field and the two `docker run` lines; `capacity` documented as attested cards.

https://claude.ai/code/session_01FJtQK6NCjUgYkGTopczEf4