### PR TITLE
compute: release card emits the miner .env

### DIFF
--- a/src/components/compute/ComputeReleaseCard.tsx
+++ b/src/components/compute/ComputeReleaseCard.tsx
@@ -18,10 +18,22 @@ import { TEXT_OPACITY, scrollbarSx, tooltipSlotProps } from '../../theme';
 
 // Images for every blessed runtime/model live under the entrius org; the release row says which one to pull.
 const DOCKER_HUB_URL = 'https://hub.docker.com/u/entrius';
+const MINER_GUIDE_URL = 'https://docs.gittensor.io/compute-miner.html';
 
 const MONO = '"JetBrains Mono", monospace';
 
-/** The exact commands miners run — the runtime and, beside it, the attest container that answers the validators'
+/** The release side of a miner's `.env` for docker-compose.miner.yml (miner.env.example in the gittensor repo) —
+ *  the values only this card can supply, one paste. */
+export const buildMinerEnv = (release: ServingRelease): string =>
+  [
+    `RUNTIME_IMAGE=${release.image}`,
+    release.attestImage ? `ATTEST_IMAGE=${release.attestImage}` : null,
+    `MODEL_SHA256=${release.modelSha256}`,
+  ]
+    .filter(Boolean)
+    .join('\n');
+
+/** The no-compose path: the runtime and, beside it, the attest container that answers the validators'
  *  hardware challenge on every GPU of the box. Kept in one place so docs can link here. */
 export const buildSparkinferRunCommand = (release: ServingRelease): string =>
   [
@@ -76,6 +88,55 @@ const CopyButton: React.FC<{ text: string; label: string }> = ({
   );
 };
 
+const CommandBlock: React.FC<{ label: string; text: string }> = ({
+  label,
+  text,
+}) => {
+  const theme = useTheme();
+  const muted = alpha(theme.palette.common.white, TEXT_OPACITY.muted);
+  return (
+    <>
+      <Typography
+        variant="dataLabel"
+        sx={{ display: 'block', color: muted, mb: 0.5 }}
+      >
+        {label}
+      </Typography>
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'flex-start',
+          gap: 1,
+          borderRadius: 2,
+          border: `1px solid ${theme.palette.border.light}`,
+          backgroundColor: theme.palette.surface.subtle,
+          px: 1.5,
+          py: 1,
+        }}
+      >
+        <Box
+          component="pre"
+          sx={{
+            m: 0,
+            flex: 1,
+            minWidth: 0,
+            overflowX: 'hidden',
+            fontFamily: MONO,
+            fontSize: '0.78rem',
+            lineHeight: 1.5,
+            whiteSpace: 'pre-wrap',
+            overflowWrap: 'anywhere',
+            ...scrollbarSx,
+          }}
+        >
+          <code>{text}</code>
+        </Box>
+        <CopyButton text={text} label={label} />
+      </Box>
+    </>
+  );
+};
+
 const Field: React.FC<{
   label: string;
   value: string;
@@ -120,6 +181,7 @@ export const ComputeReleaseCard: React.FC<{ release: ServingRelease }> = ({
   release,
 }) => {
   const theme = useTheme();
+  const env = buildMinerEnv(release);
   const command = buildSparkinferRunCommand(release);
   const muted = alpha(theme.palette.common.white, TEXT_OPACITY.muted);
   return (
@@ -168,7 +230,7 @@ export const ComputeReleaseCard: React.FC<{ release: ServingRelease }> = ({
         <Field label="Model" value={release.modelId} />
         <Field label="Runtime pin" value={release.runtimePin} copyable />
         <Field label="Model file" value={release.modelFile} />
-        <Field label="Image" value={release.image} copyable />
+        <Field label="Runtime image" value={release.image} copyable />
       </Box>
       {release.attestImage && (
         <Box sx={{ mb: 2 }}>
@@ -179,46 +241,16 @@ export const ComputeReleaseCard: React.FC<{ release: ServingRelease }> = ({
         <Field label="Model SHA-256" value={release.modelSha256} copyable />
       </Box>
 
-      <Typography
-        variant="dataLabel"
-        sx={{ display: 'block', color: muted, mb: 0.5 }}
-      >
-        Run it
-      </Typography>
-      <Box
-        sx={{
-          display: 'flex',
-          alignItems: 'flex-start',
-          gap: 1,
-          borderRadius: 2,
-          border: `1px solid ${theme.palette.border.light}`,
-          backgroundColor: theme.palette.surface.subtle,
-          px: 1.5,
-          py: 1,
-        }}
-      >
-        <Box
-          component="pre"
-          sx={{
-            m: 0,
-            flex: 1,
-            minWidth: 0,
-            overflowX: 'hidden',
-            fontFamily: MONO,
-            fontSize: '0.78rem',
-            lineHeight: 1.5,
-            whiteSpace: 'pre-wrap',
-            overflowWrap: 'anywhere',
-            ...scrollbarSx,
-          }}
-        >
-          <code>{command}</code>
-        </Box>
-        <CopyButton text={command} label="docker commands" />
+      <CommandBlock label="Miner .env" text={env} />
+      <Box sx={{ mt: 2 }}>
+        <CommandBlock label="Run it without compose" text={command} />
       </Box>
 
       <Stack direction="row" flexWrap="wrap" gap={2} sx={{ mt: 1.5 }}>
-        {[{ label: 'Docker Hub', href: DOCKER_HUB_URL }].map((link) => (
+        {[
+          { label: 'Miner guide', href: MINER_GUIDE_URL },
+          { label: 'Docker Hub', href: DOCKER_HUB_URL },
+        ].map((link) => (
           <Link
             key={link.href}
             href={link.href}


### PR DESCRIPTION
UI half of the docker-only miner onboarding (entrius/gittensor#1746, docs entrius/gittensor-docs-ui#39 + #40). The docs now send miners to this card to fill `.env` for `docker-compose.miner.yml`; the card still led with the old hand-wired `docker run` lines.

- The "Run it" block is replaced by a **Miner .env** block — `RUNTIME_IMAGE` / `ATTEST_IMAGE` / `MODEL_SHA256` generated from the release, one copy button, one paste into the miner's `.env`. Scales to future releases untouched: whatever release the card (or a future release picker) shows, the block emits it.
- The docker-run lines survive demoted to **Run it without compose** (still correct for hand-rolled multi-card boxes and validator references), sharing one `CommandBlock` component with the env block.
- The "Image" field is relabeled **Runtime image** to match the env var and the docs table (the miner-facing interface names no specific runtime).
- A **Miner guide** link (docs.gittensor.io/compute-miner.html) joins Docker Hub under the card.

`npm run lint` and `npm run build` pass. No tests added.

Same release train as gittensor#1746: the compose file this promotes lands on `main` raw URLs at the next test→main promotion.

https://claude.ai/code/session_014c7dZFY9dzzhRxE4oFy96u