### PR TITLE
compute: Current release card for a model-directory release (Qwen3.8-27B)

### DIFF
--- a/src/api/mocks/servingMock.ts
+++ b/src/api/mocks/servingMock.ts
@@ -149,7 +149,7 @@ export const mockServingStatus = (): ServingStatus => {
     gpuHourUsd: 0.7,
     // $0.70 card-hour over ~338 tok/s aggregate ≈ $0.58 per million output tokens
     usdPerMTokens: 0.575,
-    usdPerMPromptTokens: 0.0081,
+    usdPerMPromptTokens: 0.0259,
     pricingSource: 'validator',
     alphaPerHour,
     alphaUsd: ALPHA_USD,

--- a/src/api/mocks/servingMock.ts
+++ b/src/api/mocks/servingMock.ts
@@ -57,13 +57,14 @@ const buildMiner = (
     : ready
       ? 0.8 + rand() * 0.2
       : 0.4 + rand() * 0.35;
-  const decodeTps = quarantined ? null : 300 + rand() * 160;
+  // Qwen3.8-27B NVFP4 on one 5090: ~99 tok/s single-stream, ~338 tok/s aggregate across streams
+  const decodeTps = quarantined ? null : 90 + rand() * 12;
   const ttftMs = quarantined ? null : 35 + rand() * 120;
   const attested = ready;
   const credit = ready ? 0.85 + rand() * 0.15 : 0.5 + rand() * 0.4;
-  // ~84k output tokens is one 5090 flat out for a 5-minute round
-  const tokens = ready ? Math.floor(20_000 + rand() * 60_000) : 0;
-  const roundScore = ready ? tokens / 84_000 : 0;
+  // ~101k output tokens (338 tok/s aggregate × 300 s) is one 5090 flat out for a 5-minute round
+  const tokens = ready ? Math.floor(25_000 + rand() * 70_000) : 0;
+  const roundScore = ready ? tokens / 101_000 : 0;
   const settledScore = ready ? roundScore * (0.9 + rand() * 0.1) : 0;
   const rounds24h = 280 + Math.floor(rand() * 8);
   const readyRounds24h = ready
@@ -75,7 +76,7 @@ const buildMiner = (
     hotkey: hotkeyFor(row.uid),
     githubId: row.githubId,
     username: row.username,
-    modelId: 'gpt-oss-20b',
+    modelId: 'qwen3.8-27b',
     status: row.status,
     windowMean: Number(windowMean.toFixed(3)),
     windowN,
@@ -146,7 +147,8 @@ export const mockServingStatus = (): ServingStatus => {
     poolShare: 0.0212,
     poolCap: 0.1,
     gpuHourUsd: 0.7,
-    usdPerMTokens: 0.694,
+    // $0.70 card-hour over ~338 tok/s aggregate ≈ $0.58 per million output tokens
+    usdPerMTokens: 0.575,
     usdPerMPromptTokens: 0.0081,
     pricingSource: 'validator',
     alphaPerHour,
@@ -156,12 +158,20 @@ export const mockServingStatus = (): ServingStatus => {
     estUsdPerCardDay: Number((alphaPerHour * 24 * ALPHA_USD).toFixed(2)),
     roundsLast24h: 287,
     release: {
-      modelId: 'gpt-oss-20b',
-      runtimePin: 'gittensor-ai-lab/sparkinfer@12954e6',
-      modelSha256:
-        '9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08',
-      modelFile: 'gpt-oss-20b-q8_0.gguf',
-      image: 'entrius/sparkinfer:12954e6',
+      modelId: 'qwen3.8-27b',
+      runtimePin: 'gittensor-ai-lab/sparkinfer@19ef39ec2',
+      modelSha256: null,
+      modelFile:
+        'gittensor-model-hub/Qwen3.8-27B-NVFP4-RTX5090@8e2c0cd25468ac5c1f85f621c2b8edb15ea1f03a',
+      modelDirSha256:
+        'model-00001-of-00002.safetensors=cdd37b0e61eccc8a3d7d08f9d1a4f52856a9d88e4e8b42089bd18a970e3a01ec,model-00002-of-00002.safetensors=713b84b8287e2193290214766c5384fa6475c5626a628e4021c2c9ca90aa61df',
+      runtimeEnv: {
+        CTX: '131072',
+        MODEL_NAME: 'qwen3.8-27b',
+        TOK_REPO: 'Qwen/Qwen3.8-27B',
+      },
+      image:
+        'entrius/sparkinfer:19ef39ec2@sha256:d35719b03f320f7c30abcb7f6b495e64fb7edbe4187c8744775277dc661a23bb',
       attestImage: 'entrius/gt-attest:v1',
     },
   };
@@ -194,7 +204,7 @@ export const mockServingMinerDetail = (
       miner.status === 'ready' && !missed
         ? Math.floor(miner.tokens * jitter())
         : 0;
-    const roundScore = Number((tokens / 84_000).toFixed(3));
+    const roundScore = Number((tokens / 101_000).toFixed(3));
     rounds.push({
       roundTs: ts,
       status: miner.status,

--- a/src/api/models/Serving.ts
+++ b/src/api/models/Serving.ts
@@ -6,14 +6,28 @@ export type ServingMinerStatus = 'ready' | 'probation' | 'quarantined';
 /** Where the alpha price used for USD estimates came from. */
 export type ServingPricingSource = 'validator' | 'taostats' | 'none';
 
-/** The model/runtime pin the validator currently enforces. */
+/**
+ * The model/runtime pin the validator currently enforces. The model artifact takes one of two shapes:
+ *  - a GGUF release: `modelFile` is the file name and `modelSha256` its digest (`modelDirSha256` null);
+ *  - a Hugging Face model-directory release: `modelFile` is `<hf repo>@<hf commit sha>`, `modelSha256` is null and
+ *    `modelDirSha256` carries one digest per weight shard.
+ */
 export interface ServingRelease {
   modelId: string;
-  /** e.g. "gittensor-ai-lab/sparkinfer@12954e6" */
+  /** e.g. "gittensor-ai-lab/sparkinfer@19ef39ec2" */
   runtimePin: string;
-  modelSha256: string;
+  /** The GGUF file's sha256; null for a model-directory release. */
+  modelSha256: string | null;
+  /** A GGUF file name (e.g. "Qwen3.6-35B-A3B-UD-Q4_K_M.gguf") or, for a directory release, `<hf repo>@<hf commit sha>`
+   *  (e.g. "gittensor-model-hub/Qwen3.8-27B-NVFP4-RTX5090@8e2c0cd2…"). */
   modelFile: string;
-  /** e.g. "entrius/sparkinfer:7498736@sha256:…" — the runtime container */
+  /** Directory release only: "model-00001-of-00002.safetensors=<sha256>,model-00002-of-00002.safetensors=<sha256>" —
+   *  every weight shard the runtime entrypoint verifies before serving. Null for a GGUF release. */
+  modelDirSha256: string | null;
+  /** Extra env the runtime container needs for this release, e.g. {"CTX":"131072","MODEL_NAME":"qwen3.8-27b",
+   *  "TOK_REPO":"Qwen/Qwen3.8-27B"}; null when the image's defaults suffice. */
+  runtimeEnv: Record<string, string> | null;
+  /** e.g. "entrius/sparkinfer:19ef39ec2@sha256:…" — the runtime container */
   image: string;
   /** e.g. "entrius/gt-attest:v1" — the attest container every box runs beside the runtime; null on older rounds */
   attestImage: string | null;

--- a/src/components/compute/ComputeReleaseCard.tsx
+++ b/src/components/compute/ComputeReleaseCard.tsx
@@ -22,28 +22,73 @@ const MINER_GUIDE_URL = 'https://docs.gittensor.io/compute-miner.html';
 
 const MONO = '"JetBrains Mono", monospace';
 
+/** Split "file=sha256,file=sha256" for display; the runtime takes the joined string verbatim. */
+export const splitShardDigests = (digests: string): string[] =>
+  digests
+    .split(',')
+    .map((part) => part.trim())
+    .filter(Boolean);
+
+/** A directory release's `modelFile` is "<hf repo>@<hf commit sha>" — the two halves the entrypoint pins on. */
+const splitModelDir = (
+  modelFile: string,
+): { repo: string; revision: string } => {
+  const at = modelFile.lastIndexOf('@');
+  return at < 0
+    ? { repo: modelFile, revision: '' }
+    : { repo: modelFile.slice(0, at), revision: modelFile.slice(at + 1) };
+};
+
+const isDirectoryRelease = (release: ServingRelease): boolean =>
+  Boolean(release.modelDirSha256);
+
+/** The runtime container's release env as KEY=value pairs, in the order the .env block and the `-e` flags list them.
+ *  A GGUF release pins one file (MODEL_SHA256); a model-directory release pins the Hugging Face repo at a commit plus
+ *  every weight shard's digest (MODEL_DIR_REPO / MODEL_DIR_REVISION / MODEL_DIR_SHA256) —
+ *  docker/sparkinfer-entrypoint.sh in the gittensor repo refuses to start on a mismatch. `runtimeEnv` (CTX,
+ *  MODEL_NAME, TOK_REPO…) rides along whenever the release carries it. */
+export const buildRuntimeEnvPairs = (
+  release: ServingRelease,
+): Array<[string, string]> => {
+  const model: Array<[string, string]> = release.modelDirSha256
+    ? (() => {
+        const { repo, revision } = splitModelDir(release.modelFile);
+        return [
+          ['MODEL_DIR_REPO', repo],
+          ['MODEL_DIR_REVISION', revision],
+          ['MODEL_DIR_SHA256', release.modelDirSha256],
+        ];
+      })()
+    : [['MODEL_SHA256', release.modelSha256 ?? '']];
+  return [...model, ...Object.entries(release.runtimeEnv ?? {})];
+};
+
 /** The release side of a miner's `.env` for docker-compose.miner.yml (miner.env.example in the gittensor repo) —
  *  the values only this card can supply, one paste. */
 export const buildMinerEnv = (release: ServingRelease): string =>
   [
     `RUNTIME_IMAGE=${release.image}`,
     release.attestImage ? `ATTEST_IMAGE=${release.attestImage}` : null,
-    `MODEL_SHA256=${release.modelSha256}`,
+    ...buildRuntimeEnvPairs(release).map(([key, value]) => `${key}=${value}`),
   ]
     .filter(Boolean)
     .join('\n');
 
 /** The no-compose path: the runtime and, beside it, the attest container that answers the validators'
  *  hardware challenge on every GPU of the box. Kept in one place so docs can link here. */
-export const buildSparkinferRunCommand = (release: ServingRelease): string =>
-  [
-    `docker run -d --name sparkinfer --gpus all --restart unless-stopped -p 127.0.0.1:8080:8080 -v sparkmodels:/opt/sparkinfer/models -e MODEL_SHA256=${release.modelSha256} -e SPARKINFER_DETERMINISTIC=1 ${release.image}`,
+export const buildSparkinferRunCommand = (release: ServingRelease): string => {
+  const env = buildRuntimeEnvPairs(release)
+    .map(([key, value]) => `-e ${key}=${value}`)
+    .join(' ');
+  return [
+    `docker run -d --name sparkinfer --gpus all --restart unless-stopped -p 127.0.0.1:8080:8080 -v sparkmodels:/opt/sparkinfer/models ${env} -e SPARKINFER_DETERMINISTIC=1 ${release.image}`,
     release.attestImage
       ? `docker run -d --name gt-attest --gpus all --restart unless-stopped -p 127.0.0.1:8081:8081 ${release.attestImage}`
       : null,
   ]
     .filter(Boolean)
     .join('\n');
+};
 
 const CopyButton: React.FC<{ text: string; label: string }> = ({
   text,
@@ -88,10 +133,12 @@ const CopyButton: React.FC<{ text: string; label: string }> = ({
   );
 };
 
-const CommandBlock: React.FC<{ label: string; text: string }> = ({
-  label,
-  text,
-}) => {
+const CommandBlock: React.FC<{
+  label: string;
+  text: string;
+  /** What the copy button puts on the clipboard when it differs from the displayed text. */
+  copyText?: string;
+}> = ({ label, text, copyText = text }) => {
   const theme = useTheme();
   const muted = alpha(theme.palette.common.white, TEXT_OPACITY.muted);
   return (
@@ -131,7 +178,7 @@ const CommandBlock: React.FC<{ label: string; text: string }> = ({
         >
           <code>{text}</code>
         </Box>
-        <CopyButton text={text} label={label} />
+        <CopyButton text={copyText} label={label} />
       </Box>
     </>
   );
@@ -162,6 +209,7 @@ const Field: React.FC<{
             fontFamily: MONO,
             fontSize: '0.82rem',
             overflowWrap: 'anywhere',
+            whiteSpace: 'pre-line',
             minWidth: 0,
           }}
         >
@@ -184,6 +232,10 @@ export const ComputeReleaseCard: React.FC<{ release: ServingRelease }> = ({
   const env = buildMinerEnv(release);
   const command = buildSparkinferRunCommand(release);
   const muted = alpha(theme.palette.common.white, TEXT_OPACITY.muted);
+  const directory = isDirectoryRelease(release);
+  const runtimeEnv = Object.entries(release.runtimeEnv ?? {})
+    .map(([key, value]) => `${key}=${value}`)
+    .join('\n');
   return (
     <Box
       component="section"
@@ -229,7 +281,11 @@ export const ComputeReleaseCard: React.FC<{ release: ServingRelease }> = ({
       >
         <Field label="Model" value={release.modelId} />
         <Field label="Runtime pin" value={release.runtimePin} copyable />
-        <Field label="Model file" value={release.modelFile} />
+        {directory ? (
+          <Field label="Model directory" value={release.modelFile} copyable />
+        ) : (
+          <Field label="Model file" value={release.modelFile} />
+        )}
         <Field label="Runtime image" value={release.image} copyable />
       </Box>
       {release.attestImage && (
@@ -237,9 +293,28 @@ export const ComputeReleaseCard: React.FC<{ release: ServingRelease }> = ({
           <Field label="Attest image" value={release.attestImage} copyable />
         </Box>
       )}
-      <Box sx={{ mb: 2 }}>
-        <Field label="Model SHA-256" value={release.modelSha256} copyable />
-      </Box>
+      {runtimeEnv && (
+        <Box sx={{ mb: 2 }}>
+          <Field label="Runtime env" value={runtimeEnv} copyable />
+        </Box>
+      )}
+      {release.modelDirSha256 ? (
+        <Box sx={{ mb: 2 }}>
+          <CommandBlock
+            label="Shard SHA-256"
+            text={splitShardDigests(release.modelDirSha256).join('\n')}
+            copyText={release.modelDirSha256}
+          />
+        </Box>
+      ) : (
+        <Box sx={{ mb: 2 }}>
+          <Field
+            label="Model SHA-256"
+            value={release.modelSha256 ?? '—'}
+            copyable={release.modelSha256 !== null}
+          />
+        </Box>
+      )}
 
       <CommandBlock label="Miner .env" text={env} />
       <Box sx={{ mt: 2 }}>


### PR DESCRIPTION
## What

The serving release moves to **Qwen3.8-27B NVFP4** (entrius/gittensor#1758), a Hugging Face model *directory* pinned by commit + per-shard sha256 rather than one GGUF file. The Current release card now renders that shape and emits the matching miner `.env` / `docker run` lines.

- `ServingRelease` gains `modelDirSha256` (`file=sha256,…`) and `runtimeEnv` (`{CTX, MODEL_NAME, TOK_REPO}`), both nullable; `modelSha256` is nullable. Both come from two new `serving_rounds` columns (entrius/gittensor-db PR) that das passes through (entrius/das-gittensor PR).
- Directory release: **Model directory** (`repo@commit`, copyable), **Shard SHA-256** block (one per line, copies as the comma-joined string), **Runtime env** field; `.env` block = `RUNTIME_IMAGE`, `ATTEST_IMAGE`, `MODEL_DIR_REPO`, `MODEL_DIR_REVISION`, `MODEL_DIR_SHA256`, `CTX`, `MODEL_NAME`, `TOK_REPO` — exactly what `docker-compose.miner.yml` / `miner.env.example` read. The docker command passes the same as `-e`.
- GGUF release: unchanged look (Model file, Model SHA-256, `MODEL_SHA256=`).
- One helper (`buildRuntimeEnvPairs`) feeds both blocks so they cannot drift.
- Mock updated to the 27B release and its rates (~$0.58/M output, ~$0.026/M prompt, ~101k tokens per flat-out round).

## Order

Merge after gittensor-db (columns) and das-gittensor (fields); the card degrades to the GGUF look while `modelDirSha256` is null, so merging early is harmless.

## Checks

`tsc -b`, `eslint --max-warnings 0`, prettier: clean.

https://claude.ai/code/session_01VjhStJbNW6WzxucTcwuw4y
